### PR TITLE
Add Python bindings and C FFI expansion plans

### DIFF
--- a/documents/CFFIExpansionPlan.md
+++ b/documents/CFFIExpansionPlan.md
@@ -1,0 +1,829 @@
+# C FFI Expansion Plan
+
+## Purpose
+
+Extend the Ferric C FFI surface with 32 new functions covering fact iteration, structured assertion, fact type discrimination, template/rule/module introspection, agenda/halt queries, and improved execution variants. All additions are purely additive — no existing functions are modified.
+
+## Design Principles
+
+All new functions follow the established patterns from the existing FFI:
+
+1. **Error codes.** Every fallible function returns `FerricError`. Output values are written through pointer parameters.
+2. **Null safety.** Null engine pointers → `FERRIC_ERROR_NULL_POINTER` with global error message. Null output pointers are checked and rejected.
+3. **Thread affinity.** Every `ferric_engine_*` function validates thread affinity before any mutable borrow.
+4. **Dual error channels.** Errors are written to both the per-engine error state and the global thread-local error state.
+5. **Buffer copy pattern.** String-returning functions use the established `(buf, buf_len, out_len)` triple. Size query: pass `NULL` buf with `buf_len=0`. Returns `FERRIC_ERROR_BUFFER_TOO_SMALL` when buffer is insufficient, writing the required size to `*out_len`.
+6. **Array output pattern.** Array-returning functions use `(out_array, max_count, out_count)`. Size query: pass `NULL` array with `max_count=0`. `*out_count` always receives the total count.
+
+---
+
+## New Types
+
+### `FerricFactType`
+
+```c
+typedef enum {
+    FERRIC_FACT_TYPE_ORDERED  = 0,
+    FERRIC_FACT_TYPE_TEMPLATE = 1,
+} FerricFactType;
+```
+
+Added to `crates/ferric-ffi/src/types.rs` as:
+
+```rust
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FerricFactType {
+    Ordered = 0,
+    Template = 1,
+}
+```
+
+### `FerricHaltReason`
+
+```c
+typedef enum {
+    FERRIC_HALT_REASON_AGENDA_EMPTY    = 0,
+    FERRIC_HALT_REASON_LIMIT_REACHED   = 1,
+    FERRIC_HALT_REASON_HALT_REQUESTED  = 2,
+} FerricHaltReason;
+```
+
+Added to `crates/ferric-ffi/src/types.rs` as:
+
+```rust
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FerricHaltReason {
+    AgendaEmpty = 0,
+    LimitReached = 1,
+    HaltRequested = 2,
+}
+
+impl From<ferric_runtime::HaltReason> for FerricHaltReason {
+    fn from(reason: ferric_runtime::HaltReason) -> Self {
+        match reason {
+            ferric_runtime::HaltReason::AgendaEmpty => Self::AgendaEmpty,
+            ferric_runtime::HaltReason::LimitReached => Self::LimitReached,
+            ferric_runtime::HaltReason::HaltRequested => Self::HaltRequested,
+        }
+    }
+}
+```
+
+### Reverse Value Conversion: `ferric_to_value`
+
+New function in `crates/ferric-ffi/src/types.rs` for converting C-facing `FerricValue` back to Rust `Value`:
+
+```rust
+/// Convert a C-facing `FerricValue` to a Rust `Value`.
+///
+/// For Symbol and String types, the `string_ptr` is read as a NUL-terminated
+/// C string. For Symbol, the string is interned via the engine's symbol table.
+///
+/// # Safety
+///
+/// - `fv` must be a valid `FerricValue` with active fields matching `value_type`.
+/// - `string_ptr` (for Symbol/String) must be a valid NUL-terminated string.
+/// - `multifield_ptr` (for Multifield) must point to `multifield_len` valid `FerricValue`s.
+pub(crate) unsafe fn ferric_to_value(
+    fv: &FerricValue,
+    engine: &mut Engine,
+) -> Result<Value, String> {
+    match fv.value_type {
+        FerricValueType::Void => Ok(Value::Void),
+        FerricValueType::Integer => Ok(Value::Integer(fv.integer)),
+        FerricValueType::Float => Ok(Value::Float(fv.float)),
+        FerricValueType::Symbol => {
+            if fv.string_ptr.is_null() {
+                return Err("symbol string_ptr is null".to_string());
+            }
+            let name = CStr::from_ptr(fv.string_ptr).to_str()
+                .map_err(|e| format!("symbol is not valid UTF-8: {e}"))?;
+            let sym = engine.intern_symbol(name)
+                .map_err(|e| e.to_string())?;
+            Ok(Value::Symbol(sym))
+        }
+        FerricValueType::String => {
+            if fv.string_ptr.is_null() {
+                return Err("string string_ptr is null".to_string());
+            }
+            let s = CStr::from_ptr(fv.string_ptr).to_str()
+                .map_err(|e| format!("string is not valid UTF-8: {e}"))?;
+            let fs = engine.create_string(s)
+                .map_err(|e| e.to_string())?;
+            Ok(Value::String(fs))
+        }
+        FerricValueType::Multifield => {
+            if fv.multifield_len == 0 {
+                return Ok(Value::Multifield(vec![]));
+            }
+            if fv.multifield_ptr.is_null() {
+                return Err("multifield_ptr is null with non-zero length".to_string());
+            }
+            let mut values = Vec::with_capacity(fv.multifield_len);
+            for i in 0..fv.multifield_len {
+                let elem = &*fv.multifield_ptr.add(i);
+                values.push(ferric_to_value(elem, engine)?);
+            }
+            Ok(Value::Multifield(values))
+        }
+        FerricValueType::ExternalAddress => {
+            Err("ExternalAddress cannot be converted from FFI".to_string())
+        }
+    }
+}
+```
+
+---
+
+## New Functions (32 total)
+
+### 1. Fact Iteration (2 functions)
+
+#### `ferric_engine_fact_ids`
+
+Copy all user-visible fact IDs to a caller-provided array.
+
+```c
+FerricError ferric_engine_fact_ids(
+    const FerricEngine *engine,
+    uint64_t           *out_ids,     // NULL for size query
+    size_t              max_ids,     // capacity of out_ids array
+    size_t             *out_count    // receives total fact count
+);
+```
+
+**Wraps:** `Engine::facts()` → collect `FactId`s, convert to `u64` via `KeyData::as_ffi()`.
+
+**Behavior:**
+- `out_ids == NULL && max_ids == 0`: Size query. Writes total count to `*out_count`, returns `Ok`.
+- `out_ids != NULL`: Copies up to `max_ids` IDs. `*out_count` always receives total count. Returns `Ok` (partial copy is allowed).
+- `out_count == NULL`: Returns `NullPointer`.
+
+#### `ferric_engine_find_fact_ids`
+
+Find fact IDs by relation name.
+
+```c
+FerricError ferric_engine_find_fact_ids(
+    const FerricEngine *engine,
+    const char         *relation,    // NUL-terminated relation name
+    uint64_t           *out_ids,     // NULL for size query
+    size_t              max_ids,
+    size_t             *out_count
+);
+```
+
+**Wraps:** `Engine::find_facts(relation)` → collect `FactId`s.
+
+**Behavior:** Same size-query pattern as `ferric_engine_fact_ids`. Returns `NullPointer` if `relation` is null.
+
+---
+
+### 2. Fact Type & Names (3 functions)
+
+#### `ferric_engine_get_fact_type`
+
+Discriminate ordered vs. template fact.
+
+```c
+FerricError ferric_engine_get_fact_type(
+    const FerricEngine *engine,
+    uint64_t            fact_id,
+    FerricFactType     *out_type
+);
+```
+
+**Wraps:** `Engine::get_fact(fid)` → discriminate `Fact::Ordered` vs `Fact::Template`.
+
+**Behavior:** Returns `NotFound` if fact does not exist. Returns `NullPointer` if `out_type` is null.
+
+#### `ferric_engine_get_fact_relation`
+
+Get the relation name for an ordered fact.
+
+```c
+FerricError ferric_engine_get_fact_relation(
+    const FerricEngine *engine,
+    uint64_t            fact_id,
+    char               *buf,
+    size_t              buf_len,
+    size_t             *out_len
+);
+```
+
+**Wraps:** `Engine::get_fact(fid)` → `OrderedFact::relation` → resolve symbol to string.
+
+**Behavior:** Standard buffer copy pattern. Returns `NotFound` if fact does not exist. Returns `InvalidArgument` if the fact is a template fact (not ordered).
+
+#### `ferric_engine_get_fact_template_name`
+
+Get the template name for a template fact.
+
+```c
+FerricError ferric_engine_get_fact_template_name(
+    const FerricEngine *engine,
+    uint64_t            fact_id,
+    char               *buf,
+    size_t              buf_len,
+    size_t             *out_len
+);
+```
+
+**Wraps:** `Engine::get_fact(fid)` → `TemplateFact::template_id` → `Engine::template_name_by_id()`.
+
+**Behavior:** Standard buffer copy pattern. Returns `NotFound` if fact does not exist. Returns `InvalidArgument` if the fact is an ordered fact (not template).
+
+---
+
+### 3. Structured Assertion (1 function)
+
+#### `ferric_engine_assert_ordered`
+
+Assert an ordered fact from structured values, bypassing CLIPS source parsing.
+
+```c
+FerricError ferric_engine_assert_ordered(
+    FerricEngine       *engine,
+    const char         *relation,       // NUL-terminated relation name
+    const FerricValue  *fields,         // array of field values
+    size_t              field_count,     // number of fields
+    uint64_t           *out_fact_id     // receives the new fact ID
+);
+```
+
+**Wraps:** `Engine::assert_ordered(relation, values)` after converting each `FerricValue` via `ferric_to_value()`.
+
+**Behavior:**
+- `relation == NULL`: Returns `NullPointer`.
+- `fields == NULL && field_count > 0`: Returns `NullPointer`.
+- `fields == NULL && field_count == 0`: Asserts a zero-field fact (e.g., `(initial-fact)`-style).
+- `out_fact_id == NULL`: Fact is asserted but ID is not returned.
+- Conversion failure in any field value: Returns `InvalidArgument` with description.
+
+---
+
+### 4. Value Construction Helpers (5 functions)
+
+Pure helpers that create `FerricValue` structs. No engine pointer needed.
+
+#### `ferric_value_integer`
+
+```c
+FerricValue ferric_value_integer(int64_t value);
+```
+
+Returns a `FerricValue` with `value_type = Integer`, `integer = value`.
+
+#### `ferric_value_float`
+
+```c
+FerricValue ferric_value_float(double value);
+```
+
+Returns a `FerricValue` with `value_type = Float`, `float = value`.
+
+#### `ferric_value_symbol`
+
+```c
+FerricValue ferric_value_symbol(const char *name);
+```
+
+Returns a `FerricValue` with `value_type = Symbol`, `string_ptr` = heap-copy of `name`. The caller owns the `string_ptr` and must free with `ferric_value_free`. Returns a void value if `name` is null.
+
+#### `ferric_value_string`
+
+```c
+FerricValue ferric_value_string(const char *s);
+```
+
+Returns a `FerricValue` with `value_type = String`, `string_ptr` = heap-copy of `s`. Same ownership rules as `ferric_value_symbol`. Returns a void value if `s` is null.
+
+#### `ferric_value_void`
+
+```c
+FerricValue ferric_value_void(void);
+```
+
+Returns a `FerricValue` with `value_type = Void` and all fields zeroed/null.
+
+---
+
+### 5. Template Introspection (4 functions)
+
+#### `ferric_engine_template_count`
+
+```c
+FerricError ferric_engine_template_count(
+    const FerricEngine *engine,
+    size_t             *out_count
+);
+```
+
+**Wraps:** `Engine::templates().len()`.
+
+#### `ferric_engine_template_name`
+
+```c
+FerricError ferric_engine_template_name(
+    const FerricEngine *engine,
+    size_t              index,
+    char               *buf,
+    size_t              buf_len,
+    size_t             *out_len
+);
+```
+
+**Wraps:** `Engine::templates()[index]` — name of the template at zero-based index.
+
+**Behavior:** Standard buffer copy pattern. Returns `InvalidArgument` if `index >= template_count`.
+
+#### `ferric_engine_template_slot_count`
+
+```c
+FerricError ferric_engine_template_slot_count(
+    const FerricEngine *engine,
+    const char         *template_name,
+    size_t             *out_count
+);
+```
+
+**Wraps:** NEW `Engine::template_slot_names(name)` → `.len()`.
+
+**Behavior:** Returns `NotFound` if template name is not registered. Returns `NullPointer` if `template_name` or `out_count` is null.
+
+#### `ferric_engine_template_slot_name`
+
+```c
+FerricError ferric_engine_template_slot_name(
+    const FerricEngine *engine,
+    const char         *template_name,
+    size_t              slot_index,
+    char               *buf,
+    size_t              buf_len,
+    size_t             *out_len
+);
+```
+
+**Wraps:** NEW `Engine::template_slot_names(name)[slot_index]`.
+
+**Behavior:** Standard buffer copy pattern. Returns `NotFound` if template not found. Returns `InvalidArgument` if `slot_index >= slot_count`.
+
+---
+
+### 6. Rule Introspection (2 functions)
+
+#### `ferric_engine_rule_count`
+
+```c
+FerricError ferric_engine_rule_count(
+    const FerricEngine *engine,
+    size_t             *out_count
+);
+```
+
+**Wraps:** `Engine::rules().len()`.
+
+#### `ferric_engine_rule_info`
+
+```c
+FerricError ferric_engine_rule_info(
+    const FerricEngine *engine,
+    size_t              index,
+    char               *buf,         // receives the rule name
+    size_t              buf_len,
+    size_t             *out_len,
+    int32_t            *out_salience // receives salience value
+);
+```
+
+**Wraps:** `Engine::rules()[index]` — returns `(&str, i32)` tuple.
+
+**Behavior:** Standard buffer copy pattern for the name. `*out_salience` written if non-null. Returns `InvalidArgument` if `index >= rule_count`.
+
+---
+
+### 7. Module Operations (6 functions)
+
+#### `ferric_engine_current_module`
+
+```c
+FerricError ferric_engine_current_module(
+    const FerricEngine *engine,
+    char               *buf,
+    size_t              buf_len,
+    size_t             *out_len
+);
+```
+
+**Wraps:** `Engine::current_module()`.
+
+**Behavior:** Standard buffer copy pattern. Always succeeds (MAIN module always exists).
+
+#### `ferric_engine_get_focus`
+
+```c
+FerricError ferric_engine_get_focus(
+    const FerricEngine *engine,
+    char               *buf,
+    size_t              buf_len,
+    size_t             *out_len
+);
+```
+
+**Wraps:** `Engine::get_focus()`.
+
+**Behavior:** Standard buffer copy pattern. Returns `NotFound` if focus stack is empty (writes `*out_len = 0`).
+
+#### `ferric_engine_focus_stack_depth`
+
+```c
+FerricError ferric_engine_focus_stack_depth(
+    const FerricEngine *engine,
+    size_t             *out_depth
+);
+```
+
+**Wraps:** `Engine::get_focus_stack().len()`.
+
+#### `ferric_engine_focus_stack_entry`
+
+```c
+FerricError ferric_engine_focus_stack_entry(
+    const FerricEngine *engine,
+    size_t              index,
+    char               *buf,
+    size_t              buf_len,
+    size_t             *out_len
+);
+```
+
+**Wraps:** `Engine::get_focus_stack()[index]`.
+
+**Behavior:** Standard buffer copy pattern. Returns `InvalidArgument` if `index >= stack_depth`. Index 0 = bottom of stack, last index = top (current focus).
+
+#### `ferric_engine_module_count`
+
+```c
+FerricError ferric_engine_module_count(
+    const FerricEngine *engine,
+    size_t             *out_count
+);
+```
+
+**Wraps:** NEW `Engine::modules().len()`.
+
+#### `ferric_engine_module_name`
+
+```c
+FerricError ferric_engine_module_name(
+    const FerricEngine *engine,
+    size_t              index,
+    char               *buf,
+    size_t              buf_len,
+    size_t             *out_len
+);
+```
+
+**Wraps:** NEW `Engine::modules()[index]`.
+
+**Behavior:** Standard buffer copy pattern. Returns `InvalidArgument` if `index >= module_count`.
+
+---
+
+### 8. Agenda, Halt, Input, Clear (5 functions)
+
+#### `ferric_engine_agenda_count`
+
+```c
+FerricError ferric_engine_agenda_count(
+    const FerricEngine *engine,
+    size_t             *out_count
+);
+```
+
+**Wraps:** `Engine::agenda_len()`.
+
+#### `ferric_engine_is_halted`
+
+```c
+FerricError ferric_engine_is_halted(
+    const FerricEngine *engine,
+    int32_t            *out_halted   // 1 = halted, 0 = not halted
+);
+```
+
+**Wraps:** `Engine::is_halted()`.
+
+#### `ferric_engine_halt`
+
+```c
+FerricError ferric_engine_halt(
+    FerricEngine *engine
+);
+```
+
+**Wraps:** `Engine::halt()`.
+
+**Behavior:** Always succeeds. Idempotent — calling halt on an already-halted engine is a no-op.
+
+#### `ferric_engine_push_input`
+
+```c
+FerricError ferric_engine_push_input(
+    FerricEngine *engine,
+    const char   *line
+);
+```
+
+**Wraps:** `Engine::push_input(line)`.
+
+**Behavior:** Returns `NullPointer` if `line` is null.
+
+#### `ferric_engine_clear`
+
+```c
+FerricError ferric_engine_clear(
+    FerricEngine *engine
+);
+```
+
+**Wraps:** `Engine::clear()`.
+
+**Behavior:** Resets the engine to a blank slate (removes all facts, rules, templates, globals, functions, generics, and modules except MAIN). Always succeeds.
+
+---
+
+### 9. Convenience & Improved Variants (4 functions)
+
+#### `ferric_engine_new_with_source`
+
+Create an engine from CLIPS source with default configuration.
+
+```c
+FerricEngine *ferric_engine_new_with_source(
+    const char *source
+);
+```
+
+**Wraps:** `Engine::with_rules(source)`.
+
+**Behavior:** Returns `NULL` on parse/compile error (sets global error message). Returns valid engine handle on success.
+
+#### `ferric_engine_new_with_source_config`
+
+Create an engine from CLIPS source with explicit configuration.
+
+```c
+FerricEngine *ferric_engine_new_with_source_config(
+    const char         *source,
+    const FerricConfig *config   // NULL → defaults
+);
+```
+
+**Wraps:** `Engine::with_rules_config(source, config)`.
+
+**Behavior:** Same null/error handling as `ferric_engine_new_with_source`. `config == NULL` → default configuration.
+
+#### `ferric_engine_clear_output`
+
+Clear a specific output channel.
+
+```c
+FerricError ferric_engine_clear_output(
+    FerricEngine *engine,
+    const char   *channel
+);
+```
+
+**Wraps:** `Engine::clear_output_channel(channel)`.
+
+**Behavior:** Returns `NullPointer` if `channel` is null. Always succeeds otherwise (clearing a non-existent channel is a no-op).
+
+#### `ferric_engine_run_ex`
+
+Extended run with halt reason output.
+
+```c
+FerricError ferric_engine_run_ex(
+    FerricEngine     *engine,
+    int64_t           limit,
+    uint64_t         *out_fired,    // may be NULL
+    FerricHaltReason *out_reason    // may be NULL
+);
+```
+
+**Wraps:** `Engine::run(limit)` → `RunResult { rules_fired, halt_reason }`.
+
+**Behavior:** Same limit semantics as existing `ferric_engine_run` (negative = unlimited). Additionally writes `halt_reason` to `*out_reason` if non-null.
+
+---
+
+## Shared Prerequisites (ferric-runtime changes)
+
+Both the Python bindings and this FFI expansion require new public methods on `Engine` and `ModuleRegistry`. These are identical to those listed in the Python Bindings Plan:
+
+### `Engine::template_slot_names`
+
+```rust
+/// Return the slot names for a named template, or `None` if the template
+/// does not exist.
+pub fn template_slot_names(&self, name: &str) -> Option<Vec<&str>> {
+    let tid = self.template_ids.get(name)?;
+    let def = self.template_defs.get(*tid)?;
+    Some(def.slot_names.iter().map(String::as_str).collect())
+}
+```
+
+Required by: `ferric_engine_template_slot_count`, `ferric_engine_template_slot_name`.
+
+### `Engine::template_name_by_id`
+
+```rust
+/// Return the template name for a `TemplateId`, or `None` if the ID
+/// is not registered.
+pub fn template_name_by_id(&self, tid: TemplateId) -> Option<&str> {
+    self.template_defs.get(tid).map(|def| def.name.as_str())
+}
+```
+
+Required by: `ferric_engine_get_fact_template_name`.
+
+### `Engine::modules`
+
+```rust
+/// Return the names of all registered modules.
+pub fn modules(&self) -> Vec<&str> {
+    self.module_registry.module_names()
+}
+```
+
+Required by: `ferric_engine_module_count`, `ferric_engine_module_name`.
+
+### `ModuleRegistry::module_names`
+
+```rust
+/// Return the names of all registered modules.
+pub fn module_names(&self) -> Vec<&str> {
+    self.modules.values().map(|m| m.name.as_str()).collect()
+}
+```
+
+Required by: `Engine::modules()`.
+
+---
+
+## Existing FFI Functions (Unchanged)
+
+The following functions exist today and are **not modified** by this plan:
+
+| Function | Purpose |
+|---|---|
+| `ferric_engine_new` | Create engine (default config) |
+| `ferric_engine_new_with_config` | Create engine (explicit config) |
+| `ferric_engine_free` | Free engine handle |
+| `ferric_engine_load_string` | Load CLIPS source string |
+| `ferric_engine_last_error` | Per-engine error (borrowed pointer) |
+| `ferric_engine_last_error_copy` | Per-engine error (buffer copy) |
+| `ferric_engine_clear_error` | Clear per-engine error |
+| `ferric_engine_reset` | Reset engine to initial state |
+| `ferric_engine_run` | Run execution loop |
+| `ferric_engine_step` | Single-step execution |
+| `ferric_engine_assert_string` | Assert fact from CLIPS source |
+| `ferric_engine_retract` | Retract fact by ID |
+| `ferric_engine_get_output` | Get output channel (borrowed pointer) |
+| `ferric_engine_action_diagnostic_count` | Diagnostic count |
+| `ferric_engine_action_diagnostic_copy` | Copy diagnostic to buffer |
+| `ferric_engine_clear_action_diagnostics` | Clear diagnostics |
+| `ferric_engine_fact_count` | User-visible fact count |
+| `ferric_engine_get_fact_field_count` | Field count for a fact |
+| `ferric_engine_get_fact_field` | Get single field value |
+| `ferric_engine_get_global` | Get global variable value |
+| `ferric_last_error_global` | Global error (borrowed pointer) |
+| `ferric_last_error_global_copy` | Global error (buffer copy) |
+| `ferric_clear_error_global` | Clear global error |
+| `ferric_string_free` | Free heap string |
+| `ferric_value_free` | Free FerricValue resources |
+| `ferric_value_array_free` | Free FerricValue array |
+
+---
+
+## Implementation Sequencing
+
+### Phase A: Prerequisites
+
+1. Add `Engine::template_slot_names`, `Engine::template_name_by_id`, `Engine::modules` to `crates/ferric-runtime/src/engine.rs`.
+2. Add `ModuleRegistry::module_names` to `crates/ferric-runtime/src/modules.rs`.
+3. Unit tests for all new methods.
+
+### Phase B: New Types & Value Conversion
+
+4. Add `FerricFactType`, `FerricHaltReason` to `crates/ferric-ffi/src/types.rs`.
+5. Add `ferric_to_value()` reverse conversion to `crates/ferric-ffi/src/types.rs`.
+6. Add 5 value construction helpers (`ferric_value_integer`, etc.) to `crates/ferric-ffi/src/types.rs`.
+
+### Phase C: New Engine Functions
+
+Implement in `crates/ferric-ffi/src/engine.rs` in dependency order:
+
+7. Fact iteration: `ferric_engine_fact_ids`, `ferric_engine_find_fact_ids`.
+8. Fact type & names: `ferric_engine_get_fact_type`, `ferric_engine_get_fact_relation`, `ferric_engine_get_fact_template_name`.
+9. Structured assertion: `ferric_engine_assert_ordered`.
+10. Template introspection: `ferric_engine_template_count`, `ferric_engine_template_name`, `ferric_engine_template_slot_count`, `ferric_engine_template_slot_name`.
+11. Rule introspection: `ferric_engine_rule_count`, `ferric_engine_rule_info`.
+12. Module operations: `ferric_engine_current_module`, `ferric_engine_get_focus`, `ferric_engine_focus_stack_depth`, `ferric_engine_focus_stack_entry`, `ferric_engine_module_count`, `ferric_engine_module_name`.
+13. Agenda/halt/input/clear: `ferric_engine_agenda_count`, `ferric_engine_is_halted`, `ferric_engine_halt`, `ferric_engine_push_input`, `ferric_engine_clear`.
+14. Convenience: `ferric_engine_new_with_source`, `ferric_engine_new_with_source_config`, `ferric_engine_clear_output`, `ferric_engine_run_ex`.
+
+### Phase D: Header & Tests
+
+15. Verify `cbindgen` generates correct C header entries for all new functions and types.
+16. Add FFI integration tests in `crates/ferric-ffi/src/tests.rs` covering:
+    - Each new function's happy path.
+    - Null pointer rejection for all pointer parameters.
+    - Buffer-too-small / size-query patterns.
+    - Thread violation detection on new functions.
+    - Value construction and `ferric_to_value` round-trip.
+
+---
+
+## Testing Approach
+
+### Unit Tests (Rust)
+
+Each new function gets at least:
+
+1. **Happy path:** Create engine, load rules, exercise the function, verify output.
+2. **Null pointer:** Pass null engine, null output pointers → correct error code.
+3. **Not found:** Query non-existent facts, templates, modules → `NotFound`.
+4. **Buffer pattern:** Size query (null buf, 0 len), exact-fit buffer, undersized buffer.
+
+### Integration Tests
+
+End-to-end scenarios:
+
+1. **Fact lifecycle:** Assert ordered (structured), iterate fact IDs, discriminate type, read relation/template name, retract, verify ID disappears from iteration.
+2. **Template introspection:** Load `(deftemplate person (slot name) (slot age))`, verify template count, name, slot count, slot names.
+3. **Rule introspection:** Load rules, verify rule count and info (name, salience).
+4. **Module introspection:** Load multi-module rules, verify module count and names, focus stack operations.
+5. **Extended run:** Verify `ferric_engine_run_ex` returns correct halt reasons for each scenario (agenda empty, limit reached, halt requested).
+6. **Value construction → assert:** Build `FerricValue` array with value helpers, call `ferric_engine_assert_ordered`, verify fields via `ferric_engine_get_fact_field`.
+
+### Property-Based Tests
+
+Use `proptest` for:
+
+- Arbitrary `FerricValue` → `ferric_to_value` → `value_to_ferric` round-trip (for Integer, Float, Symbol types).
+- Arbitrary relation names with arbitrary field counts → assert and retrieve.
+
+---
+
+## Summary: New Functions by Category
+
+| # | Category | Function | Wraps |
+|---|---|---|---|
+| 1 | Fact Iteration | `ferric_engine_fact_ids` | `Engine::facts()` |
+| 2 | Fact Iteration | `ferric_engine_find_fact_ids` | `Engine::find_facts()` |
+| 3 | Fact Type | `ferric_engine_get_fact_type` | `Fact::Ordered` vs `Fact::Template` |
+| 4 | Fact Type | `ferric_engine_get_fact_relation` | `OrderedFact::relation` |
+| 5 | Fact Type | `ferric_engine_get_fact_template_name` | `Engine::template_name_by_id()` |
+| 6 | Assertion | `ferric_engine_assert_ordered` | `Engine::assert_ordered()` |
+| 7 | Value | `ferric_value_integer` | Pure constructor |
+| 8 | Value | `ferric_value_float` | Pure constructor |
+| 9 | Value | `ferric_value_symbol` | Pure constructor |
+| 10 | Value | `ferric_value_string` | Pure constructor |
+| 11 | Value | `ferric_value_void` | Pure constructor |
+| 12 | Template | `ferric_engine_template_count` | `Engine::templates().len()` |
+| 13 | Template | `ferric_engine_template_name` | `Engine::templates()[i]` |
+| 14 | Template | `ferric_engine_template_slot_count` | `Engine::template_slot_names()` |
+| 15 | Template | `ferric_engine_template_slot_name` | `Engine::template_slot_names()[i]` |
+| 16 | Rule | `ferric_engine_rule_count` | `Engine::rules().len()` |
+| 17 | Rule | `ferric_engine_rule_info` | `Engine::rules()[i]` |
+| 18 | Module | `ferric_engine_current_module` | `Engine::current_module()` |
+| 19 | Module | `ferric_engine_get_focus` | `Engine::get_focus()` |
+| 20 | Module | `ferric_engine_focus_stack_depth` | `Engine::get_focus_stack().len()` |
+| 21 | Module | `ferric_engine_focus_stack_entry` | `Engine::get_focus_stack()[i]` |
+| 22 | Module | `ferric_engine_module_count` | `Engine::modules()` |
+| 23 | Module | `ferric_engine_module_name` | `Engine::modules()[i]` |
+| 24 | Agenda | `ferric_engine_agenda_count` | `Engine::agenda_len()` |
+| 25 | Halt | `ferric_engine_is_halted` | `Engine::is_halted()` |
+| 26 | Halt | `ferric_engine_halt` | `Engine::halt()` |
+| 27 | Input | `ferric_engine_push_input` | `Engine::push_input()` |
+| 28 | Clear | `ferric_engine_clear` | `Engine::clear()` |
+| 29 | Convenience | `ferric_engine_new_with_source` | `Engine::with_rules()` |
+| 30 | Convenience | `ferric_engine_new_with_source_config` | `Engine::with_rules_config()` |
+| 31 | Convenience | `ferric_engine_clear_output` | `Engine::clear_output_channel()` |
+| 32 | Convenience | `ferric_engine_run_ex` | `Engine::run()` + `HaltReason` |
+
+---
+
+## Critical Files
+
+| File | Changes |
+|---|---|
+| `crates/ferric-runtime/src/engine.rs` | Add 3 new pub methods |
+| `crates/ferric-runtime/src/modules.rs` | Add `module_names()` |
+| `crates/ferric-ffi/src/types.rs` | Add `FerricFactType`, `FerricHaltReason`, value constructors, `ferric_to_value` |
+| `crates/ferric-ffi/src/engine.rs` | Add 27 new `extern "C"` functions |
+| `crates/ferric-ffi/src/tests.rs` | Add tests for all new functions |

