### PR TITLE
Audit and harden Python bindings (PYB-001 through PYB-010)

### DIFF
--- a/PYB-001_DROP_THREAD_AFFINITY_FOLLOWUP.md
+++ b/PYB-001_DROP_THREAD_AFFINITY_FOLLOWUP.md
@@ -1,0 +1,111 @@
+# PYB-001 Follow-Up: Cross-Thread Drop Leak in Python Engine Wrapper
+
+## Context
+
+The PYB-001 remediation replaced PyO3 `unsendable` panics with explicit thread checks and `FerricRuntimeError` for cross-thread calls.
+
+That behavior goal is mostly achieved, but the current implementation introduces a new high-severity lifecycle problem in destructor behavior.
+
+## Current Problem
+
+In [`crates/ferric-python/src/engine.rs`](/Users/prb/conductor/workspaces/ferric-rules/stockholm/crates/ferric-python/src/engine.rs):
+
+- `PyEngine` now stores `engine: ManuallyDrop<Engine>` ([line 46](/Users/prb/conductor/workspaces/ferric-rules/stockholm/crates/ferric-python/src/engine.rs:46))
+- `unsafe impl Send` and `unsafe impl Sync` are added ([lines 66-67](/Users/prb/conductor/workspaces/ferric-rules/stockholm/crates/ferric-python/src/engine.rs:66))
+- `Drop` has thread-conditional behavior ([lines 69-88](/Users/prb/conductor/workspaces/ferric-rules/stockholm/crates/ferric-python/src/engine.rs:69)):
+  - same thread: drop inner `Engine`
+  - foreign thread: intentionally leak `Engine` and print to stderr
+
+This means foreign-thread finalization does not panic, but leaks engine resources (facts, rete graph memory, interned symbols, etc.).
+
+## Why This Is High Severity
+
+1. Resource management regression
+- The engine can hold substantial state; repeated foreign-thread drops can leak unbounded memory.
+
+2. Unsafe contract fragility
+- `unsafe impl Send/Sync` is justified by “every entry point checks thread,” but future methods can violate this by omission.
+- The design shifts safety burden to human discipline across all future edits.
+
+3. Runtime side effects in destructor
+- `eprintln!` in `Drop` emits noise in normal application logs and test output.
+
+4. Test suite currently encodes leak behavior as acceptable
+- [`tests/test_threading.py`](/Users/prb/conductor/workspaces/ferric-rules/stockholm/crates/ferric-python/tests/test_threading.py) has `TestCrossThreadDrop.test_drop_on_foreign_thread_no_panic`, which treats “leak but no crash” as passing behavior.
+
+## Reproduction
+
+```python
+import ferric, threading, gc
+
+eng = ferric.Engine()
+for i in range(10000):
+    eng.assert_fact("x", i)
+
+def drop_on_other_thread(e):
+    del e
+
+t = threading.Thread(target=drop_on_other_thread, args=(eng,))
+del eng
+t.start()
+t.join()
+gc.collect()
+```
+
+Observed today:
+- no panic
+- stderr message: engine leaked due to wrong-thread drop
+- inner `Engine` not dropped
+
+## Target Behavior
+
+1. Cross-thread method/property access still raises `ferric.FerricRuntimeError`.
+2. Cross-thread object finalization does **not** leak engine resources.
+3. No panic-derived `PanicException` for public API usage paths.
+4. No stderr writes from `Drop`.
+
+## Recommended Fix Direction
+
+Use a design that avoids `unsafe Send/Sync` + `ManuallyDrop` leak fallback.
+
+Preferred characteristics:
+- No custom unsafe auto-trait impls for `PyEngine`
+- Deterministic ownership and cleanup semantics
+- Thread-affinity enforcement at call boundary, not via panic
+
+Possible implementation paths (Claude should choose one and justify):
+
+1. Re-architecture around explicit close/owner indirection
+- Move actual engine ownership into a creator-thread-owned registry/handle model.
+- `PyEngine` instances carry a lightweight handle; `drop` releases handle metadata safely.
+- Actual engine destruction occurs on creator thread via explicit close/managed teardown.
+
+2. Safe rollback if above is too large
+- Revert to `#[pyclass(unsendable)]` semantics temporarily (panic path), remove unsafe/leak behavior, and document follow-up work to get catchable errors without unsafe drop leaks.
+- This is less ergonomic but safer than silent resource leaks.
+
+## Acceptance Criteria
+
+1. No intentional leak path remains in `Drop`.
+2. No `unsafe impl Send`/`unsafe impl Sync` on `PyEngine` unless backed by a stronger proven invariant than per-method checks.
+3. No `eprintln!` in destructor paths.
+4. Cross-thread call tests still pass (`FerricRuntimeError` expected) or are explicitly revised if fallback strategy is chosen.
+5. Add/adjust tests to validate destructor behavior:
+- A non-leaking teardown test (or equivalent instrumentation-backed assertion)
+- No unraisable drop warnings in pytest output for expected usage
+6. `crates/ferric-python` test suite passes under `maturin develop` flow.
+
+## Suggested Test/Instrumentation Additions
+
+Because leak assertions are hard from Python black-box tests, add Rust-side instrumentation under `cfg(test)` or a test-only feature:
+
+- `ENGINE_INSTANCE_COUNT` atomic increment on create, decrement on true drop
+- expose test helper (only in test builds) to assert count returns to baseline
+
+This gives strong confidence that cross-thread scenarios do not silently leak.
+
+## Scope Notes
+
+- Breaking API changes from PYB-002/PYB-003 are acceptable for now per project direction.
+- This follow-up is specifically about eliminating leak-prone teardown semantics introduced by PYB-001 remediation.
+

--- a/PYTHON_BINDING_REMEDIATION_REPORT.md
+++ b/PYTHON_BINDING_REMEDIATION_REPORT.md
@@ -1,0 +1,246 @@
+# Python Binding Remediation Report
+
+Date: 2026-03-27
+
+Scope audited:
+- `crates/ferric-python/src/*.rs`
+- `crates/ferric-python/tests/*.py`
+- Runtime API parity against `crates/ferric-runtime/src/engine.rs`
+- Process/CI coverage for Python bindings
+
+Validation run during audit:
+- `cd crates/ferric-python && uv run pytest tests -q` -> `137 passed`
+- Additional targeted runtime probes were executed for edge cases called out below.
+
+## Coverage Snapshot
+
+Current tests are strong on happy-path lifecycle, execution, facts, template facts, serialization, and basic error hierarchy. The suite is light or absent on several high-risk areas:
+- Thread-affinity behavior (cross-thread use)
+- Type fidelity edge cases (symbol vs string semantics)
+- API contract edge cases (`assert_string` cardinality semantics)
+- Identity semantics across engine instances (fact equality/hashing)
+- API surface gaps (`load_file` path-like input, focus mutators, modules, diagnostics clearing)
+- Negative conversion/error-path breadth (unsupported Python types, error aggregation shape)
+
+## Remediation Issues
+
+## PYB-001: Cross-thread access surfaces as `PanicException` (Rust panic path)
+
+- Priority: P0
+- Size: L
+- Depends on: None
+
+### What and why
+`PyEngine` is `#[pyclass(unsendable)]`. Accessing the same engine from a different Python thread currently triggers a Rust panic inside PyO3 and raises `pyo3_runtime.PanicException` (a `BaseException`, not an `Exception`), with panic output emitted to stderr.
+
+This is a correctness/safety issue because thread-affinity misuse should produce a regular ferric runtime error, not a panic-derived exception path.
+
+### Sketch fix
+- Introduce a non-panicking thread-affinity gate at the Python boundary.
+- Ensure cross-thread misuse raises `FerricRuntimeError` with a stable message.
+- Avoid exposing raw PyO3 panic semantics to library consumers.
+
+### Acceptance criteria
+1. Cross-thread method/property access raises `ferric.FerricRuntimeError`, not `PanicException`.
+2. No Rust panic output is emitted for this case.
+3. A dedicated test covers cross-thread read and mutating calls.
+
+## PYB-002: Structured assertions cannot represent CLIPS `String` values
+
+- Priority: P0
+- Size: L
+- Depends on: None
+
+### What and why
+`python_to_value` maps Python `str` to `Value::Symbol` unconditionally. This makes structured APIs (`assert_fact`, `assert_template`) unable to express CLIPS string literals distinctly from symbols.
+
+Observed behavior: a template asserted with `name="Alice"` only matches `(name Alice)` rules, not `(name "Alice")` rules.
+
+This is a semantic correctness gap and prevents full CLIPS value fidelity from Python.
+
+### Sketch fix
+- Introduce explicit Python-side value types (for example `Symbol`, `String`) or equivalent constructors/helpers.
+- Define and document default mapping rules and migration behavior.
+- Ensure conversions preserve symbol/string distinction in both directions.
+
+### Acceptance criteria
+1. Python API can intentionally create both CLIPS symbols and CLIPS strings via structured assertion APIs.
+2. Rule matching distinguishes them correctly in tests.
+3. Value round-trip tests verify symbol vs string fidelity.
+
+## PYB-003: `assert_string` silently accepts multi-fact asserts but returns one ID
+
+- Priority: P1
+- Size: S
+- Depends on: None
+
+### What and why
+`assert_string` wraps input as `(assert {source})`, then returns only the first `asserted_facts` entry. Inputs like `"(a) (b)"` assert two facts but return one id, making the API contract ambiguous and lossy.
+
+### Sketch fix
+- Make contract explicit and enforced:
+  - Option A: require exactly one fact and error otherwise.
+  - Option B: return `list[int]` for all asserted IDs (possibly via a new method to preserve compatibility).
+
+### Acceptance criteria
+1. Multi-fact input no longer silently drops IDs.
+2. API docs specify cardinality behavior.
+3. Tests cover single-fact, multi-fact, and malformed input.
+
+## PYB-004: `Fact.__eq__` / `__hash__` conflate facts from different engines
+
+- Priority: P1
+- Size: M
+- Depends on: None
+
+### What and why
+`Fact` equality/hash use only `fact.id`. Because IDs are engine-local, facts from different engines can compare equal and collide in hash sets/maps.
+
+Observed behavior: first asserted fact in two fresh engines has same ID and compares equal.
+
+### Sketch fix
+- Include engine identity in fact snapshot identity semantics (for example hidden `engine_instance_id` + `fact_id` tuple).
+- Update `__eq__` and `__hash__` accordingly.
+
+### Acceptance criteria
+1. Same fact ID from different engines is not equal.
+2. Hash behavior matches equality.
+3. Existing same-engine equality semantics remain intact.
+
+## PYB-005: PyO3 classes/enums are registered under `builtins`, not `ferric`
+
+- Priority: P1
+- Size: S
+- Depends on: None
+
+### What and why
+Core Python types (`Engine`, `Fact`, enums, result types) currently report `__module__ == "builtins"`. This is non-idiomatic and hurts introspection/documentation quality.
+
+### Sketch fix
+- Add `module = "ferric"` on all `#[pyclass]` declarations.
+- Verify exception classes and regular classes have consistent module attribution.
+
+### Acceptance criteria
+1. All exported ferric classes/enums report `__module__ == "ferric"`.
+2. Regression tests cover module attribution for representative types.
+
+## PYB-006: Python API omits important runtime capabilities
+
+- Priority: P1
+- Size: M
+- Depends on: None
+
+### What and why
+`ferric_runtime::Engine` exposes capabilities that Python currently lacks, including:
+- Focus mutation (`set_focus`, `push_focus`)
+- Module enumeration (`modules`)
+- Diagnostics reset (`clear_action_diagnostics`)
+- Direct template slot accessor (`get_fact_slot_by_name`)
+
+Python currently exposes only part of this surface (mostly read-only focus state), limiting practical parity and forcing workarounds.
+
+### Sketch fix
+- Add targeted missing methods with Pythonic naming and exception mapping.
+- Keep behavior aligned with existing runtime semantics.
+
+### Acceptance criteria
+1. Added methods expose the missing runtime operations above.
+2. Methods are documented and covered by tests (success + error paths).
+3. Error types map to ferric exception hierarchy consistently.
+
+## PYB-007: `load_file` rejects `pathlib.Path` (inconsistent with snapshot APIs)
+
+- Priority: P1
+- Size: S
+- Depends on: None
+
+### What and why
+`load_file` currently takes `&str`, so `pathlib.Path` inputs raise `TypeError`. `save_snapshot` / `from_snapshot_file` already accept path-like values via `PathBuf`, so behavior is inconsistent and non-idiomatic for Python.
+
+### Sketch fix
+- Change `load_file` signature to `PathBuf` like snapshot file methods.
+- Preserve existing `str` usage compatibility.
+
+### Acceptance criteria
+1. `engine.load_file(pathlib.Path(...))` works.
+2. Existing string path behavior is unchanged.
+3. Tests cover both `str` and `Path` inputs.
+
+## PYB-008: Conversion code uses `expect(...)`, leaving panic paths in bindings
+
+- Priority: P1
+- Size: M
+- Depends on: None
+
+### What and why
+`value_to_python` currently uses multiple `expect(...)` calls. Allocation/conversion failures should surface as Python exceptions, not panic-derived failures.
+
+### Sketch fix
+- Refactor `value_to_python` to return `PyResult<PyObject>`.
+- Propagate errors through all callers (`fact_to_python`, `get_global`, etc.).
+- Remove panic-based conversion assumptions from Python boundary code.
+
+### Acceptance criteria
+1. No `expect(...)` remains in conversion paths crossing the Python boundary.
+2. Conversion failures propagate as Python exceptions.
+3. Existing behavior is preserved for normal inputs.
+
+## PYB-009: Error translation drops multi-error context
+
+- Priority: P1
+- Size: M
+- Depends on: None
+
+### What and why
+`load_errors_to_pyerr` returns immediately on first parse/compile error, which can hide additional loader diagnostics from the same call. This reduces debuggability for users loading larger sources with multiple problems.
+
+### Sketch fix
+- Preserve aggregated diagnostics while still classifying exception type.
+- Consider attaching structured detail (for example an `.errors` list on exception instances).
+
+### Acceptance criteria
+1. Multi-error load failures expose all relevant diagnostics.
+2. Parse/compile classification remains accurate.
+3. Tests cover multi-error payload behavior.
+
+## PYB-010: Test/process gaps on tricky Python-binding edge cases
+
+- Priority: P1
+- Size: M
+- Depends on: PYB-001, PYB-002, PYB-003, PYB-004, PYB-005, PYB-006, PYB-007, PYB-008, PYB-009
+
+### What and why
+Current test suite is broad but still misses several risky behaviors:
+- Cross-thread access behavior
+- Symbol/string semantic fidelity
+- `assert_string` cardinality edge cases
+- Cross-engine fact identity semantics
+- `load_file` path-like support
+- Focus/module mutation APIs (once added)
+- Rich multi-error mapping behavior
+
+Also, local preflight (`just preflight-pr`) does not currently include `crates/ferric-python` pytest execution.
+
+### Sketch fix
+- Expand tests to cover the edge cases above.
+- Add a local binding-test recipe and include it in preflight-pr.
+- Keep CI and local preflight expectations aligned.
+
+### Acceptance criteria
+1. New tests exist for all edge cases listed above.
+2. A single local command path runs ferric-python tests as part of PR preflight.
+3. CI and local preflight coverage for Python bindings are consistent.
+
+## Suggested Implementation Order
+
+1. PYB-001
+2. PYB-002
+3. PYB-003
+4. PYB-004
+5. PYB-005
+6. PYB-007
+7. PYB-008
+8. PYB-009
+9. PYB-006
+10. PYB-010
+

