### PR TITLE
Add CI job for CLIPS compatibility assessment

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
@@ -51,21 +55,56 @@ jobs:
       - name: Run compat assessment
         run: python3 scripts/compat-run.py --workers 4 --timeout 30
 
-      # ── Report ──────────────────────────────────────────────────────
+      # ── PR report ───────────────────────────────────────────────────
       - name: Generate comparison report
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        run: python3 scripts/compat-diff.py /tmp/base-manifest.json tests/examples/compat-manifest.json >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          python3 scripts/compat-diff.py \
+            /tmp/base-manifest.json tests/examples/compat-manifest.json \
+            --tsv /tmp/compat-diff.tsv \
+            --report /tmp/compat-report.md \
+            --repo "${{ github.repository }}" \
+            --base-sha "${{ github.event.pull_request.base.sha }}" \
+            --head-sha "${{ github.sha }}" \
+            >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Generate standalone report
-        if: github.event_name == 'push'
-        run: python3 scripts/compat-report.py >> "$GITHUB_STEP_SUMMARY"
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        run: gh pr comment "${{ github.event.number }}" --body-file /tmp/compat-report.md
+        env:
+          GH_TOKEN: ${{ github.token }}
 
-      - name: Upload manifests
-        if: always()
+      - name: Upload comparison artifacts
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
-          name: compat-manifests
+          name: compat-report
+          retention-days: 30
           path: |
+            /tmp/compat-diff.tsv
+            /tmp/compat-report.md
             tests/examples/compat-manifest.json
             /tmp/base-manifest.json
+
+      # ── Push-to-main report ─────────────────────────────────────────
+      - name: Generate standalone report
+        if: github.event_name == 'push'
+        run: |
+          python3 scripts/compat-report.py \
+            --tsv /tmp/compat-report.tsv \
+            --report /tmp/compat-report.md \
+            --repo "${{ github.repository }}" \
+            --commit-sha "${{ github.sha }}" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload standalone artifacts
+        if: github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: compat-report
+          retention-days: 30
+          path: |
+            /tmp/compat-report.tsv
+            /tmp/compat-report.md
+            tests/examples/compat-manifest.json

--- a/scripts/compat-diff.py
+++ b/scripts/compat-diff.py
@@ -6,12 +6,20 @@ compat-run.py) and emits a Markdown table showing classification
 changes between the two.
 
 Usage:
-    python scripts/compat-diff.py BASE_MANIFEST HEAD_MANIFEST
+    python scripts/compat-diff.py BASE_MANIFEST HEAD_MANIFEST [options]
 
-The output is written to stdout as GitHub-flavored Markdown, suitable
-for appending to $GITHUB_STEP_SUMMARY.
+Options:
+    --tsv FILE          Write per-file raw data as TSV
+    --report FILE       Write a self-contained Markdown report with context
+    --repo OWNER/REPO   GitHub repository (for commit links)
+    --base-sha SHA      Base commit SHA (for commit links)
+    --head-sha SHA      Head commit SHA (for commit links)
+
+Stdout is always the comparison table (suitable for $GITHUB_STEP_SUMMARY).
 """
 
+import argparse
+import csv
 import json
 import sys
 
@@ -35,21 +43,14 @@ def fmt_delta(n):
     return "0"
 
 
-def main():
-    if len(sys.argv) != 3:
-        print(f"usage: {sys.argv[0]} BASE_MANIFEST HEAD_MANIFEST", file=sys.stderr)
-        sys.exit(1)
+def compute_diff(base, head):
+    """Compute counts and per-file changes between two manifests.
 
