### PR TITLE
Multi-format serialization support

### DIFF
--- a/.claude/agent-memory/lint-fixer/MEMORY.md
+++ b/.claude/agent-memory/lint-fixer/MEMORY.md
@@ -13,10 +13,11 @@
 3. **redundant_closure_for_method_calls**: Replace `.map(|n| n.to_string())` with `.map(std::string::ToString::to_string)`
 4. **uninlined_format_args**: In format! macros, inline variables directly instead of passing as positional args: `format!("{x}")` instead of `format!("{}", x)`
 5. **ref_option**: Use `Option<&T>` instead of `&Option<T>` in function parameters. Requires changing `.clone()` to `.cloned()` for owned copies, and callers pass `.as_ref()` instead of `&opt`
-6. **cast_precision_loss**: `i64 as f64` casts; allow with `#[allow(clippy::cast_precision_loss)]` when intentional
+6. **cast_precision_loss**: `i64 as f64` casts; use `f64::from(i)` instead; allow with `#[allow(clippy::cast_precision_loss)]` if necessary
 7. **cast_possible_truncation**: `f64 as i64` casts; allow with `#[allow(clippy::cast_possible_truncation)]` when intentional (e.g., integer division semantics)
 8. **float_cmp**: Direct `==` comparison of f64 values; allow with `#[allow(clippy::float_cmp)]` when combined with epsilon-based comparison as fallback
 9. **doc_markdown**: Type names in doc comments need backticks (e.g., `VarMap` not VarMap)
+10. **format_push_string**: `facts.push_str(&format!(...))` should use `writeln!` or `write!` instead. Requires `use std::fmt::Write;` import. Use `writeln!` when format ends with `\n`, `write!` otherwise.
 
 ### thiserror `#[error]` and ref_option interaction
 - When changing `format_span(span: &Option<T>)` to `format_span(span: Option<&T>)`, the thiserror `#[error]` attributes that call `format_span(.span)` need to change to `format_span(.span.as_ref())` since `.span` in thiserror context gives `&Option<T>`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +123,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -229,6 +244,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +336,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "endian-type"
@@ -437,12 +479,16 @@ name = "ferric-runtime"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "ciborium",
  "criterion",
  "ferric-core",
  "ferric-parser",
+ "postcard",
  "proptest",
+ "rmp-serde",
  "rustc-hash",
  "serde",
+ "serde_json",
  "slotmap",
  "smallvec",
  "tempfile",
@@ -499,6 +545,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +567,20 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -626,6 +695,15 @@ name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -753,6 +831,19 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -983,10 +1074,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1049,6 +1168,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1135,6 +1260,21 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ cbindgen = "0.29"
 # Serialization
 serde = { version = "1", features = ["derive", "rc"] }
 bincode = "1"
+serde_json = "1"
+ciborium = "0.2"
+rmp-serde = "1"
+postcard = { version = "1", features = ["alloc"] }
 
 # Slot-based storage (serde feature always on — negligible cost, needed when serde is enabled)
 slotmap = { version = "1", features = ["serde"] }

--- a/bindings/go/engine.go
+++ b/bindings/go/engine.go
@@ -3,6 +3,7 @@ package ferric
 import (
 	"context"
 	"fmt"
+	"os"
 	"runtime"
 
 	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
@@ -37,8 +38,12 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 
 	if cfg.snapshot != nil {
 		// Deserialize from snapshot — skips parse/compile.
+		ffiFormat, err := formatToFFI(cfg.snapshotFormat)
+		if err != nil {
+			return nil, err
+		}
 		var rc ffi.ErrorCode
-		h, rc = ffi.EngineDeserializeAs(cfg.snapshot, formatToFFI(cfg.snapshotFormat))
+		h, rc = ffi.EngineDeserializeAs(cfg.snapshot, ffiFormat)
 		if rc != ffi.ErrOK {
 			return nil, errorFromFFI(rc, nil)
 		}
@@ -83,6 +88,18 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 		}
 	})
 	return e, nil
+}
+
+// NewEngineFromFile creates a new engine by deserializing a snapshot from the
+// given file path. The format must match the one used during serialization.
+// Additional options (e.g., WithMaxCallDepth) are applied after restoration.
+func NewEngineFromFile(path string, format Format, opts ...EngineOption) (*Engine, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	combined := append([]EngineOption{WithSnapshot(data, format)}, opts...)
+	return NewEngine(combined...)
 }
 
 func makeConfig(cfg *engineConfig) (*ffi.Config, error) {
@@ -422,11 +439,25 @@ func (e *Engine) Clear() {
 // specified format. The snapshot can be used with WithSnapshot to create
 // new engines that skip the parse/compile pipeline.
 func (e *Engine) Serialize(format Format) ([]byte, error) {
-	data, rc := ffi.EngineSerializeAs(e.handle, formatToFFI(format))
+	ffiFormat, err := formatToFFI(format)
+	if err != nil {
+		return nil, err
+	}
+	data, rc := ffi.EngineSerializeAs(e.handle, ffiFormat)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
 	return data, nil
+}
+
+// SerializeToFile writes a serialized snapshot of the engine to the given
+// file path using the specified format.
+func (e *Engine) SerializeToFile(path string, format Format) error {
+	data, err := e.Serialize(format)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
 }
 
 // --- Introspection ---

--- a/bindings/go/engine.go
+++ b/bindings/go/engine.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
@@ -94,9 +95,9 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 // given file path. The format must match the one used during serialization.
 // Additional options (e.g., WithMaxCallDepth) are applied after restoration.
 func NewEngineFromFile(path string, format Format, opts ...EngineOption) (*Engine, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- caller-controlled path
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ferric: reading snapshot file: %w", err)
 	}
 	combined := append([]EngineOption{WithSnapshot(data, format)}, opts...)
 	return NewEngine(combined...)
@@ -457,7 +458,10 @@ func (e *Engine) SerializeToFile(path string, format Format) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0644)
+	if err = os.WriteFile(filepath.Clean(path), data, 0600); err != nil { // #nosec G306
+		return fmt.Errorf("ferric: writing snapshot file: %w", err)
+	}
+	return nil
 }
 
 // --- Introspection ---

