### PR TITLE
Migrate ferric-cli to use clap for argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -64,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -177,6 +177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -189,6 +190,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -304,7 +317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -344,6 +357,7 @@ dependencies = [
 name = "ferric-cli"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "ferric-core",
  "ferric-parser",
  "ferric-runtime",
@@ -507,7 +521,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -822,7 +836,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -974,7 +988,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1220,7 +1234,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ repository = "https://github.com/prb/ferric-rules"
 # Error handling
 thiserror = "2"
 
+# CLI argument parsing
+clap = { version = "4", features = ["derive"] }
+
 # Line editing for interactive REPL
 rustyline = "17"
 

--- a/crates/ferric-cli/Cargo.toml
+++ b/crates/ferric-cli/Cargo.toml
@@ -12,6 +12,7 @@ name = "ferric"
 path = "src/main.rs"
 
 [dependencies]
+clap = { workspace = true }
 ferric-core = { workspace = true }
 ferric-parser = { workspace = true }
 ferric-runtime = { workspace = true }

--- a/crates/ferric-cli/src/commands/check.rs
+++ b/crates/ferric-cli/src/commands/check.rs
@@ -5,22 +5,15 @@
 //! Exit codes:
 //! - 0: File is valid
 //! - 1: Validation/parse/compile error
-//! - 2: Usage error (missing file argument)
 
 use std::path::Path;
 
 use ferric_runtime::{Engine, EngineConfig};
 
-use super::common::{emit_error, parse_file_args};
+use super::common::emit_error;
 
 /// Execute the `check` subcommand.
-pub fn execute(args: &[String]) -> i32 {
-    let (json_mode, file_arg) = match parse_file_args(args, "check") {
-        Ok(parsed) => parsed,
-        Err(code) => return code,
-    };
-
-    let file_path = Path::new(file_arg);
+pub fn execute(json_mode: bool, file_path: &Path) -> i32 {
     if !file_path.exists() {
         emit_error(
             json_mode,

--- a/crates/ferric-cli/src/commands/common.rs
+++ b/crates/ferric-cli/src/commands/common.rs
@@ -1,25 +1,5 @@
 use std::fmt::{Display, Write as _};
 
-pub(crate) fn parse_file_args<'a>(
-    args: &'a [String],
-    command: &str,
-) -> Result<(bool, &'a str), i32> {
-    match args {
-        [file] => Ok((false, file.as_str())),
-        [flag, file] if flag == "--json" => Ok((true, file.as_str())),
-        [] => {
-            eprintln!("ferric {command}: missing file argument");
-            eprintln!("Usage: ferric {command} [--json] <file>");
-            Err(2)
-        }
-        _ => {
-            eprintln!("ferric {command}: invalid arguments");
-            eprintln!("Usage: ferric {command} [--json] <file>");
-            Err(2)
-        }
-    }
-}
-
 pub(crate) fn emit_error(json_mode: bool, command: &str, kind: &str, message: impl Display) {
     emit_message(json_mode, command, "error", kind, message);
 }

--- a/crates/ferric-cli/src/commands/repl.rs
+++ b/crates/ferric-cli/src/commands/repl.rs
@@ -26,7 +26,7 @@ const PROMPT: &str = "CLIPS> ";
 const CONTINUATION_PROMPT: &str = "... ";
 
 /// Execute the `repl` subcommand.
-pub fn execute(_args: &[String]) -> i32 {
+pub fn execute() -> i32 {
     let mut engine = Engine::new(EngineConfig::default());
 
     println!("Ferric REPL v{}", env!("CARGO_PKG_VERSION"));

--- a/crates/ferric-cli/src/commands/run.rs
+++ b/crates/ferric-cli/src/commands/run.rs
@@ -5,22 +5,15 @@
 //! Exit codes:
 //! - 0: Success
 //! - 1: Runtime/load error
-//! - 2: Usage error (missing file argument)
 
 use std::path::Path;
 
 use ferric_runtime::{Engine, EngineConfig, RunLimit};
 
-use super::common::{emit_error, emit_warning, parse_file_args};
+use super::common::{emit_error, emit_warning};
 
 /// Execute the `run` subcommand.
-pub fn execute(args: &[String]) -> i32 {
-    let (json_mode, file_arg) = match parse_file_args(args, "run") {
-        Ok(parsed) => parsed,
-        Err(code) => return code,
-    };
-
-    let file_path = Path::new(file_arg);
+pub fn execute(json_mode: bool, file_path: &Path) -> i32 {
     if !file_path.exists() {
         emit_error(
             json_mode,

--- a/crates/ferric-cli/src/main.rs
+++ b/crates/ferric-cli/src/main.rs
@@ -22,23 +22,60 @@
 
 mod commands;
 
-fn main() {
-    let args: Vec<String> = std::env::args().collect();
+use std::path::PathBuf;
 
-    let exit_code = match args.get(1).map(String::as_str) {
-        Some("run") => commands::run::execute(&args[2..]),
-        Some("check") => commands::check::execute(&args[2..]),
-        Some("repl") => commands::repl::execute(&args[2..]),
-        Some("version" | "--version" | "-V") => commands::version::execute(),
-        Some(unknown) => {
-            eprintln!("ferric: unknown command '{unknown}'");
-            eprintln!("Usage: ferric <run|check|repl|version> [args...]");
-            2
-        }
-        None => {
-            eprintln!("Usage: ferric <run|check|repl|version> [args...]");
-            2
-        }
+use clap::{Parser, Subcommand};
+
+/// Command-line interface for the Ferric rules engine.
+#[derive(Parser)]
+#[command(
+    name = "ferric",
+    version,
+    subcommand_required = true,
+    arg_required_else_help = true
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Load and execute a CLIPS file.
+    Run {
+        /// Emit diagnostics as JSON objects on stderr.
+        #[arg(long)]
+        json: bool,
+
+        /// Path to the CLIPS file to execute.
+        file: PathBuf,
+    },
+
+    /// Parse and validate a CLIPS file without executing.
+    Check {
+        /// Emit diagnostics as JSON objects on stderr.
+        #[arg(long)]
+        json: bool,
+
+        /// Path to the CLIPS file to validate.
+        file: PathBuf,
+    },
+
+    /// Start an interactive REPL session.
+    Repl,
+
+    /// Print version information.
+    Version,
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    let exit_code = match cli.command {
+        Command::Run { json, file } => commands::run::execute(json, &file),
+        Command::Check { json, file } => commands::check::execute(json, &file),
+        Command::Repl => commands::repl::execute(),
+        Command::Version => commands::version::execute(),
     };
 
     std::process::exit(exit_code);

--- a/crates/ferric-cli/tests/cli_integration.rs
+++ b/crates/ferric-cli/tests/cli_integration.rs
@@ -39,21 +39,21 @@ fn no_args_exits_usage_error() {
 fn unknown_command_exits_usage_error() {
     let output = run_ferric(&["frobnicate"]);
     assert_exit_code(&output, 2);
-    assert_stderr_contains(&output, "unknown command");
+    assert_stderr_contains(&output, "unrecognized subcommand");
 }
 
 #[test]
 fn run_without_file_exits_usage_error() {
     let output = run_ferric(&["run"]);
     assert_exit_code(&output, 2);
-    assert_stderr_contains(&output, "missing file");
+    assert_stderr_contains(&output, "required arguments");
 }
 
 #[test]
 fn check_without_file_exits_usage_error() {
     let output = run_ferric(&["check"]);
     assert_exit_code(&output, 2);
-    assert_stderr_contains(&output, "missing file");
+    assert_stderr_contains(&output, "required arguments");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Replace manual `std::env::args()` dispatch with clap derive macros for a better CLI developer experience: auto-generated `--help`, informative error messages, colored output, and typo suggestions.

Simplify command handlers by passing typed arguments directly instead of raw args slices. All 37 integration tests pass with minor assertion updates for clap's standard error wording.

## Changes

- Add clap 4 with derive feature to workspace dependencies
- Replace manual dispatch in main.rs with clap `Cli` struct and `Command` subcommand enum
- Simplify `run` and `check` command signatures to accept typed `bool` and `&Path` instead of `&[String]`
- Remove `parse_file_args` helper from common.rs (now handled by clap)
- Update 3 integration test assertions to match clap's error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)