--- a/documents/PythonBindingsPlan.md
+++ b/documents/PythonBindingsPlan.md
@@ -1,0 +1,691 @@
+# Python Bindings Plan — `ferric-python`
+
+## Purpose
+
+Provide native Python bindings for the Ferric rules engine using PyO3 and maturin, enabling Python developers to embed and interact with the engine without CLIPS source-level indirection for common operations.
+
+## Crate Structure
+
+New workspace member at `crates/ferric-python/`:
+
+```
+crates/ferric-python/
+├── Cargo.toml
+├── pyproject.toml
+├── build.rs
+├── src/
+│   ├── lib.rs          # #[pymodule] definition
+│   ├── engine.rs       # #[pyclass(unsendable)] Engine wrapper
+│   ├── value.rs        # Rust Value <-> Python native type conversion
+│   ├── fact.rs         # Fact, OrderedFact, TemplateFact Python classes
+│   ├── config.rs       # Strategy, Encoding PyO3 enums
+│   ├── result.rs       # RunResult, HaltReason, FiredRule
+│   └── error.rs        # Exception hierarchy (FerricError, etc.)
+└── tests/
+    ├── conftest.py
+    ├── test_engine.py
+    ├── test_facts.py
+    ├── test_execution.py
+    ├── test_values.py
+    ├── test_config.py
+    ├── test_errors.py
+    ├── test_introspection.py
+    └── test_io.py
+```
+
+### `Cargo.toml`
+
+```toml
+[package]
+name = "ferric-python"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lib]
+name = "ferric"
+crate-type = ["cdylib"]
+
+[dependencies]
+ferric-core = { workspace = true }
+ferric-runtime = { workspace = true }
+pyo3 = { version = "0.22", features = ["extension-module"] }
+
+[build-dependencies]
+pyo3-build-config = "0.22"
+```
+
+### `pyproject.toml`
+
+```toml
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "ferric"
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Rust",
+    "Programming Language :: Python :: Implementation :: CPython",
+]
+
+[tool.maturin]
+features = ["pyo3/extension-module"]
+```
+
+### `build.rs`
+
+```rust
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+}
+```
+
+### Workspace Changes
+
+Add to root `Cargo.toml`:
+
+```toml
+[workspace]
+members = [
+    # ... existing members ...
+    "crates/ferric-python",
+]
+
+[workspace.dependencies]
+pyo3 = { version = "0.22", features = ["extension-module"] }
+pyo3-build-config = "0.22"
+```
+
+---
+
+## Python API Surface
+
+### Module Root
+
+```python
+import ferric
+
+engine = ferric.Engine()
+```
+
+The `#[pymodule]` function registers all classes and enums into a single `ferric` module.
+
+### Engine Lifecycle
+
+```python
+# Default configuration (UTF-8, Depth strategy)
+engine = ferric.Engine()
+
+# Explicit configuration
+engine = ferric.Engine(strategy=Strategy.DEPTH, encoding=Encoding.UTF8)
+
+# Convenience: load source and reset in one call
+engine = ferric.Engine.from_source("(defrule ...)")
+engine = ferric.Engine.from_source("(defrule ...)", strategy=Strategy.LEX)
+
+# Context manager (calls engine.clear() on exit)
+with ferric.Engine.from_source(rules) as engine:
+    result = engine.run()
+```
+
+**Rust mapping:**
+
+| Python | Rust |
+|---|---|
+| `Engine()` | `Engine::new(EngineConfig::default())` |
+| `Engine(strategy=..., encoding=...)` | `Engine::new(EngineConfig { ... })` |
+| `Engine.from_source(src)` | `Engine::with_rules(src)` |
+| `Engine.from_source(src, strategy=...)` | `Engine::with_rules_config(src, config)` |
+| `__enter__` / `__exit__` | Return self / call `Engine::clear()` |
+
+### Loading
+
+```python
+engine.load("(defrule ...)")           # CLIPS source string
+engine.load_file("rules.clp")         # Load from file path
+```
+
+**Rust mapping:**
+
+| Python | Rust |
+|---|---|
+| `engine.load(src)` | `Engine::load_str(src)` |
+| `engine.load_file(path)` | `Engine::load_file(path)` |
+
+### Fact Operations
+
+```python
+# Assert via CLIPS syntax
+fid = engine.assert_string('(color red)')
+
+# Assert structured (no CLIPS parsing)
+fid = engine.assert_fact("color", "red")
+fid = engine.assert_fact("point", 3, 4.5)
+
+# Retract
+engine.retract(fid)
+
+# Query
+fact = engine.get_fact(fid)        # Fact object or None
+facts = engine.facts()             # list[Fact]
+facts = engine.find_facts("color") # list[Fact] by relation
+```
+
+**Rust mapping:**
+
+| Python | Rust |
+|---|---|
+| `engine.assert_string(src)` | `Engine::load_str(src)` with `(assert ...)` wrapper, or direct source parsing |
+| `engine.assert_fact(rel, *args)` | `Engine::assert_ordered(rel, values)` with `python_to_value()` conversion |
+| `engine.retract(fid)` | `Engine::retract(FactId)` |
+| `engine.get_fact(fid)` | `Engine::get_fact(FactId)` → snapshot to `Fact` pyclass |
+| `engine.facts()` | `Engine::facts()` → collect snapshots |
+| `engine.find_facts(rel)` | `Engine::find_facts(rel)` → collect snapshots |
+
+`assert_string` parses a bare fact assertion string by wrapping it in `(assert ...)` and loading via `Engine::load_str`, then extracting the resulting fact ID. Alternatively, it can use the engine's assertion path directly if the string is a bare ordered fact like `(color red)`.
+
+### Execution
+
+```python
+result = engine.run()              # RunResult(rules_fired=N, halt_reason=...)
+result = engine.run(limit=100)     # Run at most 100 rule firings
+fired = engine.step()              # FiredRule or None
+engine.halt()
+engine.reset()
+engine.clear()
+```
+
+**Rust mapping:**
+
+| Python | Rust |
+|---|---|
+| `engine.run()` | `Engine::run(RunLimit::Unlimited)` |
+| `engine.run(limit=N)` | `Engine::run(RunLimit::Count(N))` |
+| `engine.step()` | `Engine::step()` |
+| `engine.halt()` | `Engine::halt()` |
+| `engine.reset()` | `Engine::reset()` |
+| `engine.clear()` | `Engine::clear()` |
+
+### Properties
+
+```python
+engine.fact_count       # int — number of user-visible facts
+engine.is_halted        # bool
+engine.agenda_size      # int — number of pending activations
+engine.current_module   # str — name of the current module
+engine.focus            # str | None — top of focus stack
+engine.focus_stack      # list[str] — all modules in focus stack
+engine.diagnostics      # list[str] — non-fatal action diagnostics
+```
+
+**Rust mapping:**
+
+| Python | Rust |
+|---|---|
+| `fact_count` | `Engine::facts()?.count()` |
+| `is_halted` | `Engine::is_halted()` |
+| `agenda_size` | `Engine::agenda_len()` |
+| `current_module` | `Engine::current_module()` |
+| `focus` | `Engine::get_focus()` |
+| `focus_stack` | `Engine::get_focus_stack()` |
+| `diagnostics` | `Engine::action_diagnostics()` → map to strings |
+
+### Introspection
+
+```python
+engine.rules()          # list[tuple[str, int]]  — (name, salience)
+engine.templates()      # list[str]              — template names
+engine.get_global("x")  # Python native value or None
+```
+
+**Rust mapping:**
+
+| Python | Rust |
+|---|---|
+| `engine.rules()` | `Engine::rules()` |
+| `engine.templates()` | `Engine::templates()` |
+| `engine.get_global(name)` | `Engine::get_global(name)` → `value_to_python()` |
+
+### I/O
+
+```python
+engine.get_output("stdout")      # str | None
+engine.clear_output("stdout")
+engine.push_input("some line")
+```
+
+**Rust mapping:**
+
+| Python | Rust |
+|---|---|
+| `engine.get_output(ch)` | `Engine::get_output(ch)` |
+| `engine.clear_output(ch)` | `Engine::clear_output_channel(ch)` |
+| `engine.push_input(line)` | `Engine::push_input(line)` |
+
+### Python Protocols
+
+```python
+repr(engine)      # "Engine(facts=3, rules=2, halted=False)"
+len(engine)       # fact_count
+fid in engine     # __contains__ by fact ID
+```
+
+`__repr__` uses `fact_count`, `rules().len()`, and `is_halted`. `__len__` returns `fact_count`. `__contains__` calls `get_fact(fid)` and returns `True` if the result is `Some`.
+
+---
+
+## Value Conversion
+
+### `value_to_python(py, val, engine)` — Rust → Python
+
+| Rust `Value` | Python type | Notes |
+|---|---|---|
+| `Integer(i64)` | `int` | Direct conversion |
+| `Float(f64)` | `float` | Direct conversion |
+| `Symbol(sym)` | `str` | Resolve via `engine.resolve_symbol(sym)` |
+| `String(s)` | `str` | `FerricString::as_str()` |
+| `Multifield(vals)` | `list` | Recursive conversion of each element |
+| `Void` | `None` | Maps to Python `None` |
+| `ExternalAddress` | `None` | Not supported in v1 |
+
+### `python_to_value(obj, engine)` — Python → Rust
+
+| Python type | Rust `Value` | Notes |
+|---|---|---|
+| `int` | `Integer(i64)` | Overflow → `FerricError` |
+| `float` | `Float(f64)` | Direct conversion |
+| `str` | `Symbol(sym)` | Intern via `engine.intern_symbol(s)` |
+| `bool` | `Symbol` | `True` → `TRUE`, `False` → `FALSE` |
+| `list` | `Multifield` | Recursive conversion |
+| `tuple` | `Multifield` | Same as list |
+| `None` | `Void` | |
+
+Implementation notes:
+- `python_to_value` must borrow the engine mutably for `intern_symbol` (symbol creation).
+- Round-trip fidelity: `int → Integer → int`, `float → Float → float`. Symbol round-trip: `str → Symbol → str` (resolved text).
+- Strings in CLIPS source syntax (`"hello"`) are `Value::String`; bare words are `Value::Symbol`. The Python API uses `str` for both — `python_to_value` defaults to Symbol since that's the common case for structured assertion.
+
+---
+
+## Fact Representation
+
+`Fact` is a `#[pyclass]` holding a **snapshot** (value copy, not engine reference). This avoids lifetime issues and ensures facts remain valid after engine mutations.
+
+### Fields
+
+```python
+fact.id             # int — fact ID (from FactId, converted to u64)
+fact.fact_type      # FactType.ORDERED or FactType.TEMPLATE
+fact.relation       # str | None — ordered fact relation name
+fact.template_name  # str | None — template fact template name
+fact.fields         # list — ordered: field values; template: slot values
+fact.slots          # dict[str, object] | None — template only
+```
+
+### FactType Enum
+
+```python
+class FactType:
+    ORDERED = 0
+    TEMPLATE = 1
+```
+
+Implemented as a `#[pyclass]` with `#[classattr]` constants.
+
+### Snapshot Construction
+
+When creating a `Fact` snapshot from Rust:
+
+```rust
+fn fact_to_python(py: Python, fact_id: FactId, fact: &ferric_core::Fact, engine: &Engine) -> Fact {
+    match fact {
+        ferric_core::Fact::Ordered(ordered) => Fact {
+            id: fact_id.data().as_ffi(),
+            fact_type: FactType::ORDERED,
+            relation: Some(engine.resolve_symbol(ordered.relation)
+                .unwrap_or("<unknown>").to_string()),
+            template_name: None,
+            fields: ordered.fields.iter()
+                .map(|v| value_to_python(py, v, engine))
+                .collect(),
+            slots: None,
+        },
+        ferric_core::Fact::Template(template) => {
+            let tmpl_name = engine.template_name_by_id(template.template_id)
+                .unwrap_or("<unknown>").to_string();
+            let slot_names = engine.template_slot_names(&tmpl_name);
+            Fact {
+                id: fact_id.data().as_ffi(),
+                fact_type: FactType::TEMPLATE,
+                relation: None,
+                template_name: Some(tmpl_name),
+                fields: template.slot_values.iter()
+                    .map(|v| value_to_python(py, v, engine))
+                    .collect(),
+                slots: slot_names.map(|names| {
+                    names.iter().zip(template.slot_values.iter())
+                        .map(|(name, val)| (name.to_string(), value_to_python(py, val, engine)))
+                        .collect()
+                }),
+            }
+        }
+    }
+}
+```
+
+### Protocols
+
+- `__repr__`: `"Fact(id=3, type=ORDERED, relation='color', fields=['red'])"` or `"Fact(id=5, type=TEMPLATE, template='person', slots={'name': 'Alice'})"`.
+- `__eq__`: By fact ID (two `Fact` snapshots with the same `id` are equal).
+- `__hash__`: Hash of fact ID.
+
+---
+
+## Configuration Enums
+
+### Strategy
+
+```python
+class Strategy:
+    DEPTH = 0
+    BREADTH = 1
+    LEX = 2
+    MEA = 3
+```
+
+Maps to `ConflictResolutionStrategy` in `ferric_core`.
+
+### Encoding
+
+```python
+class Encoding:
+    ASCII = 0
+    UTF8 = 1
+    ASCII_SYMBOLS_UTF8_STRINGS = 2
+```
+
+Maps to `StringEncoding` in `ferric_core`.
+
+Both implemented as `#[pyclass]` with `#[classattr]` constants.
+
+---
+
+## Exception Hierarchy
+
+```
+FerricError (base)
+├── FerricParseError
+├── FerricCompileError
+├── FerricRuntimeError
+├── FerricFactNotFoundError
+├── FerricModuleNotFoundError
+└── FerricEncodingError
+```
+
+All prefixed with `Ferric` to avoid shadowing Python builtins (`RuntimeError`, `ModuleNotFoundError`).
+
+### Mapping from Rust Errors
+
+```rust
+impl From<EngineError> for PyErr {
+    fn from(err: EngineError) -> Self {
+        match err {
+            EngineError::WrongThread { .. } => FerricRuntimeError::new_err(err.to_string()),
+            EngineError::FactNotFound(_) => FerricFactNotFoundError::new_err(err.to_string()),
+            EngineError::Encoding(_) => FerricEncodingError::new_err(err.to_string()),
+            _ => FerricError::new_err(err.to_string()),
+        }
+    }
+}
+
+impl From<LoadError> for PyErr {
+    fn from(err: LoadError) -> Self {
+        match err {
+            LoadError::Parse(_) => FerricParseError::new_err(err.to_string()),
+            LoadError::Compile(_) => FerricCompileError::new_err(err.to_string()),
+            _ => FerricError::new_err(err.to_string()),
+        }
+    }
+}
+
+impl From<InitError> for PyErr {
+    fn from(err: InitError) -> Self {
+        // InitError wraps LoadError
+        FerricError::new_err(err.to_string())
+    }
+}
+```
+
+---
+
+## Thread Safety
+
+### Design
+
+- `Engine` wrapper is `#[pyclass(unsendable)]` — PyO3 rejects cross-thread access at runtime.
+- The GIL serializes all calls → no concurrent `Rc` access within the Engine.
+- Engine's Rust-level thread-affinity check passes because all calls come from the same OS thread that created the engine.
+
+### Free-threaded Python (3.13+)
+
+`unsendable` correctly rejects cross-thread access. No extra work needed — the PyO3 `unsendable` annotation handles this case.
+
+### Interior Wrapper
+
+```rust
+#[pyclass(unsendable)]
+pub struct PyEngine {
+    engine: Engine,
+}
+```
+
+The `PyEngine` struct holds an owned `Engine`. All `#[pymethods]` take `&self` or `&mut self` through PyO3's borrow mechanism, which serializes access via the GIL.
+
+---
+
+## Result Types
+
+### RunResult
+
+```python
+class RunResult:
+    rules_fired: int        # Number of rules fired
+    halt_reason: HaltReason # Why execution stopped
+```
+
+### HaltReason
+
+```python
+class HaltReason:
+    AGENDA_EMPTY = 0
+    LIMIT_REACHED = 1
+    HALT_REQUESTED = 2
+```
+
+### FiredRule
+
+```python
+class FiredRule:
+    rule_name: str   # Name of the fired rule
+```
+
+`FiredRule` is returned by `engine.step()`. The `rule_name` is resolved from `RuleId` via `Engine::rule_name()`.
+
+---
+
+## `#[pymodule]` Definition
+
+```rust
+#[pymodule]
+fn ferric(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyEngine>()?;
+    m.add_class::<Fact>()?;
+    m.add_class::<FactType>()?;
+    m.add_class::<Strategy>()?;
+    m.add_class::<Encoding>()?;
+    m.add_class::<RunResult>()?;
+    m.add_class::<HaltReason>()?;
+    m.add_class::<FiredRule>()?;
+
+    // Register exception hierarchy
+    m.add("FerricError", m.py().get_type::<FerricError>())?;
+    m.add("FerricParseError", m.py().get_type::<FerricParseError>())?;
+    m.add("FerricCompileError", m.py().get_type::<FerricCompileError>())?;
+    m.add("FerricRuntimeError", m.py().get_type::<FerricRuntimeError>())?;
+    m.add("FerricFactNotFoundError", m.py().get_type::<FerricFactNotFoundError>())?;
+    m.add("FerricModuleNotFoundError", m.py().get_type::<FerricModuleNotFoundError>())?;
+    m.add("FerricEncodingError", m.py().get_type::<FerricEncodingError>())?;
+
+    Ok(())
+}
+```
+
+---
+
+## Shared Prerequisites (ferric-runtime changes)
+
+The following new **public methods** must be added to `Engine` in `crates/ferric-runtime/src/engine.rs` before the Python bindings can be fully implemented. These are small, safe additions that do not break any existing API.
+
+### `Engine::template_slot_names`
+
+```rust
+/// Return the slot names for a named template, or `None` if the template
+/// does not exist.
+pub fn template_slot_names(&self, name: &str) -> Option<Vec<&str>> {
+    let tid = self.template_ids.get(name)?;
+    let def = self.template_defs.get(*tid)?;
+    Some(def.slot_names.iter().map(String::as_str).collect())
+}
+```
+
+Required by: `Fact.slots` (template fact slot-name-to-value mapping).
+
+### `Engine::template_name_by_id`
+
+```rust
+/// Return the template name for a `TemplateId`, or `None` if the ID
+/// is not registered.
+pub fn template_name_by_id(&self, tid: TemplateId) -> Option<&str> {
+    self.template_defs.get(tid).map(|def| def.name.as_str())
+}
+```
+
+Required by: `fact_to_python()` (resolving template name from `TemplateFact::template_id`).
+
+### `Engine::modules`
+
+```rust
+/// Return the names of all registered modules.
+pub fn modules(&self) -> Vec<&str> {
+    self.module_registry.module_names()
+}
+```
+
+Required by: future introspection API (not strictly needed for v1 Python bindings, but part of the shared prerequisite set).
+
+### `ModuleRegistry::module_names`
+
+New method on `ModuleRegistry` in `crates/ferric-runtime/src/modules.rs`:
+
+```rust
+/// Return the names of all registered modules.
+pub fn module_names(&self) -> Vec<&str> {
+    self.modules.values().map(|m| m.name.as_str()).collect()
+}
+```
+
+Required by: `Engine::modules()`.
+
+---
+
+## Testing
+
+### Test Files
+
+```
+crates/ferric-python/tests/
+    conftest.py           # shared fixtures (engine instances, common rules)
+    test_engine.py        # lifecycle: create, from_source, context manager, reset, clear
+    test_facts.py         # assert_string, assert_fact, retract, get_fact, facts(), find_facts()
+    test_execution.py     # run(), step(), halt(), run(limit=N)
+    test_values.py        # conversion round-trips: int, float, str, list, None
+    test_config.py        # Strategy/Encoding enums, keyword args
+    test_errors.py        # exception hierarchy, error messages
+    test_introspection.py # rules(), templates(), get_global()
+    test_io.py            # get_output(), clear_output(), push_input()
+```
+
+### Running Tests
+
+```bash
+cd crates/ferric-python
+maturin develop
+pytest tests/ -v
+```
+
+### Key Test Scenarios
+
+1. **Engine lifecycle:** Create default engine, create with config, `from_source` happy path and parse error, context manager calls `clear()` on exit (including on exception).
+2. **Fact operations:** Assert ordered fact via CLIPS string, assert structured fact with type conversion, retract by ID, retract nonexistent ID raises `FerricFactNotFoundError`, `get_fact` returns `None` for missing, `facts()` excludes initial-fact, `find_facts` filters by relation.
+3. **Execution:** `run()` fires all rules, `run(limit=1)` fires exactly one, `step()` returns `FiredRule` or `None`, `halt()` stops execution, `reset()` clears facts and re-asserts deffacts.
+4. **Value round-trips:** `int → assert_fact → get_fact → int`, `float → assert_fact → get_fact → float`, `str → Symbol → str`, nested `list` → Multifield → `list`.
+5. **Error hierarchy:** `isinstance(FerricParseError(), FerricError)` is `True`, parse error from invalid source, compile error from invalid rule, runtime error from wrong thread.
+6. **Protocols:** `repr()` includes fact count and rule count, `len()` equals `fact_count`, `in` operator checks fact existence.
+
+---
+
+## Distribution
+
+### Build
+
+maturin builds platform-specific wheels:
+
+```bash
+maturin build --release
+```
+
+### PyPI
+
+Package name: `ferric`. Install: `pip install ferric`.
+
+### CI Matrix
+
+Use `PyO3/maturin-action` for cross-platform wheel building:
+
+| Platform | Targets |
+|---|---|
+| Linux | manylinux (x86_64, aarch64) |
+| macOS | arm64, x86_64 (universal2) |
+| Windows | x86_64 |
+
+### Python Version Support
+
+Python 3.9+ (matching PyO3 0.22 support matrix).
+
+---
+
+## Implementation Sequencing
+
+1. **Shared prerequisites:** Add `template_slot_names`, `template_name_by_id`, `modules`, `module_names` to ferric-runtime.
+2. **Crate scaffold:** Create `crates/ferric-python/` with `Cargo.toml`, `pyproject.toml`, `build.rs`, empty `src/lib.rs`.
+3. **Value conversion:** Implement `value.rs` with `value_to_python` and `python_to_value`.
+4. **Error hierarchy:** Implement `error.rs` with exception classes and `From` impls.
+5. **Config enums:** Implement `config.rs` with `Strategy`, `Encoding`.
+6. **Result types:** Implement `result.rs` with `RunResult`, `HaltReason`, `FiredRule`.
+7. **Fact representation:** Implement `fact.rs` with `Fact`, `FactType`.
+8. **Engine wrapper:** Implement `engine.rs` with `PyEngine` and all `#[pymethods]`.
+9. **Module registration:** Implement `lib.rs` with `#[pymodule]`.
+10. **Tests:** Write pytest suite covering all API surface.
+
+---
+
+## Non-Goals (v1)
+
+- `ExternalAddress` support (maps to `None`).
+- Template fact assertion via Python dict (requires template-aware assertion path).
+- Async/await support (engine is synchronous and thread-affine).
+- Submodule structure (flat `import ferric` is sufficient for v1).
+- `__iter__` on engine for fact iteration (use `engine.facts()` instead).


### PR DESCRIPTION
## Summary

- **PythonBindingsPlan.md**: Comprehensive design for PyO3-based Python bindings via new `ferric-python` crate, covering crate structure, full API surface, value conversion, exception hierarchy, threading, testing, and distribution.
- **CFFIExpansionPlan.md**: Plan for 32 new C FFI functions covering fact iteration, structured assertion, template/rule/module introspection, agenda queries, and convenience variants.

Both plans share prerequisite changes to `ferric-runtime` (3 new Engine methods + `ModuleRegistry::module_names`) that unlock additional introspection capabilities for both Python and C embedders.

## Implementation Order

Prerequisites land first (ferric-runtime changes), then Python bindings and C FFI can be implemented independently, each adding their own stable API surface over the shared foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)