### PR TITLE
Exclude .clp files from GitHub language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Exclude CLIPS test fixtures from GitHub language statistics.
+# See: https://github.com/github-linguist/linguist/blob/main/docs/overrides.md
+*.clp linguist-vendored


### PR DESCRIPTION
## Summary
- Adds a `.gitattributes` file marking `*.clp` as `linguist-vendored`
- The ~5,500 CLIPS test fixture files currently cause GitHub to classify the repo as "CLIPS" instead of "Rust"
- This tells GitHub's Linguist to exclude those files from language stats, so the repo correctly shows as Rust

## Test plan
- [x] Verify `.gitattributes` syntax is correct per [Linguist docs](https://github.com/github-linguist/linguist/blob/main/docs/overrides.md)
- [ ] After merge, confirm GitHub language bar updates to show Rust as primary (may take up to 60 minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)