-    base_path, head_path = sys.argv[1], sys.argv[2]
-    base = load_manifest(base_path)
-    head = load_manifest(head_path)
-
+    Returns (base_counts, head_counts, regressions, real_improvements, reason_changes).
+    """
     base_files = base.get("files", {})
     head_files = head.get("files", {})
 
-    # ------------------------------------------------------------------
-    # Summary counts
-    # ------------------------------------------------------------------
     base_counts = {cls: 0 for cls in DISPLAY_ORDER}
     head_counts = {cls: 0 for cls in DISPLAY_ORDER}
 
@@ -63,12 +64,6 @@ def main():
         if cls in head_counts:
             head_counts[cls] += 1
 
-    base_total = sum(base_counts.values())
-    head_total = sum(head_counts.values())
-
-    # ------------------------------------------------------------------
-    # Per-file changes
-    # ------------------------------------------------------------------
     improvements = []
     regressions = []
 
@@ -78,13 +73,12 @@ def main():
         h = head_files.get(key)
 
         if b is None or h is None:
-            continue  # new or removed file; not a classification change
+            continue
 
         b_cls = b["classification"]
         h_cls = h["classification"]
 
         if b_cls == h_cls:
-            # Check if reason changed within the same classification
             b_reason = b.get("reason", "")
             h_reason = h.get("reason", "")
             if b_reason != h_reason:
@@ -100,67 +94,175 @@ def main():
         else:
             regressions.append(entry)
 
-    # Filter out same-classification reason-only changes from improvements
-    # (those are neutral, not real improvements)
     real_improvements = [e for e in improvements if e[1] != e[3]]
     reason_changes = [e for e in improvements if e[1] == e[3]]
 
-    # ------------------------------------------------------------------
-    # Output Markdown
-    # ------------------------------------------------------------------
-    print("## CLIPS Compatibility Report")
-    print()
-    print("| Classification | Base | Head | Delta |")
-    print("|---|---:|---:|---|")
+    return base_counts, head_counts, regressions, real_improvements, reason_changes
+
+
+def format_markdown(base_counts, head_counts, regressions, real_improvements,
+                    reason_changes, *, repo=None, base_sha=None, head_sha=None):
+    """Build the full Markdown report as a list of lines."""
+    lines = []
+
+    lines.append("## CLIPS Compatibility Report")
+    lines.append("")
+
+    # Context blurb + commit links
+    lines.append("Compares ferric's compatibility with CLIPS across a corpus of")
+    lines.append("example `.clp` files. Each file is classified as **equivalent**")
+    lines.append("(output matches CLIPS), **divergent** (runs but output differs),")
+    lines.append("**incompatible** (cannot run), or **pending** (not yet tested).")
+    lines.append("")
+
+    if repo and base_sha and head_sha:
+        base_link = f"[`{base_sha[:10]}`](https://github.com/{repo}/commit/{base_sha})"
+        head_link = f"[`{head_sha[:10]}`](https://github.com/{repo}/commit/{head_sha})"
+        lines.append(f"Base: {base_link} | Head: {head_link}")
+        lines.append("")
+
+    base_total = sum(base_counts.values())
+    head_total = sum(head_counts.values())
+
+    lines.append("| Classification | Base | Head | Delta |")
+    lines.append("|---|---:|---:|---|")
     for cls in DISPLAY_ORDER:
         b = base_counts[cls]
         h = head_counts[cls]
         d = h - b
         delta_str = f"**{fmt_delta(d)}**" if d != 0 else "—"
-        print(f"| {cls} | {b} | {h} | {delta_str} |")
+        lines.append(f"| {cls} | {b} | {h} | {delta_str} |")
     d_total = head_total - base_total
     delta_total = f"**{fmt_delta(d_total)}**" if d_total != 0 else "—"
-    print(f"| **total** | **{base_total}** | **{head_total}** | {delta_total} |")
+    lines.append(f"| **total** | **{base_total}** | **{head_total}** | {delta_total} |")
 
     # Regressions
-    print()
+    lines.append("")
     if regressions:
-        print(f"### Regressions ({len(regressions)})")
-        print()
-        print("| File | Before | After |")
-        print("|---|---|---|")
+        lines.append(f"### Regressions ({len(regressions)})")
+        lines.append("")
+        lines.append("| File | Before | After |")
+        lines.append("|---|---|---|")
         for path, b_cls, b_reason, h_cls, h_reason in regressions:
-            print(f"| `{path}` | {b_cls} ({b_reason}) | {h_cls} ({h_reason}) |")
+            lines.append(f"| `{path}` | {b_cls} ({b_reason}) | {h_cls} ({h_reason}) |")
     else:
-        print("### Regressions")
-        print()
-        print("None")
+        lines.append("### Regressions")
+        lines.append("")
+        lines.append("None")
 
     # Improvements
-    print()
+    lines.append("")
     if real_improvements:
-        print(f"### Improvements ({len(real_improvements)})")
-        print()
-        print("| File | Before | After |")
-        print("|---|---|---|")
+        lines.append(f"### Improvements ({len(real_improvements)})")
+        lines.append("")
+        lines.append("| File | Before | After |")
+        lines.append("|---|---|---|")
         for path, b_cls, b_reason, h_cls, h_reason in real_improvements:
-            print(f"| `{path}` | {b_cls} ({b_reason}) | {h_cls} ({h_reason}) |")
+            lines.append(f"| `{path}` | {b_cls} ({b_reason}) | {h_cls} ({h_reason}) |")
     else:
-        print("### Improvements")
-        print()
-        print("None")
+        lines.append("### Improvements")
+        lines.append("")
+        lines.append("None")
 
-    # Reason-only changes (informational)
+    # Reason-only changes
     if reason_changes:
-        print()
-        print(f"<details><summary>Reason changes within same classification ({len(reason_changes)})</summary>")
-        print()
-        print("| File | Classification | Before | After |")
-        print("|---|---|---|---|")
+        lines.append("")
+        lines.append(f"<details><summary>Reason changes within same classification ({len(reason_changes)})</summary>")
+        lines.append("")
+        lines.append("| File | Classification | Before | After |")
+        lines.append("|---|---|---|---|")
         for path, b_cls, b_reason, h_cls, h_reason in reason_changes:
-            print(f"| `{path}` | {b_cls} | {b_reason} | {h_reason} |")
-        print()
-        print("</details>")
+            lines.append(f"| `{path}` | {b_cls} | {b_reason} | {h_reason} |")
+        lines.append("")
+        lines.append("</details>")
+
+    return lines
+
+
+def write_tsv(base, head, tsv_path):
+    """Write per-file raw data as TSV."""
+    base_files = base.get("files", {})
+    head_files = head.get("files", {})
+    all_keys = sorted(set(base_files) | set(head_files))
+
+    fieldnames = [
+        "path", "source",
+        "base_classification", "base_reason",
+        "head_classification", "head_reason",
+        "change",
+    ]
+
+    with open(tsv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+
+        for key in all_keys:
+            b = base_files.get(key)
+            h = head_files.get(key)
+
+            b_cls = b["classification"] if b else ""
+            b_reason = b.get("reason", "") if b else ""
+            h_cls = h["classification"] if h else ""
+            h_reason = h.get("reason", "") if h else ""
+            source = (h or b).get("source", "")
+
+            if not b:
+                change = "added"
+            elif not h:
+                change = "removed"
+            elif b_cls != h_cls:
+                b_rank = RANK.get(b_cls, 99)
+                h_rank = RANK.get(h_cls, 99)
+                change = "improvement" if h_rank < b_rank else "regression"
+            elif b_reason != h_reason:
+                change = "reason-changed"
+            else:
+                change = "unchanged"
+
+            writer.writerow({
+                "path": key,
+                "source": source,
+                "base_classification": b_cls,
+                "base_reason": b_reason,
+                "head_classification": h_cls,
+                "head_reason": h_reason,
+                "change": change,
+            })
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare two compat manifests")
+    parser.add_argument("base_manifest", help="Base manifest JSON")
+    parser.add_argument("head_manifest", help="Head manifest JSON")
+    parser.add_argument("--tsv", metavar="FILE", help="Write per-file data as TSV")
+    parser.add_argument("--report", metavar="FILE", help="Write self-contained Markdown report")
+    parser.add_argument("--repo", metavar="OWNER/REPO", help="GitHub repository for commit links")
+    parser.add_argument("--base-sha", metavar="SHA", help="Base commit SHA")
+    parser.add_argument("--head-sha", metavar="SHA", help="Head commit SHA")
+
+    args = parser.parse_args()
+
+    base = load_manifest(args.base_manifest)
+    head = load_manifest(args.head_manifest)
+
+    base_counts, head_counts, regressions, real_improvements, reason_changes = compute_diff(base, head)
+
+    # Always write the comparison table to stdout (for $GITHUB_STEP_SUMMARY)
+    md_lines = format_markdown(
+        base_counts, head_counts, regressions, real_improvements, reason_changes,
+        repo=args.repo, base_sha=args.base_sha, head_sha=args.head_sha,
+    )
+    print("\n".join(md_lines))
+
+    # Optional: write self-contained Markdown report to file
+    if args.report:
+        with open(args.report, "w", encoding="utf-8") as f:
+            f.write("\n".join(md_lines))
+            f.write("\n")
+
+    # Optional: write TSV
+    if args.tsv:
+        write_tsv(base, head, args.tsv)
 
     # Exit with code 1 if there are regressions.
     # The CI workflow uses continue-on-error so this surfaces as a

--- a/scripts/compat-report.py
+++ b/scripts/compat-report.py
@@ -2,10 +2,12 @@
 """Report generator for CLIPS compatibility assessment.
 
 Reads the manifest produced by compat-scan.py / compat-run.py and