--- a/crates/ferric-python/Cargo.toml
+++ b/crates/ferric-python/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { workspace = true, optional = true }
 [features]
 default = ["serde"]
 serde = ["ferric-runtime/serde"]
+testing = []
 tracing = ["dep:tracing", "ferric-runtime/tracing"]
 
 [build-dependencies]

--- a/crates/ferric-python/src/config.rs
+++ b/crates/ferric-python/src/config.rs
@@ -3,7 +3,7 @@
 use pyo3::prelude::*;
 
 /// Conflict resolution strategy.
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, module = "ferric")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Strategy {
     /// Depth-first (CLIPS default).
@@ -21,7 +21,7 @@ pub enum Strategy {
 }
 
 /// String encoding mode.
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, module = "ferric")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Encoding {
     /// ASCII-only encoding.
@@ -58,7 +58,7 @@ impl From<Encoding> for ferric_core::StringEncoding {
 
 /// Serialization format for engine snapshots.
 #[cfg(feature = "serde")]
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, module = "ferric")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Format {
     /// Compact binary (bincode). Fast and small.

--- a/crates/ferric-python/src/engine.rs
+++ b/crates/ferric-python/src/engine.rs
@@ -1,6 +1,7 @@
 //! Python Engine wrapper.
 
 use std::path::{Path, PathBuf};
+use std::thread::ThreadId;
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -12,7 +13,9 @@ use ferric_runtime::Engine;
 use slotmap::{Key, KeyData};
 
 use crate::config::{Encoding, Strategy};
-use crate::error::{engine_error_to_pyerr, init_error_to_pyerr, load_errors_to_pyerr};
+use crate::error::{
+    engine_error_to_pyerr, init_error_to_pyerr, load_errors_to_pyerr, FerricRuntimeError,
+};
 use crate::fact::{fact_to_python, Fact};
 use crate::result::{FiredRule, RunResult};
 use crate::value::{python_to_value, value_to_python};
@@ -32,9 +35,32 @@ fn make_config(strategy: Option<Strategy>, encoding: Option<Encoding>) -> Engine
 /// The Ferric rules engine.
 ///
 /// Thread-affine: must be used only from the thread that created it.
-#[pyclass(name = "Engine", unsendable)]
+/// Cross-thread access raises `FerricRuntimeError` (not a panic).
+#[pyclass(name = "Engine")]
 pub struct PyEngine {
     engine: Engine,
+    creator_thread: ThreadId,
+}
+
+// SAFETY: We enforce thread affinity ourselves via `check_thread()` at every
+// Python entry point, converting violations into `FerricRuntimeError` instead
+// of the `PanicException` that PyO3's `unsendable` would produce.  The inner
+// `Engine` is never actually accessed from a foreign thread.
+unsafe impl Send for PyEngine {}
+unsafe impl Sync for PyEngine {}
+
+impl PyEngine {
+    /// Check that the caller is on the thread that created this engine.
+    fn check_thread(&self) -> PyResult<()> {
+        let current = std::thread::current().id();
+        if current != self.creator_thread {
+            return Err(FerricRuntimeError::new_err(format!(
+                "engine called from wrong thread (created on {:?}, called from {:?})",
+                self.creator_thread, current,
+            )));
+        }
+        Ok(())
+    }
 }
 
 #[pymethods]
@@ -51,6 +77,7 @@ impl PyEngine {
         let config = make_config(strategy, encoding);
         Self {
             engine: Engine::new(config),
+            creator_thread: std::thread::current().id(),
         }
     }
 
@@ -64,7 +91,10 @@ impl PyEngine {
     ) -> PyResult<Self> {
         let config = make_config(strategy, encoding);
         let engine = Engine::with_rules_config(source, config).map_err(init_error_to_pyerr)?;
-        Ok(Self { engine })
+        Ok(Self {
+            engine,
+            creator_thread: std::thread::current().id(),
+        })
     }
 
     // -- Context manager --
@@ -79,21 +109,24 @@ impl PyEngine {
         _exc_type: Option<&Bound<'_, PyAny>>,
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
-    ) -> bool {
+    ) -> PyResult<bool> {
+        self.check_thread()?;
         self.engine.clear();
-        false // don't suppress exceptions
+        Ok(false) // don't suppress exceptions
     }
 
     // -- Loading --
 
     /// Load CLIPS source into the engine.
     fn load(&mut self, source: &str) -> PyResult<()> {
+        self.check_thread()?;
         self.engine.load_str(source).map_err(load_errors_to_pyerr)?;
         Ok(())
     }
 
     /// Load CLIPS source from a file path.
     fn load_file(&mut self, path: &str) -> PyResult<()> {
+        self.check_thread()?;
         self.engine
             .load_file(Path::new(path))
             .map_err(load_errors_to_pyerr)?;
@@ -104,6 +137,7 @@ impl PyEngine {
 
     /// Assert a fact from a CLIPS syntax string like `"(color red)"`.
     fn assert_string(&mut self, source: &str) -> PyResult<u64> {
+        self.check_thread()?;
         let wrapped = format!("(assert {source})");
         let result = self
             .engine
@@ -131,6 +165,7 @@ impl PyEngine {
         relation: &str,
         args: &Bound<'_, PyTuple>,
     ) -> PyResult<u64> {
+        self.check_thread()?;
         let mut values = Vec::with_capacity(args.len());
         for item in args.iter() {
             values.push(python_to_value(&item, &mut self.engine)?);
@@ -161,6 +196,7 @@ impl PyEngine {
         template_name: &str,
         kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<u64> {
+        self.check_thread()?;
         let (names, values) = match kwargs {
             Some(dict) => {
                 let mut names = Vec::with_capacity(dict.len());
@@ -185,12 +221,14 @@ impl PyEngine {
 
     /// Retract a fact by its ID.
     fn retract(&mut self, fact_id: u64) -> PyResult<()> {
+        self.check_thread()?;
         let fid = FactId::from(KeyData::from_ffi(fact_id));
         self.engine.retract(fid).map_err(engine_error_to_pyerr)
     }
 
     /// Get a fact by its ID, or `None` if it does not exist.
     fn get_fact(&self, py: Python<'_>, fact_id: u64) -> PyResult<Option<Fact>> {
+        self.check_thread()?;
         let fid = FactId::from(KeyData::from_ffi(fact_id));
         let fact = self.engine.get_fact(fid).map_err(engine_error_to_pyerr)?;
         match fact {
@@ -201,6 +239,7 @@ impl PyEngine {
 
     /// Return all facts currently in working memory.
     fn facts(&self, py: Python<'_>) -> PyResult<Vec<Fact>> {
+        self.check_thread()?;
         let iter = self.engine.facts().map_err(engine_error_to_pyerr)?;
         let mut result = Vec::new();
         for (fid, fact) in iter {
@@ -211,6 +250,7 @@ impl PyEngine {
 
     /// Find facts by relation name.
     fn find_facts(&self, py: Python<'_>, relation: &str) -> PyResult<Vec<Fact>> {
+        self.check_thread()?;
         let facts = self
             .engine
             .find_facts(relation)
@@ -231,6 +271,7 @@ impl PyEngine {
     /// * `limit` — Maximum number of rule firings (default: unlimited).
     #[pyo3(signature = (*, limit=None))]
     fn run(&mut self, limit: Option<usize>) -> PyResult<RunResult> {
+        self.check_thread()?;
         let run_limit = match limit {
             Some(n) => RunLimit::Count(n),
             None => RunLimit::Unlimited,
@@ -241,6 +282,7 @@ impl PyEngine {
 
     /// Fire a single rule activation. Returns `FiredRule` or `None`.
     fn step(&mut self) -> PyResult<Option<FiredRule>> {
+        self.check_thread()?;
         let result = self.engine.step().map_err(engine_error_to_pyerr)?;
         Ok(result.map(|fr| {
             let name = self
@@ -253,18 +295,23 @@ impl PyEngine {
     }
 
     /// Request the engine to halt.
-    fn halt(&mut self) {
+    fn halt(&mut self) -> PyResult<()> {
+        self.check_thread()?;
         self.engine.halt();
+        Ok(())
     }
 
     /// Reset the engine: clear facts and re-assert deffacts.
     fn reset(&mut self) -> PyResult<()> {
+        self.check_thread()?;
         self.engine.reset().map_err(engine_error_to_pyerr)
     }
 
     /// Clear the engine: remove all rules, facts, templates, etc.
-    fn clear(&mut self) {
+    fn clear(&mut self) -> PyResult<()> {
+        self.check_thread()?;
         self.engine.clear();
+        Ok(())
     }
 
     // -- Properties --
@@ -272,58 +319,68 @@ impl PyEngine {
     /// Number of user-visible facts.
     #[getter]
     fn fact_count(&self) -> PyResult<usize> {
+        self.check_thread()?;
         let count = self.engine.facts().map_err(engine_error_to_pyerr)?.count();
         Ok(count)
     }
 
     /// Whether the engine is currently halted.
     #[getter]
-    fn is_halted(&self) -> bool {
-        self.engine.is_halted()
+    fn is_halted(&self) -> PyResult<bool> {
+        self.check_thread()?;
+        Ok(self.engine.is_halted())
     }
 
     /// Number of pending activations on the agenda.
     #[getter]
-    fn agenda_size(&self) -> usize {
-        self.engine.agenda_len()
+    fn agenda_size(&self) -> PyResult<usize> {
+        self.check_thread()?;
+        Ok(self.engine.agenda_len())
     }
 
     /// Name of the current module.
     #[getter]
-    fn current_module(&self) -> &str {
-        self.engine.current_module()
+    fn current_module(&self) -> PyResult<String> {
+        self.check_thread()?;
+        Ok(self.engine.current_module().to_owned())
     }
 
     /// Top of the focus stack, or `None`.
     #[getter]
-    fn focus(&self) -> Option<&str> {
-        self.engine.get_focus()
+    fn focus(&self) -> PyResult<Option<String>> {
+        self.check_thread()?;
+        Ok(self.engine.get_focus().map(str::to_owned))
     }
 
     /// Full focus stack as a list of module names (bottom to top).
     #[getter]
-    fn focus_stack(&self) -> Vec<String> {
-        self.engine
+    fn focus_stack(&self) -> PyResult<Vec<String>> {
+        self.check_thread()?;
+        Ok(self
+            .engine
             .get_focus_stack()
             .into_iter()
             .map(String::from)
-            .collect()
+            .collect())
     }
 
     /// Non-fatal action diagnostics from the most recent run/step.
     #[getter]
-    fn diagnostics(&self) -> Vec<String> {
-        self.engine
+    fn diagnostics(&self) -> PyResult<Vec<String>> {
+        self.check_thread()?;
+        Ok(self
+            .engine
             .action_diagnostics()
             .iter()
             .map(ToString::to_string)
-            .collect()
+            .collect())
     }
 
     // -- Introspection --
 
     /// Return a list of `(name, salience)` tuples for all rules.
     fn rules(&self, py: Python<'_>) -> PyResult<PyObject> {
+        self.check_thread()?;
         let rules = self.engine.rules();
         let list = PyList::empty(py);
         for (name, salience) in rules {
@@ -340,36 +397,45 @@ impl PyEngine {
     }
 
     /// Return a list of template names.
-    fn templates(&self) -> Vec<String> {
-        self.engine
+    fn templates(&self) -> PyResult<Vec<String>> {
+        self.check_thread()?;
+        Ok(self
+            .engine
             .templates()
             .into_iter()
             .map(String::from)
-            .collect()
+            .collect())
     }
 
     /// Get the value of a global variable, or `None`.
-    fn get_global(&self, py: Python<'_>, name: &str) -> Option<PyObject> {
-        self.engine
+    fn get_global(&self, py: Python<'_>, name: &str) -> PyResult<Option<PyObject>> {
+        self.check_thread()?;
+        Ok(self
+            .engine
             .get_global(name)
-            .map(|v| value_to_python(py, v, &self.engine))
+            .map(|v| value_to_python(py, v, &self.engine)))
     }
 
     // -- I/O --
 
     /// Get captured output for a channel (e.g. "stdout").
-    fn get_output(&self, channel: &str) -> Option<String> {
-        self.engine.get_output(channel).map(String::from)
+    fn get_output(&self, channel: &str) -> PyResult<Option<String>> {
+        self.check_thread()?;
+        Ok(self.engine.get_output(channel).map(String::from))
     }
 
     /// Clear captured output for a channel.
-    fn clear_output(&mut self, channel: &str) {
+    fn clear_output(&mut self, channel: &str) -> PyResult<()> {
+        self.check_thread()?;
         self.engine.clear_output_channel(channel);
+        Ok(())
     }
 
     /// Push a line of input for `read`/`readline`.
-    fn push_input(&mut self, line: &str) {
+    fn push_input(&mut self, line: &str) -> PyResult<()> {
+        self.check_thread()?;
         self.engine.push_input(line);
+        Ok(())
     }
 
     // -- Serialization --
@@ -388,6 +454,7 @@ impl PyEngine {
         py: Python<'py>,
         format: Option<crate::config::Format>,
     ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
+        self.check_thread()?;
         let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
         let bytes = self
             .engine
@@ -411,7 +478,10 @@ impl PyEngine {
         let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
         let engine = Engine::deserialize(data, fmt)
             .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
-        Ok(Self { engine })
+        Ok(Self {
+            engine,
+            creator_thread: std::thread::current().id(),
+        })
     }
 
     /// Save a serialized engine snapshot to a file.
@@ -423,6 +493,7 @@ impl PyEngine {
     #[cfg(feature = "serde")]
     #[pyo3(signature = (path, *, format=None))]
     fn save_snapshot(&self, path: PathBuf, format: Option<crate::config::Format>) -> PyResult<()> {
+        self.check_thread()?;
         let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
         let bytes = self
             .engine
@@ -448,12 +519,16 @@ impl PyEngine {
         let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
         let engine = Engine::deserialize(&data, fmt)
             .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
-        Ok(Self { engine })
+        Ok(Self {
+            engine,
+            creator_thread: std::thread::current().id(),
+        })
     }
 
     // -- Python protocols --
 
     fn __repr__(&self) -> PyResult<String> {
+        self.check_thread()?;
         let fact_count = self.engine.facts().map_err(engine_error_to_pyerr)?.count();
         let rule_count = self.engine.rules().len();
         let halted = self.engine.is_halted();
@@ -463,11 +538,13 @@ impl PyEngine {
     }
 
     fn __len__(&self) -> PyResult<usize> {
+        self.check_thread()?;
         let count = self.engine.facts().map_err(engine_error_to_pyerr)?.count();
         Ok(count)
     }
 
     fn __contains__(&self, fact_id: u64) -> PyResult<bool> {
+        self.check_thread()?;
         let fid = FactId::from(KeyData::from_ffi(fact_id));
         let fact = self.engine.get_fact(fid).map_err(engine_error_to_pyerr)?;
         Ok(fact.is_some())

--- a/crates/ferric-python/src/engine.rs
+++ b/crates/ferric-python/src/engine.rs
@@ -1,6 +1,6 @@
 //! Python Engine wrapper.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::ThreadId;
 
@@ -132,11 +132,11 @@ impl PyEngine {
         Ok(())
     }
 
-    /// Load CLIPS source from a file path.
-    fn load_file(&mut self, path: &str) -> PyResult<()> {
+    /// Load CLIPS source from a file path (str or os.PathLike).
+    fn load_file(&mut self, path: PathBuf) -> PyResult<()> {
         self.check_thread()?;
         self.engine
-            .load_file(Path::new(path))
+            .load_file(&path)
             .map_err(load_errors_to_pyerr)?;
         Ok(())
     }

--- a/crates/ferric-python/src/engine.rs
+++ b/crates/ferric-python/src/engine.rs
@@ -40,7 +40,7 @@ fn make_config(strategy: Option<Strategy>, encoding: Option<Encoding>) -> Engine
 ///
 /// Thread-affine: must be used only from the thread that created it.
 /// Cross-thread access raises `FerricRuntimeError` (not a panic).
-#[pyclass(name = "Engine")]
+#[pyclass(name = "Engine", module = "ferric")]
 pub struct PyEngine {
     engine: Engine,
     creator_thread: ThreadId,

--- a/crates/ferric-python/src/engine.rs
+++ b/crates/ferric-python/src/engine.rs
@@ -1,7 +1,11 @@
 //! Python Engine wrapper.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::ThreadId;
+
+/// Global counter for assigning unique engine IDs.
+static NEXT_ENGINE_ID: AtomicU64 = AtomicU64::new(1);
 
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
@@ -40,6 +44,8 @@ fn make_config(strategy: Option<Strategy>, encoding: Option<Encoding>) -> Engine
 pub struct PyEngine {
     engine: Engine,
     creator_thread: ThreadId,
+    /// Unique identifier for this engine instance (used in Fact identity).
+    engine_id: u64,
 }
 
 // SAFETY: We enforce thread affinity ourselves via `check_thread()` at every
@@ -78,6 +84,7 @@ impl PyEngine {
         Self {
             engine: Engine::new(config),
             creator_thread: std::thread::current().id(),
+            engine_id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
         }
     }
 
@@ -94,6 +101,7 @@ impl PyEngine {
         Ok(Self {
             engine,
             creator_thread: std::thread::current().id(),
+            engine_id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
         })
     }
 
@@ -244,7 +252,7 @@ impl PyEngine {
         let fid = FactId::from(KeyData::from_ffi(fact_id));
         let fact = self.engine.get_fact(fid).map_err(engine_error_to_pyerr)?;
         match fact {
-            Some(f) => Ok(Some(fact_to_python(py, fid, f, &self.engine)?)),
+            Some(f) => Ok(Some(fact_to_python(py, fid, f, &self.engine, self.engine_id)?)),
             None => Ok(None),
         }
     }
@@ -255,7 +263,7 @@ impl PyEngine {
         let iter = self.engine.facts().map_err(engine_error_to_pyerr)?;
         let mut result = Vec::new();
         for (fid, fact) in iter {
-            result.push(fact_to_python(py, fid, fact, &self.engine)?);
+            result.push(fact_to_python(py, fid, fact, &self.engine, self.engine_id)?);
         }
         Ok(result)
     }
@@ -269,7 +277,7 @@ impl PyEngine {
             .map_err(engine_error_to_pyerr)?;
         let mut result = Vec::new();
         for (fid, fact) in facts {
-            result.push(fact_to_python(py, fid, fact, &self.engine)?);
+            result.push(fact_to_python(py, fid, fact, &self.engine, self.engine_id)?);
         }
         Ok(result)
     }
@@ -493,6 +501,7 @@ impl PyEngine {
         Ok(Self {
             engine,
             creator_thread: std::thread::current().id(),
+            engine_id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
         })
     }
 
@@ -534,6 +543,7 @@ impl PyEngine {
         Ok(Self {
             engine,
             creator_thread: std::thread::current().id(),
+            engine_id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
         })
     }
 

--- a/crates/ferric-python/src/engine.rs
+++ b/crates/ferric-python/src/engine.rs
@@ -135,21 +135,33 @@ impl PyEngine {
 
     // -- Fact operations --
 
-    /// Assert a fact from a CLIPS syntax string like `"(color red)"`.
-    fn assert_string(&mut self, source: &str) -> PyResult<u64> {
+    /// Assert one or more facts from CLIPS syntax, e.g. `"(color red)"`.
+    ///
+    /// Returns a list of fact IDs for all asserted facts.
+    ///
+    /// # Example
+    ///
+    /// ```python
+    /// ids = engine.assert_string("(color red) (color blue)")
+    /// assert len(ids) == 2
+    /// ```
+    fn assert_string(&mut self, source: &str) -> PyResult<Vec<u64>> {
         self.check_thread()?;
         let wrapped = format!("(assert {source})");
         let result = self
             .engine
             .load_str(&wrapped)
             .map_err(load_errors_to_pyerr)?;
-        if let Some(fid) = result.asserted_facts.first() {
-            Ok(fid.data().as_ffi())
-        } else {
-            Err(crate::error::FerricError::new_err(
-                "assert_string did not produce a fact",
-            ))
+        if result.asserted_facts.is_empty() {
+            return Err(crate::error::FerricError::new_err(
+                "assert_string did not produce any facts",
+            ));
         }
+        Ok(result
+            .asserted_facts
+            .iter()
+            .map(|fid| fid.data().as_ffi())
+            .collect())
     }
 
     /// Assert a structured ordered fact.

--- a/crates/ferric-python/src/engine.rs
+++ b/crates/ferric-python/src/engine.rs
@@ -135,9 +135,7 @@ impl PyEngine {
     /// Load CLIPS source from a file path (str or os.PathLike).
     fn load_file(&mut self, path: PathBuf) -> PyResult<()> {
         self.check_thread()?;
-        self.engine
-            .load_file(&path)
-            .map_err(load_errors_to_pyerr)?;
+        self.engine.load_file(&path).map_err(load_errors_to_pyerr)?;
         Ok(())
     }
 
@@ -252,7 +250,13 @@ impl PyEngine {
         let fid = FactId::from(KeyData::from_ffi(fact_id));
         let fact = self.engine.get_fact(fid).map_err(engine_error_to_pyerr)?;
         match fact {
-            Some(f) => Ok(Some(fact_to_python(py, fid, f, &self.engine, self.engine_id)?)),
+            Some(f) => Ok(Some(fact_to_python(
+                py,
+                fid,
+                f,
+                &self.engine,
+                self.engine_id,
+            )?)),
             None => Ok(None),
         }
     }

--- a/crates/ferric-python/src/engine.rs
+++ b/crates/ferric-python/src/engine.rs
@@ -396,6 +396,51 @@ impl PyEngine {
             .collect())
     }
 
+    /// Set focus to exactly one module, replacing the previous focus stack.
+    fn set_focus(&mut self, module_name: &str) -> PyResult<()> {
+        self.check_thread()?;
+        self.engine
+            .set_focus(module_name)
+            .map_err(engine_error_to_pyerr)
+    }
+
+    /// Push a module onto the focus stack.
+    fn push_focus(&mut self, module_name: &str) -> PyResult<()> {
+        self.check_thread()?;
+        self.engine
+            .push_focus(module_name)
+            .map_err(engine_error_to_pyerr)
+    }
+
+    /// Return a list of registered module names.
+    fn modules(&self) -> PyResult<Vec<String>> {
+        self.check_thread()?;
+        Ok(self
+            .engine
+            .modules()
+            .into_iter()
+            .map(String::from)
+            .collect())
+    }
+
+    /// Clear accumulated action diagnostics.
+    fn clear_diagnostics(&mut self) -> PyResult<()> {
+        self.check_thread()?;
+        self.engine.clear_action_diagnostics();
+        Ok(())
+    }
+
+    /// Get the value of a template fact slot by name.
+    fn get_fact_slot(&self, py: Python<'_>, fact_id: u64, slot_name: &str) -> PyResult<PyObject> {
+        self.check_thread()?;
+        let fid = FactId::from(KeyData::from_ffi(fact_id));
+        let val = self
+            .engine
+            .get_fact_slot_by_name(fid, slot_name)
+            .map_err(engine_error_to_pyerr)?;
+        Ok(value_to_python(py, val, &self.engine))
+    }
+
     // -- Introspection --
 
     /// Return a list of `(name, salience)` tuples for all rules.

--- a/crates/ferric-python/src/engine.rs
+++ b/crates/ferric-python/src/engine.rs
@@ -438,7 +438,7 @@ impl PyEngine {
             .engine
             .get_fact_slot_by_name(fid, slot_name)
             .map_err(engine_error_to_pyerr)?;
-        Ok(value_to_python(py, val, &self.engine))
+        value_to_python(py, val, &self.engine)
     }
 
     // -- Introspection --
@@ -475,10 +475,10 @@ impl PyEngine {
     /// Get the value of a global variable, or `None`.
     fn get_global(&self, py: Python<'_>, name: &str) -> PyResult<Option<PyObject>> {
         self.check_thread()?;
-        Ok(self
-            .engine
+        self.engine
             .get_global(name)
-            .map(|v| value_to_python(py, v, &self.engine)))
+            .map(|v| value_to_python(py, v, &self.engine))
+            .transpose()
     }
 
     // -- I/O --

--- a/crates/ferric-python/src/engine.rs
+++ b/crates/ferric-python/src/engine.rs
@@ -1,14 +1,17 @@
 //! Python Engine wrapper.
+//!
+//! Engine instances live in a thread-local registry on their creator thread.
+//! `PyEngine` is a lightweight handle (engine ID + thread ID) that is naturally
+//! `Send + Sync` — no `unsafe` required.
 
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::thread::ThreadId;
-
-/// Global counter for assigning unique engine IDs.
-static NEXT_ENGINE_ID: AtomicU64 = AtomicU64::new(1);
+use std::thread::{self, ThreadId};
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyTuple};
 
 use ferric_core::FactId;
 use ferric_runtime::config::EngineConfig;
@@ -24,6 +27,18 @@ use crate::fact::{fact_to_python, Fact};
 use crate::result::{FiredRule, RunResult};
 use crate::value::{python_to_value, value_to_python};
 
+/// Global counter for assigning unique engine IDs.
+static NEXT_ENGINE_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Live engine instance count (testing instrumentation only).
+#[cfg(feature = "testing")]
+static ENGINE_INSTANCE_COUNT: AtomicU64 = AtomicU64::new(0);
+
+thread_local! {
+    /// Thread-local registry of engines owned by this thread.
+    static ENGINES: RefCell<HashMap<u64, Engine>> = RefCell::new(HashMap::new());
+}
+
 /// Build an `EngineConfig` from optional Python args.
 fn make_config(strategy: Option<Strategy>, encoding: Option<Encoding>) -> EngineConfig {
     let mut config = EngineConfig::default();
@@ -36,36 +51,82 @@ fn make_config(strategy: Option<Strategy>, encoding: Option<Encoding>) -> Engine
     config
 }
 
+/// Register a newly-created engine in the thread-local registry.
+fn register_engine(engine: Engine) -> (u64, ThreadId) {
+    let engine_id = NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed);
+    ENGINES.with(|engines| {
+        engines.borrow_mut().insert(engine_id, engine);
+    });
+    #[cfg(feature = "testing")]
+    ENGINE_INSTANCE_COUNT.fetch_add(1, Ordering::Relaxed);
+    (engine_id, thread::current().id())
+}
+
 /// The Ferric rules engine.
 ///
 /// Thread-affine: must be used only from the thread that created it.
 /// Cross-thread access raises `FerricRuntimeError` (not a panic).
+///
+/// The actual engine data lives in a thread-local registry on the creator
+/// thread.  This struct is a lightweight handle that is naturally `Send + Sync`.
 #[pyclass(name = "Engine", module = "ferric")]
 pub struct PyEngine {
-    engine: Engine,
-    creator_thread: ThreadId,
-    /// Unique identifier for this engine instance (used in Fact identity).
     engine_id: u64,
+    creator_thread: ThreadId,
 }
 
-// SAFETY: We enforce thread affinity ourselves via `check_thread()` at every
-// Python entry point, converting violations into `FerricRuntimeError` instead
-// of the `PanicException` that PyO3's `unsendable` would produce.  The inner
-// `Engine` is never actually accessed from a foreign thread.
-unsafe impl Send for PyEngine {}
-unsafe impl Sync for PyEngine {}
-
 impl PyEngine {
-    /// Check that the caller is on the thread that created this engine.
-    fn check_thread(&self) -> PyResult<()> {
-        let current = std::thread::current().id();
+    /// Check thread + look up engine in TLS; run closure with `&mut Engine`.
+    fn with_engine<F, R>(&self, f: F) -> PyResult<R>
+    where
+        F: FnOnce(&mut Engine) -> PyResult<R>,
+    {
+        let current = thread::current().id();
         if current != self.creator_thread {
             return Err(FerricRuntimeError::new_err(format!(
                 "engine called from wrong thread (created on {:?}, called from {:?})",
                 self.creator_thread, current,
             )));
         }
-        Ok(())
+        ENGINES.with(|engines| {
+            let mut map = engines.borrow_mut();
+            let engine = map
+                .get_mut(&self.engine_id)
+                .ok_or_else(|| FerricRuntimeError::new_err("engine has been closed"))?;
+            f(engine)
+        })
+    }
+
+    /// Remove engine from registry.  Returns `true` if it was present.
+    fn remove_engine(&self) -> bool {
+        if thread::current().id() != self.creator_thread {
+            return false;
+        }
+        let removed =
+            ENGINES.with(|engines| engines.borrow_mut().remove(&self.engine_id).is_some());
+        #[cfg(feature = "testing")]
+        if removed {
+            ENGINE_INSTANCE_COUNT.fetch_sub(1, Ordering::Relaxed);
+        }
+        removed
+    }
+}
+
+impl Drop for PyEngine {
+    fn drop(&mut self) {
+        if thread::current().id() == self.creator_thread {
+            // Try to remove from TLS.  `try_with` handles TLS-already-destroyed
+            // during interpreter shutdown.
+            let _removed = ENGINES
+                .try_with(|engines| engines.borrow_mut().remove(&self.engine_id).is_some())
+                .unwrap_or(false);
+            #[cfg(feature = "testing")]
+            if _removed {
+                ENGINE_INSTANCE_COUNT.fetch_sub(1, Ordering::Relaxed);
+            }
+        }
+        // Foreign thread: no-op.  Engine stays in creator thread's TLS and is
+        // cleaned up when that thread exits (TLS destructors run).
     }
 }
 
@@ -75,16 +136,16 @@ impl PyEngine {
     ///
     /// # Arguments
     ///
-    /// * `strategy` — Conflict resolution strategy (default: `Strategy.DEPTH`).
-    /// * `encoding` — String encoding mode (default: `Encoding.UTF8`).
+    /// * `strategy` -- Conflict resolution strategy (default: `Strategy.DEPTH`).
+    /// * `encoding` -- String encoding mode (default: `Encoding.UTF8`).
     #[new]
     #[pyo3(signature = (*, strategy=None, encoding=None))]
     fn new(strategy: Option<Strategy>, encoding: Option<Encoding>) -> Self {
         let config = make_config(strategy, encoding);
+        let (engine_id, creator_thread) = register_engine(Engine::new(config));
         Self {
-            engine: Engine::new(config),
-            creator_thread: std::thread::current().id(),
-            engine_id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
+            engine_id,
+            creator_thread,
         }
     }
 
@@ -98,10 +159,10 @@ impl PyEngine {
     ) -> PyResult<Self> {
         let config = make_config(strategy, encoding);
         let engine = Engine::with_rules_config(source, config).map_err(init_error_to_pyerr)?;
+        let (engine_id, creator_thread) = register_engine(engine);
         Ok(Self {
-            engine,
-            creator_thread: std::thread::current().id(),
-            engine_id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
+            engine_id,
+            creator_thread,
         })
     }
 
@@ -113,30 +174,47 @@ impl PyEngine {
 
     #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
     fn __exit__(
-        &mut self,
+        &self,
         _exc_type: Option<&Bound<'_, PyAny>>,
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<bool> {
-        self.check_thread()?;
-        self.engine.clear();
+        self.close()?;
         Ok(false) // don't suppress exceptions
+    }
+
+    /// Explicitly close and destroy this engine.
+    ///
+    /// After calling `close()`, any further method calls will raise
+    /// `FerricRuntimeError`.  This is idempotent.
+    fn close(&self) -> PyResult<()> {
+        let current = thread::current().id();
+        if current != self.creator_thread {
+            return Err(FerricRuntimeError::new_err(format!(
+                "engine called from wrong thread (created on {:?}, called from {:?})",
+                self.creator_thread, current,
+            )));
+        }
+        self.remove_engine();
+        Ok(())
     }
 
     // -- Loading --
 
     /// Load CLIPS source into the engine.
-    fn load(&mut self, source: &str) -> PyResult<()> {
-        self.check_thread()?;
-        self.engine.load_str(source).map_err(load_errors_to_pyerr)?;
-        Ok(())
+    fn load(&self, source: &str) -> PyResult<()> {
+        self.with_engine(|engine| {
+            engine.load_str(source).map_err(load_errors_to_pyerr)?;
+            Ok(())
+        })
     }
 
     /// Load CLIPS source from a file path (str or os.PathLike).
-    fn load_file(&mut self, path: PathBuf) -> PyResult<()> {
-        self.check_thread()?;
-        self.engine.load_file(&path).map_err(load_errors_to_pyerr)?;
-        Ok(())
+    fn load_file(&self, path: PathBuf) -> PyResult<()> {
+        self.with_engine(|engine| {
+            engine.load_file(&path).map_err(load_errors_to_pyerr)?;
+            Ok(())
+        })
     }
 
     // -- Fact operations --
@@ -151,57 +229,55 @@ impl PyEngine {
     /// ids = engine.assert_string("(color red) (color blue)")
     /// assert len(ids) == 2
     /// ```
-    fn assert_string(&mut self, source: &str) -> PyResult<Vec<u64>> {
-        self.check_thread()?;
-        let wrapped = format!("(assert {source})");
-        let result = self
-            .engine
-            .load_str(&wrapped)
-            .map_err(load_errors_to_pyerr)?;
-        if result.asserted_facts.is_empty() {
-            return Err(crate::error::FerricError::new_err(
-                "assert_string did not produce any facts",
-            ));
-        }
-        Ok(result
-            .asserted_facts
-            .iter()
-            .map(|fid| fid.data().as_ffi())
-            .collect())
+    fn assert_string(&self, source: &str) -> PyResult<Vec<u64>> {
+        self.with_engine(|engine| {
+            let wrapped = format!("(assert {source})");
+            let result = engine.load_str(&wrapped).map_err(load_errors_to_pyerr)?;
+            if result.asserted_facts.is_empty() {
+                return Err(crate::error::FerricError::new_err(
+                    "assert_string did not produce any facts",
+                ));
+            }
+            Ok(result
+                .asserted_facts
+                .iter()
+                .map(|fid| fid.data().as_ffi())
+                .collect())
+        })
     }
 
     /// Assert a structured ordered fact.
     ///
     /// # Arguments
     ///
-    /// * `relation` — The fact relation name.
-    /// * `args` — The field values.
+    /// * `relation` -- The fact relation name.
+    /// * `args` -- The field values.
     #[pyo3(signature = (relation, *args))]
     fn assert_fact(
-        &mut self,
+        &self,
         py: Python<'_>,
         relation: &str,
         args: &Bound<'_, PyTuple>,
     ) -> PyResult<u64> {
-        self.check_thread()?;
-        let mut values = Vec::with_capacity(args.len());
-        for item in args.iter() {
-            values.push(python_to_value(&item, &mut self.engine)?);
-        }
-        let fid = self
-            .engine
-            .assert_ordered(relation, values)
-            .map_err(engine_error_to_pyerr)?;
         let _ = py;
-        Ok(fid.data().as_ffi())
+        self.with_engine(|engine| {
+            let mut values = Vec::with_capacity(args.len());
+            for item in args.iter() {
+                values.push(python_to_value(&item, engine)?);
+            }
+            let fid = engine
+                .assert_ordered(relation, values)
+                .map_err(engine_error_to_pyerr)?;
+            Ok(fid.data().as_ffi())
+        })
     }
 
     /// Assert a structured template fact.
     ///
     /// # Arguments
     ///
-    /// * `template_name` — The deftemplate name.
-    /// * `kwargs` — Slot name/value pairs.
+    /// * `template_name` -- The deftemplate name.
+    /// * `kwargs` -- Slot name/value pairs.
     ///
     /// # Example
     ///
@@ -210,80 +286,78 @@ impl PyEngine {
     /// ```
     #[pyo3(signature = (template_name, **kwargs))]
     fn assert_template(
-        &mut self,
+        &self,
         template_name: &str,
         kwargs: Option<&Bound<'_, PyDict>>,
     ) -> PyResult<u64> {
-        self.check_thread()?;
-        let (names, values) = match kwargs {
-            Some(dict) => {
-                let mut names = Vec::with_capacity(dict.len());
-                let mut values = Vec::with_capacity(dict.len());
-                for (key, val) in dict.iter() {
-                    let name: String = key.extract()?;
-                    names.push(name);
-                    values.push(python_to_value(&val, &mut self.engine)?);
+        self.with_engine(|engine| {
+            let (names, values) = match kwargs {
+                Some(dict) => {
+                    let mut names = Vec::with_capacity(dict.len());
+                    let mut values = Vec::with_capacity(dict.len());
+                    for (key, val) in dict.iter() {
+                        let name: String = key.extract()?;
+                        names.push(name);
+                        values.push(python_to_value(&val, engine)?);
+                    }
+                    (names, values)
                 }
-                (names, values)
-            }
-            None => (Vec::new(), Vec::new()),
-        };
+                None => (Vec::new(), Vec::new()),
+            };
 
-        let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
-        let fid = self
-            .engine
-            .assert_template(template_name, &name_refs, values)
-            .map_err(engine_error_to_pyerr)?;
-        Ok(fid.data().as_ffi())
+            let name_refs: Vec<&str> = names.iter().map(String::as_str).collect();
+            let fid = engine
+                .assert_template(template_name, &name_refs, values)
+                .map_err(engine_error_to_pyerr)?;
+            Ok(fid.data().as_ffi())
+        })
     }
 
     /// Retract a fact by its ID.
-    fn retract(&mut self, fact_id: u64) -> PyResult<()> {
-        self.check_thread()?;
-        let fid = FactId::from(KeyData::from_ffi(fact_id));
-        self.engine.retract(fid).map_err(engine_error_to_pyerr)
+    fn retract(&self, fact_id: u64) -> PyResult<()> {
+        self.with_engine(|engine| {
+            let fid = FactId::from(KeyData::from_ffi(fact_id));
+            engine.retract(fid).map_err(engine_error_to_pyerr)
+        })
     }
 
     /// Get a fact by its ID, or `None` if it does not exist.
     fn get_fact(&self, py: Python<'_>, fact_id: u64) -> PyResult<Option<Fact>> {
-        self.check_thread()?;
-        let fid = FactId::from(KeyData::from_ffi(fact_id));
-        let fact = self.engine.get_fact(fid).map_err(engine_error_to_pyerr)?;
-        match fact {
-            Some(f) => Ok(Some(fact_to_python(
-                py,
-                fid,
-                f,
-                &self.engine,
-                self.engine_id,
-            )?)),
-            None => Ok(None),
-        }
+        let eid = self.engine_id;
+        self.with_engine(|engine| {
+            let fid = FactId::from(KeyData::from_ffi(fact_id));
+            let fact = engine.get_fact(fid).map_err(engine_error_to_pyerr)?;
+            match fact {
+                Some(f) => Ok(Some(fact_to_python(py, fid, f, engine, eid)?)),
+                None => Ok(None),
+            }
+        })
     }
 
     /// Return all facts currently in working memory.
     fn facts(&self, py: Python<'_>) -> PyResult<Vec<Fact>> {
-        self.check_thread()?;
-        let iter = self.engine.facts().map_err(engine_error_to_pyerr)?;
-        let mut result = Vec::new();
-        for (fid, fact) in iter {
-            result.push(fact_to_python(py, fid, fact, &self.engine, self.engine_id)?);
-        }
-        Ok(result)
+        let eid = self.engine_id;
+        self.with_engine(|engine| {
+            let iter = engine.facts().map_err(engine_error_to_pyerr)?;
+            let mut result = Vec::new();
+            for (fid, fact) in iter {
+                result.push(fact_to_python(py, fid, fact, engine, eid)?);
+            }
+            Ok(result)
+        })
     }
 
     /// Find facts by relation name.
     fn find_facts(&self, py: Python<'_>, relation: &str) -> PyResult<Vec<Fact>> {
-        self.check_thread()?;
-        let facts = self
-            .engine
-            .find_facts(relation)
-            .map_err(engine_error_to_pyerr)?;
-        let mut result = Vec::new();
-        for (fid, fact) in facts {
-            result.push(fact_to_python(py, fid, fact, &self.engine, self.engine_id)?);
-        }
-        Ok(result)
+        let eid = self.engine_id;
+        self.with_engine(|engine| {
+            let facts = engine.find_facts(relation).map_err(engine_error_to_pyerr)?;
+            let mut result = Vec::new();
+            for (fid, fact) in facts {
+                result.push(fact_to_python(py, fid, fact, engine, eid)?);
+            }
+            Ok(result)
+        })
     }
 
     // -- Execution --
@@ -292,50 +366,52 @@ impl PyEngine {
     ///
     /// # Arguments
     ///
-    /// * `limit` — Maximum number of rule firings (default: unlimited).
+    /// * `limit` -- Maximum number of rule firings (default: unlimited).
     #[pyo3(signature = (*, limit=None))]
-    fn run(&mut self, limit: Option<usize>) -> PyResult<RunResult> {
-        self.check_thread()?;
-        let run_limit = match limit {
-            Some(n) => RunLimit::Count(n),
-            None => RunLimit::Unlimited,
-        };
-        let result = self.engine.run(run_limit).map_err(engine_error_to_pyerr)?;
-        Ok(result.into())
+    fn run(&self, limit: Option<usize>) -> PyResult<RunResult> {
+        self.with_engine(|engine| {
+            let run_limit = match limit {
+                Some(n) => RunLimit::Count(n),
+                None => RunLimit::Unlimited,
+            };
+            let result = engine.run(run_limit).map_err(engine_error_to_pyerr)?;
+            Ok(result.into())
+        })
     }
 
     /// Fire a single rule activation. Returns `FiredRule` or `None`.
-    fn step(&mut self) -> PyResult<Option<FiredRule>> {
-        self.check_thread()?;
-        let result = self.engine.step().map_err(engine_error_to_pyerr)?;
-        Ok(result.map(|fr| {
-            let name = self
-                .engine
-                .rule_name(fr.rule_id)
-                .unwrap_or("<unknown>")
-                .to_string();
-            FiredRule { rule_name: name }
-        }))
+    fn step(&self) -> PyResult<Option<FiredRule>> {
+        self.with_engine(|engine| {
+            let result = engine.step().map_err(engine_error_to_pyerr)?;
+            Ok(result.map(|fr| {
+                let name = engine
+                    .rule_name(fr.rule_id)
+                    .unwrap_or("<unknown>")
+                    .to_string();
+                FiredRule { rule_name: name }
+            }))
+        })
     }
 
     /// Request the engine to halt.
-    fn halt(&mut self) -> PyResult<()> {
-        self.check_thread()?;
-        self.engine.halt();
-        Ok(())
+    fn halt(&self) -> PyResult<()> {
+        self.with_engine(|engine| {
+            engine.halt();
+            Ok(())
+        })
     }
 
     /// Reset the engine: clear facts and re-assert deffacts.
-    fn reset(&mut self) -> PyResult<()> {
-        self.check_thread()?;
-        self.engine.reset().map_err(engine_error_to_pyerr)
+    fn reset(&self) -> PyResult<()> {
+        self.with_engine(|engine| engine.reset().map_err(engine_error_to_pyerr))
     }
 
     /// Clear the engine: remove all rules, facts, templates, etc.
-    fn clear(&mut self) -> PyResult<()> {
-        self.check_thread()?;
-        self.engine.clear();
-        Ok(())
+    fn clear(&self) -> PyResult<()> {
+        self.with_engine(|engine| {
+            engine.clear();
+            Ok(())
+        })
     }
 
     // -- Properties --
@@ -343,168 +419,155 @@ impl PyEngine {
     /// Number of user-visible facts.
     #[getter]
     fn fact_count(&self) -> PyResult<usize> {
-        self.check_thread()?;
-        let count = self.engine.facts().map_err(engine_error_to_pyerr)?.count();
-        Ok(count)
+        self.with_engine(|engine| {
+            let count = engine.facts().map_err(engine_error_to_pyerr)?.count();
+            Ok(count)
+        })
     }
 
     /// Whether the engine is currently halted.
     #[getter]
     fn is_halted(&self) -> PyResult<bool> {
-        self.check_thread()?;
-        Ok(self.engine.is_halted())
+        self.with_engine(|engine| Ok(engine.is_halted()))
     }
 
     /// Number of pending activations on the agenda.
     #[getter]
     fn agenda_size(&self) -> PyResult<usize> {
-        self.check_thread()?;
-        Ok(self.engine.agenda_len())
+        self.with_engine(|engine| Ok(engine.agenda_len()))
     }
 
     /// Name of the current module.
     #[getter]
     fn current_module(&self) -> PyResult<String> {
-        self.check_thread()?;
-        Ok(self.engine.current_module().to_owned())
+        self.with_engine(|engine| Ok(engine.current_module().to_owned()))
     }
 
     /// Top of the focus stack, or `None`.
     #[getter]
     fn focus(&self) -> PyResult<Option<String>> {
-        self.check_thread()?;
-        Ok(self.engine.get_focus().map(str::to_owned))
+        self.with_engine(|engine| Ok(engine.get_focus().map(str::to_owned)))
     }
 
     /// Full focus stack as a list of module names (bottom to top).
     #[getter]
     fn focus_stack(&self) -> PyResult<Vec<String>> {
-        self.check_thread()?;
-        Ok(self
-            .engine
-            .get_focus_stack()
-            .into_iter()
-            .map(String::from)
-            .collect())
+        self.with_engine(|engine| {
+            Ok(engine
+                .get_focus_stack()
+                .into_iter()
+                .map(String::from)
+                .collect())
+        })
     }
 
     /// Non-fatal action diagnostics from the most recent run/step.
     #[getter]
     fn diagnostics(&self) -> PyResult<Vec<String>> {
-        self.check_thread()?;
-        Ok(self
-            .engine
-            .action_diagnostics()
-            .iter()
-            .map(ToString::to_string)
-            .collect())
+        self.with_engine(|engine| {
+            Ok(engine
+                .action_diagnostics()
+                .iter()
+                .map(ToString::to_string)
+                .collect())
+        })
     }
 
     /// Set focus to exactly one module, replacing the previous focus stack.
-    fn set_focus(&mut self, module_name: &str) -> PyResult<()> {
-        self.check_thread()?;
-        self.engine
-            .set_focus(module_name)
-            .map_err(engine_error_to_pyerr)
+    fn set_focus(&self, module_name: &str) -> PyResult<()> {
+        self.with_engine(|engine| engine.set_focus(module_name).map_err(engine_error_to_pyerr))
     }
 
     /// Push a module onto the focus stack.
-    fn push_focus(&mut self, module_name: &str) -> PyResult<()> {
-        self.check_thread()?;
-        self.engine
-            .push_focus(module_name)
-            .map_err(engine_error_to_pyerr)
+    fn push_focus(&self, module_name: &str) -> PyResult<()> {
+        self.with_engine(|engine| {
+            engine
+                .push_focus(module_name)
+                .map_err(engine_error_to_pyerr)
+        })
     }
 
     /// Return a list of registered module names.
     fn modules(&self) -> PyResult<Vec<String>> {
-        self.check_thread()?;
-        Ok(self
-            .engine
-            .modules()
-            .into_iter()
-            .map(String::from)
-            .collect())
+        self.with_engine(|engine| Ok(engine.modules().into_iter().map(String::from).collect()))
     }
 
     /// Clear accumulated action diagnostics.
-    fn clear_diagnostics(&mut self) -> PyResult<()> {
-        self.check_thread()?;
-        self.engine.clear_action_diagnostics();
-        Ok(())
+    fn clear_diagnostics(&self) -> PyResult<()> {
+        self.with_engine(|engine| {
+            engine.clear_action_diagnostics();
+            Ok(())
+        })
     }
 
     /// Get the value of a template fact slot by name.
     fn get_fact_slot(&self, py: Python<'_>, fact_id: u64, slot_name: &str) -> PyResult<PyObject> {
-        self.check_thread()?;
-        let fid = FactId::from(KeyData::from_ffi(fact_id));
-        let val = self
-            .engine
-            .get_fact_slot_by_name(fid, slot_name)
-            .map_err(engine_error_to_pyerr)?;
-        value_to_python(py, val, &self.engine)
+        self.with_engine(|engine| {
+            let fid = FactId::from(KeyData::from_ffi(fact_id));
+            let val = engine
+                .get_fact_slot_by_name(fid, slot_name)
+                .map_err(engine_error_to_pyerr)?;
+            value_to_python(py, val, engine)
+        })
     }
 
     // -- Introspection --
 
     /// Return a list of `(name, salience)` tuples for all rules.
     fn rules(&self, py: Python<'_>) -> PyResult<PyObject> {
-        self.check_thread()?;
-        let rules = self.engine.rules();
-        let list = PyList::empty(py);
-        for (name, salience) in rules {
-            let tuple = pyo3::types::PyTuple::new(
-                py,
-                [
-                    name.into_pyobject(py)?.into_any(),
-                    salience.into_pyobject(py)?.into_any(),
-                ],
-            )?;
-            list.append(tuple)?;
-        }
-        Ok(list.into_any().unbind())
+        self.with_engine(|engine| {
+            let rules = engine.rules();
+            let list = PyList::empty(py);
+            for (name, salience) in rules {
+                let tuple = PyTuple::new(
+                    py,
+                    [
+                        name.into_pyobject(py)?.into_any(),
+                        salience.into_pyobject(py)?.into_any(),
+                    ],
+                )?;
+                list.append(tuple)?;
+            }
+            Ok(list.into_any().unbind())
+        })
     }
 
     /// Return a list of template names.
     fn templates(&self) -> PyResult<Vec<String>> {
-        self.check_thread()?;
-        Ok(self
-            .engine
-            .templates()
-            .into_iter()
-            .map(String::from)
-            .collect())
+        self.with_engine(|engine| Ok(engine.templates().into_iter().map(String::from).collect()))
     }
 
     /// Get the value of a global variable, or `None`.
     fn get_global(&self, py: Python<'_>, name: &str) -> PyResult<Option<PyObject>> {
-        self.check_thread()?;
-        self.engine
-            .get_global(name)
-            .map(|v| value_to_python(py, v, &self.engine))
-            .transpose()
+        self.with_engine(|engine| {
+            engine
+                .get_global(name)
+                .map(|v| value_to_python(py, v, engine))
+                .transpose()
+        })
     }
 
     // -- I/O --
 
     /// Get captured output for a channel (e.g. "stdout").
     fn get_output(&self, channel: &str) -> PyResult<Option<String>> {
-        self.check_thread()?;
-        Ok(self.engine.get_output(channel).map(String::from))
+        self.with_engine(|engine| Ok(engine.get_output(channel).map(String::from)))
     }
 
     /// Clear captured output for a channel.
-    fn clear_output(&mut self, channel: &str) -> PyResult<()> {
-        self.check_thread()?;
-        self.engine.clear_output_channel(channel);
-        Ok(())
+    fn clear_output(&self, channel: &str) -> PyResult<()> {
+        self.with_engine(|engine| {
+            engine.clear_output_channel(channel);
+            Ok(())
+        })
     }
 
     /// Push a line of input for `read`/`readline`.
-    fn push_input(&mut self, line: &str) -> PyResult<()> {
-        self.check_thread()?;
-        self.engine.push_input(line);
-        Ok(())
+    fn push_input(&self, line: &str) -> PyResult<()> {
+        self.with_engine(|engine| {
+            engine.push_input(line);
+            Ok(())
+        })
     }
 
     // -- Serialization --
@@ -513,7 +576,7 @@ impl PyEngine {
     ///
     /// # Arguments
     ///
-    /// * `format` — Serialization format (default: `Format.BINCODE`).
+    /// * `format` -- Serialization format (default: `Format.BINCODE`).
     ///
     /// Returns `bytes` containing the serialized engine state.
     #[cfg(feature = "serde")]
@@ -523,23 +586,21 @@ impl PyEngine {
         py: Python<'py>,
         format: Option<crate::config::Format>,
     ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
-        self.check_thread()?;
-        let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
-        let bytes = self
-            .engine
-            .serialize(fmt)
-            .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
-        Ok(pyo3::types::PyBytes::new(py, &bytes))
+        self.with_engine(|engine| {
+            let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
+            let bytes = engine
+                .serialize(fmt)
+                .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
+            Ok(pyo3::types::PyBytes::new(py, &bytes))
+        })
     }
 
     /// Create an engine by deserializing a snapshot.
     ///
     /// # Arguments
     ///
-    /// * `data` — Serialized engine state (bytes).
-    /// * `format` — Serialization format (default: `Format.BINCODE`).
-    /// * `strategy` — Conflict resolution strategy override (unused for snapshots).
-    /// * `encoding` — String encoding mode override (unused for snapshots).
+    /// * `data` -- Serialized engine state (bytes).
+    /// * `format` -- Serialization format (default: `Format.BINCODE`).
     #[staticmethod]
     #[cfg(feature = "serde")]
     #[pyo3(signature = (data, *, format=None))]
@@ -547,10 +608,10 @@ impl PyEngine {
         let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
         let engine = Engine::deserialize(data, fmt)
             .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
+        let (engine_id, creator_thread) = register_engine(engine);
         Ok(Self {
-            engine,
-            creator_thread: std::thread::current().id(),
-            engine_id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
+            engine_id,
+            creator_thread,
         })
     }
 
@@ -558,28 +619,28 @@ impl PyEngine {
     ///
     /// # Arguments
     ///
-    /// * `path` — File path (str or os.PathLike).
-    /// * `format` — Serialization format (default: `Format.BINCODE`).
+    /// * `path` -- File path (str or os.PathLike).
+    /// * `format` -- Serialization format (default: `Format.BINCODE`).
     #[cfg(feature = "serde")]
     #[pyo3(signature = (path, *, format=None))]
     fn save_snapshot(&self, path: PathBuf, format: Option<crate::config::Format>) -> PyResult<()> {
-        self.check_thread()?;
-        let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
-        let bytes = self
-            .engine
-            .serialize(fmt)
-            .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
-        std::fs::write(&path, &bytes)
-            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
-        Ok(())
+        self.with_engine(|engine| {
+            let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
+            let bytes = engine
+                .serialize(fmt)
+                .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
+            std::fs::write(&path, &bytes)
+                .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
+            Ok(())
+        })
     }
 
     /// Create an engine by deserializing a snapshot from a file.
     ///
     /// # Arguments
     ///
-    /// * `path` — File path (str or os.PathLike).
-    /// * `format` — Serialization format (default: `Format.BINCODE`).
+    /// * `path` -- File path (str or os.PathLike).
+    /// * `format` -- Serialization format (default: `Format.BINCODE`).
     #[staticmethod]
     #[cfg(feature = "serde")]
     #[pyo3(signature = (path, *, format=None))]
@@ -589,37 +650,45 @@ impl PyEngine {
         let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
         let engine = Engine::deserialize(&data, fmt)
             .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
+        let (engine_id, creator_thread) = register_engine(engine);
         Ok(Self {
-            engine,
-            creator_thread: std::thread::current().id(),
-            engine_id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
+            engine_id,
+            creator_thread,
         })
     }
 
     // -- Python protocols --
 
     fn __repr__(&self) -> PyResult<String> {
-        self.check_thread()?;
-        let fact_count = self.engine.facts().map_err(engine_error_to_pyerr)?.count();
-        let rule_count = self.engine.rules().len();
-        let halted = self.engine.is_halted();
-        Ok(format!(
-            "Engine(facts={fact_count}, rules={rule_count}, halted={halted})"
-        ))
+        self.with_engine(|engine| {
+            let fact_count = engine.facts().map_err(engine_error_to_pyerr)?.count();
+            let rule_count = engine.rules().len();
+            let halted = engine.is_halted();
+            Ok(format!(
+                "Engine(facts={fact_count}, rules={rule_count}, halted={halted})"
+            ))
+        })
     }
 
     fn __len__(&self) -> PyResult<usize> {
-        self.check_thread()?;
-        let count = self.engine.facts().map_err(engine_error_to_pyerr)?.count();
-        Ok(count)
+        self.with_engine(|engine| {
+            let count = engine.facts().map_err(engine_error_to_pyerr)?.count();
+            Ok(count)
+        })
     }
 
     fn __contains__(&self, fact_id: u64) -> PyResult<bool> {
-        self.check_thread()?;
-        let fid = FactId::from(KeyData::from_ffi(fact_id));
-        let fact = self.engine.get_fact(fid).map_err(engine_error_to_pyerr)?;
-        Ok(fact.is_some())
+        self.with_engine(|engine| {
+            let fid = FactId::from(KeyData::from_ffi(fact_id));
+            let fact = engine.get_fact(fid).map_err(engine_error_to_pyerr)?;
+            Ok(fact.is_some())
+        })
     }
 }
 
-use pyo3::types::PyTuple;
+/// Return the number of live engine instances (testing instrumentation).
+#[cfg(feature = "testing")]
+#[pyfunction]
+pub fn engine_instance_count() -> u64 {
+    ENGINE_INSTANCE_COUNT.load(Ordering::Relaxed)
+}

--- a/crates/ferric-python/src/error.rs
+++ b/crates/ferric-python/src/error.rs
@@ -79,22 +79,28 @@ pub fn engine_error_to_pyerr(err: EngineError) -> PyErr {
 }
 
 /// Convert a `Vec<LoadError>` into a single Python exception.
+///
+/// All error messages are joined into the exception message so no
+/// diagnostics are lost.  The exception *type* is determined by the
+/// first parse or compile error encountered (parse takes precedence).
 pub fn load_errors_to_pyerr(errors: Vec<LoadError>) -> PyErr {
-    // Check if any error is a parse error vs compile error
-    for err in &errors {
-        match err {
-            LoadError::Parse(_) => return FerricParseError::new_err(err.to_string()),
-            LoadError::Compile(_) => return FerricCompileError::new_err(err.to_string()),
-            _ => {}
-        }
-    }
-    // Default: join all messages under FerricError
     let msg = errors
         .iter()
         .map(ToString::to_string)
         .collect::<Vec<_>>()
-        .join("; ");
-    FerricError::new_err(msg)
+        .join("\n");
+
+    // Classify by scanning for parse errors first, then compile errors.
+    let has_parse = errors.iter().any(|e| matches!(e, LoadError::Parse(_)));
+    let has_compile = errors.iter().any(|e| matches!(e, LoadError::Compile(_)));
+
+    if has_parse {
+        FerricParseError::new_err(msg)
+    } else if has_compile {
+        FerricCompileError::new_err(msg)
+    } else {
+        FerricError::new_err(msg)
+    }
 }
 
 /// Convert an `InitError` into a Python exception.

--- a/crates/ferric-python/src/fact.rs
+++ b/crates/ferric-python/src/fact.rs
@@ -111,7 +111,7 @@ pub fn fact_to_python(
                 .fields
                 .iter()
                 .map(|v| value_to_python(py, v, engine))
-                .collect();
+                .collect::<PyResult<_>>()?;
             let fields_list = pyo3::types::PyList::new(py, fields)?.into_any().unbind();
 
             Ok(Fact {
@@ -133,7 +133,7 @@ pub fn fact_to_python(
                 .slots
                 .iter()
                 .map(|v| value_to_python(py, v, engine))
-                .collect();
+                .collect::<PyResult<_>>()?;
             let fields_list = pyo3::types::PyList::new(py, &fields)?.into_any().unbind();
 
             // Build slots dict if we can resolve slot names (by ID to avoid

--- a/crates/ferric-python/src/fact.rs
+++ b/crates/ferric-python/src/fact.rs
@@ -12,7 +12,7 @@ use slotmap::Key;
 use crate::value::value_to_python;
 
 /// Fact type discriminator.
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, module = "ferric")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FactType {
     #[pyo3(name = "ORDERED")]
@@ -24,7 +24,7 @@ pub enum FactType {
 /// A snapshot of a fact from the engine.
 ///
 /// This is a value copy — it does not hold a reference to the engine.
-#[pyclass]
+#[pyclass(module = "ferric")]
 pub struct Fact {
     /// Fact ID (as u64 from slotmap `KeyData::as_ffi()`).
     #[pyo3(get)]

--- a/crates/ferric-python/src/fact.rs
+++ b/crates/ferric-python/src/fact.rs
@@ -29,6 +29,9 @@ pub struct Fact {
     /// Fact ID (as u64 from slotmap `KeyData::as_ffi()`).
     #[pyo3(get)]
     pub id: u64,
+    /// Engine instance ID (used for cross-engine equality/hash).
+    #[pyo3(get)]
+    pub engine_id: u64,
     /// Whether this is an ordered or template fact.
     #[pyo3(get)]
     pub fact_type: FactType,
@@ -77,11 +80,12 @@ impl Fact {
     }
 
     fn __eq__(&self, other: &Self) -> bool {
-        self.id == other.id
+        self.engine_id == other.engine_id && self.id == other.id
     }
 
     fn __hash__(&self) -> u64 {
         let mut hasher = DefaultHasher::new();
+        self.engine_id.hash(&mut hasher);
         self.id.hash(&mut hasher);
         hasher.finish()
     }
@@ -93,6 +97,7 @@ pub fn fact_to_python(
     fact_id: FactId,
     fact: &CoreFact,
     engine: &Engine,
+    engine_id: u64,
 ) -> PyResult<Fact> {
     let id = fact_id.data().as_ffi();
 
@@ -111,6 +116,7 @@ pub fn fact_to_python(
 
             Ok(Fact {
                 id,
+                engine_id,
                 fact_type: FactType::Ordered,
                 relation: Some(relation),
                 template_name: None,
@@ -145,6 +151,7 @@ pub fn fact_to_python(
 
             Ok(Fact {
                 id,
+                engine_id,
                 fact_type: FactType::Template,
                 relation: None,
                 template_name: Some(tmpl_name),

--- a/crates/ferric-python/src/lib.rs
+++ b/crates/ferric-python/src/lib.rs
@@ -37,5 +37,9 @@ fn ferric(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Exception hierarchy
     error::register_exceptions(m)?;
 
+    // Testing instrumentation
+    #[cfg(feature = "testing")]
+    m.add_function(wrap_pyfunction!(engine::engine_instance_count, m)?)?;
+
     Ok(())
 }

--- a/crates/ferric-python/src/lib.rs
+++ b/crates/ferric-python/src/lib.rs
@@ -19,6 +19,10 @@ fn ferric(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<fact::Fact>()?;
     m.add_class::<fact::FactType>()?;
 
+    // Value types (symbol vs string distinction)
+    m.add_class::<value::Symbol>()?;
+    m.add_class::<value::ClipsString>()?;
+
     // Config enums
     m.add_class::<config::Strategy>()?;
     m.add_class::<config::Encoding>()?;

--- a/crates/ferric-python/src/result.rs
+++ b/crates/ferric-python/src/result.rs
@@ -3,7 +3,7 @@
 use pyo3::prelude::*;
 
 /// Why execution stopped.
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, module = "ferric")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum HaltReason {
     /// The agenda was empty.
@@ -28,7 +28,7 @@ impl From<ferric_runtime::HaltReason> for HaltReason {
 }
 
 /// Result of an execution run.
-#[pyclass]
+#[pyclass(module = "ferric")]
 #[derive(Clone, Debug)]
 pub struct RunResult {
     /// Number of rules fired.
@@ -59,7 +59,7 @@ impl From<ferric_runtime::RunResult> for RunResult {
 }
 
 /// Information about a fired rule.
-#[pyclass]
+#[pyclass(module = "ferric")]
 #[derive(Clone, Debug)]
 pub struct FiredRule {
     /// Name of the rule that fired.

--- a/crates/ferric-python/src/value.rs
+++ b/crates/ferric-python/src/value.rs
@@ -12,7 +12,7 @@ use ferric_runtime::{Engine, Multifield, Value};
 ///
 /// Wraps a Python string and converts to `Value::Symbol` on the Rust side.
 /// Plain Python `str` also maps to Symbol by default.
-#[pyclass(name = "Symbol")]
+#[pyclass(name = "Symbol", module = "ferric")]
 #[derive(Clone, Debug)]
 pub struct Symbol {
     #[pyo3(get)]
@@ -55,7 +55,7 @@ impl Symbol {
 ///
 /// Without this wrapper, Python `str` maps to `Value::Symbol`.
 /// Use `String("text")` to create a CLIPS string literal.
-#[pyclass(name = "String")]
+#[pyclass(name = "String", module = "ferric")]
 #[derive(Clone, Debug)]
 pub struct ClipsString {
     #[pyo3(get)]

--- a/crates/ferric-python/src/value.rs
+++ b/crates/ferric-python/src/value.rs
@@ -1,9 +1,98 @@
 //! Value conversion between Rust and Python.
 
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyFloat, PyInt, PyList, PyString, PyTuple};
 
 use ferric_runtime::{Engine, Multifield, Value};
+
+/// A CLIPS symbol value.
+///
+/// Wraps a Python string and converts to `Value::Symbol` on the Rust side.
+/// Plain Python `str` also maps to Symbol by default.
+#[pyclass(name = "Symbol")]
+#[derive(Clone, Debug)]
+pub struct Symbol {
+    #[pyo3(get)]
+    pub value: String,
+}
+
+#[pymethods]
+impl Symbol {
+    #[new]
+    fn new(value: String) -> Self {
+        Self { value }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("Symbol({:?})", self.value)
+    }
+
+    fn __str__(&self) -> &str {
+        &self.value
+    }
+
+    fn __eq__(&self, other: &Bound<'_, PyAny>) -> bool {
+        if let Ok(sym) = other.downcast::<Symbol>() {
+            return self.value == sym.borrow().value;
+        }
+        if let Ok(s) = other.extract::<String>() {
+            return self.value == s;
+        }
+        false
+    }
+
+    fn __hash__(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.value.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+/// A CLIPS string value (distinct from a symbol).
+///
+/// Without this wrapper, Python `str` maps to `Value::Symbol`.
+/// Use `String("text")` to create a CLIPS string literal.
+#[pyclass(name = "String")]
+#[derive(Clone, Debug)]
+pub struct ClipsString {
+    #[pyo3(get)]
+    pub value: String,
+}
+
+#[pymethods]
+impl ClipsString {
+    #[new]
+    fn new(value: String) -> Self {
+        Self { value }
+    }
+
+    fn __repr__(&self) -> std::string::String {
+        format!("String({:?})", self.value)
+    }
+
+    fn __str__(&self) -> &str {
+        &self.value
+    }
+
+    fn __eq__(&self, other: &Bound<'_, PyAny>) -> bool {
+        if let Ok(cs) = other.downcast::<ClipsString>() {
+            return self.value == cs.borrow().value;
+        }
+        if let Ok(s) = other.extract::<String>() {
+            return self.value == s;
+        }
+        false
+    }
+
+    fn __hash__(&self) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        self.value.hash(&mut hasher);
+        hasher.finish()
+    }
+}
 
 /// Convert a Rust `Value` to a Python object.
 pub fn value_to_python(py: Python<'_>, val: &Value, engine: &Engine) -> PyObject {
@@ -20,17 +109,21 @@ pub fn value_to_python(py: Python<'_>, val: &Value, engine: &Engine) -> PyObject
             .unbind(),
         Value::Symbol(sym) => {
             let s = engine.resolve_symbol(*sym).unwrap_or("<unknown>");
-            s.into_pyobject(py)
-                .expect("str conversion")
-                .into_any()
-                .unbind()
-        }
-        Value::String(s) => s
-            .as_str()
+            Symbol {
+                value: s.to_owned(),
+            }
             .into_pyobject(py)
-            .expect("str conversion")
+            .expect("Symbol conversion")
             .into_any()
-            .unbind(),
+            .unbind()
+        }
+        Value::String(s) => ClipsString {
+            value: s.as_str().to_owned(),
+        }
+        .into_pyobject(py)
+        .expect("String conversion")
+        .into_any()
+        .unbind(),
         Value::Multifield(mf) => {
             let items: Vec<PyObject> = mf
                 .as_slice()
@@ -52,6 +145,23 @@ pub fn value_to_python(py: Python<'_>, val: &Value, engine: &Engine) -> PyObject
 ///
 /// Returns a `PyErr` if the Python object cannot be converted.
 pub fn python_to_value(obj: &Bound<'_, PyAny>, engine: &mut Engine) -> PyResult<Value> {
+    // Check marker types first: Symbol and ClipsString
+    if let Ok(cs) = obj.downcast::<ClipsString>() {
+        let val = cs.borrow().value.clone();
+        let fs = engine
+            .create_string(&val)
+            .map_err(crate::error::engine_error_to_pyerr)?;
+        return Ok(Value::String(fs));
+    }
+
+    if let Ok(sym) = obj.downcast::<Symbol>() {
+        let val = sym.borrow().value.clone();
+        let sid = engine
+            .intern_symbol(&val)
+            .map_err(crate::error::engine_error_to_pyerr)?;
+        return Ok(Value::Symbol(sid));
+    }
+
     // Check bool before int (bool is a subclass of int in Python)
     if let Ok(b) = obj.downcast::<PyBool>() {
         let sym_name = if b.is_true() { "TRUE" } else { "FALSE" };
@@ -71,6 +181,7 @@ pub fn python_to_value(obj: &Bound<'_, PyAny>, engine: &mut Engine) -> PyResult<
         return Ok(Value::Float(val));
     }
 
+    // Plain Python str defaults to Symbol (backward-compatible).
     if let Ok(s) = obj.downcast::<PyString>() {
         let val: String = s.extract()?;
         let sym = engine

--- a/crates/ferric-python/src/value.rs
+++ b/crates/ferric-python/src/value.rs
@@ -1,8 +1,5 @@
 //! Value conversion between Rust and Python.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyFloat, PyInt, PyList, PyString, PyTuple};
 
@@ -44,10 +41,8 @@ impl Symbol {
         false
     }
 
-    fn __hash__(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        self.value.hash(&mut hasher);
-        hasher.finish()
+    fn __hash__(&self, py: Python<'_>) -> PyResult<isize> {
+        PyString::new(py, &self.value).hash()
     }
 }
 
@@ -87,10 +82,8 @@ impl ClipsString {
         false
     }
 
-    fn __hash__(&self) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        self.value.hash(&mut hasher);
-        hasher.finish()
+    fn __hash__(&self, py: Python<'_>) -> PyResult<isize> {
+        PyString::new(py, &self.value).hash()
     }
 }
 

--- a/crates/ferric-python/src/value.rs
+++ b/crates/ferric-python/src/value.rs
@@ -95,47 +95,38 @@ impl ClipsString {
 }
 
 /// Convert a Rust `Value` to a Python object.
-pub fn value_to_python(py: Python<'_>, val: &Value, engine: &Engine) -> PyObject {
+///
+/// # Errors
+///
+/// Returns a `PyErr` if the Python object cannot be created.
+pub fn value_to_python(py: Python<'_>, val: &Value, engine: &Engine) -> PyResult<PyObject> {
     match val {
-        Value::Integer(i) => i
-            .into_pyobject(py)
-            .expect("int conversion")
-            .into_any()
-            .unbind(),
-        Value::Float(f) => f
-            .into_pyobject(py)
-            .expect("float conversion")
-            .into_any()
-            .unbind(),
+        Value::Integer(i) => Ok(i.into_pyobject(py)?.into_any().unbind()),
+        Value::Float(f) => Ok(f.into_pyobject(py)?.into_any().unbind()),
         Value::Symbol(sym) => {
             let s = engine.resolve_symbol(*sym).unwrap_or("<unknown>");
-            Symbol {
+            Ok(Symbol {
                 value: s.to_owned(),
             }
-            .into_pyobject(py)
-            .expect("Symbol conversion")
+            .into_pyobject(py)?
             .into_any()
-            .unbind()
+            .unbind())
         }
-        Value::String(s) => ClipsString {
+        Value::String(s) => Ok(ClipsString {
             value: s.as_str().to_owned(),
         }
-        .into_pyobject(py)
-        .expect("String conversion")
+        .into_pyobject(py)?
         .into_any()
-        .unbind(),
+        .unbind()),
         Value::Multifield(mf) => {
-            let items: Vec<PyObject> = mf
+            let items: PyResult<Vec<PyObject>> = mf
                 .as_slice()
                 .iter()
                 .map(|v| value_to_python(py, v, engine))
                 .collect();
-            PyList::new(py, items)
-                .expect("list conversion")
-                .into_any()
-                .unbind()
+            Ok(PyList::new(py, items?)?.into_any().unbind())
         }
-        Value::Void | Value::ExternalAddress(_) => py.None(),
+        Value::Void | Value::ExternalAddress(_) => Ok(py.None()),
     }
 }
 

--- a/crates/ferric-python/tests/test_api_surface.py
+++ b/crates/ferric-python/tests/test_api_surface.py
@@ -1,0 +1,94 @@
+"""Tests for PYB-006: additional runtime API surface."""
+
+import pytest
+import ferric
+
+
+class TestFocusMutation:
+    def test_set_focus(self):
+        engine = ferric.Engine()
+        engine.load('(defmodule A) (defmodule B)')
+        engine.reset()
+        engine.set_focus("A")
+        assert engine.focus == "A"
+
+    def test_set_focus_nonexistent_raises(self):
+        engine = ferric.Engine()
+        with pytest.raises(ferric.FerricModuleNotFoundError):
+            engine.set_focus("NONEXISTENT")
+
+    def test_push_focus(self):
+        engine = ferric.Engine()
+        engine.load('(defmodule A) (defmodule B)')
+        engine.reset()
+        engine.push_focus("A")
+        engine.push_focus("B")
+        assert engine.focus == "B"
+        assert "A" in engine.focus_stack
+
+    def test_push_focus_nonexistent_raises(self):
+        engine = ferric.Engine()
+        with pytest.raises(ferric.FerricModuleNotFoundError):
+            engine.push_focus("NONEXISTENT")
+
+
+class TestModuleEnumeration:
+    def test_modules_default(self):
+        engine = ferric.Engine()
+        mods = engine.modules()
+        assert "MAIN" in mods
+
+    def test_modules_after_defmodule(self):
+        engine = ferric.Engine()
+        engine.load('(defmodule FOO)')
+        mods = engine.modules()
+        assert "MAIN" in mods
+        assert "FOO" in mods
+
+
+class TestClearDiagnostics:
+    def test_clear_diagnostics(self):
+        engine = ferric.Engine()
+        # Diagnostics should be empty initially
+        assert engine.diagnostics == []
+        engine.clear_diagnostics()
+        assert engine.diagnostics == []
+
+
+class TestGetFactSlot:
+    def test_get_slot_value(self):
+        engine = ferric.Engine()
+        engine.load('(deftemplate person (slot name) (slot age))')
+        engine.reset()
+        fid = engine.assert_template("person", name="Alice", age=30)
+        val = engine.get_fact_slot(fid, "name")
+        assert val == "Alice"
+
+    def test_get_slot_integer(self):
+        engine = ferric.Engine()
+        engine.load('(deftemplate person (slot name) (slot age))')
+        engine.reset()
+        fid = engine.assert_template("person", name="Alice", age=30)
+        val = engine.get_fact_slot(fid, "age")
+        assert val == 30
+
+    def test_get_slot_not_found(self):
+        engine = ferric.Engine()
+        engine.load('(deftemplate person (slot name))')
+        engine.reset()
+        fid = engine.assert_template("person", name="Alice")
+        with pytest.raises(ferric.FerricSlotNotFoundError):
+            engine.get_fact_slot(fid, "nonexistent")
+
+    def test_get_slot_not_template_fact(self):
+        engine = ferric.Engine()
+        fid = engine.assert_fact("color", "red")
+        with pytest.raises(ferric.FerricRuntimeError):
+            engine.get_fact_slot(fid, "name")
+
+    def test_get_slot_fact_not_found(self):
+        engine = ferric.Engine()
+        fid = engine.assert_fact("color", "red")
+        engine.retract(fid)
+        with pytest.raises(ferric.FerricFactNotFoundError):
+            engine.get_fact_slot(fid, "name")

--- a/crates/ferric-python/tests/test_config.py
+++ b/crates/ferric-python/tests/test_config.py
@@ -43,3 +43,37 @@ class TestEncoding:
     def test_encoding_as_kwarg(self):
         engine = ferric.Engine(encoding=ferric.Encoding.ASCII)
         assert engine.fact_count == 0
+
+
+class TestModuleAttribution:
+    """Exported classes must report __module__ == 'ferric'."""
+
+    def test_engine_module(self):
+        assert ferric.Engine.__module__ == "ferric"
+
+    def test_fact_module(self):
+        assert ferric.Fact.__module__ == "ferric"
+
+    def test_fact_type_module(self):
+        assert ferric.FactType.__module__ == "ferric"
+
+    def test_strategy_module(self):
+        assert ferric.Strategy.__module__ == "ferric"
+
+    def test_encoding_module(self):
+        assert ferric.Encoding.__module__ == "ferric"
+
+    def test_run_result_module(self):
+        assert ferric.RunResult.__module__ == "ferric"
+
+    def test_halt_reason_module(self):
+        assert ferric.HaltReason.__module__ == "ferric"
+
+    def test_fired_rule_module(self):
+        assert ferric.FiredRule.__module__ == "ferric"
+
+    def test_symbol_module(self):
+        assert ferric.Symbol.__module__ == "ferric"
+
+    def test_string_module(self):
+        assert ferric.String.__module__ == "ferric"

--- a/crates/ferric-python/tests/test_engine.py
+++ b/crates/ferric-python/tests/test_engine.py
@@ -3,6 +3,7 @@
 import pathlib
 import tempfile
 
+import pytest
 import ferric
 
 
@@ -49,16 +50,16 @@ class TestFromSource:
 
 
 class TestContextManager:
-    def test_context_manager_clears_on_exit(self):
+    def test_context_manager_closes_on_exit(self):
         with ferric.Engine.from_source(
             '(deffacts startup (color red))'
         ) as engine:
             assert engine.fact_count >= 1
-        # After exit, engine is cleared
-        assert engine.fact_count == 0
-        assert len(engine.rules()) == 0
+        # After exit, engine is closed
+        with pytest.raises(ferric.FerricRuntimeError, match="closed"):
+            engine.fact_count
 
-    def test_context_manager_clears_on_exception(self):
+    def test_context_manager_closes_on_exception(self):
         try:
             with ferric.Engine.from_source(
                 '(deffacts startup (color red))'
@@ -66,7 +67,8 @@ class TestContextManager:
                 raise ValueError("test error")
         except ValueError:
             pass
-        assert engine.fact_count == 0
+        with pytest.raises(ferric.FerricRuntimeError, match="closed"):
+            engine.fact_count
 
 
 class TestLoadFile:

--- a/crates/ferric-python/tests/test_engine.py
+++ b/crates/ferric-python/tests/test_engine.py
@@ -1,5 +1,8 @@
 """Tests for Engine lifecycle: create, from_source, context manager, reset, clear."""
 
+import pathlib
+import tempfile
+
 import ferric
 
 
@@ -64,6 +67,24 @@ class TestContextManager:
         except ValueError:
             pass
         assert engine.fact_count == 0
+
+
+class TestLoadFile:
+    def test_load_file_str_path(self):
+        with tempfile.NamedTemporaryFile(suffix=".clp", mode="w", delete=False) as f:
+            f.write("(defrule r1 (go) => (assert (done)))")
+            path = f.name
+        engine = ferric.Engine()
+        engine.load_file(path)
+        assert len(engine.rules()) == 1
+
+    def test_load_file_pathlib_path(self):
+        with tempfile.NamedTemporaryFile(suffix=".clp", mode="w", delete=False) as f:
+            f.write("(defrule r2 (start) => (assert (end)))")
+            path = pathlib.Path(f.name)
+        engine = ferric.Engine()
+        engine.load_file(path)
+        assert len(engine.rules()) == 1
 
 
 class TestResetClear:

--- a/crates/ferric-python/tests/test_errors.py
+++ b/crates/ferric-python/tests/test_errors.py
@@ -58,3 +58,26 @@ class TestCatchBase:
         engine.retract(fid)
         with pytest.raises(ferric.FerricError):
             engine.retract(fid)
+
+
+class TestMultiErrorContext:
+    """PYB-009: load errors should preserve all diagnostics."""
+
+    def test_multi_error_message_contains_all(self):
+        """Multiple parse errors should all appear in the exception message."""
+        engine = ferric.Engine()
+        try:
+            # Two separate malformed constructs
+            engine.load("(defrule bad1 (defrule bad2")
+        except ferric.FerricParseError as e:
+            msg = str(e)
+            # The message should contain content about the parse failure
+            assert len(msg) > 0
+        except ferric.FerricError:
+            pass  # Any ferric error is acceptable
+
+    def test_multi_error_is_parse_type(self):
+        """If parse errors are present, exception type should be FerricParseError."""
+        engine = ferric.Engine()
+        with pytest.raises(ferric.FerricParseError):
+            engine.load("(defrule incomplete")

--- a/crates/ferric-python/tests/test_facts.py
+++ b/crates/ferric-python/tests/test_facts.py
@@ -6,20 +6,32 @@ import ferric
 
 class TestAssertString:
     def test_assert_ordered_fact(self, engine):
-        fid = engine.assert_string("(color red)")
-        assert isinstance(fid, int)
-        assert fid > 0
+        ids = engine.assert_string("(color red)")
+        assert isinstance(ids, list)
+        assert len(ids) == 1
+        assert isinstance(ids[0], int)
+        assert ids[0] > 0
 
-    def test_assert_multiple(self, engine):
-        fid1 = engine.assert_string("(color red)")
-        fid2 = engine.assert_string("(color blue)")
-        assert fid1 != fid2
+    def test_assert_multiple_in_one_call(self, engine):
+        ids = engine.assert_string("(color red) (color blue)")
+        assert len(ids) == 2
+        assert ids[0] != ids[1]
+
+    def test_assert_separate_calls(self, engine):
+        ids1 = engine.assert_string("(color red)")
+        ids2 = engine.assert_string("(color blue)")
+        assert ids1[0] != ids2[0]
 
     def test_assert_string_with_number(self, engine):
-        fid = engine.assert_string("(count 42)")
-        fact = engine.get_fact(fid)
+        ids = engine.assert_string("(count 42)")
+        fact = engine.get_fact(ids[0])
         assert fact is not None
         assert fact.relation == "count"
+
+    def test_assert_string_empty_raises(self, engine):
+        """Malformed or empty input that produces no facts should error."""
+        with pytest.raises(ferric.FerricError):
+            engine.assert_string("")
 
 
 class TestAssertFact:

--- a/crates/ferric-python/tests/test_protocols.py
+++ b/crates/ferric-python/tests/test_protocols.py
@@ -86,3 +86,34 @@ class TestFactEquality:
         fact = engine.get_fact(fid)
         s = {fact}
         assert len(s) == 1
+
+    def test_cross_engine_not_equal(self):
+        """Facts with same ID from different engines must not compare equal."""
+        e1 = ferric.Engine()
+        e2 = ferric.Engine()
+        fid1 = e1.assert_fact("color", "red")
+        fid2 = e2.assert_fact("color", "red")
+        f1 = e1.get_fact(fid1)
+        f2 = e2.get_fact(fid2)
+        # IDs may be the same (both first fact), but they're from different engines
+        assert f1 != f2
+
+    def test_cross_engine_hash_distinct(self):
+        """Facts from different engines should not collide in sets."""
+        e1 = ferric.Engine()
+        e2 = ferric.Engine()
+        fid1 = e1.assert_fact("color", "red")
+        fid2 = e2.assert_fact("color", "red")
+        f1 = e1.get_fact(fid1)
+        f2 = e2.get_fact(fid2)
+        s = {f1, f2}
+        assert len(s) == 2
+
+    def test_same_engine_same_fact_still_equal(self):
+        """Two snapshots of the same fact from the same engine are equal."""
+        engine = ferric.Engine()
+        fid = engine.assert_fact("color", "red")
+        f1 = engine.get_fact(fid)
+        f2 = engine.get_fact(fid)
+        assert f1 == f2
+        assert hash(f1) == hash(f2)

--- a/crates/ferric-python/tests/test_threading.py
+++ b/crates/ferric-python/tests/test_threading.py
@@ -1,5 +1,6 @@
 """Tests for cross-thread access raising FerricRuntimeError."""
 
+import gc
 import threading
 
 import pytest
@@ -67,6 +68,27 @@ class TestCrossThreadMethod:
             _run_in_thread(lambda: engine.facts())
 
 
+class TestCrossThreadDrop:
+    """Dropping engine on wrong thread must not panic."""
+
+    def test_drop_on_foreign_thread_no_panic(self, capsys):
+        """Engine dropped on foreign thread: no panic, no stderr output."""
+        engine = ferric.Engine()
+        engine.assert_fact("color", "red")
+
+        def drop_it(eng):
+            del eng
+
+        t = threading.Thread(target=drop_it, args=(engine,))
+        del engine
+        t.start()
+        t.join()
+        # No panic/segfault, and no stderr noise
+        captured = capsys.readouterr()
+        assert "leaked" not in captured.err
+        assert "ferric" not in captured.err
+
+
 class TestCrossThreadIsNotPanic:
     """Ensure the exception is FerricRuntimeError, NOT PanicException."""
 
@@ -88,3 +110,68 @@ class TestCrossThreadIsNotPanic:
         assert isinstance(exc, ferric.FerricRuntimeError)
         assert not isinstance(exc, BaseException) or isinstance(exc, Exception)
         assert "wrong thread" in str(exc)
+
+
+class TestClose:
+    """Tests for explicit engine close/lifecycle."""
+
+    def test_close_releases_engine(self):
+        engine = ferric.Engine()
+        engine.assert_fact("x", 1)
+        engine.close()
+        with pytest.raises(ferric.FerricRuntimeError, match="closed"):
+            engine.fact_count
+
+    def test_close_idempotent(self):
+        engine = ferric.Engine()
+        engine.close()
+        engine.close()  # should not raise
+
+    def test_context_manager_closes(self):
+        with ferric.Engine() as engine:
+            engine.assert_fact("x", 1)
+        with pytest.raises(ferric.FerricRuntimeError, match="closed"):
+            engine.fact_count
+
+    def test_close_from_wrong_thread(self):
+        engine = ferric.Engine()
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            _run_in_thread(lambda: engine.close())
+
+
+_has_testing = hasattr(ferric, "engine_instance_count")
+
+
+@pytest.mark.skipif(not _has_testing, reason="testing feature not enabled")
+class TestInstanceCount:
+    """Tests for engine instance counting instrumentation."""
+
+    def test_create_and_drop(self):
+        gc.collect()  # flush pending deallocations from earlier tests
+        baseline = ferric.engine_instance_count()
+        engine = ferric.Engine()
+        assert ferric.engine_instance_count() == baseline + 1
+        del engine
+        gc.collect()
+        assert ferric.engine_instance_count() == baseline
+
+    def test_close_decrements(self):
+        baseline = ferric.engine_instance_count()
+        engine = ferric.Engine()
+        assert ferric.engine_instance_count() == baseline + 1
+        engine.close()
+        assert ferric.engine_instance_count() == baseline
+
+    def test_thread_exit_cleans_up(self):
+        """Engine created on a worker thread is cleaned up when thread exits."""
+        baseline = ferric.engine_instance_count()
+
+        def create_engine_on_thread():
+            _eng = ferric.Engine()
+            # engine lives in this thread's TLS; thread exit destroys TLS
+
+        t = threading.Thread(target=create_engine_on_thread)
+        t.start()
+        t.join()
+        gc.collect()
+        assert ferric.engine_instance_count() == baseline

--- a/crates/ferric-python/tests/test_threading.py
+++ b/crates/ferric-python/tests/test_threading.py
@@ -1,0 +1,90 @@
+"""Tests for cross-thread access raising FerricRuntimeError."""
+
+import threading
+
+import pytest
+import ferric
+
+
+def _run_in_thread(fn):
+    """Run `fn` in a new thread and propagate any exception."""
+    result = {}
+
+    def target():
+        try:
+            fn()
+        except Exception as exc:
+            result["exc"] = exc
+
+    t = threading.Thread(target=target)
+    t.start()
+    t.join()
+    if "exc" in result:
+        raise result["exc"]
+
+
+class TestCrossThreadProperty:
+    """Cross-thread reads of properties must raise FerricRuntimeError."""
+
+    def test_fact_count(self, engine):
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            _run_in_thread(lambda: engine.fact_count)
+
+    def test_is_halted(self, engine):
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            _run_in_thread(lambda: engine.is_halted)
+
+    def test_agenda_size(self, engine):
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            _run_in_thread(lambda: engine.agenda_size)
+
+    def test_current_module(self, engine):
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            _run_in_thread(lambda: engine.current_module)
+
+
+class TestCrossThreadMethod:
+    """Cross-thread method calls must raise FerricRuntimeError."""
+
+    def test_run(self, engine):
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            _run_in_thread(lambda: engine.run())
+
+    def test_reset(self, engine):
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            _run_in_thread(lambda: engine.reset())
+
+    def test_load(self, engine):
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            _run_in_thread(lambda: engine.load("(assert (x))"))
+
+    def test_assert_fact(self, engine):
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            _run_in_thread(lambda: engine.assert_fact("color", "red"))
+
+    def test_facts(self, engine):
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            _run_in_thread(lambda: engine.facts())
+
+
+class TestCrossThreadIsNotPanic:
+    """Ensure the exception is FerricRuntimeError, NOT PanicException."""
+
+    def test_not_panic_exception(self, engine):
+        exc = None
+
+        def target():
+            nonlocal exc
+            try:
+                engine.run()
+            except Exception as e:
+                exc = e
+
+        t = threading.Thread(target=target)
+        t.start()
+        t.join()
+
+        assert exc is not None
+        assert isinstance(exc, ferric.FerricRuntimeError)
+        assert not isinstance(exc, BaseException) or isinstance(exc, Exception)
+        assert "wrong thread" in str(exc)

--- a/crates/ferric-python/tests/test_values.py
+++ b/crates/ferric-python/tests/test_values.py
@@ -40,7 +40,120 @@ class TestStringRoundTrip:
         fid = engine.assert_fact("color", "red")
         fact = engine.get_fact(fid)
         assert fact.fields[0] == "red"
-        assert isinstance(fact.fields[0], str)
+        assert isinstance(fact.fields[0], ferric.Symbol)
+
+    def test_symbol_equals_str(self, engine):
+        """Symbol compares equal to plain str with same value."""
+        fid = engine.assert_fact("color", "red")
+        fact = engine.get_fact(fid)
+        assert fact.fields[0] == "red"
+        assert str(fact.fields[0]) == "red"
+
+
+class TestSymbolType:
+    def test_symbol_constructor(self):
+        sym = ferric.Symbol("hello")
+        assert sym.value == "hello"
+        assert str(sym) == "hello"
+
+    def test_symbol_repr(self):
+        sym = ferric.Symbol("hello")
+        assert repr(sym) == 'Symbol("hello")'
+
+    def test_symbol_equality(self):
+        a = ferric.Symbol("x")
+        b = ferric.Symbol("x")
+        assert a == b
+
+    def test_symbol_hash(self):
+        a = ferric.Symbol("x")
+        b = ferric.Symbol("x")
+        assert hash(a) == hash(b)
+
+    def test_symbol_roundtrip(self, engine):
+        fid = engine.assert_fact("data", ferric.Symbol("hello"))
+        fact = engine.get_fact(fid)
+        assert isinstance(fact.fields[0], ferric.Symbol)
+        assert fact.fields[0] == "hello"
+
+
+class TestClipsStringType:
+    def test_string_constructor(self):
+        s = ferric.String("hello")
+        assert s.value == "hello"
+        assert str(s) == "hello"
+
+    def test_string_repr(self):
+        s = ferric.String("hello")
+        assert repr(s) == 'String("hello")'
+
+    def test_string_equality(self):
+        a = ferric.String("x")
+        b = ferric.String("x")
+        assert a == b
+
+    def test_string_hash(self):
+        a = ferric.String("x")
+        b = ferric.String("x")
+        assert hash(a) == hash(b)
+
+    def test_string_roundtrip(self, engine):
+        fid = engine.assert_fact("data", ferric.String("hello"))
+        fact = engine.get_fact(fid)
+        assert isinstance(fact.fields[0], ferric.String)
+        assert fact.fields[0] == "hello"
+
+
+class TestSymbolStringDistinction:
+    def test_symbol_and_string_distinct_types(self):
+        sym = ferric.Symbol("x")
+        s = ferric.String("x")
+        assert type(sym) != type(s)
+
+    def test_rule_matches_symbol_not_string(self):
+        """A rule matching symbol 'Alice' fires for Symbol but not String."""
+        engine = ferric.Engine()
+        engine.load(
+            '(defrule match-symbol (name Alice) => (assert (matched symbol)))'
+        )
+        engine.reset()
+        # Assert with plain str (becomes Symbol) - should match
+        engine.assert_fact("name", "Alice")
+        result = engine.run()
+        assert result.rules_fired == 1
+
+    def test_rule_matches_string_literal(self):
+        """A rule matching string literal fires for String values."""
+        engine = ferric.Engine()
+        engine.load(
+            '(defrule match-string (name "Alice") => (assert (matched string)))'
+        )
+        engine.reset()
+        # Assert with String wrapper - should match string pattern
+        engine.assert_fact("name", ferric.String("Alice"))
+        result = engine.run()
+        assert result.rules_fired == 1
+
+    def test_symbol_does_not_match_string_pattern(self):
+        """A Symbol value should not match a string literal pattern."""
+        engine = ferric.Engine()
+        engine.load(
+            '(defrule match-string (name "Alice") => (assert (matched string)))'
+        )
+        engine.reset()
+        # Assert with plain str (becomes Symbol) - should NOT match string pattern
+        engine.assert_fact("name", "Alice")
+        result = engine.run()
+        assert result.rules_fired == 0
+
+    def test_string_in_template(self, engine):
+        """ClipsString works in template assertions."""
+        engine.load('(deftemplate person (slot name))')
+        engine.reset()
+        fid = engine.assert_template("person", name=ferric.String("Alice"))
+        fact = engine.get_fact(fid)
+        assert isinstance(fact.slots["name"], ferric.String)
+        assert fact.slots["name"] == "Alice"
 
 
 class TestBoolConversion:

--- a/crates/ferric-python/tests/test_values.py
+++ b/crates/ferric-python/tests/test_values.py
@@ -193,3 +193,30 @@ class TestListConversion:
         fact = engine.get_fact(fid)
         assert isinstance(fact.fields[0], list)
         assert fact.fields[0] == [1, 2]
+
+
+class TestHashContract:
+    """hash(a) == hash(b) whenever a == b (Python invariant)."""
+
+    def test_symbol_hash_equals_str_hash(self):
+        sym = ferric.Symbol("hello")
+        assert sym == "hello"
+        assert hash(sym) == hash("hello")
+
+    def test_string_hash_equals_str_hash(self):
+        s = ferric.String("hello")
+        assert s == "hello"
+        assert hash(s) == hash("hello")
+
+    def test_symbol_in_dict(self):
+        d = {}
+        d[ferric.Symbol("key")] = "value"
+        assert d["key"] == "value"
+
+    def test_string_in_set(self):
+        s = {ferric.String("a"), "a"}
+        assert len(s) == 1
+
+    def test_symbol_and_string_distinct_in_set(self):
+        s = {ferric.Symbol("x"), ferric.String("x")}
+        assert len(s) == 2

--- a/justfile
+++ b/justfile
@@ -114,20 +114,24 @@ py-lint:
 py-lint-fix:
     cd tools/ferric-tools && uv run ruff check --fix src/ tests/
 
-# Run Python tests
+# Run Python tests (tools)
 py-test:
     cd tools/ferric-tools && uv run pytest
+
+# Build and test Python bindings
+py-bindings-test:
+    cd crates/ferric-python && PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv run maturin develop --quiet && .venv/bin/python -m pytest tests/
 
 # ── Composite checks ────────────────────────────────────────────────────────
 
 # Full preflight: format check, clippy, all tests, cargo check, Python checks, Go lint
-check: fmt-check clippy test cargo-check py-fmt-check py-lint py-test go-lint
+check: fmt-check clippy test cargo-check py-fmt-check py-lint py-test py-bindings-test go-lint
 
 # Same as `check` — alias for the preflight script
 preflight: check
 
 # PR preflight: auto-fix formatting, then clippy + tests + cargo check + Python checks + Go lint
-preflight-pr: fmt clippy test cargo-check py-fmt py-lint-fix py-test go-lint
+preflight-pr: fmt clippy test cargo-check py-fmt py-lint-fix py-test py-bindings-test go-lint
 
 # ── Tracing / profiling ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Comprehensive audit of `ferric-python` bindings identifying 10 issues (PYB-001 through PYB-010), all resolved in this PR.
- Replaced panic paths with proper Python exceptions: cross-thread access now raises `FerricRuntimeError` instead of `PanicException`, and all `expect()` calls removed from value conversion code.
- **PYB-001 follow-up**: Eliminated cross-thread drop leak by replacing `ManuallyDrop<Engine>` + `unsafe impl Send/Sync` with a thread-local registry. `PyEngine` is now a lightweight handle (naturally `Send+Sync`), no `unsafe` code remains, and foreign-thread finalization is a silent no-op instead of a resource leak.
- **PYB-003 fix**: `Symbol`/`String` `__hash__` now delegates to `PyString.hash()` so `hash(Symbol("x")) == hash("x")`, satisfying Python's equal-objects-equal-hashes invariant for dict/set interop.
- Added `Symbol`/`String` wrapper types for CLIPS value fidelity, fixed `assert_string` to return all fact IDs, and included engine identity in `Fact` equality/hash.
- Added explicit `close()` method and updated `__exit__` to call `close()` (standard Python context manager pattern). Engine instance counting instrumentation available under `testing` feature flag.
- Expanded runtime API surface (`set_focus`, `push_focus`, `modules`, `clear_action_diagnostics`, `get_fact_slot_by_name`), accepted `pathlib.Path` in `load_file`, set correct `module="ferric"` on all PyO3 classes, and preserved full multi-error context in load error translation.
- Added Python binding tests to `just preflight-pr` and expanded test suite to 207 tests covering threading, close lifecycle, instance counting, value fidelity, API surface gaps, and error edge cases.

## Test plan

- [x] `just preflight-pr` passes (now includes `ferric-python` pytest)
- [x] 207 Python tests pass via `cd crates/ferric-python && uv run pytest tests -q`
- [x] All Rust workspace tests pass (`cargo test --workspace`)
- [x] `cargo clippy` clean with and without `testing` feature
- [x] No `unsafe` code in `PyEngine` (thread-local registry is naturally `Send+Sync`)
- [x] No `eprintln!` in destructor paths
- [x] Instance count instrumentation validates no leaks on create/drop, close, and thread exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)