--- a/bindings/go/engine.go
+++ b/bindings/go/engine.go
@@ -38,7 +38,7 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 	if cfg.snapshot != nil {
 		// Deserialize from snapshot — skips parse/compile.
 		var rc ffi.ErrorCode
-		h, rc = ffi.EngineDeserialize(cfg.snapshot)
+		h, rc = ffi.EngineDeserializeAs(cfg.snapshot, formatToFFI(cfg.snapshotFormat))
 		if rc != ffi.ErrOK {
 			return nil, errorFromFFI(rc, nil)
 		}
@@ -418,11 +418,11 @@ func (e *Engine) Clear() {
 	ffi.EngineClear(e.handle)
 }
 
-// Serialize produces a binary snapshot of the engine's current state.
-// The snapshot can be used with WithSnapshot to create new engines
-// that skip the parse/compile pipeline.
-func (e *Engine) Serialize() ([]byte, error) {
-	data, rc := ffi.EngineSerialize(e.handle)
+// Serialize produces a snapshot of the engine's current state using the
+// specified format. The snapshot can be used with WithSnapshot to create
+// new engines that skip the parse/compile pipeline.
+func (e *Engine) Serialize(format Format) ([]byte, error) {
+	data, rc := ffi.EngineSerializeAs(e.handle, formatToFFI(format))
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}

--- a/bindings/go/engine_options.go
+++ b/bindings/go/engine_options.go
@@ -1,14 +1,17 @@
 package ferric
 
+import "github.com/prb/ferric-rules/bindings/go/internal/ffi"
+
 // EngineOption configures an Engine.
 type EngineOption func(*engineConfig)
 
 type engineConfig struct {
-	strategy     Strategy
-	encoding     Encoding
-	maxCallDepth int
-	source       string // if non-empty, load+reset at creation
-	snapshot     []byte // if non-nil, deserialize instead of creating fresh
+	strategy       Strategy
+	encoding       Encoding
+	maxCallDepth   int
+	source         string // if non-empty, load+reset at creation
+	snapshot       []byte // if non-nil, deserialize instead of creating fresh
+	snapshotFormat Format // format of snapshot data
 }
 
 // WithStrategy sets the conflict resolution strategy.
@@ -31,10 +34,31 @@ func WithSource(clips string) EngineOption {
 	return func(c *engineConfig) { c.source = clips }
 }
 
-// WithSnapshot creates the engine by deserializing a binary snapshot
-// previously produced by Engine.Serialize. This skips parsing and
-// compilation, providing fast engine instantiation.
-// Mutually exclusive with WithSource.
-func WithSnapshot(data []byte) EngineOption {
-	return func(c *engineConfig) { c.snapshot = data }
+// WithSnapshot creates the engine by deserializing a snapshot previously
+// produced by Engine.Serialize. The format must match the one used during
+// serialization. This skips parsing and compilation, providing fast engine
+// instantiation. Mutually exclusive with WithSource.
+func WithSnapshot(data []byte, format Format) EngineOption {
+	return func(c *engineConfig) {
+		c.snapshot = data
+		c.snapshotFormat = format
+	}
+}
+
+// formatToFFI converts a public Format to the FFI-level format enum.
+func formatToFFI(f Format) ffi.SerializationFormat {
+	switch f {
+	case FormatBincode:
+		return ffi.FormatBincode
+	case FormatJSON:
+		return ffi.FormatJSON
+	case FormatCBOR:
+		return ffi.FormatCBOR
+	case FormatMessagePack:
+		return ffi.FormatMessagePack
+	case FormatPostcard:
+		return ffi.FormatPostcard
+	default:
+		return ffi.FormatBincode
+	}
 }

--- a/bindings/go/engine_options.go
+++ b/bindings/go/engine_options.go
@@ -1,6 +1,10 @@
 package ferric
 
-import "github.com/prb/ferric-rules/bindings/go/internal/ffi"
+import (
+	"fmt"
+
+	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
+)
 
 // EngineOption configures an Engine.
 type EngineOption func(*engineConfig)
@@ -46,19 +50,19 @@ func WithSnapshot(data []byte, format Format) EngineOption {
 }
 
 // formatToFFI converts a public Format to the FFI-level format enum.
-func formatToFFI(f Format) ffi.SerializationFormat {
+func formatToFFI(f Format) (ffi.SerializationFormat, error) {
 	switch f {
 	case FormatBincode:
-		return ffi.FormatBincode
+		return ffi.FormatBincode, nil
 	case FormatJSON:
-		return ffi.FormatJSON
+		return ffi.FormatJSON, nil
 	case FormatCBOR:
-		return ffi.FormatCBOR
+		return ffi.FormatCBOR, nil
 	case FormatMessagePack:
-		return ffi.FormatMessagePack
+		return ffi.FormatMessagePack, nil
 	case FormatPostcard:
-		return ffi.FormatPostcard
+		return ffi.FormatPostcard, nil
 	default:
-		return ffi.FormatBincode
+		return 0, fmt.Errorf("%w: unsupported serialization format %d", ErrInvalidArgument, f)
 	}
 }

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -891,6 +891,10 @@ enum FerricError ferric_engine_free_unchecked(struct FerricEngine *engine);
 #if defined(FERRIC_SERDE)
 // Serialize engine state to bytes in the specified format.
 //
+// `format` is a uint32_t corresponding to FerricSerializationFormat discriminants
+// (0 = Bincode, 1 = JSON, 2 = CBOR, 3 = MessagePack, 4 = Postcard).
+// Returns FERRIC_ERROR_INVALID_ARGUMENT for out-of-range values.
+//
 // See `ferric_engine_serialize_bincode` for memory allocation details.
 //
 // # Safety
@@ -900,7 +904,7 @@ enum FerricError ferric_engine_free_unchecked(struct FerricEngine *engine);
 // - If `alloc_fn` is non-null, it must return a valid pointer to `size` bytes
 //   (or null to signal failure).
 enum FerricError ferric_engine_serialize_as(const struct FerricEngine *engine,
-                                            enum FerricSerializationFormat format,
+                                            uint32_t format,
                                             FerricAllocFn alloc_fn,
                                             void *alloc_context,
                                             uint8_t **out_data,
@@ -909,6 +913,10 @@ enum FerricError ferric_engine_serialize_as(const struct FerricEngine *engine,
 
 #if defined(FERRIC_SERDE)
 // Deserialize an engine from bytes in the specified format.
+//
+// `format` is a uint32_t corresponding to FerricSerializationFormat discriminants
+// (0 = Bincode, 1 = JSON, 2 = CBOR, 3 = MessagePack, 4 = Postcard).
+// Returns FERRIC_ERROR_INVALID_ARGUMENT for out-of-range values.
 //
 // See `ferric_engine_deserialize_bincode` for details.
 //
@@ -919,7 +927,7 @@ enum FerricError ferric_engine_serialize_as(const struct FerricEngine *engine,
 // - The returned engine must be freed with `ferric_engine_free`.
 enum FerricError ferric_engine_deserialize_as(const uint8_t *data,
                                               uintptr_t len,
-                                              enum FerricSerializationFormat format,
+                                              uint32_t format,
                                               struct FerricEngine **out_engine);
 #endif
 

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -156,6 +156,21 @@ typedef enum FerricHaltReason {
     FERRIC_HALT_REASON_HALT_REQUESTED = 2,
 } FerricHaltReason;
 
+// C-facing string-encoding configuration for `FerricConfig`.
+typedef enum FerricStringEncoding {
+    FERRIC_STRING_ENCODING_ASCII = 0,
+    FERRIC_STRING_ENCODING_UTF8 = 1,
+    FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS = 2,
+} FerricStringEncoding;
+
+// C-facing conflict-resolution strategy for `FerricConfig`.
+typedef enum FerricConflictStrategy {
+    FERRIC_CONFLICT_STRATEGY_DEPTH = 0,
+    FERRIC_CONFLICT_STRATEGY_BREADTH = 1,
+    FERRIC_CONFLICT_STRATEGY_LEX = 2,
+    FERRIC_CONFLICT_STRATEGY_MEA = 3,
+} FerricConflictStrategy;
+
 #if defined(FERRIC_SERDE)
 // Serialization format selector for `ferric_engine_serialize_as` and
 // `ferric_engine_deserialize_as`.
@@ -172,21 +187,6 @@ typedef enum FerricSerializationFormat {
     FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4,
 } FerricSerializationFormat;
 #endif
-
-// C-facing string-encoding configuration for `FerricConfig`.
-typedef enum FerricStringEncoding {
-    FERRIC_STRING_ENCODING_ASCII = 0,
-    FERRIC_STRING_ENCODING_UTF8 = 1,
-    FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS = 2,
-} FerricStringEncoding;
-
-// C-facing conflict-resolution strategy for `FerricConfig`.
-typedef enum FerricConflictStrategy {
-    FERRIC_CONFLICT_STRATEGY_DEPTH = 0,
-    FERRIC_CONFLICT_STRATEGY_BREADTH = 1,
-    FERRIC_CONFLICT_STRATEGY_LEX = 2,
-    FERRIC_CONFLICT_STRATEGY_MEA = 3,
-} FerricConflictStrategy;
 
 // Opaque engine handle exposed to C.
 //
@@ -891,9 +891,9 @@ enum FerricError ferric_engine_free_unchecked(struct FerricEngine *engine);
 #if defined(FERRIC_SERDE)
 // Serialize engine state to bytes in the specified format.
 //
-// `format` is a uint32_t corresponding to FerricSerializationFormat discriminants
-// (0 = Bincode, 1 = JSON, 2 = CBOR, 3 = MessagePack, 4 = Postcard).
-// Returns FERRIC_ERROR_INVALID_ARGUMENT for out-of-range values.
+// `format` is a `u32` corresponding to `FerricSerializationFormat` discriminants
+// (0 = Bincode, 1 = JSON, 2 = CBOR, 3 = `MessagePack`, 4 = Postcard).
+// Returns `FERRIC_ERROR_INVALID_ARGUMENT` for out-of-range values.
 //
 // See `ferric_engine_serialize_bincode` for memory allocation details.
 //
@@ -914,9 +914,9 @@ enum FerricError ferric_engine_serialize_as(const struct FerricEngine *engine,
 #if defined(FERRIC_SERDE)
 // Deserialize an engine from bytes in the specified format.
 //
-// `format` is a uint32_t corresponding to FerricSerializationFormat discriminants
-// (0 = Bincode, 1 = JSON, 2 = CBOR, 3 = MessagePack, 4 = Postcard).
-// Returns FERRIC_ERROR_INVALID_ARGUMENT for out-of-range values.
+// `format` is a `u32` corresponding to `FerricSerializationFormat` discriminants
+// (0 = Bincode, 1 = JSON, 2 = CBOR, 3 = `MessagePack`, 4 = Postcard).
+// Returns `FERRIC_ERROR_INVALID_ARGUMENT` for out-of-range values.
 //
 // See `ferric_engine_deserialize_bincode` for details.
 //

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -156,6 +156,23 @@ typedef enum FerricHaltReason {
     FERRIC_HALT_REASON_HALT_REQUESTED = 2,
 } FerricHaltReason;
 
+#if defined(FERRIC_SERDE)
+// Serialization format selector for `ferric_engine_serialize_as` and
+// `ferric_engine_deserialize_as`.
+typedef enum FerricSerializationFormat {
+    // Compact binary (bincode). Fast and small.
+    FERRIC_SERIALIZATION_FORMAT_BINCODE = 0,
+    // JSON (human-readable, larger output).
+    FERRIC_SERIALIZATION_FORMAT_JSON = 1,
+    // CBOR (Concise Binary Object Representation).
+    FERRIC_SERIALIZATION_FORMAT_CBOR = 2,
+    // `MessagePack` (compact binary, JSON-like schema).
+    FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK = 3,
+    // Postcard (compact, `no_std`-friendly binary).
+    FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4,
+} FerricSerializationFormat;
+#endif
+
 // C-facing string-encoding configuration for `FerricConfig`.
 typedef enum FerricStringEncoding {
     FERRIC_STRING_ENCODING_ASCII = 0,
@@ -222,7 +239,7 @@ typedef struct FerricValue {
 #if defined(FERRIC_SERDE)
 // Callback type for caller-controlled memory allocation.
 //
-// When non-null, called by `ferric_engine_serialize` with the exact byte
+// When non-null, called by serialization functions with the exact byte
 // count needed. The `context` parameter is passed through unchanged from
 // the serialize call.
 //
@@ -872,10 +889,42 @@ enum FerricError ferric_engine_get_fact_slot_by_name(const struct FerricEngine *
 enum FerricError ferric_engine_free_unchecked(struct FerricEngine *engine);
 
 #if defined(FERRIC_SERDE)
-// Serialize engine state to bytes.
+// Serialize engine state to bytes in the specified format.
 //
-// Produces a binary snapshot that can be passed to `ferric_engine_deserialize`
-// to reconstruct an equivalent engine, skipping the parse/compile pipeline.
+// See `ferric_engine_serialize_bincode` for memory allocation details.
+//
+// # Safety
+//
+// - `engine` must be a valid engine pointer.
+// - `out_data` and `out_len` must be valid, non-null pointers.
+// - If `alloc_fn` is non-null, it must return a valid pointer to `size` bytes
+//   (or null to signal failure).
+enum FerricError ferric_engine_serialize_as(const struct FerricEngine *engine,
+                                            enum FerricSerializationFormat format,
+                                            FerricAllocFn alloc_fn,
+                                            void *alloc_context,
+                                            uint8_t **out_data,
+                                            uintptr_t *out_len);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Deserialize an engine from bytes in the specified format.
+//
+// See `ferric_engine_deserialize_bincode` for details.
+//
+// # Safety
+//
+// - `data` must point to `len` valid, readable bytes.
+// - `out_engine` must be a valid, non-null pointer.
+// - The returned engine must be freed with `ferric_engine_free`.
+enum FerricError ferric_engine_deserialize_as(const uint8_t *data,
+                                              uintptr_t len,
+                                              enum FerricSerializationFormat format,
+                                              struct FerricEngine **out_engine);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Serialize engine state to bincode.
 //
 // ## Memory allocation
 //
@@ -895,16 +944,15 @@ enum FerricError ferric_engine_free_unchecked(struct FerricEngine *engine);
 // - `out_data` and `out_len` must be valid, non-null pointers.
 // - If `alloc_fn` is non-null, it must return a valid pointer to `size` bytes
 //   (or null to signal failure).
-enum FerricError ferric_engine_serialize(const struct FerricEngine *engine,
-                                         FerricAllocFn alloc_fn,
-                                         void *alloc_context,
-                                         uint8_t **out_data,
-                                         uintptr_t *out_len);
+enum FerricError ferric_engine_serialize_bincode(const struct FerricEngine *engine,
+                                                 FerricAllocFn alloc_fn,
+                                                 void *alloc_context,
+                                                 uint8_t **out_data,
+                                                 uintptr_t *out_len);
 #endif
 
 #if defined(FERRIC_SERDE)
-// Deserialize an engine from bytes previously produced by
-// `ferric_engine_serialize`.
+// Deserialize an engine from bincode bytes.
 //
 // The returned engine handle is ready for use (e.g. `ferric_engine_run`).
 // Its thread affinity is set to the calling thread.
@@ -914,20 +962,124 @@ enum FerricError ferric_engine_serialize(const struct FerricEngine *engine,
 // - `data` must point to `len` valid, readable bytes.
 // - `out_engine` must be a valid, non-null pointer.
 // - The returned engine must be freed with `ferric_engine_free`.
-enum FerricError ferric_engine_deserialize(const uint8_t *data,
-                                           uintptr_t len,
-                                           struct FerricEngine **out_engine);
+enum FerricError ferric_engine_deserialize_bincode(const uint8_t *data,
+                                                   uintptr_t len,
+                                                   struct FerricEngine **out_engine);
 #endif
 
 #if defined(FERRIC_SERDE)
-// Free a byte buffer that was allocated by `ferric_engine_serialize` when
+// Serialize engine state to JSON.
+//
+// See `ferric_engine_serialize_bincode` for memory allocation details.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_serialize_bincode`.
+enum FerricError ferric_engine_serialize_json(const struct FerricEngine *engine,
+                                              FerricAllocFn alloc_fn,
+                                              void *alloc_context,
+                                              uint8_t **out_data,
+                                              uintptr_t *out_len);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Deserialize an engine from JSON bytes.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_deserialize_bincode`.
+enum FerricError ferric_engine_deserialize_json(const uint8_t *data,
+                                                uintptr_t len,
+                                                struct FerricEngine **out_engine);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Serialize engine state to CBOR.
+//
+// See `ferric_engine_serialize_bincode` for memory allocation details.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_serialize_bincode`.
+enum FerricError ferric_engine_serialize_cbor(const struct FerricEngine *engine,
+                                              FerricAllocFn alloc_fn,
+                                              void *alloc_context,
+                                              uint8_t **out_data,
+                                              uintptr_t *out_len);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Deserialize an engine from CBOR bytes.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_deserialize_bincode`.
+enum FerricError ferric_engine_deserialize_cbor(const uint8_t *data,
+                                                uintptr_t len,
+                                                struct FerricEngine **out_engine);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Serialize engine state to `MessagePack`.
+//
+// See `ferric_engine_serialize_bincode` for memory allocation details.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_serialize_bincode`.
+enum FerricError ferric_engine_serialize_msgpack(const struct FerricEngine *engine,
+                                                 FerricAllocFn alloc_fn,
+                                                 void *alloc_context,
+                                                 uint8_t **out_data,
+                                                 uintptr_t *out_len);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Deserialize an engine from `MessagePack` bytes.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_deserialize_bincode`.
+enum FerricError ferric_engine_deserialize_msgpack(const uint8_t *data,
+                                                   uintptr_t len,
+                                                   struct FerricEngine **out_engine);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Serialize engine state to Postcard.
+//
+// See `ferric_engine_serialize_bincode` for memory allocation details.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_serialize_bincode`.
+enum FerricError ferric_engine_serialize_postcard(const struct FerricEngine *engine,
+                                                  FerricAllocFn alloc_fn,
+                                                  void *alloc_context,
+                                                  uint8_t **out_data,
+                                                  uintptr_t *out_len);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Deserialize an engine from Postcard bytes.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_deserialize_bincode`.
+enum FerricError ferric_engine_deserialize_postcard(const uint8_t *data,
+                                                    uintptr_t len,
+                                                    struct FerricEngine **out_engine);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Free a byte buffer that was allocated by a serialize function when
 // `alloc_fn` was null.
 //
 // Null pointers and zero lengths are safely ignored.
 //
 // # Safety
 //
-// - `data` must be a pointer returned by `ferric_engine_serialize` (with
+// - `data` must be a pointer returned by a serialize function (with
 //   null `alloc_fn`), or null.
 // - `len` must be the length reported by the corresponding serialize call.
 // - The buffer must not have been previously freed.

--- a/bindings/go/internal/ffi/serialization.go
+++ b/bindings/go/internal/ffi/serialization.go
@@ -8,14 +8,14 @@ package ffi
 import "C"
 import "unsafe"
 
-// EngineSerialize serializes engine state to a byte slice.
+// EngineSerializeAs serializes engine state to a byte slice in the given format.
 // Uses the Rust-allocated path (null alloc_fn), copies to Go memory,
 // then frees the Rust buffer.
-func EngineSerialize(h EngineHandle) ([]byte, ErrorCode) {
+func EngineSerializeAs(h EngineHandle, format SerializationFormat) ([]byte, ErrorCode) {
 	var data *C.uint8_t
 	var length C.uintptr_t
 
-	rc := ErrorCode(C.ferric_engine_serialize(h, nil, nil, &data, &length)) //nolint:gocritic // dupSubExpr false positive in cgo-generated code
+	rc := ErrorCode(C.ferric_engine_serialize_as(h, format, nil, nil, &data, &length)) //nolint:gocritic // dupSubExpr false positive in cgo-generated code
 	if rc != ErrOK {
 		return nil, rc
 	}
@@ -34,17 +34,19 @@ func EngineSerialize(h EngineHandle) ([]byte, ErrorCode) {
 	return goBytes, ErrOK
 }
 
-// EngineDeserialize creates an engine from previously serialized bytes.
+// EngineDeserializeAs creates an engine from previously serialized bytes
+// in the given format.
 // The returned handle is ready for use; its thread affinity is set to the calling thread.
-func EngineDeserialize(data []byte) (EngineHandle, ErrorCode) {
+func EngineDeserializeAs(data []byte, format SerializationFormat) (EngineHandle, ErrorCode) {
 	if len(data) == 0 {
 		return nil, ErrInvalidArgument
 	}
 
 	var engine EngineHandle
-	rc := ErrorCode(C.ferric_engine_deserialize(
+	rc := ErrorCode(C.ferric_engine_deserialize_as(
 		(*C.uint8_t)(unsafe.Pointer(&data[0])),
 		C.uintptr_t(len(data)),
+		format,
 		&engine, //nolint:gocritic // dupSubExpr false positive in cgo-generated code
 	))
 	return engine, rc

--- a/bindings/go/internal/ffi/serialization.go
+++ b/bindings/go/internal/ffi/serialization.go
@@ -15,7 +15,7 @@ func EngineSerializeAs(h EngineHandle, format SerializationFormat) ([]byte, Erro
 	var data *C.uint8_t
 	var length C.uintptr_t
 
-	rc := ErrorCode(C.ferric_engine_serialize_as(h, format, nil, nil, &data, &length)) //nolint:gocritic // dupSubExpr false positive in cgo-generated code
+	rc := ErrorCode(C.ferric_engine_serialize_as(h, C.uint32_t(format), nil, nil, &data, &length)) //nolint:gocritic // dupSubExpr false positive in cgo-generated code
 	if rc != ErrOK {
 		return nil, rc
 	}
@@ -46,7 +46,7 @@ func EngineDeserializeAs(data []byte, format SerializationFormat) (EngineHandle,
 	rc := ErrorCode(C.ferric_engine_deserialize_as(
 		(*C.uint8_t)(unsafe.Pointer(&data[0])),
 		C.uintptr_t(len(data)),
-		format,
+		C.uint32_t(format),
 		&engine, //nolint:gocritic // dupSubExpr false positive in cgo-generated code
 	))
 	return engine, rc

--- a/bindings/go/internal/ffi/types.go
+++ b/bindings/go/internal/ffi/types.go
@@ -1,6 +1,7 @@
 package ffi
 
 /*
+#define FERRIC_SERDE
 #include "lib/ferric.h"
 */
 import "C"
@@ -79,6 +80,18 @@ const (
 	ConflictStrategyBreadth ConflictStrategy = C.FERRIC_CONFLICT_STRATEGY_BREADTH
 	ConflictStrategyLEX     ConflictStrategy = C.FERRIC_CONFLICT_STRATEGY_LEX
 	ConflictStrategyMEA     ConflictStrategy = C.FERRIC_CONFLICT_STRATEGY_MEA
+)
+
+// SerializationFormat mirrors the C FerricSerializationFormat enum.
+type SerializationFormat = C.enum_FerricSerializationFormat
+
+// SerializationFormat values mirror C.FERRIC_SERIALIZATION_FORMAT_*.
+const (
+	FormatBincode    SerializationFormat = C.FERRIC_SERIALIZATION_FORMAT_BINCODE
+	FormatJSON       SerializationFormat = C.FERRIC_SERIALIZATION_FORMAT_JSON
+	FormatCBOR       SerializationFormat = C.FERRIC_SERIALIZATION_FORMAT_CBOR
+	FormatMessagePack SerializationFormat = C.FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK
+	FormatPostcard   SerializationFormat = C.FERRIC_SERIALIZATION_FORMAT_POSTCARD
 )
 
 // Config mirrors the C FerricConfig struct.

--- a/bindings/go/result.go
+++ b/bindings/go/result.go
@@ -26,6 +26,22 @@ const (
 	EncodingASCIISymbolsUTF8Strings
 )
 
+// Format selects the serialization format for Engine.SerializeAs / WithSnapshotAs.
+type Format int
+
+const (
+	// FormatBincode uses compact binary encoding (default, fast and small).
+	FormatBincode Format = iota
+	// FormatJSON uses human-readable JSON encoding.
+	FormatJSON
+	// FormatCBOR uses CBOR (Concise Binary Object Representation).
+	FormatCBOR
+	// FormatMessagePack uses MessagePack encoding.
+	FormatMessagePack
+	// FormatPostcard uses Postcard encoding (compact, no_std-friendly).
+	FormatPostcard
+)
+
 // HaltReason describes why engine execution stopped.
 type HaltReason int
 

--- a/bindings/go/serialization_test.go
+++ b/bindings/go/serialization_test.go
@@ -3,6 +3,8 @@ package ferric
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"slices"
 	"testing"
 )
@@ -238,5 +240,80 @@ func TestCrossFormatRejection(t *testing.T) {
 	_, err = NewEngine(WithSnapshot(snap, FormatJSON))
 	if err == nil {
 		t.Fatal("expected error when deserializing bincode as JSON")
+	}
+}
+
+func TestSerializeToFileRoundtrip(t *testing.T) {
+	for _, tc := range allFormats() {
+		t.Run(tc.name, func(t *testing.T) {
+			src := `
+				(deftemplate sensor (slot id (type INTEGER)) (slot value (type FLOAT)))
+				(defrule alert
+					(sensor (id ?id) (value ?v&:(> ?v 100.0)))
+					=>
+					(printout t "ALERT " ?id crlf))
+				(defglobal ?*threshold* = 42)
+			`
+			e, err := NewEngine(WithSource(src))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer mustClose(t, e)
+
+			path := filepath.Join(t.TempDir(), "snapshot.bin")
+			if err := e.SerializeToFile(path, tc.format); err != nil {
+				t.Fatalf("SerializeToFile failed: %v", err)
+			}
+
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("snapshot file not found: %v", err)
+			}
+			if info.Size() == 0 {
+				t.Fatal("snapshot file is empty")
+			}
+
+			e2, err := NewEngineFromFile(path, tc.format)
+			if err != nil {
+				t.Fatalf("NewEngineFromFile failed: %v", err)
+			}
+			defer mustClose(t, e2)
+
+			rules := e2.Rules()
+			if len(rules) != 1 {
+				t.Fatalf("expected 1 rule, got %d", len(rules))
+			}
+			if rules[0].Name != "alert" {
+				t.Fatalf("expected rule 'alert', got %q", rules[0].Name)
+			}
+
+			val, err := e2.GetGlobal("threshold")
+			if err != nil {
+				t.Fatalf("GetGlobal failed: %v", err)
+			}
+			if val != int64(42) {
+				t.Fatalf("expected 42, got %v", val)
+			}
+		})
+	}
+}
+
+func TestNewEngineFromFileNonexistent(t *testing.T) {
+	_, err := NewEngineFromFile("/nonexistent/path/snap.bin", FormatBincode)
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestSerializeToFileUnwritable(t *testing.T) {
+	e, err := NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, e)
+
+	err = e.SerializeToFile("/nonexistent/dir/snap.bin", FormatBincode)
+	if err == nil {
+		t.Fatal("expected error for unwritable path")
 	}
 }

--- a/bindings/go/serialization_test.go
+++ b/bindings/go/serialization_test.go
@@ -8,119 +8,135 @@ import (
 )
 
 // ---------------------------------------------------------------------------
-// Engine.Serialize / WithSnapshot roundtrip
+// Engine.Serialize / WithSnapshot roundtrip — all formats
 // ---------------------------------------------------------------------------
 
+func allFormats() []struct {
+	name   string
+	format Format
+} {
+	return []struct {
+		name   string
+		format Format
+	}{
+		{"Bincode", FormatBincode},
+		{"JSON", FormatJSON},
+		{"CBOR", FormatCBOR},
+		{"MessagePack", FormatMessagePack},
+		{"Postcard", FormatPostcard},
+	}
+}
+
 func TestSerializeRoundtrip(t *testing.T) {
-	// Create an engine with rules + template + globals and serialize it.
-	src := `
-		(deftemplate sensor (slot id (type INTEGER)) (slot value (type FLOAT)))
-		(defrule alert
-			(sensor (id ?id) (value ?v&:(> ?v 100.0)))
-			=>
-			(printout t "ALERT: sensor " ?id " value " ?v crlf))
-		(defglobal ?*threshold* = 42)
-	`
-	e, err := NewEngine(WithSource(src))
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, tc := range allFormats() {
+		t.Run(tc.name, func(t *testing.T) {
+			src := `
+				(deftemplate sensor (slot id (type INTEGER)) (slot value (type FLOAT)))
+				(defrule alert
+					(sensor (id ?id) (value ?v&:(> ?v 100.0)))
+					=>
+					(printout t "ALERT: sensor " ?id " value " ?v crlf))
+				(defglobal ?*threshold* = 42)
+			`
+			e, err := NewEngine(WithSource(src))
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	snap, err := e.Serialize()
-	if err != nil {
-		t.Fatalf("Serialize failed: %v", err)
-	}
-	mustClose(t, e)
+			snap, err := e.Serialize(tc.format)
+			if err != nil {
+				t.Fatalf("Serialize failed: %v", err)
+			}
+			mustClose(t, e)
 
-	if len(snap) == 0 {
-		t.Fatal("expected non-empty snapshot")
-	}
+			if len(snap) == 0 {
+				t.Fatal("expected non-empty snapshot")
+			}
 
-	// Create a new engine from the snapshot.
-	e2, err := NewEngine(WithSnapshot(snap))
-	if err != nil {
-		t.Fatalf("NewEngine(WithSnapshot) failed: %v", err)
-	}
-	defer mustClose(t, e2)
+			e2, err := NewEngine(WithSnapshot(snap, tc.format))
+			if err != nil {
+				t.Fatalf("NewEngine(WithSnapshot) failed: %v", err)
+			}
+			defer mustClose(t, e2)
 
-	// Verify rules survived.
-	rules := e2.Rules()
-	if len(rules) != 1 {
-		t.Fatalf("expected 1 rule, got %d", len(rules))
-	}
-	if rules[0].Name != "alert" {
-		t.Fatalf("expected rule 'alert', got %q", rules[0].Name)
-	}
+			rules := e2.Rules()
+			if len(rules) != 1 {
+				t.Fatalf("expected 1 rule, got %d", len(rules))
+			}
+			if rules[0].Name != "alert" {
+				t.Fatalf("expected rule 'alert', got %q", rules[0].Name)
+			}
 
-	// Verify templates survived.
-	tmpls := e2.Templates()
-	if !slices.Contains(tmpls, "sensor") {
-		t.Fatalf("expected 'sensor' template, got: %v", tmpls)
-	}
+			tmpls := e2.Templates()
+			if !slices.Contains(tmpls, "sensor") {
+				t.Fatalf("expected 'sensor' template, got: %v", tmpls)
+			}
 
-	// Verify globals survived.
-	val, err := e2.GetGlobal("threshold")
-	if err != nil {
-		t.Fatalf("GetGlobal failed: %v", err)
-	}
-	if val != int64(42) {
-		t.Fatalf("expected 42, got %v", val)
+			val, err := e2.GetGlobal("threshold")
+			if err != nil {
+				t.Fatalf("GetGlobal failed: %v", err)
+			}
+			if val != int64(42) {
+				t.Fatalf("expected 42, got %v", val)
+			}
+		})
 	}
 }
 
 func TestSnapshotEngineCanRun(t *testing.T) {
-	// Create, serialize, restore, then run the engine and verify output.
-	src := `
-		(deftemplate sensor (slot id (type INTEGER)) (slot value (type FLOAT)))
-		(defrule alert
-			(sensor (id ?id) (value ?v&:(> ?v 100.0)))
-			=>
-			(printout t "ALERT " ?id crlf))
-	`
-	e, err := NewEngine(WithSource(src))
-	if err != nil {
-		t.Fatal(err)
-	}
-	snap, err := e.Serialize()
-	if err != nil {
-		t.Fatal(err)
-	}
-	mustClose(t, e)
+	for _, tc := range allFormats() {
+		t.Run(tc.name, func(t *testing.T) {
+			src := `
+				(deftemplate sensor (slot id (type INTEGER)) (slot value (type FLOAT)))
+				(defrule alert
+					(sensor (id ?id) (value ?v&:(> ?v 100.0)))
+					=>
+					(printout t "ALERT " ?id crlf))
+			`
+			e, err := NewEngine(WithSource(src))
+			if err != nil {
+				t.Fatal(err)
+			}
+			snap, err := e.Serialize(tc.format)
+			if err != nil {
+				t.Fatal(err)
+			}
+			mustClose(t, e)
 
-	// Restore and exercise.
-	e2, err := NewEngine(WithSnapshot(snap))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer mustClose(t, e2)
+			e2, err := NewEngine(WithSnapshot(snap, tc.format))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer mustClose(t, e2)
 
-	_, err = e2.AssertTemplate("sensor", map[string]any{
-		"id":    int64(7),
-		"value": 200.0,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+			_, err = e2.AssertTemplate("sensor", map[string]any{
+				"id":    int64(7),
+				"value": 200.0,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	result, err := e2.Run(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if result.RulesFired != 1 {
-		t.Fatalf("expected 1 rule fired, got %d", result.RulesFired)
-	}
+			result, err := e2.Run(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.RulesFired != 1 {
+				t.Fatalf("expected 1 rule fired, got %d", result.RulesFired)
+			}
 
-	output, ok := e2.GetOutput("t")
-	if !ok {
-		t.Fatal("expected output")
-	}
-	if output != "ALERT 7\n" {
-		t.Fatalf("unexpected output: %q", output)
+			output, ok := e2.GetOutput("t")
+			if !ok {
+				t.Fatal("expected output")
+			}
+			if output != "ALERT 7\n" {
+				t.Fatalf("unexpected output: %q", output)
+			}
+		})
 	}
 }
 
 func TestSnapshotMultipleInstances(t *testing.T) {
-	// A single snapshot can produce multiple independent engines.
 	src := `
 		(defrule count => (assert (counted)))
 	`
@@ -128,32 +144,29 @@ func TestSnapshotMultipleInstances(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	snap, err := e.Serialize()
+	snap, err := e.Serialize(FormatBincode)
 	if err != nil {
 		t.Fatal(err)
 	}
 	mustClose(t, e)
 
-	// Create two engines from the same snapshot.
-	e1, err := NewEngine(WithSnapshot(snap))
+	e1, err := NewEngine(WithSnapshot(snap, FormatBincode))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer mustClose(t, e1)
 
-	e2, err := NewEngine(WithSnapshot(snap))
+	e2, err := NewEngine(WithSnapshot(snap, FormatBincode))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer mustClose(t, e2)
 
-	// Run e1 only.
 	result1 := mustRun(context.Background(), t, e1)
 	if result1.RulesFired != 1 {
 		t.Fatalf("e1: expected 1 fired, got %d", result1.RulesFired)
 	}
 
-	// e2 should still have a clean agenda (not affected by e1).
 	result2 := mustRun(context.Background(), t, e2)
 	if result2.RulesFired != 1 {
 		t.Fatalf("e2: expected 1 fired, got %d", result2.RulesFired)
@@ -161,44 +174,69 @@ func TestSnapshotMultipleInstances(t *testing.T) {
 }
 
 func TestDeserializeInvalidData(t *testing.T) {
-	_, err := NewEngine(WithSnapshot([]byte("not valid snapshot data")))
-	if err == nil {
-		t.Fatal("expected error for invalid snapshot")
-	}
-	if !errors.Is(err, ErrSerialization) {
-		t.Fatalf("expected SerializationError, got: %T %v", err, err)
+	for _, tc := range allFormats() {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewEngine(WithSnapshot([]byte("not valid snapshot data"), tc.format))
+			if err == nil {
+				t.Fatal("expected error for invalid snapshot")
+			}
+			if !errors.Is(err, ErrSerialization) {
+				t.Fatalf("expected SerializationError, got: %T %v", err, err)
+			}
+		})
 	}
 }
 
 func TestSerializeEmptyEngine(t *testing.T) {
+	for _, tc := range allFormats() {
+		t.Run(tc.name, func(t *testing.T) {
+			e, err := NewEngine()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer mustClose(t, e)
+
+			snap, err := e.Serialize(tc.format)
+			if err != nil {
+				t.Fatalf("Serialize failed: %v", err)
+			}
+			if len(snap) == 0 {
+				t.Fatal("expected non-empty snapshot even for empty engine")
+			}
+
+			e2, err := NewEngine(WithSnapshot(snap, tc.format))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer mustClose(t, e2)
+
+			err = e2.Load(`(defrule r => (assert (done)))`)
+			if err != nil {
+				t.Fatalf("Load into restored engine failed: %v", err)
+			}
+			result := mustRun(context.Background(), t, e2)
+			if result.RulesFired != 1 {
+				t.Fatalf("expected 1, got %d", result.RulesFired)
+			}
+		})
+	}
+}
+
+func TestCrossFormatRejection(t *testing.T) {
+	// Serialize as bincode, try to deserialize as JSON — should fail.
 	e, err := NewEngine()
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer mustClose(t, e)
 
-	snap, err := e.Serialize()
-	if err != nil {
-		t.Fatalf("Serialize failed: %v", err)
-	}
-	if len(snap) == 0 {
-		t.Fatal("expected non-empty snapshot even for empty engine")
-	}
-
-	// Roundtrip: create from snapshot and verify it's functional.
-	e2, err := NewEngine(WithSnapshot(snap))
+	snap, err := e.Serialize(FormatBincode)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer mustClose(t, e2)
 
-	// Should be able to load source into the restored engine.
-	err = e2.Load(`(defrule r => (assert (done)))`)
-	if err != nil {
-		t.Fatalf("Load into restored engine failed: %v", err)
-	}
-	result := mustRun(context.Background(), t, e2)
-	if result.RulesFired != 1 {
-		t.Fatalf("expected 1, got %d", result.RulesFired)
+	_, err = NewEngine(WithSnapshot(snap, FormatJSON))
+	if err == nil {
+		t.Fatal("expected error when deserializing bincode as JSON")
 	}
 }

--- a/crates/ferric-cli/Cargo.toml
+++ b/crates/ferric-cli/Cargo.toml
@@ -25,6 +25,7 @@ tracing-chrome = { workspace = true, optional = true }
 [features]
 tracing = ["trace-chrome"]
 trace-chrome = ["dep:tracing", "dep:tracing-chrome", "dep:tracing-subscriber", "ferric-runtime/tracing"]
+serde = ["ferric-runtime/serde"]
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/ferric-cli/src/commands/mod.rs
+++ b/crates/ferric-cli/src/commands/mod.rs
@@ -4,4 +4,6 @@ pub mod check;
 pub(crate) mod common;
 pub mod repl;
 pub mod run;
+#[cfg(feature = "serde")]
+pub mod snapshot;
 pub mod version;

--- a/crates/ferric-cli/src/commands/repl/mod.rs
+++ b/crates/ferric-cli/src/commands/repl/mod.rs
@@ -42,7 +42,30 @@ use self::session::ReplSession;
 const PROMPT: &str = "CLIPS> ";
 
 /// Execute the `repl` subcommand.
-pub fn execute(load_files: &[PathBuf]) -> i32 {
+///
+/// `snapshot` is an optional `(path, format)` pair. When provided, the engine
+/// is restored from the snapshot file instead of starting fresh.
+pub fn execute(
+    load_files: &[PathBuf],
+    #[cfg(feature = "serde")] snapshot: Option<(
+        PathBuf,
+        ferric_runtime::serialization::SerializationFormat,
+    )>,
+    #[cfg(not(feature = "serde"))] _snapshot: Option<std::convert::Infallible>,
+) -> i32 {
+    #[cfg(feature = "serde")]
+    let mut session = if let Some((path, format)) = snapshot {
+        match ReplSession::from_snapshot(&path, format) {
+            Ok(s) => s,
+            Err(err) => {
+                eprintln!("ferric repl: error loading snapshot: {err}");
+                return 1;
+            }
+        }
+    } else {
+        ReplSession::new()
+    };
+    #[cfg(not(feature = "serde"))]
     let mut session = ReplSession::new();
 
     println!("Ferric REPL v{}", env!("CARGO_PKG_VERSION"));

--- a/crates/ferric-cli/src/commands/repl/session.rs
+++ b/crates/ferric-cli/src/commands/repl/session.rs
@@ -32,6 +32,24 @@ impl ReplSession {
         }
     }
 
+    /// Create a session by restoring an engine from a serialized snapshot file.
+    #[cfg(feature = "serde")]
+    pub fn from_snapshot(
+        path: &std::path::Path,
+        format: ferric_runtime::serialization::SerializationFormat,
+    ) -> Result<Self, String> {
+        let data =
+            std::fs::read(path).map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+        let engine = Engine::deserialize(&data, format)
+            .map_err(|e| format!("deserialization failed: {e}"))?;
+        Ok(Self {
+            engine,
+            watch_facts: false,
+            watch_rules: false,
+            loaded_files: Vec::new(),
+        })
+    }
+
     /// Load files at startup. Errors are printed but do not abort the session.
     pub fn preload_files(&mut self, files: &[PathBuf]) {
         for path in files {

--- a/crates/ferric-cli/src/commands/snapshot.rs
+++ b/crates/ferric-cli/src/commands/snapshot.rs
@@ -1,0 +1,104 @@
+//! `ferric snapshot` — serialize an engine state to a file.
+//!
+//! Pipeline: load file → reset → serialize → write output
+//!
+//! Exit codes:
+//! - 0: Success
+//! - 1: Load/serialize/IO error
+
+use std::io::Write;
+use std::path::Path;
+
+use ferric_runtime::serialization::SerializationFormat;
+use ferric_runtime::{Engine, EngineConfig};
+
+use super::common::{emit_error, emit_warning};
+
+/// Execute the `snapshot` subcommand.
+///
+/// Loads the given CLIPS file, resets the engine, serializes it using the
+/// specified format, and writes the result to the output path (or stdout
+/// if `output` is `"-"`).
+pub fn execute(json_mode: bool, file: &Path, output: &Path, format: SerializationFormat) -> i32 {
+    if !file.exists() {
+        emit_error(
+            json_mode,
+            "snapshot",
+            "io_error",
+            format_args!("file not found: {}", file.display()),
+        );
+        return 1;
+    }
+
+    let mut engine = Engine::new(EngineConfig::default());
+
+    if let Err(errors) = engine.load_file(file) {
+        for err in &errors {
+            emit_error(json_mode, "snapshot", "load_error", err);
+        }
+        return 1;
+    }
+
+    if let Err(err) = engine.reset() {
+        emit_error(
+            json_mode,
+            "snapshot",
+            "runtime_error",
+            format_args!("reset failed: {err}"),
+        );
+        return 1;
+    }
+
+    // Emit any load warnings.
+    // (load_file only returns warnings via the Ok branch; we check action_diagnostics
+    // here since reset can also produce diagnostics in some configurations.)
+    for diag in engine.action_diagnostics() {
+        emit_warning(json_mode, "snapshot", "action_warning", diag);
+    }
+
+    let bytes = match engine.serialize(format) {
+        Ok(b) => b,
+        Err(err) => {
+            emit_error(
+                json_mode,
+                "snapshot",
+                "serialize_error",
+                format_args!("serialization failed: {err}"),
+            );
+            return 1;
+        }
+    };
+
+    let output_str = output.to_string_lossy();
+    if output_str == "-" {
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        if let Err(err) = handle.write_all(&bytes) {
+            emit_error(
+                json_mode,
+                "snapshot",
+                "io_error",
+                format_args!("error writing to stdout: {err}"),
+            );
+            return 1;
+        }
+    } else {
+        if let Err(err) = std::fs::write(output, &bytes) {
+            emit_error(
+                json_mode,
+                "snapshot",
+                "io_error",
+                format_args!("error writing to {}: {err}", output.display()),
+            );
+            return 1;
+        }
+        eprintln!(
+            "Wrote {} bytes ({}) to {}",
+            bytes.len(),
+            format.name(),
+            output.display()
+        );
+    }
+
+    0
+}

--- a/crates/ferric-cli/src/main.rs
+++ b/crates/ferric-cli/src/main.rs
@@ -26,6 +26,30 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
 
+/// CLI-facing serialization format selector.
+#[cfg(feature = "serde")]
+#[derive(Clone, Copy, clap::ValueEnum)]
+enum CliFormat {
+    Bincode,
+    Json,
+    Cbor,
+    Msgpack,
+    Postcard,
+}
+
+#[cfg(feature = "serde")]
+impl From<CliFormat> for ferric_runtime::serialization::SerializationFormat {
+    fn from(f: CliFormat) -> Self {
+        match f {
+            CliFormat::Bincode => Self::Bincode,
+            CliFormat::Json => Self::Json,
+            CliFormat::Cbor => Self::Cbor,
+            CliFormat::Msgpack => Self::MessagePack,
+            CliFormat::Postcard => Self::Postcard,
+        }
+    }
+}
+
 /// Command-line interface for the Ferric rules engine.
 #[derive(Parser)]
 #[command(
@@ -71,6 +95,35 @@ enum Command {
         /// Files to load before entering interactive mode.
         #[arg(long)]
         load: Vec<PathBuf>,
+
+        /// Restore engine from a serialized snapshot file instead of starting fresh.
+        #[cfg(feature = "serde")]
+        #[arg(long, value_name = "PATH")]
+        snapshot: Option<PathBuf>,
+
+        /// Format of the snapshot file (default: bincode).
+        #[cfg(feature = "serde")]
+        #[arg(long, value_enum, default_value = "bincode")]
+        snapshot_format: CliFormat,
+    },
+
+    /// Serialize engine state from a CLIPS file to a binary snapshot.
+    #[cfg(feature = "serde")]
+    Snapshot {
+        /// Emit diagnostics as JSON objects on stderr.
+        #[arg(long)]
+        json: bool,
+
+        /// Path to the CLIPS file to load.
+        file: PathBuf,
+
+        /// Output file path (use "-" for stdout).
+        #[arg(short, long)]
+        output: PathBuf,
+
+        /// Serialization format.
+        #[arg(long, value_enum, default_value = "bincode")]
+        format: CliFormat,
     },
 
     /// Print version information.
@@ -98,7 +151,31 @@ fn main() {
     let exit_code = match cli.command {
         Command::Run { json, file } => commands::run::execute(json, &file),
         Command::Check { json, file } => commands::check::execute(json, &file),
-        Command::Repl { load } => commands::repl::execute(&load),
+        Command::Repl {
+            load,
+            #[cfg(feature = "serde")]
+            snapshot,
+            #[cfg(feature = "serde")]
+            snapshot_format,
+        } => {
+            #[cfg(feature = "serde")]
+            let snap = snapshot.map(|p| {
+                (
+                    p,
+                    ferric_runtime::serialization::SerializationFormat::from(snapshot_format),
+                )
+            });
+            #[cfg(not(feature = "serde"))]
+            let snap = None::<std::convert::Infallible>;
+            commands::repl::execute(&load, snap)
+        }
+        #[cfg(feature = "serde")]
+        Command::Snapshot {
+            json,
+            file,
+            output,
+            format,
+        } => commands::snapshot::execute(json, &file, &output, format.into()),
         Command::Version => commands::version::execute(),
     };
 

--- a/crates/ferric-core/src/agenda.rs
+++ b/crates/ferric-core/src/agenda.rs
@@ -115,6 +115,7 @@ pub struct AgendaKey {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Agenda {
     /// Ordered activations: key -> `ActivationId`.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_helpers::btree_map"))]
     ordering: BTreeMap<AgendaKey, ActivationId>,
     /// All activations: `ActivationId` -> `Activation`.
     activations: SlotMap<ActivationId, Activation>,

--- a/crates/ferric-core/src/serde_helpers.rs
+++ b/crates/ferric-core/src/serde_helpers.rs
@@ -202,6 +202,39 @@ pub mod fx_hash_map_of_fx_hash_map_of_fx_hash_set {
     }
 }
 
+/// Serialize/deserialize `BTreeMap<K, V>` as `Vec<(K, V)>`.
+///
+/// `BTreeMap` has native serde support, but its default serialization uses
+/// the key as a JSON object key — which only works when `K` serializes to a
+/// string. This helper sidesteps that limitation by converting to a list of
+/// pairs, allowing arbitrary key types with all formats including JSON.
+pub mod btree_map {
+    use serde::de::Deserializer;
+    use serde::ser::Serializer;
+    use serde::{Deserialize, Serialize};
+    use std::collections::BTreeMap;
+
+    pub fn serialize<K, V, S>(map: &BTreeMap<K, V>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        K: Serialize,
+        V: Serialize,
+        S: Serializer,
+    {
+        let entries: Vec<(&K, &V)> = map.iter().collect();
+        entries.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, K, V, D>(deserializer: D) -> Result<BTreeMap<K, V>, D::Error>
+    where
+        K: Deserialize<'de> + Ord,
+        V: Deserialize<'de>,
+        D: Deserializer<'de>,
+    {
+        let entries: Vec<(K, V)> = Vec::deserialize(deserializer)?;
+        Ok(entries.into_iter().collect())
+    }
+}
+
 /// Serialize/deserialize `std::collections::HashSet<T>` as `Vec<T>`.
 ///
 /// std `HashSet` has native serde support, but this helper is provided

--- a/crates/ferric-ffi/cbindgen.toml
+++ b/crates/ferric-ffi/cbindgen.toml
@@ -26,6 +26,7 @@ include = [
     "FerricHaltReason",
     "FerricValueType",
     "FerricValue",
+    "FerricSerializationFormat",
 ]
 
 [struct]

--- a/crates/ferric-ffi/ferric.h
+++ b/crates/ferric-ffi/ferric.h
@@ -156,6 +156,21 @@ typedef enum FerricHaltReason {
     FERRIC_HALT_REASON_HALT_REQUESTED = 2,
 } FerricHaltReason;
 
+// C-facing string-encoding configuration for `FerricConfig`.
+typedef enum FerricStringEncoding {
+    FERRIC_STRING_ENCODING_ASCII = 0,
+    FERRIC_STRING_ENCODING_UTF8 = 1,
+    FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS = 2,
+} FerricStringEncoding;
+
+// C-facing conflict-resolution strategy for `FerricConfig`.
+typedef enum FerricConflictStrategy {
+    FERRIC_CONFLICT_STRATEGY_DEPTH = 0,
+    FERRIC_CONFLICT_STRATEGY_BREADTH = 1,
+    FERRIC_CONFLICT_STRATEGY_LEX = 2,
+    FERRIC_CONFLICT_STRATEGY_MEA = 3,
+} FerricConflictStrategy;
+
 #if defined(FERRIC_SERDE)
 // Serialization format selector for `ferric_engine_serialize_as` and
 // `ferric_engine_deserialize_as`.
@@ -172,21 +187,6 @@ typedef enum FerricSerializationFormat {
     FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4,
 } FerricSerializationFormat;
 #endif
-
-// C-facing string-encoding configuration for `FerricConfig`.
-typedef enum FerricStringEncoding {
-    FERRIC_STRING_ENCODING_ASCII = 0,
-    FERRIC_STRING_ENCODING_UTF8 = 1,
-    FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS = 2,
-} FerricStringEncoding;
-
-// C-facing conflict-resolution strategy for `FerricConfig`.
-typedef enum FerricConflictStrategy {
-    FERRIC_CONFLICT_STRATEGY_DEPTH = 0,
-    FERRIC_CONFLICT_STRATEGY_BREADTH = 1,
-    FERRIC_CONFLICT_STRATEGY_LEX = 2,
-    FERRIC_CONFLICT_STRATEGY_MEA = 3,
-} FerricConflictStrategy;
 
 // Opaque engine handle exposed to C.
 //
@@ -891,6 +891,10 @@ enum FerricError ferric_engine_free_unchecked(struct FerricEngine *engine);
 #if defined(FERRIC_SERDE)
 // Serialize engine state to bytes in the specified format.
 //
+// `format` is a `u32` corresponding to `FerricSerializationFormat` discriminants
+// (0 = Bincode, 1 = JSON, 2 = CBOR, 3 = `MessagePack`, 4 = Postcard).
+// Returns `FERRIC_ERROR_INVALID_ARGUMENT` for out-of-range values.
+//
 // See `ferric_engine_serialize_bincode` for memory allocation details.
 //
 // # Safety
@@ -900,7 +904,7 @@ enum FerricError ferric_engine_free_unchecked(struct FerricEngine *engine);
 // - If `alloc_fn` is non-null, it must return a valid pointer to `size` bytes
 //   (or null to signal failure).
 enum FerricError ferric_engine_serialize_as(const struct FerricEngine *engine,
-                                            enum FerricSerializationFormat format,
+                                            uint32_t format,
                                             FerricAllocFn alloc_fn,
                                             void *alloc_context,
                                             uint8_t **out_data,
@@ -909,6 +913,10 @@ enum FerricError ferric_engine_serialize_as(const struct FerricEngine *engine,
 
 #if defined(FERRIC_SERDE)
 // Deserialize an engine from bytes in the specified format.
+//
+// `format` is a `u32` corresponding to `FerricSerializationFormat` discriminants
+// (0 = Bincode, 1 = JSON, 2 = CBOR, 3 = `MessagePack`, 4 = Postcard).
+// Returns `FERRIC_ERROR_INVALID_ARGUMENT` for out-of-range values.
 //
 // See `ferric_engine_deserialize_bincode` for details.
 //
@@ -919,7 +927,7 @@ enum FerricError ferric_engine_serialize_as(const struct FerricEngine *engine,
 // - The returned engine must be freed with `ferric_engine_free`.
 enum FerricError ferric_engine_deserialize_as(const uint8_t *data,
                                               uintptr_t len,
-                                              enum FerricSerializationFormat format,
+                                              uint32_t format,
                                               struct FerricEngine **out_engine);
 #endif
 

--- a/crates/ferric-ffi/ferric.h
+++ b/crates/ferric-ffi/ferric.h
@@ -156,6 +156,23 @@ typedef enum FerricHaltReason {
     FERRIC_HALT_REASON_HALT_REQUESTED = 2,
 } FerricHaltReason;
 
+#if defined(FERRIC_SERDE)
+// Serialization format selector for `ferric_engine_serialize_as` and
+// `ferric_engine_deserialize_as`.
+typedef enum FerricSerializationFormat {
+    // Compact binary (bincode). Fast and small.
+    FERRIC_SERIALIZATION_FORMAT_BINCODE = 0,
+    // JSON (human-readable, larger output).
+    FERRIC_SERIALIZATION_FORMAT_JSON = 1,
+    // CBOR (Concise Binary Object Representation).
+    FERRIC_SERIALIZATION_FORMAT_CBOR = 2,
+    // `MessagePack` (compact binary, JSON-like schema).
+    FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK = 3,
+    // Postcard (compact, `no_std`-friendly binary).
+    FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4,
+} FerricSerializationFormat;
+#endif
+
 // C-facing string-encoding configuration for `FerricConfig`.
 typedef enum FerricStringEncoding {
     FERRIC_STRING_ENCODING_ASCII = 0,
@@ -222,7 +239,7 @@ typedef struct FerricValue {
 #if defined(FERRIC_SERDE)
 // Callback type for caller-controlled memory allocation.
 //
-// When non-null, called by `ferric_engine_serialize` with the exact byte
+// When non-null, called by serialization functions with the exact byte
 // count needed. The `context` parameter is passed through unchanged from
 // the serialize call.
 //
@@ -872,10 +889,42 @@ enum FerricError ferric_engine_get_fact_slot_by_name(const struct FerricEngine *
 enum FerricError ferric_engine_free_unchecked(struct FerricEngine *engine);
 
 #if defined(FERRIC_SERDE)
-// Serialize engine state to bytes.
+// Serialize engine state to bytes in the specified format.
 //
-// Produces a binary snapshot that can be passed to `ferric_engine_deserialize`
-// to reconstruct an equivalent engine, skipping the parse/compile pipeline.
+// See `ferric_engine_serialize_bincode` for memory allocation details.
+//
+// # Safety
+//
+// - `engine` must be a valid engine pointer.
+// - `out_data` and `out_len` must be valid, non-null pointers.
+// - If `alloc_fn` is non-null, it must return a valid pointer to `size` bytes
+//   (or null to signal failure).
+enum FerricError ferric_engine_serialize_as(const struct FerricEngine *engine,
+                                            enum FerricSerializationFormat format,
+                                            FerricAllocFn alloc_fn,
+                                            void *alloc_context,
+                                            uint8_t **out_data,
+                                            uintptr_t *out_len);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Deserialize an engine from bytes in the specified format.
+//
+// See `ferric_engine_deserialize_bincode` for details.
+//
+// # Safety
+//
+// - `data` must point to `len` valid, readable bytes.
+// - `out_engine` must be a valid, non-null pointer.
+// - The returned engine must be freed with `ferric_engine_free`.
+enum FerricError ferric_engine_deserialize_as(const uint8_t *data,
+                                              uintptr_t len,
+                                              enum FerricSerializationFormat format,
+                                              struct FerricEngine **out_engine);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Serialize engine state to bincode.
 //
 // ## Memory allocation
 //
@@ -895,16 +944,15 @@ enum FerricError ferric_engine_free_unchecked(struct FerricEngine *engine);
 // - `out_data` and `out_len` must be valid, non-null pointers.
 // - If `alloc_fn` is non-null, it must return a valid pointer to `size` bytes
 //   (or null to signal failure).
-enum FerricError ferric_engine_serialize(const struct FerricEngine *engine,
-                                         FerricAllocFn alloc_fn,
-                                         void *alloc_context,
-                                         uint8_t **out_data,
-                                         uintptr_t *out_len);
+enum FerricError ferric_engine_serialize_bincode(const struct FerricEngine *engine,
+                                                 FerricAllocFn alloc_fn,
+                                                 void *alloc_context,
+                                                 uint8_t **out_data,
+                                                 uintptr_t *out_len);
 #endif
 
 #if defined(FERRIC_SERDE)
-// Deserialize an engine from bytes previously produced by
-// `ferric_engine_serialize`.
+// Deserialize an engine from bincode bytes.
 //
 // The returned engine handle is ready for use (e.g. `ferric_engine_run`).
 // Its thread affinity is set to the calling thread.
@@ -914,20 +962,124 @@ enum FerricError ferric_engine_serialize(const struct FerricEngine *engine,
 // - `data` must point to `len` valid, readable bytes.
 // - `out_engine` must be a valid, non-null pointer.
 // - The returned engine must be freed with `ferric_engine_free`.
-enum FerricError ferric_engine_deserialize(const uint8_t *data,
-                                           uintptr_t len,
-                                           struct FerricEngine **out_engine);
+enum FerricError ferric_engine_deserialize_bincode(const uint8_t *data,
+                                                   uintptr_t len,
+                                                   struct FerricEngine **out_engine);
 #endif
 
 #if defined(FERRIC_SERDE)
-// Free a byte buffer that was allocated by `ferric_engine_serialize` when
+// Serialize engine state to JSON.
+//
+// See `ferric_engine_serialize_bincode` for memory allocation details.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_serialize_bincode`.
+enum FerricError ferric_engine_serialize_json(const struct FerricEngine *engine,
+                                              FerricAllocFn alloc_fn,
+                                              void *alloc_context,
+                                              uint8_t **out_data,
+                                              uintptr_t *out_len);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Deserialize an engine from JSON bytes.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_deserialize_bincode`.
+enum FerricError ferric_engine_deserialize_json(const uint8_t *data,
+                                                uintptr_t len,
+                                                struct FerricEngine **out_engine);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Serialize engine state to CBOR.
+//
+// See `ferric_engine_serialize_bincode` for memory allocation details.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_serialize_bincode`.
+enum FerricError ferric_engine_serialize_cbor(const struct FerricEngine *engine,
+                                              FerricAllocFn alloc_fn,
+                                              void *alloc_context,
+                                              uint8_t **out_data,
+                                              uintptr_t *out_len);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Deserialize an engine from CBOR bytes.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_deserialize_bincode`.
+enum FerricError ferric_engine_deserialize_cbor(const uint8_t *data,
+                                                uintptr_t len,
+                                                struct FerricEngine **out_engine);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Serialize engine state to `MessagePack`.
+//
+// See `ferric_engine_serialize_bincode` for memory allocation details.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_serialize_bincode`.
+enum FerricError ferric_engine_serialize_msgpack(const struct FerricEngine *engine,
+                                                 FerricAllocFn alloc_fn,
+                                                 void *alloc_context,
+                                                 uint8_t **out_data,
+                                                 uintptr_t *out_len);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Deserialize an engine from `MessagePack` bytes.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_deserialize_bincode`.
+enum FerricError ferric_engine_deserialize_msgpack(const uint8_t *data,
+                                                   uintptr_t len,
+                                                   struct FerricEngine **out_engine);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Serialize engine state to Postcard.
+//
+// See `ferric_engine_serialize_bincode` for memory allocation details.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_serialize_bincode`.
+enum FerricError ferric_engine_serialize_postcard(const struct FerricEngine *engine,
+                                                  FerricAllocFn alloc_fn,
+                                                  void *alloc_context,
+                                                  uint8_t **out_data,
+                                                  uintptr_t *out_len);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Deserialize an engine from Postcard bytes.
+//
+// # Safety
+//
+// Same safety requirements as `ferric_engine_deserialize_bincode`.
+enum FerricError ferric_engine_deserialize_postcard(const uint8_t *data,
+                                                    uintptr_t len,
+                                                    struct FerricEngine **out_engine);
+#endif
+
+#if defined(FERRIC_SERDE)
+// Free a byte buffer that was allocated by a serialize function when
 // `alloc_fn` was null.
 //
 // Null pointers and zero lengths are safely ignored.
 //
 // # Safety
 //
-// - `data` must be a pointer returned by `ferric_engine_serialize` (with
+// - `data` must be a pointer returned by a serialize function (with
 //   null `alloc_fn`), or null.
 // - `len` must be the length reported by the corresponding serialize call.
 // - The buffer must not have been previously freed.

--- a/crates/ferric-ffi/src/engine.rs
+++ b/crates/ferric-ffi/src/engine.rs
@@ -2054,6 +2054,19 @@ pub enum FerricSerializationFormat {
 
 #[cfg(feature = "serde")]
 impl FerricSerializationFormat {
+    /// Try to convert a raw C integer to a valid format variant.
+    /// Returns `None` for out-of-range discriminants.
+    fn from_raw(raw: u32) -> Option<Self> {
+        match raw {
+            0 => Some(Self::Bincode),
+            1 => Some(Self::Json),
+            2 => Some(Self::Cbor),
+            3 => Some(Self::MessagePack),
+            4 => Some(Self::Postcard),
+            _ => None,
+        }
+    }
+
     fn to_runtime(self) -> ferric_runtime::SerializationFormat {
         match self {
             Self::Bincode => ferric_runtime::SerializationFormat::Bincode,
@@ -2171,6 +2184,10 @@ unsafe fn deserialize_engine_impl(
 
 /// Serialize engine state to bytes in the specified format.
 ///
+/// `format` is a `u32` corresponding to `FerricSerializationFormat` discriminants
+/// (0 = Bincode, 1 = JSON, 2 = CBOR, 3 = `MessagePack`, 4 = Postcard).
+/// Returns `FERRIC_ERROR_INVALID_ARGUMENT` for out-of-range values.
+///
 /// See `ferric_engine_serialize_bincode` for memory allocation details.
 ///
 /// # Safety
@@ -2183,15 +2200,19 @@ unsafe fn deserialize_engine_impl(
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_serialize_as(
     engine: *const FerricEngine,
-    format: FerricSerializationFormat,
+    format: u32,
     alloc_fn: FerricAllocFn,
     alloc_context: *mut std::ffi::c_void,
     out_data: *mut *mut u8,
     out_len: *mut usize,
 ) -> FerricError {
+    let Some(fmt) = FerricSerializationFormat::from_raw(format) else {
+        set_global_error(format!("invalid serialization format: {format}"));
+        return FerricError::InvalidArgument;
+    };
     serialize_engine_impl(
         engine,
-        format.to_runtime(),
+        fmt.to_runtime(),
         alloc_fn,
         alloc_context,
         out_data,
@@ -2200,6 +2221,10 @@ pub unsafe extern "C" fn ferric_engine_serialize_as(
 }
 
 /// Deserialize an engine from bytes in the specified format.
+///
+/// `format` is a `u32` corresponding to `FerricSerializationFormat` discriminants
+/// (0 = Bincode, 1 = JSON, 2 = CBOR, 3 = `MessagePack`, 4 = Postcard).
+/// Returns `FERRIC_ERROR_INVALID_ARGUMENT` for out-of-range values.
 ///
 /// See `ferric_engine_deserialize_bincode` for details.
 ///
@@ -2213,10 +2238,14 @@ pub unsafe extern "C" fn ferric_engine_serialize_as(
 pub unsafe extern "C" fn ferric_engine_deserialize_as(
     data: *const u8,
     len: usize,
-    format: FerricSerializationFormat,
+    format: u32,
     out_engine: *mut *mut FerricEngine,
 ) -> FerricError {
-    deserialize_engine_impl(data, len, format.to_runtime(), out_engine)
+    let Some(fmt) = FerricSerializationFormat::from_raw(format) else {
+        set_global_error(format!("invalid serialization format: {format}"));
+        return FerricError::InvalidArgument;
+    };
+    deserialize_engine_impl(data, len, fmt.to_runtime(), out_engine)
 }
 
 // ── Per-format convenience functions ─────────────────────────────────────

--- a/crates/ferric-ffi/src/engine.rs
+++ b/crates/ferric-ffi/src/engine.rs
@@ -2034,9 +2034,40 @@ pub unsafe extern "C" fn ferric_engine_free_unchecked(engine: *mut FerricEngine)
 // Engine serialization / deserialization
 // ---------------------------------------------------------------------------
 
+/// Serialization format selector for `ferric_engine_serialize_as` and
+/// `ferric_engine_deserialize_as`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg(feature = "serde")]
+pub enum FerricSerializationFormat {
+    /// Compact binary (bincode). Fast and small.
+    Bincode = 0,
+    /// JSON (human-readable, larger output).
+    Json = 1,
+    /// CBOR (Concise Binary Object Representation).
+    Cbor = 2,
+    /// `MessagePack` (compact binary, JSON-like schema).
+    MessagePack = 3,
+    /// Postcard (compact, `no_std`-friendly binary).
+    Postcard = 4,
+}
+
+#[cfg(feature = "serde")]
+impl FerricSerializationFormat {
+    fn to_runtime(self) -> ferric_runtime::SerializationFormat {
+        match self {
+            Self::Bincode => ferric_runtime::SerializationFormat::Bincode,
+            Self::Json => ferric_runtime::SerializationFormat::Json,
+            Self::Cbor => ferric_runtime::SerializationFormat::Cbor,
+            Self::MessagePack => ferric_runtime::SerializationFormat::MessagePack,
+            Self::Postcard => ferric_runtime::SerializationFormat::Postcard,
+        }
+    }
+}
+
 /// Callback type for caller-controlled memory allocation.
 ///
-/// When non-null, called by `ferric_engine_serialize` with the exact byte
+/// When non-null, called by serialization functions with the exact byte
 /// count needed. The `context` parameter is passed through unchanged from
 /// the serialize call.
 ///
@@ -2046,33 +2077,12 @@ pub unsafe extern "C" fn ferric_engine_free_unchecked(engine: *mut FerricEngine)
 pub type FerricAllocFn =
     Option<unsafe extern "C" fn(size: usize, context: *mut std::ffi::c_void) -> *mut u8>;
 
-/// Serialize engine state to bytes.
-///
-/// Produces a binary snapshot that can be passed to `ferric_engine_deserialize`
-/// to reconstruct an equivalent engine, skipping the parse/compile pipeline.
-///
-/// ## Memory allocation
-///
-/// - If `alloc_fn` is **non-null**: the callback is called once with the exact
-///   byte count needed. The serialized data is written into the returned
-///   buffer. The caller owns this memory and is responsible for freeing it
-///   (via their own allocator). `alloc_context` is passed through unchanged.
-///
-/// - If `alloc_fn` is **null**: Rust allocates the output buffer internally.
-///   The caller must free it with `ferric_bytes_free(out_data, out_len)`.
-///
-/// In both cases, `*out_data` and `*out_len` are set on success.
-///
-/// # Safety
-///
-/// - `engine` must be a valid engine pointer.
-/// - `out_data` and `out_len` must be valid, non-null pointers.
-/// - If `alloc_fn` is non-null, it must return a valid pointer to `size` bytes
-///   (or null to signal failure).
-#[no_mangle]
+/// Internal helper: serialize an engine in the given format, writing output
+/// through either a caller-provided allocator or Rust allocation.
 #[cfg(feature = "serde")]
-pub unsafe extern "C" fn ferric_engine_serialize(
+unsafe fn serialize_engine_impl(
     engine: *const FerricEngine,
+    format: ferric_runtime::SerializationFormat,
     alloc_fn: FerricAllocFn,
     alloc_context: *mut std::ffi::c_void,
     out_data: *mut *mut u8,
@@ -2091,7 +2101,7 @@ pub unsafe extern "C" fn ferric_engine_serialize(
     };
 
     // Serialize to internal Vec<u8>
-    let bytes = match handle.engine.serialize_to_bytes() {
+    let bytes = match handle.engine.serialize(format) {
         Ok(b) => b,
         Err(e) => {
             set_global_error(e.to_string());
@@ -2120,22 +2130,12 @@ pub unsafe extern "C" fn ferric_engine_serialize(
     FerricError::Ok
 }
 
-/// Deserialize an engine from bytes previously produced by
-/// `ferric_engine_serialize`.
-///
-/// The returned engine handle is ready for use (e.g. `ferric_engine_run`).
-/// Its thread affinity is set to the calling thread.
-///
-/// # Safety
-///
-/// - `data` must point to `len` valid, readable bytes.
-/// - `out_engine` must be a valid, non-null pointer.
-/// - The returned engine must be freed with `ferric_engine_free`.
-#[no_mangle]
+/// Internal helper: deserialize an engine from bytes in the given format.
 #[cfg(feature = "serde")]
-pub unsafe extern "C" fn ferric_engine_deserialize(
+unsafe fn deserialize_engine_impl(
     data: *const u8,
     len: usize,
+    format: ferric_runtime::SerializationFormat,
     out_engine: *mut *mut FerricEngine,
 ) -> FerricError {
     if data.is_null() {
@@ -2149,7 +2149,7 @@ pub unsafe extern "C" fn ferric_engine_deserialize(
 
     let slice = std::slice::from_raw_parts(data, len);
 
-    let engine = match ferric_runtime::Engine::deserialize_from_bytes(slice) {
+    let engine = match ferric_runtime::Engine::deserialize(slice, format) {
         Ok(e) => e,
         Err(e) => {
             set_global_error(e.to_string());
@@ -2167,14 +2167,316 @@ pub unsafe extern "C" fn ferric_engine_deserialize(
     FerricError::Ok
 }
 
-/// Free a byte buffer that was allocated by `ferric_engine_serialize` when
+// ── Omnibus format-parameterized API ─────────────────────────────────────
+
+/// Serialize engine state to bytes in the specified format.
+///
+/// See `ferric_engine_serialize_bincode` for memory allocation details.
+///
+/// # Safety
+///
+/// - `engine` must be a valid engine pointer.
+/// - `out_data` and `out_len` must be valid, non-null pointers.
+/// - If `alloc_fn` is non-null, it must return a valid pointer to `size` bytes
+///   (or null to signal failure).
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_serialize_as(
+    engine: *const FerricEngine,
+    format: FerricSerializationFormat,
+    alloc_fn: FerricAllocFn,
+    alloc_context: *mut std::ffi::c_void,
+    out_data: *mut *mut u8,
+    out_len: *mut usize,
+) -> FerricError {
+    serialize_engine_impl(
+        engine,
+        format.to_runtime(),
+        alloc_fn,
+        alloc_context,
+        out_data,
+        out_len,
+    )
+}
+
+/// Deserialize an engine from bytes in the specified format.
+///
+/// See `ferric_engine_deserialize_bincode` for details.
+///
+/// # Safety
+///
+/// - `data` must point to `len` valid, readable bytes.
+/// - `out_engine` must be a valid, non-null pointer.
+/// - The returned engine must be freed with `ferric_engine_free`.
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_deserialize_as(
+    data: *const u8,
+    len: usize,
+    format: FerricSerializationFormat,
+    out_engine: *mut *mut FerricEngine,
+) -> FerricError {
+    deserialize_engine_impl(data, len, format.to_runtime(), out_engine)
+}
+
+// ── Per-format convenience functions ─────────────────────────────────────
+
+/// Serialize engine state to bincode.
+///
+/// ## Memory allocation
+///
+/// - If `alloc_fn` is **non-null**: the callback is called once with the exact
+///   byte count needed. The serialized data is written into the returned
+///   buffer. The caller owns this memory and is responsible for freeing it
+///   (via their own allocator). `alloc_context` is passed through unchanged.
+///
+/// - If `alloc_fn` is **null**: Rust allocates the output buffer internally.
+///   The caller must free it with `ferric_bytes_free(out_data, out_len)`.
+///
+/// In both cases, `*out_data` and `*out_len` are set on success.
+///
+/// # Safety
+///
+/// - `engine` must be a valid engine pointer.
+/// - `out_data` and `out_len` must be valid, non-null pointers.
+/// - If `alloc_fn` is non-null, it must return a valid pointer to `size` bytes
+///   (or null to signal failure).
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_serialize_bincode(
+    engine: *const FerricEngine,
+    alloc_fn: FerricAllocFn,
+    alloc_context: *mut std::ffi::c_void,
+    out_data: *mut *mut u8,
+    out_len: *mut usize,
+) -> FerricError {
+    serialize_engine_impl(
+        engine,
+        ferric_runtime::SerializationFormat::Bincode,
+        alloc_fn,
+        alloc_context,
+        out_data,
+        out_len,
+    )
+}
+
+/// Deserialize an engine from bincode bytes.
+///
+/// The returned engine handle is ready for use (e.g. `ferric_engine_run`).
+/// Its thread affinity is set to the calling thread.
+///
+/// # Safety
+///
+/// - `data` must point to `len` valid, readable bytes.
+/// - `out_engine` must be a valid, non-null pointer.
+/// - The returned engine must be freed with `ferric_engine_free`.
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_deserialize_bincode(
+    data: *const u8,
+    len: usize,
+    out_engine: *mut *mut FerricEngine,
+) -> FerricError {
+    deserialize_engine_impl(
+        data,
+        len,
+        ferric_runtime::SerializationFormat::Bincode,
+        out_engine,
+    )
+}
+
+/// Serialize engine state to JSON.
+///
+/// See `ferric_engine_serialize_bincode` for memory allocation details.
+///
+/// # Safety
+///
+/// Same safety requirements as `ferric_engine_serialize_bincode`.
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_serialize_json(
+    engine: *const FerricEngine,
+    alloc_fn: FerricAllocFn,
+    alloc_context: *mut std::ffi::c_void,
+    out_data: *mut *mut u8,
+    out_len: *mut usize,
+) -> FerricError {
+    serialize_engine_impl(
+        engine,
+        ferric_runtime::SerializationFormat::Json,
+        alloc_fn,
+        alloc_context,
+        out_data,
+        out_len,
+    )
+}
+
+/// Deserialize an engine from JSON bytes.
+///
+/// # Safety
+///
+/// Same safety requirements as `ferric_engine_deserialize_bincode`.
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_deserialize_json(
+    data: *const u8,
+    len: usize,
+    out_engine: *mut *mut FerricEngine,
+) -> FerricError {
+    deserialize_engine_impl(
+        data,
+        len,
+        ferric_runtime::SerializationFormat::Json,
+        out_engine,
+    )
+}
+
+/// Serialize engine state to CBOR.
+///
+/// See `ferric_engine_serialize_bincode` for memory allocation details.
+///
+/// # Safety
+///
+/// Same safety requirements as `ferric_engine_serialize_bincode`.
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_serialize_cbor(
+    engine: *const FerricEngine,
+    alloc_fn: FerricAllocFn,
+    alloc_context: *mut std::ffi::c_void,
+    out_data: *mut *mut u8,
+    out_len: *mut usize,
+) -> FerricError {
+    serialize_engine_impl(
+        engine,
+        ferric_runtime::SerializationFormat::Cbor,
+        alloc_fn,
+        alloc_context,
+        out_data,
+        out_len,
+    )
+}
+
+/// Deserialize an engine from CBOR bytes.
+///
+/// # Safety
+///
+/// Same safety requirements as `ferric_engine_deserialize_bincode`.
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_deserialize_cbor(
+    data: *const u8,
+    len: usize,
+    out_engine: *mut *mut FerricEngine,
+) -> FerricError {
+    deserialize_engine_impl(
+        data,
+        len,
+        ferric_runtime::SerializationFormat::Cbor,
+        out_engine,
+    )
+}
+
+/// Serialize engine state to `MessagePack`.
+///
+/// See `ferric_engine_serialize_bincode` for memory allocation details.
+///
+/// # Safety
+///
+/// Same safety requirements as `ferric_engine_serialize_bincode`.
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_serialize_msgpack(
+    engine: *const FerricEngine,
+    alloc_fn: FerricAllocFn,
+    alloc_context: *mut std::ffi::c_void,
+    out_data: *mut *mut u8,
+    out_len: *mut usize,
+) -> FerricError {
+    serialize_engine_impl(
+        engine,
+        ferric_runtime::SerializationFormat::MessagePack,
+        alloc_fn,
+        alloc_context,
+        out_data,
+        out_len,
+    )
+}
+
+/// Deserialize an engine from `MessagePack` bytes.
+///
+/// # Safety
+///
+/// Same safety requirements as `ferric_engine_deserialize_bincode`.
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_deserialize_msgpack(
+    data: *const u8,
+    len: usize,
+    out_engine: *mut *mut FerricEngine,
+) -> FerricError {
+    deserialize_engine_impl(
+        data,
+        len,
+        ferric_runtime::SerializationFormat::MessagePack,
+        out_engine,
+    )
+}
+
+/// Serialize engine state to Postcard.
+///
+/// See `ferric_engine_serialize_bincode` for memory allocation details.
+///
+/// # Safety
+///
+/// Same safety requirements as `ferric_engine_serialize_bincode`.
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_serialize_postcard(
+    engine: *const FerricEngine,
+    alloc_fn: FerricAllocFn,
+    alloc_context: *mut std::ffi::c_void,
+    out_data: *mut *mut u8,
+    out_len: *mut usize,
+) -> FerricError {
+    serialize_engine_impl(
+        engine,
+        ferric_runtime::SerializationFormat::Postcard,
+        alloc_fn,
+        alloc_context,
+        out_data,
+        out_len,
+    )
+}
+
+/// Deserialize an engine from Postcard bytes.
+///
+/// # Safety
+///
+/// Same safety requirements as `ferric_engine_deserialize_bincode`.
+#[no_mangle]
+#[cfg(feature = "serde")]
+pub unsafe extern "C" fn ferric_engine_deserialize_postcard(
+    data: *const u8,
+    len: usize,
+    out_engine: *mut *mut FerricEngine,
+) -> FerricError {
+    deserialize_engine_impl(
+        data,
+        len,
+        ferric_runtime::SerializationFormat::Postcard,
+        out_engine,
+    )
+}
+
+/// Free a byte buffer that was allocated by a serialize function when
 /// `alloc_fn` was null.
 ///
 /// Null pointers and zero lengths are safely ignored.
 ///
 /// # Safety
 ///
-/// - `data` must be a pointer returned by `ferric_engine_serialize` (with
+/// - `data` must be a pointer returned by a serialize function (with
 ///   null `alloc_fn`), or null.
 /// - `len` must be the length reported by the corresponding serialize call.
 /// - The buffer must not have been previously freed.

--- a/crates/ferric-python/Cargo.toml
+++ b/crates/ferric-python/Cargo.toml
@@ -17,6 +17,8 @@ slotmap = { workspace = true }
 tracing = { workspace = true, optional = true }
 
 [features]
+default = ["serde"]
+serde = ["ferric-runtime/serde"]
 tracing = ["dep:tracing", "ferric-runtime/tracing"]
 
 [build-dependencies]

--- a/crates/ferric-python/src/config.rs
+++ b/crates/ferric-python/src/config.rs
@@ -55,3 +55,38 @@ impl From<Encoding> for ferric_core::StringEncoding {
         }
     }
 }
+
+/// Serialization format for engine snapshots.
+#[cfg(feature = "serde")]
+#[pyclass(eq, eq_int)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Format {
+    /// Compact binary (bincode). Fast and small.
+    #[pyo3(name = "BINCODE")]
+    Bincode = 0,
+    /// JSON (human-readable, larger output).
+    #[pyo3(name = "JSON")]
+    Json = 1,
+    /// CBOR (Concise Binary Object Representation).
+    #[pyo3(name = "CBOR")]
+    Cbor = 2,
+    /// `MessagePack` (compact binary, JSON-like schema).
+    #[pyo3(name = "MSGPACK")]
+    MessagePack = 3,
+    /// Postcard (compact, no_std-friendly binary).
+    #[pyo3(name = "POSTCARD")]
+    Postcard = 4,
+}
+
+#[cfg(feature = "serde")]
+impl From<Format> for ferric_runtime::SerializationFormat {
+    fn from(f: Format) -> Self {
+        match f {
+            Format::Bincode => Self::Bincode,
+            Format::Json => Self::Json,
+            Format::Cbor => Self::Cbor,
+            Format::MessagePack => Self::MessagePack,
+            Format::Postcard => Self::Postcard,
+        }
+    }
+}

--- a/crates/ferric-python/src/engine.rs
+++ b/crates/ferric-python/src/engine.rs
@@ -1,6 +1,6 @@
 //! Python Engine wrapper.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -410,6 +410,43 @@ impl PyEngine {
     fn from_snapshot(data: &[u8], format: Option<crate::config::Format>) -> PyResult<Self> {
         let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
         let engine = Engine::deserialize(data, fmt)
+            .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
+        Ok(Self { engine })
+    }
+
+    /// Save a serialized engine snapshot to a file.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` — File path (str or os.PathLike).
+    /// * `format` — Serialization format (default: `Format.BINCODE`).
+    #[cfg(feature = "serde")]
+    #[pyo3(signature = (path, *, format=None))]
+    fn save_snapshot(&self, path: PathBuf, format: Option<crate::config::Format>) -> PyResult<()> {
+        let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
+        let bytes = self
+            .engine
+            .serialize(fmt)
+            .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
+        std::fs::write(&path, &bytes)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Create an engine by deserializing a snapshot from a file.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` — File path (str or os.PathLike).
+    /// * `format` — Serialization format (default: `Format.BINCODE`).
+    #[staticmethod]
+    #[cfg(feature = "serde")]
+    #[pyo3(signature = (path, *, format=None))]
+    fn from_snapshot_file(path: PathBuf, format: Option<crate::config::Format>) -> PyResult<Self> {
+        let data = std::fs::read(&path)
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+        let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
+        let engine = Engine::deserialize(&data, fmt)
             .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
         Ok(Self { engine })
     }

--- a/crates/ferric-python/src/engine.rs
+++ b/crates/ferric-python/src/engine.rs
@@ -372,6 +372,48 @@ impl PyEngine {
         self.engine.push_input(line);
     }
 
+    // -- Serialization --
+
+    /// Serialize the engine state to bytes in the given format.
+    ///
+    /// # Arguments
+    ///
+    /// * `format` — Serialization format (default: `Format.BINCODE`).
+    ///
+    /// Returns `bytes` containing the serialized engine state.
+    #[cfg(feature = "serde")]
+    #[pyo3(signature = (format=None))]
+    fn serialize<'py>(
+        &self,
+        py: Python<'py>,
+        format: Option<crate::config::Format>,
+    ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
+        let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
+        let bytes = self
+            .engine
+            .serialize(fmt)
+            .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
+        Ok(pyo3::types::PyBytes::new(py, &bytes))
+    }
+
+    /// Create an engine by deserializing a snapshot.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` — Serialized engine state (bytes).
+    /// * `format` — Serialization format (default: `Format.BINCODE`).
+    /// * `strategy` — Conflict resolution strategy override (unused for snapshots).
+    /// * `encoding` — String encoding mode override (unused for snapshots).
+    #[staticmethod]
+    #[cfg(feature = "serde")]
+    #[pyo3(signature = (data, *, format=None))]
+    fn from_snapshot(data: &[u8], format: Option<crate::config::Format>) -> PyResult<Self> {
+        let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
+        let engine = Engine::deserialize(data, fmt)
+            .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
+        Ok(Self { engine })
+    }
+
     // -- Python protocols --
 
     fn __repr__(&self) -> PyResult<String> {

--- a/crates/ferric-python/src/lib.rs
+++ b/crates/ferric-python/src/lib.rs
@@ -22,6 +22,8 @@ fn ferric(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Config enums
     m.add_class::<config::Strategy>()?;
     m.add_class::<config::Encoding>()?;
+    #[cfg(feature = "serde")]
+    m.add_class::<config::Format>()?;
 
     // Result types
     m.add_class::<result::RunResult>()?;

--- a/crates/ferric-python/tests/test_serialization.py
+++ b/crates/ferric-python/tests/test_serialization.py
@@ -1,0 +1,97 @@
+"""Tests for engine serialization and deserialization."""
+
+import pytest
+import ferric
+
+
+ALL_FORMATS = [
+    ferric.Format.BINCODE,
+    ferric.Format.JSON,
+    ferric.Format.CBOR,
+    ferric.Format.MSGPACK,
+    ferric.Format.POSTCARD,
+]
+
+SOURCE = """
+(deftemplate sensor (slot id (type INTEGER)) (slot value (type FLOAT)))
+(defrule alert
+    (sensor (id ?id) (value ?v&:(> ?v 100.0)))
+    =>
+    (printout t "ALERT " ?id crlf))
+(defglobal ?*threshold* = 42)
+"""
+
+
+class TestSerializeRoundtrip:
+    @pytest.mark.parametrize("fmt", ALL_FORMATS)
+    def test_roundtrip_preserves_state(self, fmt):
+        engine = ferric.Engine.from_source(SOURCE)
+        data = engine.serialize(format=fmt)
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+        restored = ferric.Engine.from_snapshot(data, format=fmt)
+        assert len(restored.rules()) == 1
+        assert restored.get_global("threshold") == 42
+
+    @pytest.mark.parametrize("fmt", ALL_FORMATS)
+    def test_deserialized_engine_can_run(self, fmt):
+        engine = ferric.Engine.from_source(SOURCE)
+        data = engine.serialize(format=fmt)
+        restored = ferric.Engine.from_snapshot(data, format=fmt)
+
+        restored.assert_string('(sensor (id 7) (value 200.0))')
+        result = restored.run()
+        assert result.rules_fired == 1
+        output = restored.get_output("t")
+        assert output == "ALERT 7\n"
+
+    @pytest.mark.parametrize("fmt", ALL_FORMATS)
+    def test_empty_engine_roundtrip(self, fmt):
+        engine = ferric.Engine()
+        data = engine.serialize(format=fmt)
+        restored = ferric.Engine.from_snapshot(data, format=fmt)
+        assert restored.fact_count == 0
+
+    def test_default_format_is_bincode(self):
+        engine = ferric.Engine.from_source(SOURCE)
+        data = engine.serialize()  # no format arg
+        restored = ferric.Engine.from_snapshot(data)  # no format arg
+        assert len(restored.rules()) == 1
+
+
+class TestSerializeErrors:
+    @pytest.mark.parametrize("fmt", ALL_FORMATS)
+    def test_invalid_data_rejected(self, fmt):
+        with pytest.raises(ferric.FerricError):
+            ferric.Engine.from_snapshot(b"not valid data", format=fmt)
+
+    def test_cross_format_rejected(self):
+        engine = ferric.Engine()
+        data = engine.serialize(format=ferric.Format.BINCODE)
+        with pytest.raises(ferric.FerricError):
+            ferric.Engine.from_snapshot(data, format=ferric.Format.JSON)
+
+
+class TestFileConvenience:
+    @pytest.mark.parametrize("fmt", ALL_FORMATS)
+    def test_save_and_load_roundtrip(self, fmt, tmp_path):
+        engine = ferric.Engine.from_source(SOURCE)
+        path = tmp_path / f"snapshot.{fmt}"
+        engine.save_snapshot(str(path), format=fmt)
+
+        assert path.exists()
+        assert path.stat().st_size > 0
+
+        restored = ferric.Engine.from_snapshot_file(str(path), format=fmt)
+        assert len(restored.rules()) == 1
+        assert restored.get_global("threshold") == 42
+
+    def test_from_snapshot_file_nonexistent(self):
+        with pytest.raises(OSError):
+            ferric.Engine.from_snapshot_file("/nonexistent/path.bin")
+
+    def test_save_snapshot_bad_path(self):
+        engine = ferric.Engine()
+        with pytest.raises(OSError):
+            engine.save_snapshot("/nonexistent/dir/snap.bin")

--- a/crates/ferric-runtime/Cargo.toml
+++ b/crates/ferric-runtime/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [features]
-serde = ["dep:serde", "dep:bincode", "ferric-core/serde", "ferric-parser/serde"]
+serde = ["dep:serde", "dep:bincode", "dep:serde_json", "dep:ciborium", "dep:rmp-serde", "dep:postcard", "ferric-core/serde", "ferric-parser/serde"]
 tracing = ["dep:tracing", "ferric-core/tracing"]
 
 [dependencies]
@@ -20,12 +20,20 @@ slotmap = { workspace = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, optional = true }
 bincode = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+ciborium = { workspace = true, optional = true }
+rmp-serde = { workspace = true, optional = true }
+postcard = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
 tempfile = "3.8"
 criterion = { workspace = true }
+serde_json = { workspace = true }
+ciborium = { workspace = true }
+rmp-serde = { workspace = true }
+postcard = { workspace = true }
 
 [[bench]]
 name = "name_registry_bench"
@@ -38,6 +46,11 @@ harness = false
 [[bench]]
 name = "template_registry_bench"
 harness = false
+
+[[bench]]
+name = "serialization_bench"
+harness = false
+required-features = ["serde"]
 
 [lints]
 workspace = true

--- a/crates/ferric-runtime/benches/serialization_bench.rs
+++ b/crates/ferric-runtime/benches/serialization_bench.rs
@@ -1,0 +1,271 @@
+//! Comparative benchmarks for engine serialization formats.
+//!
+//! Measures serialize/deserialize timing and output size across all supported
+//! formats, using engines of varying complexity.
+//!
+//! Run with: `cargo bench -p ferric-runtime --features serde --bench serialization_bench`
+
+use std::fmt::Write;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use ferric_runtime::config::EngineConfig;
+use ferric_runtime::serialization::SerializationFormat;
+use ferric_runtime::Engine;
+
+/// Create a minimal engine (no rules, no facts — just default state).
+fn engine_empty() -> Engine {
+    Engine::new(EngineConfig::default())
+}
+
+/// Create a small engine with a few rules and facts.
+fn engine_small() -> Engine {
+    let mut e = Engine::new(EngineConfig::default());
+    e.load_str(
+        r#"
+        (deftemplate sensor (slot id (type INTEGER)) (slot value (type FLOAT)))
+        (defrule alert
+            (sensor (id ?id) (value ?v&:(> ?v 100.0)))
+            =>
+            (printout t "ALERT " ?id crlf))
+        (deffacts initial
+            (sensor (id 1) (value 50.0))
+            (sensor (id 2) (value 150.0))
+            (sensor (id 3) (value 75.0)))
+    "#,
+    )
+    .unwrap();
+    e.reset().unwrap();
+    e
+}
+
+/// Create a medium engine with multiple templates, rules, globals, and functions.
+fn engine_medium() -> Engine {
+    let mut e = Engine::new(EngineConfig::default());
+    e.load_str(
+        r#"
+        (deftemplate person (slot name) (slot age (type INTEGER)) (slot role))
+        (deftemplate task (slot id (type INTEGER)) (slot assignee) (slot priority (type INTEGER)) (slot status))
+        (deftemplate project (slot name) (slot budget (type FLOAT)) (slot active))
+
+        (defglobal ?*task-counter* = 0)
+        (defglobal ?*alert-threshold* = 100)
+
+        (deffunction next-task-id ()
+            (bind ?*task-counter* (+ ?*task-counter* 1))
+            ?*task-counter*)
+
+        (defrule assign-high-priority
+            (person (name ?n) (role "engineer"))
+            (task (id ?id) (priority ?p&:(> ?p 5)) (status "open") (assignee nil))
+            =>
+            (printout t "Assign task " ?id " to " ?n crlf))
+
+        (defrule escalate
+            (task (id ?id) (priority ?p&:(> ?p 8)) (status "open"))
+            =>
+            (printout t "Escalate task " ?id crlf))
+
+        (defrule budget-check
+            (project (name ?pn) (budget ?b&:(< ?b 1000.0)) (active TRUE))
+            =>
+            (printout t "Low budget: " ?pn crlf))
+
+        (defrule complete-task
+            (task (id ?id) (status "done"))
+            =>
+            (printout t "Task " ?id " completed" crlf))
+
+        (defrule onboard
+            (person (name ?n) (role "new"))
+            =>
+            (printout t "Onboarding " ?n crlf))
+
+        (deffacts people
+            (person (name "Alice") (age 30) (role "engineer"))
+            (person (name "Bob") (age 25) (role "engineer"))
+            (person (name "Charlie") (age 22) (role "new"))
+            (person (name "Diana") (age 35) (role "manager")))
+
+        (deffacts tasks
+            (task (id 1) (assignee nil) (priority 9) (status "open"))
+            (task (id 2) (assignee nil) (priority 3) (status "open"))
+            (task (id 3) (assignee nil) (priority 7) (status "open"))
+            (task (id 4) (assignee "Alice") (priority 5) (status "done"))
+            (task (id 5) (assignee nil) (priority 10) (status "open")))
+
+        (deffacts projects
+            (project (name "Alpha") (budget 5000.0) (active TRUE))
+            (project (name "Beta") (budget 500.0) (active TRUE))
+            (project (name "Gamma") (budget 50000.0) (active FALSE)))
+    "#,
+    )
+    .unwrap();
+    e.reset().unwrap();
+    e
+}
+
+/// Create a large engine with many rules, templates, and repetitive facts.
+fn engine_large() -> Engine {
+    let mut e = Engine::new(EngineConfig::default());
+
+    // Base schema
+    e.load_str(
+        r"
+        (deftemplate item (slot id (type INTEGER)) (slot category) (slot value (type FLOAT)) (slot status))
+        (deftemplate order (slot id (type INTEGER)) (slot item-id (type INTEGER)) (slot qty (type INTEGER)))
+        (deftemplate customer (slot id (type INTEGER)) (slot name) (slot tier))
+    ",
+    )
+    .unwrap();
+
+    // Generate 20 rules
+    for i in 0..20 {
+        let threshold = (i + 1) * 50;
+        e.load_str(&format!(
+            r#"(defrule rule-{i}
+                (item (id ?id) (value ?v&:(> ?v {threshold}.0)) (status "active"))
+                =>
+                (printout t "Rule {i} matched item " ?id crlf))"#,
+        ))
+        .unwrap();
+    }
+
+    // Generate 100 facts
+    let mut facts = String::new();
+    facts.push_str("(deffacts bulk\n");
+    for i in 0..100 {
+        let category = match i % 4 {
+            0 => "electronics",
+            1 => "clothing",
+            2 => "food",
+            _ => "tools",
+        };
+        let value = f64::from(i) * 12.5;
+        let status = if i % 3 == 0 { "active" } else { "archived" };
+        writeln!(
+            facts,
+            "    (item (id {i}) (category \"{category}\") (value {value}) (status \"{status}\"))"
+        )
+        .unwrap();
+    }
+    for i in 0..30 {
+        writeln!(
+            facts,
+            "    (order (id {i}) (item-id {}) (qty {}))",
+            i * 3,
+            (i % 10) + 1
+        )
+        .unwrap();
+    }
+    for i in 0..20 {
+        let tier = match i % 3 {
+            0 => "gold",
+            1 => "silver",
+            _ => "bronze",
+        };
+        writeln!(
+            facts,
+            "    (customer (id {i}) (name \"Customer{i}\") (tier \"{tier}\"))"
+        )
+        .unwrap();
+    }
+    facts.push(')');
+    e.load_str(&facts).unwrap();
+
+    e.reset().unwrap();
+    e
+}
+
+fn bench_serialize(c: &mut Criterion) {
+    let engines: Vec<(&str, Engine)> = vec![
+        ("empty", engine_empty()),
+        ("small", engine_small()),
+        ("medium", engine_medium()),
+        ("large", engine_large()),
+    ];
+
+    let mut group = c.benchmark_group("serialize");
+
+    for (engine_name, engine) in &engines {
+        for &format in SerializationFormat::ALL {
+            let id = BenchmarkId::new(format.name(), engine_name);
+            group.bench_with_input(id, &(engine, format), |b, (engine, format)| {
+                b.iter(|| engine.serialize(*format).unwrap());
+            });
+        }
+    }
+
+    group.finish();
+}
+
+fn bench_deserialize(c: &mut Criterion) {
+    let engines: Vec<(&str, Engine)> = vec![
+        ("empty", engine_empty()),
+        ("small", engine_small()),
+        ("medium", engine_medium()),
+        ("large", engine_large()),
+    ];
+
+    let mut group = c.benchmark_group("deserialize");
+
+    for (engine_name, engine) in &engines {
+        for &format in SerializationFormat::ALL {
+            let bytes = engine.serialize(format).unwrap();
+            let id = BenchmarkId::new(format.name(), engine_name);
+            group.bench_with_input(id, &(bytes, format), |b, (bytes, format)| {
+                b.iter(|| Engine::deserialize(bytes, *format).unwrap());
+            });
+        }
+    }
+
+    group.finish();
+}
+
+/// Print a summary table of serialized sizes for each engine × format combination.
+fn bench_size_report(c: &mut Criterion) {
+    let engines: Vec<(&str, Engine)> = vec![
+        ("empty", engine_empty()),
+        ("small", engine_small()),
+        ("medium", engine_medium()),
+        ("large", engine_large()),
+    ];
+
+    // Print size report as a side-effect of a trivial benchmark.
+    let mut group = c.benchmark_group("size_report");
+
+    println!("\n  Serialized Size Report (bytes)");
+    println!("  {:-<65}", "");
+    print!("  {:>9} ", "Engine");
+    for &format in SerializationFormat::ALL {
+        print!("| {:>10} ", format.name());
+    }
+    println!();
+    println!("  {:-<65}", "");
+
+    for (engine_name, engine) in &engines {
+        print!("  {engine_name:>9} ");
+        for &format in SerializationFormat::ALL {
+            let bytes = engine.serialize(format).unwrap();
+            print!("| {:>10} ", bytes.len());
+        }
+        println!();
+    }
+    println!("  {:-<65}", "");
+    println!();
+
+    // Trivial benchmark so criterion doesn't complain about empty groups.
+    let engine = engine_small();
+    group.bench_function("small_bincode", |b| {
+        b.iter(|| engine.serialize(SerializationFormat::Bincode).unwrap());
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_serialize,
+    bench_deserialize,
+    bench_size_report
+);
+criterion_main!(benches);

--- a/crates/ferric-runtime/src/lib.rs
+++ b/crates/ferric-runtime/src/lib.rs
@@ -94,7 +94,7 @@ pub use loader::{LoadError, LoadResult, RuleDef};
 pub use modules::{ModuleId, ModuleRegistry};
 pub use qualified_name::{parse_qualified_name, QualifiedName};
 #[cfg(feature = "serde")]
-pub use serialization::SerializationError;
+pub use serialization::{SerializationError, SerializationFormat};
 
 // Re-export Stage 2 AST types for working with loaded constructs
 pub use ferric_parser::{

--- a/crates/ferric-runtime/src/loader.rs
+++ b/crates/ferric-runtime/src/loader.rs
@@ -1216,7 +1216,18 @@ impl Engine {
             LoadError::InvalidAssert("fact relation must be a symbol".to_string())
         })?;
 
-        // Remaining elements are field values
+        // Check if this is a known template — if so, parse slot syntax.
+        let current_module = self.module_registry.current_module();
+        if let Ok(template_id) = self.resolve_template_reference(relation, current_module) {
+            return self.process_assert_template_fact(
+                template_id,
+                relation,
+                &fact_list[1..],
+                result,
+            );
+        }
+
+        // Ordered fact: remaining elements are field values.
         let mut fields = Vec::new();
         for field_expr in &fact_list[1..] {
             match self.atom_to_value(field_expr, result) {
@@ -1234,6 +1245,72 @@ impl Engine {
 
         self.assert_ordered(relation, fields)
             .map_err(LoadError::Engine)
+    }
+
+    /// Process a template fact within an assert form.
+    ///
+    /// Each remaining element should be a list of the form `(slot-name value)`.
+    fn process_assert_template_fact(
+        &mut self,
+        template_id: ferric_core::TemplateId,
+        template_name: &str,
+        slot_exprs: &[SExpr],
+        result: &mut LoadResult,
+    ) -> Result<FactId, LoadError> {
+        let registered = self
+            .template_defs
+            .get(template_id)
+            .cloned()
+            .ok_or_else(|| {
+                LoadError::Compile(format!("template `{template_name}` not found in registry"))
+            })?;
+
+        // Start with defaults.
+        let mut slots: Vec<Value> = registered.defaults.clone();
+
+        for slot_expr in slot_exprs {
+            let slot_list = slot_expr.as_list().ok_or_else(|| {
+                LoadError::InvalidAssert(format!(
+                    "expected slot list in template fact `{template_name}`"
+                ))
+            })?;
+            if slot_list.is_empty() {
+                continue;
+            }
+            let slot_name = slot_list[0].as_symbol().ok_or_else(|| {
+                LoadError::InvalidAssert(format!(
+                    "expected slot name symbol in template `{template_name}`"
+                ))
+            })?;
+            let slot_idx = registered.slot_index(slot_name).ok_or_else(|| {
+                LoadError::Compile(format!(
+                    "unknown slot `{slot_name}` in template `{template_name}`"
+                ))
+            })?;
+
+            if slot_list.len() > 1 {
+                if let Some(value) = self.atom_to_value(&slot_list[1], result) {
+                    slots[slot_idx] = value;
+                }
+            }
+            // If slot_list.len() == 1, the slot keeps its default (empty multislot).
+        }
+
+        // Assert as a proper template fact.
+        let fact_id = self
+            .fact_base
+            .assert_template(template_id, slots.into_boxed_slice());
+
+        // Propagate through rete.
+        let fact = self
+            .fact_base
+            .get(fact_id)
+            .expect("just-asserted fact must exist")
+            .fact
+            .clone();
+        self.rete.assert_fact(fact_id, &fact, &self.fact_base);
+
+        Ok(fact_id)
     }
 
     /// Convert an S-expression atom to a Value.

--- a/crates/ferric-runtime/src/serialization.rs
+++ b/crates/ferric-runtime/src/serialization.rs
@@ -530,4 +530,34 @@ mod tests {
     fn all_formats_list() {
         assert_eq!(SerializationFormat::ALL.len(), 5);
     }
+
+    /// Regression: asserting a template fact (via `load_str`) into a
+    /// deserialized engine must propagate through the Rete network.
+    #[test]
+    fn assert_template_after_deserialize_fires_rule() {
+        let source = r#"
+(deftemplate sensor (slot id (type INTEGER)) (slot value (type FLOAT)))
+(defrule alert
+    (sensor (id ?id) (value ?v&:(> ?v 100.0)))
+    =>
+    (printout t "ALERT " ?id crlf))
+"#;
+        for &format in SerializationFormat::ALL {
+            let mut engine = Engine::new(EngineConfig::utf8());
+            engine.load_str(source).unwrap();
+            engine.reset().unwrap();
+
+            let bytes = engine.serialize(format).unwrap();
+            let mut restored = Engine::deserialize(&bytes, format).unwrap();
+
+            restored
+                .load_str("(assert (sensor (id 7) (value 200.0)))")
+                .unwrap();
+            let result = restored.run(RunLimit::Unlimited).unwrap();
+            assert_eq!(
+                result.rules_fired, 1,
+                "format {format:?}: expected 1 rule to fire"
+            );
+        }
+    }
 }

--- a/crates/ferric-runtime/src/serialization.rs
+++ b/crates/ferric-runtime/src/serialization.rs
@@ -1,23 +1,25 @@
 //! Engine serialization and deserialization.
 //!
-//! Provides [`Engine::serialize_to_bytes`] and [`Engine::deserialize_from_bytes`]
-//! for converting a fully-loaded engine to/from a compact binary representation.
-//! This enables workflows where a canonical rule set is loaded and compiled once,
-//! serialized, and then deserialized many times to create fresh ready-to-run
-//! engines — skipping the parse/compile pipeline entirely.
+//! Provides [`Engine::serialize`] and [`Engine::deserialize`] for converting a
+//! fully-loaded engine to/from bytes in one of several formats. This enables
+//! workflows where a canonical rule set is loaded and compiled once, serialized,
+//! and then deserialized many times to create fresh ready-to-run engines —
+//! skipping the parse/compile pipeline entirely.
 //!
-//! ## Wire format
+//! ## Supported formats
 //!
-//! ```text
-//! [4 bytes] Magic number: b"FRSE"
-//! [4 bytes] Format version: u32 = 2  (little-endian)
-//! [rest]    bincode-encoded EngineSnapshot
-//! ```
+//! | Format      | Crate          | Notes                                 |
+//! |-------------|----------------|---------------------------------------|
+//! | Bincode     | `bincode`      | Compact binary, fast (default)        |
+//! | JSON        | `serde_json`   | Human-readable, larger output         |
+//! | CBOR        | `ciborium`     | Concise Binary Object Representation  |
+//! | `MessagePack` | `rmp-serde`    | Compact binary, JSON-like schema      |
+//! | Postcard    | `postcard`     | Compact, `no_std`-friendly binary     |
 //!
 //! ## Limitations
 //!
 //! - `ExternalAddress` values cannot be serialized. If any are present in the
-//!   fact base, [`Engine::serialize_to_bytes`] returns
+//!   fact base, [`Engine::serialize`] returns
 //!   [`SerializationError::ExternalAddressPresent`].
 
 use std::collections::VecDeque;
@@ -34,14 +36,43 @@ use crate::modules::{ModuleId, ModuleRegistry};
 use crate::router::OutputRouter;
 use crate::templates::RegisteredTemplate;
 
-/// Magic bytes at the start of the serialized format.
-const MAGIC: [u8; 4] = *b"FRSE";
+/// Supported serialization formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SerializationFormat {
+    /// Compact binary format via `bincode`. Fast and small.
+    Bincode,
+    /// JSON via `serde_json`. Human-readable, larger output.
+    /// Note: JSON does not support `NaN` or `Infinity` float values.
+    Json,
+    /// CBOR (Concise Binary Object Representation) via `ciborium`.
+    Cbor,
+    /// `MessagePack` via `rmp-serde`. Compact binary with JSON-like schema.
+    MessagePack,
+    /// Postcard — compact, `no_std`-friendly binary format.
+    Postcard,
+}
 
-/// Current format version.
-const FORMAT_VERSION: u32 = 2;
+impl SerializationFormat {
+    /// Returns a human-readable name for this format.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Bincode => "bincode",
+            Self::Json => "json",
+            Self::Cbor => "cbor",
+            Self::MessagePack => "msgpack",
+            Self::Postcard => "postcard",
+        }
+    }
 
-/// Header size in bytes.
-const HEADER_SIZE: usize = 8;
+    /// All supported formats, in declaration order.
+    pub const ALL: &'static [SerializationFormat] = &[
+        Self::Bincode,
+        Self::Json,
+        Self::Cbor,
+        Self::MessagePack,
+        Self::Postcard,
+    ];
+}
 
 /// Errors from serialization and deserialization.
 #[derive(Debug, thiserror::Error)]
@@ -49,20 +80,11 @@ pub enum SerializationError {
     #[error("engine contains ExternalAddress values which cannot be serialized")]
     ExternalAddressPresent,
 
-    #[error("data too short to contain a valid header")]
-    InvalidHeader,
-
-    #[error("invalid magic number (expected FRSE)")]
-    InvalidMagic,
-
-    #[error("unsupported format version {0} (expected {FORMAT_VERSION})")]
-    UnsupportedVersion(u32),
-
     #[error("serialization failed: {0}")]
-    Encode(#[source] bincode::Error),
+    Encode(String),
 
     #[error("deserialization failed: {0}")]
-    Decode(#[source] bincode::Error),
+    Decode(String),
 }
 
 /// Borrowed snapshot of engine state — used for serialization (avoids cloning).
@@ -172,16 +194,16 @@ fn values_contain_external_address(values: &[Value]) -> bool {
 }
 
 impl Engine {
-    /// Serialize this engine to bytes.
+    /// Serialize this engine to bytes in the given format.
     ///
-    /// The returned bytes include a format header and can be passed to
-    /// [`Engine::deserialize_from_bytes`] to reconstruct an equivalent engine.
+    /// The returned bytes can be passed to [`Engine::deserialize`] (with the
+    /// same format) to reconstruct an equivalent engine.
     ///
     /// # Errors
     ///
-    /// Returns [`SerializationError::ExternalAddressPresent`] if the fact base
+    /// Returns [`SerializationError::ExternalAddressPresent`] if the engine
     /// contains any `ExternalAddress` values (which cannot be serialized).
-    pub fn serialize_to_bytes(&self) -> Result<Vec<u8>, SerializationError> {
+    pub fn serialize(&self, format: SerializationFormat) -> Result<Vec<u8>, SerializationError> {
         self.validate_serializable()?;
 
         let snapshot = EngineSnapshotRef {
@@ -211,42 +233,24 @@ impl Engine {
             input_buffer: &self.input_buffer,
         };
 
-        let mut buf = Vec::with_capacity(4096);
-        buf.extend_from_slice(&MAGIC);
-        buf.extend_from_slice(&FORMAT_VERSION.to_le_bytes());
-
-        bincode::serialize_into(&mut buf, &snapshot).map_err(SerializationError::Encode)?;
-
-        Ok(buf)
+        encode(&snapshot, format)
     }
 
     /// Deserialize an engine from bytes previously produced by
-    /// [`Engine::serialize_to_bytes`].
+    /// [`Engine::serialize`] with the same format.
     ///
     /// The returned engine is ready for [`Engine::run`]. Its thread affinity
     /// is set to the calling thread.
     ///
     /// # Errors
     ///
-    /// Returns an error if the data is too short, has an invalid magic number,
-    /// uses an unsupported format version, or is otherwise corrupt.
-    pub fn deserialize_from_bytes(data: &[u8]) -> Result<Self, SerializationError> {
-        if data.len() < HEADER_SIZE {
-            return Err(SerializationError::InvalidHeader);
-        }
-
-        if data[..4] != MAGIC {
-            return Err(SerializationError::InvalidMagic);
-        }
-
-        let version = u32::from_le_bytes(data[4..8].try_into().expect("slice is exactly 4 bytes"));
-        if version != FORMAT_VERSION {
-            return Err(SerializationError::UnsupportedVersion(version));
-        }
-
-        let snapshot: EngineSnapshotOwned =
-            bincode::deserialize(&data[HEADER_SIZE..]).map_err(SerializationError::Decode)?;
-
+    /// Returns an error if the data is malformed or does not match the
+    /// expected format.
+    pub fn deserialize(
+        data: &[u8],
+        format: SerializationFormat,
+    ) -> Result<Self, SerializationError> {
+        let snapshot: EngineSnapshotOwned = decode(data, format)?;
         Ok(snapshot.into_engine())
     }
 
@@ -288,30 +292,81 @@ impl Engine {
     }
 }
 
+/// Encode a snapshot to bytes in the given format.
+fn encode<T: serde::Serialize>(
+    value: &T,
+    format: SerializationFormat,
+) -> Result<Vec<u8>, SerializationError> {
+    match format {
+        SerializationFormat::Bincode => {
+            bincode::serialize(value).map_err(|e| SerializationError::Encode(e.to_string()))
+        }
+        SerializationFormat::Json => {
+            serde_json::to_vec(value).map_err(|e| SerializationError::Encode(e.to_string()))
+        }
+        SerializationFormat::Cbor => {
+            let mut buf = Vec::new();
+            ciborium::ser::into_writer(value, &mut buf)
+                .map_err(|e| SerializationError::Encode(e.to_string()))?;
+            Ok(buf)
+        }
+        SerializationFormat::MessagePack => {
+            rmp_serde::to_vec(value).map_err(|e| SerializationError::Encode(e.to_string()))
+        }
+        SerializationFormat::Postcard => {
+            postcard::to_allocvec(value).map_err(|e| SerializationError::Encode(e.to_string()))
+        }
+    }
+}
+
+/// Decode a snapshot from bytes in the given format.
+fn decode<T: serde::de::DeserializeOwned>(
+    data: &[u8],
+    format: SerializationFormat,
+) -> Result<T, SerializationError> {
+    match format {
+        SerializationFormat::Bincode => {
+            bincode::deserialize(data).map_err(|e| SerializationError::Decode(e.to_string()))
+        }
+        SerializationFormat::Json => {
+            serde_json::from_slice(data).map_err(|e| SerializationError::Decode(e.to_string()))
+        }
+        SerializationFormat::Cbor => {
+            ciborium::de::from_reader(data).map_err(|e| SerializationError::Decode(e.to_string()))
+        }
+        SerializationFormat::MessagePack => {
+            rmp_serde::from_slice(data).map_err(|e| SerializationError::Decode(e.to_string()))
+        }
+        SerializationFormat::Postcard => {
+            postcard::from_bytes(data).map_err(|e| SerializationError::Decode(e.to_string()))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::EngineConfig;
     use crate::execution::RunLimit;
 
-    #[test]
-    fn roundtrip_empty_engine() {
+    /// Test roundtrip for a given format with an empty engine.
+    fn roundtrip_empty(format: SerializationFormat) {
         let engine = Engine::new(EngineConfig::default());
-        let bytes = engine.serialize_to_bytes().unwrap();
+        let bytes = engine.serialize(format).unwrap();
+        assert!(
+            !bytes.is_empty(),
+            "serialized {format:?} should be non-empty"
+        );
 
-        assert_eq!(&bytes[..4], b"FRSE");
-        assert_eq!(u32::from_le_bytes(bytes[4..8].try_into().unwrap()), 1);
-
-        let engine2 = Engine::deserialize_from_bytes(&bytes).unwrap();
-        // Both empty engines should have no user-visible facts
+        let engine2 = Engine::deserialize(&bytes, format).unwrap();
         assert_eq!(
             engine.facts().unwrap().count(),
             engine2.facts().unwrap().count()
         );
     }
 
-    #[test]
-    fn roundtrip_with_rules_and_facts() {
+    /// Test roundtrip for a given format with rules and facts.
+    fn roundtrip_with_rules(format: SerializationFormat) {
         let mut engine = Engine::new(EngineConfig::default());
         engine
             .load_str(
@@ -329,10 +384,9 @@ mod tests {
             .unwrap();
         engine.reset().unwrap();
 
-        let bytes = engine.serialize_to_bytes().unwrap();
-        let mut engine2 = Engine::deserialize_from_bytes(&bytes).unwrap();
+        let bytes = engine.serialize(format).unwrap();
+        let mut engine2 = Engine::deserialize(&bytes, format).unwrap();
 
-        // Run both engines and compare output
         let result1 = engine.run(RunLimit::Unlimited).unwrap();
         let result2 = engine2.run(RunLimit::Unlimited).unwrap();
 
@@ -340,81 +394,33 @@ mod tests {
         assert_eq!(result1.rules_fired, 2);
     }
 
-    #[test]
-    fn roundtrip_with_globals_and_functions() {
+    /// Test roundtrip for a given format with globals and functions.
+    fn roundtrip_with_globals(format: SerializationFormat) {
         let mut engine = Engine::new(EngineConfig::default());
         engine
             .load_str(
-                r#"
+                r"
                 (defglobal ?*counter* = 0)
                 (deffunction increment (?x) (+ ?x 1))
                 (defrule count-up
                     (trigger)
                     =>
                     (bind ?*counter* (increment ?*counter*)))
-            "#,
+            ",
             )
             .unwrap();
         engine.reset().unwrap();
 
-        let bytes = engine.serialize_to_bytes().unwrap();
-        let mut engine2 = Engine::deserialize_from_bytes(&bytes).unwrap();
+        let bytes = engine.serialize(format).unwrap();
+        let mut engine2 = Engine::deserialize(&bytes, format).unwrap();
 
-        // Load a trigger fact and run
         engine2.load_str("(assert (trigger))").unwrap();
         let result = engine2.run(RunLimit::Unlimited).unwrap();
         assert_eq!(result.rules_fired, 1);
     }
 
-    #[test]
-    fn reject_invalid_magic() {
-        let result = Engine::deserialize_from_bytes(b"BADDxxxxxxxx");
-        assert!(matches!(result, Err(SerializationError::InvalidMagic)));
-    }
-
-    #[test]
-    fn reject_unsupported_version() {
-        let mut data = Vec::new();
-        data.extend_from_slice(b"FRSE");
-        data.extend_from_slice(&99u32.to_le_bytes());
-        data.extend_from_slice(b"some data");
-
-        let result = Engine::deserialize_from_bytes(&data);
-        assert!(matches!(
-            result,
-            Err(SerializationError::UnsupportedVersion(99))
-        ));
-    }
-
-    #[test]
-    fn reject_truncated_data() {
-        let result = Engine::deserialize_from_bytes(b"FRS");
-        assert!(matches!(result, Err(SerializationError::InvalidHeader)));
-    }
-
-    #[test]
-    fn reject_corrupt_payload() {
-        let mut data = Vec::new();
-        data.extend_from_slice(b"FRSE");
-        data.extend_from_slice(&1u32.to_le_bytes());
-        data.extend_from_slice(b"not valid bincode data at all");
-
-        let result = Engine::deserialize_from_bytes(&data);
-        assert!(matches!(result, Err(SerializationError::Decode(_))));
-    }
-
-    #[test]
-    fn deserialized_engine_has_current_thread_affinity() {
-        let engine = Engine::new(EngineConfig::default());
-        let bytes = engine.serialize_to_bytes().unwrap();
-        let engine2 = Engine::deserialize_from_bytes(&bytes).unwrap();
-
-        // Should not return WrongThread error
-        assert!(engine2.check_thread_affinity().is_ok());
-    }
-
-    #[test]
-    fn roundtrip_preserves_multiple_modules() {
+    /// Test that an engine with multiple modules roundtrips correctly.
+    fn roundtrip_modules(format: SerializationFormat) {
         let mut engine = Engine::new(EngineConfig::default());
         engine
             .load_str(
@@ -428,10 +434,100 @@ mod tests {
             .unwrap();
         engine.reset().unwrap();
 
-        let bytes = engine.serialize_to_bytes().unwrap();
-        let engine2 = Engine::deserialize_from_bytes(&bytes).unwrap();
-
-        // Verify the deserialized engine has the modules
+        let bytes = engine.serialize(format).unwrap();
+        let engine2 = Engine::deserialize(&bytes, format).unwrap();
         assert!(engine2.check_thread_affinity().is_ok());
+    }
+
+    // ── Per-format tests ─────────────────────────────────────────────────
+
+    macro_rules! format_tests {
+        ($format:ident, $mod_name:ident) => {
+            mod $mod_name {
+                use super::*;
+
+                #[test]
+                fn roundtrip_empty_engine() {
+                    roundtrip_empty(SerializationFormat::$format);
+                }
+
+                #[test]
+                fn roundtrip_with_rules_and_facts() {
+                    roundtrip_with_rules(SerializationFormat::$format);
+                }
+
+                #[test]
+                fn roundtrip_with_globals_and_functions() {
+                    roundtrip_with_globals(SerializationFormat::$format);
+                }
+
+                #[test]
+                fn roundtrip_preserves_multiple_modules() {
+                    roundtrip_modules(SerializationFormat::$format);
+                }
+            }
+        };
+    }
+
+    format_tests!(Bincode, bincode_tests);
+    format_tests!(Json, json_tests);
+    format_tests!(Cbor, cbor_tests);
+    format_tests!(MessagePack, msgpack_tests);
+    format_tests!(Postcard, postcard_tests);
+
+    // ── Cross-format and error tests ─────────────────────────────────────
+
+    #[test]
+    fn reject_wrong_format() {
+        let engine = Engine::new(EngineConfig::default());
+        let bincode_bytes = engine.serialize(SerializationFormat::Bincode).unwrap();
+
+        // Trying to decode bincode data as JSON should fail.
+        let result = Engine::deserialize(&bincode_bytes, SerializationFormat::Json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn reject_corrupt_data() {
+        for &format in SerializationFormat::ALL {
+            let result = Engine::deserialize(b"not valid data at all", format);
+            assert!(
+                result.is_err(),
+                "format {format:?} should reject corrupt data"
+            );
+        }
+    }
+
+    #[test]
+    fn reject_empty_data() {
+        for &format in SerializationFormat::ALL {
+            let result = Engine::deserialize(b"", format);
+            assert!(
+                result.is_err(),
+                "format {format:?} should reject empty data"
+            );
+        }
+    }
+
+    #[test]
+    fn deserialized_engine_has_current_thread_affinity() {
+        let engine = Engine::new(EngineConfig::default());
+        let bytes = engine.serialize(SerializationFormat::Bincode).unwrap();
+        let engine2 = Engine::deserialize(&bytes, SerializationFormat::Bincode).unwrap();
+        assert!(engine2.check_thread_affinity().is_ok());
+    }
+
+    #[test]
+    fn format_name() {
+        assert_eq!(SerializationFormat::Bincode.name(), "bincode");
+        assert_eq!(SerializationFormat::Json.name(), "json");
+        assert_eq!(SerializationFormat::Cbor.name(), "cbor");
+        assert_eq!(SerializationFormat::MessagePack.name(), "msgpack");
+        assert_eq!(SerializationFormat::Postcard.name(), "postcard");
+    }
+
+    #[test]
+    fn all_formats_list() {
+        assert_eq!(SerializationFormat::ALL.len(), 5);
     }
 }

--- a/crates/ferric/benches/serialization_bench.rs
+++ b/crates/ferric/benches/serialization_bench.rs
@@ -3,13 +3,14 @@
 use std::fmt::Write as FmtWrite;
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use ferric::runtime::serialization::SerializationFormat;
 use ferric::runtime::{Engine, EngineConfig, RunLimit};
 
 /// Engine serialization/deserialization benchmark.
 ///
-/// Measures `serialize_to_bytes()` and `deserialize_from_bytes()` round-trip
-/// latency at varying engine sizes. Also benchmarks compilation as a baseline
-/// to validate that deserialization is faster than full compilation.
+/// Measures `serialize()`/`deserialize()` round-trip latency at varying engine
+/// sizes. Also benchmarks compilation as a baseline to validate that
+/// deserialization is faster than full compilation.
 fn generate_serde_source(n_templates: usize, n_rules: usize, n_facts: usize) -> String {
     let mut source = String::new();
 
@@ -58,22 +59,23 @@ fn generate_serde_source(n_templates: usize, n_rules: usize, n_facts: usize) -> 
 
 fn bench_serde_small(c: &mut Criterion) {
     let source = generate_serde_source(5, 10, 50);
+    let format = SerializationFormat::Bincode;
 
     // Prepare engine state
     let mut engine = Engine::new(EngineConfig::utf8());
     engine.load_str(&source).unwrap();
     engine.reset().unwrap();
     engine.run(RunLimit::Unlimited).unwrap();
-    let bytes = engine.serialize_to_bytes().unwrap();
+    let bytes = engine.serialize(format).unwrap();
 
     let mut group = c.benchmark_group("serde_small");
 
     group.bench_function("serialize", |b| {
-        b.iter(|| engine.serialize_to_bytes().unwrap());
+        b.iter(|| engine.serialize(format).unwrap());
     });
 
     group.bench_function("deserialize", |b| {
-        b.iter(|| Engine::deserialize_from_bytes(&bytes).unwrap());
+        b.iter(|| Engine::deserialize(&bytes, format).unwrap());
     });
 
     let source_clone = source.clone();
@@ -90,22 +92,23 @@ fn bench_serde_small(c: &mut Criterion) {
 
 fn bench_serde_medium(c: &mut Criterion) {
     let source = generate_serde_source(20, 100, 500);
+    let format = SerializationFormat::Bincode;
 
     let mut engine = Engine::new(EngineConfig::utf8());
     engine.load_str(&source).unwrap();
     engine.reset().unwrap();
     engine.run(RunLimit::Unlimited).unwrap();
-    let bytes = engine.serialize_to_bytes().unwrap();
+    let bytes = engine.serialize(format).unwrap();
 
     let mut group = c.benchmark_group("serde_medium");
     group.sample_size(10);
 
     group.bench_function("serialize", |b| {
-        b.iter(|| engine.serialize_to_bytes().unwrap());
+        b.iter(|| engine.serialize(format).unwrap());
     });
 
     group.bench_function("deserialize", |b| {
-        b.iter(|| Engine::deserialize_from_bytes(&bytes).unwrap());
+        b.iter(|| Engine::deserialize(&bytes, format).unwrap());
     });
 
     let source_clone = source.clone();
@@ -122,22 +125,23 @@ fn bench_serde_medium(c: &mut Criterion) {
 
 fn bench_serde_large(c: &mut Criterion) {
     let source = generate_serde_source(50, 500, 2000);
+    let format = SerializationFormat::Bincode;
 
     let mut engine = Engine::new(EngineConfig::utf8());
     engine.load_str(&source).unwrap();
     engine.reset().unwrap();
     engine.run(RunLimit::Unlimited).unwrap();
-    let bytes = engine.serialize_to_bytes().unwrap();
+    let bytes = engine.serialize(format).unwrap();
 
     let mut group = c.benchmark_group("serde_large");
     group.sample_size(10);
 
     group.bench_function("serialize", |b| {
-        b.iter(|| engine.serialize_to_bytes().unwrap());
+        b.iter(|| engine.serialize(format).unwrap());
     });
 
     group.bench_function("deserialize", |b| {
-        b.iter(|| Engine::deserialize_from_bytes(&bytes).unwrap());
+        b.iter(|| Engine::deserialize(&bytes, format).unwrap());
     });
 
     let source_clone = source.clone();

--- a/justfile
+++ b/justfile
@@ -151,6 +151,10 @@ bench-engine:
 bench-waltz:
     cargo bench -p ferric --bench waltz_bench
 
+# Run serialization format comparison benchmarks
+bench-serde:
+    cargo bench -p ferric-runtime --features serde --bench serialization_bench
+
 # Run the manners benchmark suite
 bench-manners:
     cargo bench -p ferric --bench manners_bench


### PR DESCRIPTION
## Summary
- Added support for JSON, CBOR, MessagePack, and Postcard formats alongside existing Bincode
- Revised serialization API: `SerializationFormat` enum with per-format functions at C FFI level and omnibus methods (e.g., `ferric_engine_serialize_as`)
- Updated Python (PyO3) and Go bindings to match new multi-format API
- Added Criterion benchmarks for format comparison and size measurements across all formats
- Binary size impact: static lib increased from 3.3M to 11M (~3.3x) when all formats included

## Testing
- All 1700+ Rust tests pass (including 25+ serialization tests across 5 formats)
- All Go tests pass with parameterized format coverage
- Python bindings compile cleanly with serde feature
- Preflight checks: formatting, clippy, cargo check all pass

## Notes
- rkyv support deferred (requires own derive macros, not serde-based)
- Custom `BTreeMap` serde helper added for JSON compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)