-generates human-readable reports, CSV exports, and optional symlink views.
+generates human-readable reports, CSV/TSV exports, and optional symlink views.
 
 Usage:
-    python scripts/compat-report.py [--manifest FILE] [--csv FILE] [--symlinks DIR]
+    python scripts/compat-report.py [--manifest FILE] [--csv FILE] [--tsv FILE]
+                                    [--report FILE] [--symlinks DIR]
+                                    [--repo OWNER/REPO] [--commit-sha SHA]
 """
 
 import argparse
@@ -148,6 +150,129 @@ def write_csv(manifest, csv_path):
     print(f"CSV written to {csv_path}")
 
 
+def write_tsv(manifest, tsv_path):
+    fieldnames = [
+        "path", "source", "classification", "reason", "runability",
+        "features", "unsupported_features",
+        "ferric_exit", "ferric_duration_ms", "ferric_timed_out",
+        "clips_exit", "clips_duration_ms", "clips_timed_out",
+        "notes",
+    ]
+
+    with open(tsv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+
+        for path, info in sorted(manifest["files"].items()):
+            ferric = info.get("ferric") or {}
+            clips = info.get("clips") or {}
+            writer.writerow({
+                "path": path,
+                "source": info["source"],
+                "classification": info["classification"],
+                "reason": info["reason"],
+                "runability": info["runability"],
+                "features": ";".join(info.get("features", [])),
+                "unsupported_features": ";".join(info.get("unsupported_features", [])),
+                "ferric_exit": ferric.get("exit_code", ""),
+                "ferric_duration_ms": ferric.get("duration_ms", ""),
+                "ferric_timed_out": ferric.get("timed_out", ""),
+                "clips_exit": clips.get("exit_code", ""),
+                "clips_duration_ms": clips.get("duration_ms", ""),
+                "clips_timed_out": clips.get("timed_out", ""),
+                "notes": info.get("notes", ""),
+            })
+
+    print(f"TSV written to {tsv_path}")
+
+
+# ---------------------------------------------------------------------------
+# Markdown report (self-contained file)
+# ---------------------------------------------------------------------------
+
+def write_report(manifest, report_path, repo=None, commit_sha=None):
+    summary = manifest["summary"]
+    total = summary["total"]
+    generated = manifest.get("generated", "unknown")
+
+    lines = []
+    lines.append("## CLIPS Compatibility Report")
+    lines.append("")
+    lines.append("Assessment of ferric's compatibility with CLIPS across a corpus of")
+    lines.append("example `.clp` files. Each file is classified as **equivalent**")
+    lines.append("(output matches CLIPS), **divergent** (runs but output differs),")
+    lines.append("**incompatible** (cannot run), or **pending** (not yet tested).")
+    lines.append("")
+
+    if repo and commit_sha:
+        commit_link = f"[`{commit_sha[:10]}`](https://github.com/{repo}/commit/{commit_sha})"
+        lines.append(f"Commit: {commit_link} | Generated: {generated}")
+    else:
+        lines.append(f"Generated: {generated}")
+    lines.append("")
+
+    lines.append(f"| Classification | Count | % |")
+    lines.append("|---|---:|---:|")
+    for cls in ["equivalent", "divergent", "incompatible", "pending"]:
+        count = summary.get(cls, 0)
+        pct = (count / total * 100) if total else 0
+        lines.append(f"| {cls} | {count:,} | {pct:.1f}% |")
+    lines.append(f"| **total** | **{total:,}** | |")
+
+    # By-source breakdown
+    source_stats = {}
+    for info in manifest["files"].values():
+        src = info["source"] or "(root)"
+        if src not in source_stats:
+            source_stats[src] = {"equivalent": 0, "divergent": 0, "incompatible": 0, "pending": 0, "total": 0}
+        source_stats[src]["total"] += 1
+        cls = info["classification"]
+        if cls in source_stats[src]:
+            source_stats[src][cls] += 1
+
+    lines.append("")
+    lines.append("### By source")
+    lines.append("")
+    lines.append("| Source | Total | Equiv | Diverg | Incompat | Pending |")
+    lines.append("|---|---:|---:|---:|---:|---:|")
+    for src in sorted(source_stats, key=lambda s: -source_stats[s]["total"]):
+        s = source_stats[src]
+        lines.append(
+            f"| {src} | {s['total']:,} | {s['equivalent']:,} | "
+            f"{s['divergent']:,} | {s['incompatible']:,} | {s['pending']:,} |"
+        )
+
+    # Equivalent files
+    equivalent = sorted(
+        (k, v) for k, v in manifest["files"].items()
+        if v["classification"] == "equivalent"
+    )
+    if equivalent:
+        lines.append("")
+        lines.append(f"### Equivalent files ({len(equivalent)})")
+        lines.append("")
+        for k, v in equivalent:
+            lines.append(f"- `{k}` ({v['reason']})")
+
+    # Divergent files
+    divergent = sorted(
+        (k, v) for k, v in manifest["files"].items()
+        if v["classification"] == "divergent"
+    )
+    if divergent:
+        lines.append("")
+        lines.append(f"### Divergent files ({len(divergent)})")
+        lines.append("")
+        for k, v in divergent:
+            lines.append(f"- `{k}` ({v['reason']})")
+
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+        f.write("\n")
+
+    print(f"Report written to {report_path}")
+
+
 # ---------------------------------------------------------------------------
 # Symlink view
 # ---------------------------------------------------------------------------
@@ -190,6 +315,10 @@ def main():
     parser = argparse.ArgumentParser(description="Generate compatibility assessment reports")
     parser.add_argument("--manifest", default=None, help="Path to manifest file")
     parser.add_argument("--csv", default=None, metavar="FILE", help="Export as CSV")
+    parser.add_argument("--tsv", default=None, metavar="FILE", help="Export as TSV")
+    parser.add_argument("--report", default=None, metavar="FILE", help="Write self-contained Markdown report")
+    parser.add_argument("--repo", default=None, metavar="OWNER/REPO", help="GitHub repository for commit links")
+    parser.add_argument("--commit-sha", default=None, metavar="SHA", help="Commit SHA for report links")
     parser.add_argument("--symlinks", default=None, metavar="DIR", help="Create symlink directory view")
 
     args = parser.parse_args()
@@ -213,6 +342,14 @@ def main():
     if args.csv:
         print()
         write_csv(manifest, args.csv)
+
+    if args.tsv:
+        print()
+        write_tsv(manifest, args.tsv)
+
+    if args.report:
+        print()
+        write_report(manifest, args.report, repo=args.repo, commit_sha=args.commit_sha)
 
     if args.symlinks:
         print()


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow (`compat.yml`) that runs the compatibility assessment pipeline on every push to main and PR. For pull requests, it compares the base branch vs PR head and produces a summary table showing regressions, improvements, and classification deltas using a new `compat-diff.py` script.

## What's new

- **`.github/workflows/compat.yml`**: Orchestrates the compat pipeline, builds Docker CLIPS image, runs `compat-scan.py` + `compat-run.py` on both base and PR code (for PRs), and generates reports.
- **`scripts/compat-diff.py`**: Compares two manifests and outputs Markdown with summary counts, regressions, improvements, and reason-only changes.

## How it works

- **On push to main**: Runs compat pipeline once, posts `compat-report.py` output to job summary.
- **On PR**: Runs compat pipeline on base branch, saves manifest, switches to PR head, runs again, then compares the two with `compat-diff.py` and posts a delta table to the job summary.

Regressions surface as warnings (via `continue-on-error`) rather than hard failures, allowing PRs to proceed while keeping regressions visible.