### PR TITLE
Add bounds-safety annotations to FFI header

### DIFF
--- a/crates/ferric-ffi/build.rs
+++ b/crates/ferric-ffi/build.rs
@@ -53,7 +53,142 @@ pub const HEADER_PREAMBLE: &str = r"/*
  * 7. Output string pointers: ferric_engine_get_output() returns
  *    a borrowed pointer valid until the next call that writes
  *    to that channel. Do NOT free.
+ *
+ * 8. Bounds annotations: Pointer parameters and struct fields
+ *    carry FERRIC_COUNTED_BY, FERRIC_SIZED_BY, and
+ *    FERRIC_NULL_TERMINATED annotations when compiled with
+ *    Clang -fbounds-safety. Define FERRIC_NO_BOUNDS_ANNOTATIONS
+ *    before including this header to suppress.
  */";
+
+/// Bounds-safety annotation macros injected after the standard includes.
+///
+/// These macros gate on `__has_feature(bounds_safety)` (Clang with
+/// `-fbounds-safety`) and degrade to empty definitions everywhere else.
+/// Users can also define `FERRIC_NO_BOUNDS_ANNOTATIONS` to suppress
+/// all annotations unconditionally.
+const BOUNDS_SAFETY_MACROS: &str = r"
+/*
+ * ============================================================
+ * BOUNDS-SAFETY ANNOTATIONS
+ * ============================================================
+ *
+ * When compiled with a supporting compiler (Clang with
+ * -fbounds-safety), pointer parameters, struct fields, and
+ * return types carry bounds annotations that enable static
+ * and runtime checking.
+ *
+ * To disable all annotations, define FERRIC_NO_BOUNDS_ANNOTATIONS
+ * before including this header.
+ */
+
+#ifndef FERRIC_NO_BOUNDS_ANNOTATIONS
+  #if defined(__clang__) && defined(__has_feature)
+    #if __has_feature(bounds_safety)
+      #define FERRIC_COUNTED_BY(N) __counted_by(N)
+      #define FERRIC_SIZED_BY(N) __sized_by(N)
+      #define FERRIC_NULL_TERMINATED __null_terminated
+    #endif
+  #endif
+  #ifndef FERRIC_COUNTED_BY
+    #define FERRIC_COUNTED_BY(N)
+    #define FERRIC_SIZED_BY(N)
+    #define FERRIC_NULL_TERMINATED
+  #endif
+#else
+  #define FERRIC_COUNTED_BY(N)
+  #define FERRIC_SIZED_BY(N)
+  #define FERRIC_NULL_TERMINATED
+#endif
+";
+
+/// Deterministic annotation replacements applied to the cbindgen output.
+///
+/// Each `(find, replace)` pair must match exactly once in the generated header.
+/// If cbindgen's output format changes and a pattern no longer matches, the
+/// build will panic with a clear message identifying the stale pattern.
+const BOUNDS_ANNOTATIONS: &[(&str, &str)] = &[
+    // ── Struct fields ──────────────────────────────────────────────────
+    //
+    // FerricValue.string_ptr: NUL-terminated string when non-null.
+    (
+        "char *string_ptr;",
+        "char * FERRIC_NULL_TERMINATED string_ptr;",
+    ),
+    // FerricValue.multifield_ptr: array of multifield_len elements.
+    (
+        "struct FerricValue *multifield_ptr;",
+        "struct FerricValue *multifield_ptr FERRIC_COUNTED_BY(multifield_len);",
+    ),
+    // ── Return types ───────────────────────────────────────────────────
+    //
+    // ferric_engine_last_error returns a NUL-terminated string (or null).
+    (
+        "const char *ferric_engine_last_error(",
+        "const char * FERRIC_NULL_TERMINATED ferric_engine_last_error(",
+    ),
+    // ferric_engine_get_output returns a NUL-terminated string (or null).
+    (
+        "const char *ferric_engine_get_output(",
+        "const char * FERRIC_NULL_TERMINATED ferric_engine_get_output(",
+    ),
+    // ferric_last_error_global returns a NUL-terminated string (or null).
+    (
+        "const char *ferric_last_error_global(",
+        "const char * FERRIC_NULL_TERMINATED ferric_last_error_global(",
+    ),
+    // ── NUL-terminated string parameters ───────────────────────────────
+    //
+    // ferric_engine_load_string: source is NUL-terminated.
+    (
+        "const char *source);",
+        "const char * FERRIC_NULL_TERMINATED source);",
+    ),
+    // ferric_engine_assert_string: source is NUL-terminated.
+    (
+        "const char *source,",
+        "const char * FERRIC_NULL_TERMINATED source,",
+    ),
+    // ferric_engine_get_output: channel is NUL-terminated.
+    (
+        "const char *channel);",
+        "const char * FERRIC_NULL_TERMINATED channel);",
+    ),
+    // ferric_engine_get_global: name is NUL-terminated.
+    (
+        "const char *name,",
+        "const char * FERRIC_NULL_TERMINATED name,",
+    ),
+    // ferric_string_free: ptr is a NUL-terminated string.
+    (
+        "ferric_string_free(char *ptr)",
+        "ferric_string_free(char * FERRIC_NULL_TERMINATED ptr)",
+    ),
+    // ── Sized / counted buffer parameters ──────────────────────────────
+    //
+    // ferric_value_array_free: arr is an array of len FerricValues.
+    (
+        "ferric_value_array_free(struct FerricValue *arr, uintptr_t len)",
+        "ferric_value_array_free(struct FerricValue *arr FERRIC_COUNTED_BY(len), uintptr_t len)",
+    ),
+    // ferric_last_error_global_copy: buf is a byte buffer of buf_len bytes.
+    (
+        "ferric_last_error_global_copy(char *buf, uintptr_t buf_len,",
+        "ferric_last_error_global_copy(char *buf FERRIC_SIZED_BY(buf_len), uintptr_t buf_len,",
+    ),
+    // ferric_engine_last_error_copy: buf is a byte buffer of buf_len bytes.
+    // (multi-line signature — pattern spans the line break)
+    (
+        "ferric_engine_last_error_copy(const struct FerricEngine *engine,\n                                               char *buf,",
+        "ferric_engine_last_error_copy(const struct FerricEngine *engine,\n                                               char *buf FERRIC_SIZED_BY(buf_len),",
+    ),
+    // ferric_engine_action_diagnostic_copy: buf is a byte buffer of buf_len bytes.
+    // (multi-line signature — pattern spans the line break)
+    (
+        "uintptr_t index,\n                                                      char *buf,",
+        "uintptr_t index,\n                                                      char *buf FERRIC_SIZED_BY(buf_len),",
+    ),
+];
 
 fn main() {
     let crate_dir =
@@ -62,11 +197,38 @@ fn main() {
     let config = cbindgen::Config::from_file(format!("{crate_dir}/cbindgen.toml"))
         .expect("Failed to read cbindgen.toml");
 
-    cbindgen::Builder::new()
+    // Generate the header into memory so we can post-process it.
+    let bindings = cbindgen::Builder::new()
         .with_crate(&crate_dir)
         .with_config(config)
         .with_header(HEADER_PREAMBLE)
         .generate()
-        .expect("Unable to generate C bindings")
-        .write_to_file(format!("{crate_dir}/ferric.h"));
+        .expect("Unable to generate C bindings");
+
+    let mut buf = Vec::new();
+    bindings.write(&mut buf);
+    let mut header = String::from_utf8(buf).expect("cbindgen output was not valid UTF-8");
+
+    // Inject bounds-safety macro definitions after the standard includes.
+    let inject_marker = "#include <stdlib.h>";
+    let inject_pos = header
+        .find(inject_marker)
+        .expect("Could not find #include <stdlib.h> in generated header")
+        + inject_marker.len();
+    header.insert_str(inject_pos, BOUNDS_SAFETY_MACROS);
+
+    // Apply bounds-safety annotations to struct fields, function parameters,
+    // and return types. Each pattern must match exactly once; if cbindgen's
+    // output drifts, the build fails loudly rather than silently dropping
+    // an annotation.
+    for (find, replace) in BOUNDS_ANNOTATIONS {
+        let count = header.matches(find).count();
+        assert_eq!(
+            count, 1,
+            "bounds-safety annotation: expected exactly 1 match, found {count} for pattern:\n  {find}"
+        );
+        header = header.replacen(find, replace, 1);
+    }
+
+    std::fs::write(format!("{crate_dir}/ferric.h"), header).expect("Failed to write ferric.h");
 }

--- a/crates/ferric-ffi/ferric.h
+++ b/crates/ferric-ffi/ferric.h
@@ -50,6 +50,12 @@
  * 7. Output string pointers: ferric_engine_get_output() returns
  *    a borrowed pointer valid until the next call that writes
  *    to that channel. Do NOT free.
+ *
+ * 8. Bounds annotations: Pointer parameters and struct fields
+ *    carry FERRIC_COUNTED_BY, FERRIC_SIZED_BY, and
+ *    FERRIC_NULL_TERMINATED annotations when compiled with
+ *    Clang -fbounds-safety. Define FERRIC_NO_BOUNDS_ANNOTATIONS
+ *    before including this header to suppress.
  */
 
 #ifndef FERRIC_H
@@ -61,6 +67,39 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+/*
+ * ============================================================
+ * BOUNDS-SAFETY ANNOTATIONS
+ * ============================================================
+ *
+ * When compiled with a supporting compiler (Clang with
+ * -fbounds-safety), pointer parameters, struct fields, and
+ * return types carry bounds annotations that enable static
+ * and runtime checking.
+ *
+ * To disable all annotations, define FERRIC_NO_BOUNDS_ANNOTATIONS
+ * before including this header.
+ */
+
+#ifndef FERRIC_NO_BOUNDS_ANNOTATIONS
+  #if defined(__clang__) && defined(__has_feature)
+    #if __has_feature(bounds_safety)
+      #define FERRIC_COUNTED_BY(N) __counted_by(N)
+      #define FERRIC_SIZED_BY(N) __sized_by(N)
+      #define FERRIC_NULL_TERMINATED __null_terminated
+    #endif
+  #endif
+  #ifndef FERRIC_COUNTED_BY
+    #define FERRIC_COUNTED_BY(N)
+    #define FERRIC_SIZED_BY(N)
+    #define FERRIC_NULL_TERMINATED
+  #endif
+#else
+  #define FERRIC_COUNTED_BY(N)
+  #define FERRIC_SIZED_BY(N)
+  #define FERRIC_NULL_TERMINATED
+#endif
+
 
 // C-facing error codes returned by all fallible FFI entry points.
 //
@@ -158,8 +197,8 @@ typedef struct FerricValue {
     enum FerricValueType value_type;
     int64_t integer;
     double float_;
-    char *string_ptr;
-    struct FerricValue *multifield_ptr;
+    char * FERRIC_NULL_TERMINATED string_ptr;
+    struct FerricValue *multifield_ptr FERRIC_COUNTED_BY(multifield_len);
     uintptr_t multifield_len;
     uint32_t external_type_id;
     void *external_pointer;
@@ -205,7 +244,7 @@ enum FerricError ferric_engine_free(struct FerricEngine *engine);
 //
 // - `engine` must be a valid engine pointer.
 // - `source` must be a valid NUL-terminated UTF-8 string.
-enum FerricError ferric_engine_load_string(struct FerricEngine *engine, const char *source);
+enum FerricError ferric_engine_load_string(struct FerricEngine *engine, const char * FERRIC_NULL_TERMINATED source);
 
 // Retrieve the last per-engine error message.
 //
@@ -215,7 +254,7 @@ enum FerricError ferric_engine_load_string(struct FerricEngine *engine, const ch
 // # Safety
 //
 // - `engine` must be a valid engine pointer or null.
-const char *ferric_engine_last_error(const struct FerricEngine *engine);
+const char * FERRIC_NULL_TERMINATED ferric_engine_last_error(const struct FerricEngine *engine);
 
 // Copy the per-engine error message into a caller-provided buffer.
 //
@@ -240,7 +279,7 @@ const char *ferric_engine_last_error(const struct FerricEngine *engine);
 // - `buf` must point to `buf_len` writable bytes, or be null for size query.
 // - `out_len` must be a valid pointer (non-null).
 enum FerricError ferric_engine_last_error_copy(const struct FerricEngine *engine,
-                                               char *buf,
+                                               char *buf FERRIC_SIZED_BY(buf_len),
                                                uintptr_t buf_len,
                                                uintptr_t *out_len);
 
@@ -297,7 +336,7 @@ enum FerricError ferric_engine_step(struct FerricEngine *engine, int32_t *out_st
 // - `source` must be a valid NUL-terminated UTF-8 string.
 // - `out_fact_id` may be null.
 enum FerricError ferric_engine_assert_string(struct FerricEngine *engine,
-                                             const char *source,
+                                             const char * FERRIC_NULL_TERMINATED source,
                                              uint64_t *out_fact_id);
 
 // Retract a fact by its opaque fact ID obtained from a previous assert.
@@ -318,7 +357,7 @@ enum FerricError ferric_engine_retract(struct FerricEngine *engine, uint64_t fac
 //
 // - `engine` must be a valid engine pointer or null.
 // - `channel` must be a valid NUL-terminated UTF-8 string or null.
-const char *ferric_engine_get_output(const struct FerricEngine *engine, const char *channel);
+const char * FERRIC_NULL_TERMINATED ferric_engine_get_output(const struct FerricEngine *engine, const char * FERRIC_NULL_TERMINATED channel);
 
 // Get the number of action diagnostics captured during recent execution.
 //
@@ -344,7 +383,7 @@ enum FerricError ferric_engine_action_diagnostic_count(const struct FerricEngine
 // - `out_len` must be a valid pointer (non-null).
 enum FerricError ferric_engine_action_diagnostic_copy(const struct FerricEngine *engine,
                                                       uintptr_t index,
-                                                      char *buf,
+                                                      char *buf FERRIC_SIZED_BY(buf_len),
                                                       uintptr_t buf_len,
                                                       uintptr_t *out_len);
 
@@ -410,7 +449,7 @@ enum FerricError ferric_engine_get_fact_field(const struct FerricEngine *engine,
 // - `name` must be a valid NUL-terminated UTF-8 string.
 // - `out_value` must be a valid pointer to a `FerricValue`.
 enum FerricError ferric_engine_get_global(const struct FerricEngine *engine,
-                                          const char *name,
+                                          const char * FERRIC_NULL_TERMINATED name,
                                           struct FerricValue *out_value);
 
 // Retrieve the last global error message as a C string pointer.
@@ -423,7 +462,7 @@ enum FerricError ferric_engine_get_global(const struct FerricEngine *engine,
 //
 // The returned pointer must not be freed by the caller and must not be
 // used after any subsequent FFI call that may modify the error channel.
-const char *ferric_last_error_global(void);
+const char * FERRIC_NULL_TERMINATED ferric_last_error_global(void);
 
 // Clear the global error channel.
 void ferric_clear_error_global(void);
@@ -449,7 +488,7 @@ void ferric_clear_error_global(void);
 //
 // - `buf` must point to `buf_len` writable bytes, or be null for size query.
 // - `out_len` must be a valid pointer (non-null).
-enum FerricError ferric_last_error_global_copy(char *buf, uintptr_t buf_len, uintptr_t *out_len);
+enum FerricError ferric_last_error_global_copy(char *buf FERRIC_SIZED_BY(buf_len), uintptr_t buf_len, uintptr_t *out_len);
 
 // Free a heap-allocated C string returned by the FFI.
 //
@@ -459,7 +498,7 @@ enum FerricError ferric_last_error_global_copy(char *buf, uintptr_t buf_len, uin
 //
 // - `ptr` must be a pointer returned by an FFI function or null.
 // - The pointer must not have been freed already.
-void ferric_string_free(char *ptr);
+void ferric_string_free(char * FERRIC_NULL_TERMINATED ptr);
 
 // Free a `FerricValue` and its owned resources.
 //
@@ -481,6 +520,6 @@ void ferric_value_free(struct FerricValue *value);
 //
 // - `arr` must point to a contiguous array of `len` `FerricValue`s, or be null.
 // - The array must have been allocated by the FFI.
-void ferric_value_array_free(struct FerricValue *arr, uintptr_t len);
+void ferric_value_array_free(struct FerricValue *arr FERRIC_COUNTED_BY(len), uintptr_t len);
 
 #endif  /* FERRIC_H */

--- a/crates/ferric-ffi/src/tests/header.rs
+++ b/crates/ferric-ffi/src/tests/header.rs
@@ -319,3 +319,119 @@ fn header_contains_value_free_functions() {
         "Missing ferric_value_array_free"
     );
 }
+
+// ── Bounds-safety annotation tests ─────────────────────────────────────
+
+#[test]
+fn header_has_bounds_safety_macros() {
+    let header = read_committed_header();
+    assert!(
+        header.contains("#define FERRIC_COUNTED_BY(N)"),
+        "Missing FERRIC_COUNTED_BY macro definition"
+    );
+    assert!(
+        header.contains("#define FERRIC_SIZED_BY(N)"),
+        "Missing FERRIC_SIZED_BY macro definition"
+    );
+    assert!(
+        header.contains("#define FERRIC_NULL_TERMINATED"),
+        "Missing FERRIC_NULL_TERMINATED macro definition"
+    );
+    assert!(
+        header.contains("__has_feature(bounds_safety)"),
+        "Missing bounds_safety feature detection"
+    );
+}
+
+#[test]
+fn header_has_bounds_safety_escape_hatch() {
+    let header = read_committed_header();
+    assert!(
+        header.contains("FERRIC_NO_BOUNDS_ANNOTATIONS"),
+        "Missing FERRIC_NO_BOUNDS_ANNOTATIONS escape hatch"
+    );
+}
+
+#[test]
+fn header_has_counted_by_and_sized_by_annotations() {
+    let header = read_committed_header();
+
+    // Struct field: FerricValue.multifield_ptr counted_by multifield_len
+    assert!(
+        header.contains("*multifield_ptr FERRIC_COUNTED_BY(multifield_len)"),
+        "Missing FERRIC_COUNTED_BY on FerricValue.multifield_ptr"
+    );
+
+    // ferric_value_array_free: arr counted_by len
+    assert!(
+        header.contains("*arr FERRIC_COUNTED_BY(len)"),
+        "Missing FERRIC_COUNTED_BY on ferric_value_array_free arr parameter"
+    );
+
+    // ferric_last_error_global_copy: buf sized_by buf_len
+    assert!(
+        header.contains("ferric_last_error_global_copy(char *buf FERRIC_SIZED_BY(buf_len)"),
+        "Missing FERRIC_SIZED_BY on ferric_last_error_global_copy buf parameter"
+    );
+
+    // ferric_engine_last_error_copy: buf sized_by buf_len
+    assert!(
+        header.contains("*buf FERRIC_SIZED_BY(buf_len),\n                                               uintptr_t buf_len,\n                                               uintptr_t *out_len);"),
+        "Missing FERRIC_SIZED_BY on ferric_engine_last_error_copy buf parameter"
+    );
+
+    // ferric_engine_action_diagnostic_copy: buf sized_by buf_len
+    assert!(
+        header.contains("*buf FERRIC_SIZED_BY(buf_len),\n                                                      uintptr_t buf_len,\n                                                      uintptr_t *out_len);"),
+        "Missing FERRIC_SIZED_BY on ferric_engine_action_diagnostic_copy buf parameter"
+    );
+}
+
+#[test]
+fn header_has_null_terminated_annotations() {
+    let header = read_committed_header();
+
+    // Struct field: FerricValue.string_ptr
+    assert!(
+        header.contains("FERRIC_NULL_TERMINATED string_ptr"),
+        "Missing FERRIC_NULL_TERMINATED on FerricValue.string_ptr"
+    );
+
+    // Return types
+    assert!(
+        header.contains("char * FERRIC_NULL_TERMINATED ferric_engine_last_error("),
+        "Missing FERRIC_NULL_TERMINATED on ferric_engine_last_error return type"
+    );
+    assert!(
+        header.contains("char * FERRIC_NULL_TERMINATED ferric_engine_get_output("),
+        "Missing FERRIC_NULL_TERMINATED on ferric_engine_get_output return type"
+    );
+    assert!(
+        header.contains("char * FERRIC_NULL_TERMINATED ferric_last_error_global("),
+        "Missing FERRIC_NULL_TERMINATED on ferric_last_error_global return type"
+    );
+
+    // String parameters
+    assert!(
+        header.contains("FERRIC_NULL_TERMINATED source);"),
+        "Missing FERRIC_NULL_TERMINATED on load_string source parameter"
+    );
+    assert!(
+        header.contains("FERRIC_NULL_TERMINATED source,"),
+        "Missing FERRIC_NULL_TERMINATED on assert_string source parameter"
+    );
+    assert!(
+        header.contains("FERRIC_NULL_TERMINATED channel);"),
+        "Missing FERRIC_NULL_TERMINATED on get_output channel parameter"
+    );
+    assert!(
+        header.contains("FERRIC_NULL_TERMINATED name,"),
+        "Missing FERRIC_NULL_TERMINATED on get_global name parameter"
+    );
+
+    // ferric_string_free: ptr
+    assert!(
+        header.contains("FERRIC_NULL_TERMINATED ptr)"),
+        "Missing FERRIC_NULL_TERMINATED on ferric_string_free ptr parameter"
+    );
+}


### PR DESCRIPTION
## Summary

- Extended build.rs to post-process cbindgen output with 14 bounds-safety annotations
- Annotations (FERRIC_COUNTED_BY, FERRIC_SIZED_BY, FERRIC_NULL_TERMINATED) gate on `__has_feature(bounds_safety)` for Clang -fbounds-safety compatibility
- Degraded to empty macros on other compilers (zero overhead, zero ABI impact)
- Added FERRIC_NO_BOUNDS_ANNOTATIONS escape hatch for users who want to suppress annotations
- All 150 FFI tests pass; builds clean on Clang and GCC

## Annotations

14 sites annotated: 2 struct fields, 3 return types, 4 NUL-terminated string parameters, 3 sized byte buffers, 1 counted array, 1 freed string. Each annotation matches exactly once—build fails loudly if cbindgen output drifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)