### PR TITLE
Go bindings: coverage edge tests and FFI helper extraction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,9 @@ jobs:
       - run: just build-go-ffi
       - uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.8.0
+          # Keep in sync with golangci_lint_version in the justfile. v2.12.x is
+          # the first line compatible with the Go 1.26 toolchain.
+          version: v2.12.2
           working-directory: bindings/go
 
   go-test-stress:

--- a/bindings/go/.golangci.yml
+++ b/bindings/go/.golangci.yml
@@ -8,6 +8,10 @@ linters:
 
     # Very low-signal for this codebase without substantial custom policy.
     - depguard
+    # Sibling import-guard linter to depguard; unused here and deprecated in
+    # golangci-lint v2.12 (replaced by gomodguard_v2). Disable to avoid the
+    # deprecation warning without adopting an import policy we don't need.
+    - gomodguard
     - exhaustruct
     - varnamelen
     - nlreturn
@@ -39,3 +43,9 @@ linters:
         linters:
           - gocritic
         text: exitAfterDefer
+      # Repeated string literals in tests (rule sources, spec names, slot keys,
+      # fixture values) read more clearly inline than hoisted into shared
+      # constants; goconst's signal is for production code.
+      - path: _test\.go
+        linters:
+          - goconst

--- a/bindings/go/coverage_edge_test.go
+++ b/bindings/go/coverage_edge_test.go
@@ -1,0 +1,2001 @@
+//nolint:funlen,gocyclo,maintidx // Coverage edge tests intentionally enumerate related API branches together.
+package ferric
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"math"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
+	"pgregory.net/rapid"
+)
+
+func resetFFIHooks() {
+	ffiEngineNew = ffi.EngineNew
+	ffiEngineNewWithConfig = ffi.EngineNewWithConfig
+	ffiEngineNewWithSource = ffi.EngineNewWithSource
+	ffiEngineNewWithSourceConfig = ffi.EngineNewWithSourceConfig
+	ffiEngineDeserializeAs = ffi.EngineDeserializeAs
+	ffiLastErrorGlobal = ffi.LastErrorGlobal
+	ffiEngineFree = ffi.EngineFree
+	ffiEngineFreeUnchecked = ffi.EngineFreeUnchecked
+	ffiEngineLoadString = ffi.EngineLoadString
+	ffiEngineAssertString = ffi.EngineAssertString
+	ffiEngineAssertOrdered = ffi.EngineAssertOrdered
+	ffiEngineAssertTemplate = ffi.EngineAssertTemplate
+	ffiEngineRetract = ffi.EngineRetract
+	ffiEngineFactIDs = ffi.EngineFactIDs
+	ffiEngineFindFactIDs = ffi.EngineFindFactIDs
+	ffiEngineFactCount = ffi.EngineFactCount
+	ffiEngineRunEx = ffi.EngineRunEx
+	ffiEngineStep = ffi.EngineStep
+	ffiEngineHalt = ffi.EngineHalt
+	ffiEngineReset = ffi.EngineReset
+	ffiEngineClear = ffi.EngineClear
+	ffiEngineSerializeAs = ffi.EngineSerializeAs
+	ffiEngineRuleCount = ffi.EngineRuleCount
+	ffiEngineRuleInfo = ffi.EngineRuleInfo
+	ffiEngineTemplateCount = ffi.EngineTemplateCount
+	ffiEngineTemplateName = ffi.EngineTemplateName
+	ffiEngineGetGlobal = ffi.EngineGetGlobal
+	ffiEngineCurrentModule = ffi.EngineCurrentModule
+	ffiEngineGetFocus = ffi.EngineGetFocus
+	ffiEngineFocusStackDepth = ffi.EngineFocusStackDepth
+	ffiEngineFocusStackEntry = ffi.EngineFocusStackEntry
+	ffiEngineAgendaCount = ffi.EngineAgendaCount
+	ffiEngineIsHalted = ffi.EngineIsHalted
+	ffiEngineGetOutput = ffi.EngineGetOutput
+	ffiEngineClearOutput = ffi.EngineClearOutput
+	ffiEnginePushInput = ffi.EnginePushInput
+	ffiEngineActionDiagnosticCount = ffi.EngineActionDiagnosticCount
+	ffiEngineActionDiagnosticCopy = ffi.EngineActionDiagnosticCopy
+	ffiEngineClearActionDiagnostics = ffi.EngineClearActionDiagnostics
+	ffiEngineGetFactType = ffi.EngineGetFactType
+	ffiEngineGetFactFieldCount = ffi.EngineGetFactFieldCount
+	ffiEngineGetFactField = ffi.EngineGetFactField
+	ffiEngineGetFactTemplateName = ffi.EngineGetFactTemplateName
+	ffiEngineTemplateSlotCount = ffi.EngineTemplateSlotCount
+	ffiEngineTemplateSlotName = ffi.EngineTemplateSlotName
+	ffiEngineGetFactRelation = ffi.EngineGetFactRelation
+	ffiValueFree = ffi.ValueFree
+	factsToWire = FactsToWire
+}
+
+func withFFIHooks(t *testing.T) {
+	t.Helper()
+	resetFFIHooks()
+	t.Cleanup(resetFFIHooks)
+}
+
+type doneOnlyContext struct {
+	done chan struct{}
+}
+
+func (c doneOnlyContext) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c doneOnlyContext) Done() <-chan struct{}       { return c.done }
+func (c doneOnlyContext) Err() error                  { return nil }
+func (c doneOnlyContext) Value(any) any               { return nil }
+
+func TestManualConfigurationValidationBranches(t *testing.T) {
+	// These checks exercise the enum and integer validation that runs before
+	// FFI engine construction. Keeping them as direct unit tests makes invalid
+	// public options fail deterministically without depending on native errors.
+	validEncodings := []Encoding{
+		EncodingASCII,
+		EncodingUTF8,
+		EncodingASCIISymbolsUTF8Strings,
+	}
+	for _, enc := range validEncodings {
+		if _, err := toFFIStringEncoding(enc); err != nil {
+			t.Fatalf("encoding %d should be valid: %v", enc, err)
+		}
+	}
+
+	validStrategies := []Strategy{
+		StrategyDepth,
+		StrategyBreadth,
+		StrategyLEX,
+		StrategyMEA,
+	}
+	for _, strategy := range validStrategies {
+		if _, err := toFFIConflictStrategy(strategy); err != nil {
+			t.Fatalf("strategy %d should be valid: %v", strategy, err)
+		}
+	}
+
+	if _, err := NewEngine(WithEncoding(Encoding(99))); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("invalid encoding should report ErrInvalidArgument, got %v", err)
+	}
+	if _, err := NewEngine(WithStrategy(Strategy(99))); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("invalid strategy should report ErrInvalidArgument, got %v", err)
+	}
+	if _, err := NewEngine(WithMaxCallDepth(-1)); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("negative max call depth should report ErrInvalidArgument, got %v", err)
+	}
+	if _, err := formatToFFI(Format(99)); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("invalid snapshot format should report ErrInvalidArgument, got %v", err)
+	}
+	if _, err := NewEngine(WithSnapshot([]byte("data"), Format(99))); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("invalid snapshot option should report ErrInvalidArgument, got %v", err)
+	}
+}
+
+func TestManualIntegerConversionBoundaries(t *testing.T) {
+	// Boundary checks pin the public binding to Go's host integer width. These
+	// conversions guard native uintptr/uint64 values before exposing them as int.
+	maxIntUint := uint64(^uint(0) >> 1)
+	if got, err := uint64ToInt(maxIntUint); err != nil || got != int(maxIntUint) {
+		t.Fatalf("uint64 max int conversion = (%d, %v)", got, err)
+	}
+	if _, err := uint64ToInt(maxIntUint + 1); !errors.Is(err, errIntOverflow) {
+		t.Fatalf("uint64 overflow should report errIntOverflow, got %v", err)
+	}
+
+	maxIntPtr := uintptr(^uint(0) >> 1)
+	if got, err := uintptrToInt(maxIntPtr); err != nil || got != int(maxIntPtr) {
+		t.Fatalf("uintptr max int conversion = (%d, %v)", got, err)
+	}
+	if _, err := uintptrToInt(maxIntPtr + 1); !errors.Is(err, errIntOverflow) {
+		t.Fatalf("uintptr overflow should report errIntOverflow, got %v", err)
+	}
+	if got := clampUintptrToInt(maxIntPtr + 1); got != int(maxIntPtr) {
+		t.Fatalf("clamp overflow = %d, want %d", got, int(maxIntPtr))
+	}
+}
+
+func TestManualErrorTypesAndTranslations(t *testing.T) {
+	// The Go API promises stable errors.Is sentinels while still preserving
+	// concrete error types. This verifies both explicit errors and FFI mappings.
+	base := &FerricError{Code: 123, Message: "boom"}
+	if got := base.Error(); got != "ferric: boom" {
+		t.Fatalf("FerricError.Error() = %q", got)
+	}
+
+	concrete := []struct {
+		err    error
+		target error
+	}{
+		{&ParseError{}, ErrParse},
+		{&CompileError{}, ErrCompile},
+		{&RuntimeError{}, ErrRuntime},
+		{&NotFoundError{}, ErrNotFound},
+		{&IOError{}, ErrIO},
+		{&SerializationError{}, ErrSerialization},
+		{&ThreadViolationError{}, ErrThreadViolation},
+		{&InvalidArgumentError{}, ErrInvalidArgument},
+	}
+	for _, tc := range concrete {
+		if !errors.Is(tc.err, tc.target) {
+			t.Fatalf("%T should match %v", tc.err, tc.target)
+		}
+	}
+
+	ffi.ClearErrorGlobal()
+	mapped := []struct {
+		code   ffi.ErrorCode
+		target error
+	}{
+		{ffi.ErrParseError, ErrParse},
+		{ffi.ErrCompileError, ErrCompile},
+		{ffi.ErrRuntimeError, ErrRuntime},
+		{ffi.ErrNotFound, ErrNotFound},
+		{ffi.ErrIOError, ErrIO},
+		{ffi.ErrSerializationError, ErrSerialization},
+		{ffi.ErrThreadViolation, ErrThreadViolation},
+		{ffi.ErrInvalidArgument, ErrInvalidArgument},
+	}
+	for _, tc := range mapped {
+		if err := errorFromFFI(tc.code, nil); !errors.Is(err, tc.target) {
+			t.Fatalf("errorFromFFI(%d) = %T %v, want %v", tc.code, err, err, tc.target)
+		}
+	}
+	if err := errorFromFFI(ffi.ErrOK, nil); err != nil {
+		t.Fatalf("ErrOK should translate to nil, got %v", err)
+	}
+	if err := errorFromFFI(ffi.ErrNullPointer, nil); err == nil || !strings.Contains(err.Error(), "error code") {
+		t.Fatalf("unknown FFI error should use generic fallback, got %v", err)
+	}
+}
+
+func TestManualWireConversionEdges(t *testing.T) {
+	// These examples cover every supported scalar shape plus the recursive
+	// error paths. They document what callers may pass to wire conversion.
+	cases := []struct {
+		in   any
+		want WireValue
+	}{
+		{int(7), WireValue{Kind: WireValueInteger, Integer: 7}},
+		{int32(8), WireValue{Kind: WireValueInteger, Integer: 8}},
+		{float32(1.25), WireValue{Kind: WireValueFloat, Float: float64(float32(1.25))}},
+		{true, WireValue{Kind: WireValueSymbol, Text: "TRUE"}},
+		{false, WireValue{Kind: WireValueSymbol, Text: "FALSE"}},
+		{[]any{int32(1), false}, MultifieldValue(IntValue(1), SymbolValue("FALSE"))},
+	}
+	for _, tc := range cases {
+		got, err := NativeToWireValue(tc.in)
+		if err != nil {
+			t.Fatalf("NativeToWireValue(%T) unexpected error: %v", tc.in, err)
+		}
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("NativeToWireValue(%#v) = %#v, want %#v", tc.in, got, tc.want)
+		}
+	}
+
+	if _, err := NativeToWireValue(struct{}{}); !errors.Is(err, errUnsupportedWireConversionType) {
+		t.Fatalf("unsupported native type should fail, got %v", err)
+	}
+	if _, err := NativeToWireValue([]any{int64(1), struct{}{}}); !errors.Is(err, errUnsupportedWireConversionType) {
+		t.Fatalf("unsupported nested native type should fail, got %v", err)
+	}
+	unknown := WireValue{Kind: WireValueKind("bogus")}
+	if _, err := WireToNativeValue(unknown); !errors.Is(err, errUnknownWireValueKind) {
+		t.Fatalf("unknown wire kind should fail, got %v", err)
+	}
+	if _, err := WireToNativeValue(MultifieldValue(unknown)); !errors.Is(err, errUnknownWireValueKind) {
+		t.Fatalf("unknown nested wire kind should fail, got %v", err)
+	}
+	if _, err := WireSliceToNative([]WireValue{unknown}); !errors.Is(err, errUnknownWireValueKind) {
+		t.Fatalf("bad wire slice should fail, got %v", err)
+	}
+	if _, err := WireMapToNative(map[string]WireValue{"bad": unknown}); !errors.Is(err, errUnknownWireValueKind) {
+		t.Fatalf("bad wire map should fail, got %v", err)
+	}
+	if _, err := FactToWire(Fact{Type: FactTemplate, Slots: map[string]any{"bad": struct{}{}}}); !errors.Is(err, errUnsupportedWireConversionType) {
+		t.Fatalf("bad template fact should fail, got %v", err)
+	}
+	if _, err := FactToWire(Fact{Type: FactOrdered, Fields: []any{struct{}{}}}); !errors.Is(err, errUnsupportedWireConversionType) {
+		t.Fatalf("bad ordered fact should fail, got %v", err)
+	}
+	if _, err := FactsToWire([]Fact{{Type: FactOrdered, Fields: []any{struct{}{}}}}); !errors.Is(err, errUnsupportedWireConversionType) {
+		t.Fatalf("bad fact slice should fail, got %v", err)
+	}
+}
+
+func TestManualFFIValueConversionEdges(t *testing.T) {
+	// The FFI conversion layer normalizes Go convenience types into CLIPS values.
+	// These examples include bools, nil, multifields, and unsupported cleanup.
+	cases := []struct {
+		in   any
+		want any
+	}{
+		{int(7), int64(7)},
+		{int32(8), int64(8)},
+		{float32(1.25), float64(float32(1.25))},
+		{true, Symbol("TRUE")},
+		{false, Symbol("FALSE")},
+		{nil, nil},
+		{[]any{int32(1), Symbol("x"), "s", nil}, []any{int64(1), Symbol("x"), "s", nil}},
+	}
+	for _, tc := range cases {
+		v, err := goToFFIValue(tc.in)
+		if err != nil {
+			t.Fatalf("goToFFIValue(%T) unexpected error: %v", tc.in, err)
+		}
+		got := ffiValueToGoAndFree(&v)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("ffi roundtrip %#v = %#v, want %#v", tc.in, got, tc.want)
+		}
+	}
+	if _, err := goToFFIValue([]any{int64(1), struct{}{}}); !errors.Is(err, errUnsupportedGoTypeForFFI) {
+		t.Fatalf("bad multifield element should fail and clean up, got %v", err)
+	}
+	if _, err := goToFFIValue(struct{}{}); !errors.Is(err, errUnsupportedGoTypeForFFI) {
+		t.Fatalf("unsupported Go value should fail, got %v", err)
+	}
+
+	var external ffi.Value
+	*(*ffi.ValueType)(unsafe.Pointer(&external)) = ffi.ValueTypeExternalAddress
+	if got, ok := ffiValueToGo(&external).(unsafe.Pointer); !ok || got != nil {
+		t.Fatalf("zero external pointer = (%T, %v), want nil unsafe.Pointer", got, got)
+	}
+
+	var unknown ffi.Value
+	*(*ffi.ValueType)(unsafe.Pointer(&unknown)) = ffi.ValueType(9999)
+	if got := ffiValueToGo(&unknown); got != nil {
+		t.Fatalf("unknown value type = %v, want nil", got)
+	}
+}
+
+func TestManualNilEngineErrorBranches(t *testing.T) {
+	// A zero Engine has a nil native handle. The FFI should reject every native
+	// operation without panicking, which exercises the Go defensive error paths.
+	e := &Engine{}
+	assertErr := func(name string, err error) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
+	}
+
+	if err := e.Close(); err != nil {
+		t.Fatalf("Close on a nil handle should remain idempotent, got %v", err)
+	}
+	assertErr("Load", e.Load(`(defrule r =>)`))
+	if _, err := e.AssertString("(assert (x))"); err == nil {
+		t.Fatal("AssertString: expected error")
+	}
+	if _, err := e.AssertFact("x", int64(1)); err == nil {
+		t.Fatal("AssertFact: expected error")
+	}
+	if _, err := e.AssertTemplate("x", map[string]any{}); err == nil {
+		t.Fatal("AssertTemplate: expected error")
+	}
+	assertErr("Retract", e.Retract(1))
+	if _, err := e.GetFact(1); err == nil {
+		t.Fatal("GetFact: expected error")
+	}
+	if _, err := e.Facts(); err == nil {
+		t.Fatal("Facts: expected error")
+	}
+	if _, err := e.FindFacts("x"); err == nil {
+		t.Fatal("FindFacts: expected error")
+	}
+	if _, err := e.FactCount(); err == nil {
+		t.Fatal("FactCount: expected error")
+	}
+	if _, err := e.RunWithLimit(nil, 0); !errors.Is(err, errNilContext) {
+		t.Fatalf("nil context should fail with errNilContext, got %v", err)
+	}
+	if _, err := e.Run(context.Background()); err == nil {
+		t.Fatal("Run: expected error")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, err := e.RunWithLimit(ctx, 1); err == nil {
+		t.Fatal("RunWithLimit cancelable context: expected error")
+	}
+	if _, err := e.Step(); err == nil {
+		t.Fatal("Step: expected error")
+	}
+	assertErr("Reset", e.Reset())
+	if _, err := e.Serialize(FormatBincode); err == nil {
+		t.Fatal("Serialize: expected error")
+	}
+	if err := e.SerializeToFile("unused", Format(99)); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("SerializeToFile invalid format should fail before writing, got %v", err)
+	}
+	if _, err := e.GetGlobal("missing"); err == nil {
+		t.Fatal("GetGlobal: expected error")
+	}
+	if _, err := e.RulesE(); err == nil {
+		t.Fatal("RulesE: expected error")
+	}
+	if _, err := e.TemplatesE(); err == nil {
+		t.Fatal("TemplatesE: expected error")
+	}
+	if _, err := e.DiagnosticsE(); err == nil {
+		t.Fatal("DiagnosticsE: expected error")
+	}
+	if _, err := e.CurrentModuleE(); err == nil {
+		t.Fatal("CurrentModuleE: expected error")
+	}
+	if _, _, err := e.FocusE(); err == nil {
+		t.Fatal("FocusE: expected error")
+	}
+	if _, err := e.FocusStackE(); err == nil {
+		t.Fatal("FocusStackE: expected error")
+	}
+	if _, err := e.AgendaSizeE(); err == nil {
+		t.Fatal("AgendaSizeE: expected error")
+	}
+	if _, err := e.IsHaltedE(); err == nil {
+		t.Fatal("IsHaltedE: expected error")
+	}
+
+	if got := e.Rules(); got != nil {
+		t.Fatalf("Rules nil handle = %#v, want nil", got)
+	}
+	if got := e.Templates(); got != nil {
+		t.Fatalf("Templates nil handle = %#v, want nil", got)
+	}
+	if got := e.CurrentModule(); got != "" {
+		t.Fatalf("CurrentModule nil handle = %q, want empty", got)
+	}
+	if name, ok := e.Focus(); name != "" || ok {
+		t.Fatalf("Focus nil handle = (%q, %v), want empty false", name, ok)
+	}
+	if got := e.FocusStack(); got != nil {
+		t.Fatalf("FocusStack nil handle = %#v, want nil", got)
+	}
+	if got := e.AgendaSize(); got != 0 {
+		t.Fatalf("AgendaSize nil handle = %d, want 0", got)
+	}
+	if got := e.IsHalted(); got {
+		t.Fatal("IsHalted nil handle = true, want false")
+	}
+	if got := e.Diagnostics(); got != nil {
+		t.Fatalf("Diagnostics nil handle = %#v, want nil", got)
+	}
+}
+
+func TestManualIteratorErrorAndEarlyBreakBranches(t *testing.T) {
+	// Iterators intentionally hide errors in the simple forms and expose them in
+	// the E forms. This test covers nil-handle errors and yield-stop branches.
+	nilEngine := &Engine{}
+	for range nilEngine.FactIter() {
+		t.Fatal("FactIter should not yield for nil handle")
+	}
+	for range nilEngine.RuleIter() {
+		t.Fatal("RuleIter should not yield for nil handle")
+	}
+	for range nilEngine.TemplateIter() {
+		t.Fatal("TemplateIter should not yield for nil handle")
+	}
+	for range nilEngine.DiagnosticIter() {
+		t.Fatal("DiagnosticIter should not yield for nil handle")
+	}
+	for _, err := range nilEngine.FactIterE() {
+		if err == nil {
+			t.Fatal("FactIterE nil handle should yield an error")
+		}
+	}
+	for _, err := range nilEngine.RuleIterE() {
+		if err == nil {
+			t.Fatal("RuleIterE nil handle should yield an error")
+		}
+	}
+	for _, err := range nilEngine.TemplateIterE() {
+		if err == nil {
+			t.Fatal("TemplateIterE nil handle should yield an error")
+		}
+	}
+	for _, err := range nilEngine.DiagnosticIterE() {
+		if err == nil {
+			t.Fatal("DiagnosticIterE nil handle should yield an error")
+		}
+	}
+
+	lockThread(t)
+	e, err := NewEngine(WithSource(`
+		(deftemplate sensor (slot id))
+		(deftemplate alarm (slot level))
+		(defrule r1 => (assert (a)))
+		(defrule r2 => (assert (b)))
+	`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, e)
+
+	for range e.RuleIter() {
+		break
+	}
+	for range e.TemplateIter() {
+		break
+	}
+	for _, err := range e.RuleIterE() {
+		if err != nil {
+			t.Fatalf("RuleIterE unexpected error: %v", err)
+		}
+		break
+	}
+	for _, err := range e.TemplateIterE() {
+		if err != nil {
+			t.Fatalf("TemplateIterE unexpected error: %v", err)
+		}
+		break
+	}
+}
+
+func TestManualCancelableRunBatchesAndHaltReason(t *testing.T) {
+	// A cancelable context uses the batched path. A chain longer than one batch
+	// proves that LimitReached can continue across batches and still stop on the
+	// caller's total limit.
+	lockThread(t)
+	e, err := NewEngine(WithSource(`
+		(defrule chain
+			(level ?n&:(< ?n 200))
+			=>
+			(assert (level (+ ?n 1))))
+	`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, e)
+	mustAssertFact(t, e, "level", int64(0))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result, err := e.RunWithLimit(ctx, 150)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RulesFired != 150 || result.HaltReason != HaltLimitReached {
+		t.Fatalf("batched limit result = %+v, want 150/LimitReached", result)
+	}
+
+	e2, err := NewEngine(WithSource(`(defrule r => (halt))`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, e2)
+	halted, err := e2.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if halted.HaltReason != HaltRequested {
+		t.Fatalf("halted run reason = %v, want HaltRequested", halted.HaltReason)
+	}
+
+	e3, err := NewEngine(WithSource(`(defrule r => (halt))`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, e3)
+	cancelable, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cancelableHalt, err := e3.RunWithLimit(cancelable, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cancelableHalt.HaltReason != HaltRequested {
+		t.Fatalf("cancelable halted run reason = %v, want HaltRequested", cancelableHalt.HaltReason)
+	}
+}
+
+func TestManualCoordinatorWorkerAndManagerErrorBranches(t *testing.T) {
+	// These checks cover coordinator/manager failures that occur before or
+	// during worker cold-start, where user input names an unknown or invalid spec.
+	if got := (roundRobinPolicy{}).PickWorker(RouteHint{}, 0, 10); got != 0 {
+		t.Fatalf("round robin with no workers = %d, want 0", got)
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{}))
+	o := newObs(&coordConfig{logger: logger})
+	w := &worker{
+		specs:    map[string][]EngineOption{"bad": {WithSource("(defrule bad")}},
+		engines:  make(map[string]*Engine),
+		requests: make(chan workerRequest, 1),
+		stop:     make(chan struct{}),
+		done:     make(chan struct{}),
+		obs:      o,
+	}
+	if _, err := w.getOrCreateEngine("missing"); !errors.Is(err, errUnknownEngineSpec) {
+		t.Fatalf("missing worker spec should report errUnknownEngineSpec, got %v", err)
+	}
+	if _, err := w.getOrCreateEngine("bad"); err == nil || !strings.Contains(err.Error(), "creating engine") {
+		t.Fatalf("bad worker spec should fail cold start, got %v", err)
+	}
+	if !strings.Contains(buf.String(), "engine cold start failed") {
+		t.Fatalf("expected cold-start failure log, got %q", buf.String())
+	}
+
+	resp := make(chan error, 1)
+	w.handle(workerRequest{specName: "missing", resp: resp})
+	if err := <-resp; !errors.Is(err, errUnknownEngineSpec) {
+		t.Fatalf("worker handle missing spec = %v", err)
+	}
+
+	mgr, err := NewManager(WithSource(`(defrule r => (assert (ok)))`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, mgr)
+	if err := mgr.Do(nil, func(*Engine) error { return nil }); !errors.Is(err, errNilContext) {
+		t.Fatalf("Do nil context = %v", err)
+	}
+	if _, err := mgr.Evaluate(context.Background(), nil); !errors.Is(err, errNilEvaluateRequest) {
+		t.Fatalf("Evaluate nil request = %v", err)
+	}
+	if _, err := mgr.EvaluateNative(context.Background(), nil); !errors.Is(err, errNilEvaluateRequest) {
+		t.Fatalf("EvaluateNative nil request = %v", err)
+	}
+
+	badMgr, err := NewManager(WithSource("(defrule bad"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, badMgr)
+	if _, err := badMgr.Evaluate(context.Background(), &EvaluateRequest{}); err == nil {
+		t.Fatal("Evaluate with invalid source should fail during worker cold-start")
+	}
+	if _, err := badMgr.EvaluateNative(context.Background(), &EvaluateNativeRequest{}); err == nil {
+		t.Fatal("EvaluateNative with invalid source should fail during worker cold-start")
+	}
+}
+
+func TestManualAssertWireFactsAndEvaluateNativeErrors(t *testing.T) {
+	// The request conversion layer rejects malformed wire facts before running
+	// rules. These examples cover each validation branch and native conversion.
+	lockThread(t)
+	e, err := NewEngine(WithSource(`(deftemplate sensor (slot id))`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, e)
+
+	if err := assertWireFacts(e, []WireFactInput{{Kind: WireFactKindOrdered}}); !errors.Is(err, errOrderedFactPayloadMissing) {
+		t.Fatalf("missing ordered payload = %v", err)
+	}
+	if err := assertWireFacts(e, []WireFactInput{OrderedFact("x", WireValue{Kind: "bad"})}); !errors.Is(err, errUnknownWireValueKind) {
+		t.Fatalf("bad ordered field = %v", err)
+	}
+	if err := assertWireFacts(&Engine{}, []WireFactInput{OrderedFact("x", IntValue(1))}); err == nil {
+		t.Fatal("ordered assertion through nil engine should fail")
+	}
+	if err := assertWireFacts(e, []WireFactInput{{Kind: WireFactKindTemplate}}); !errors.Is(err, errTemplateFactPayloadMissing) {
+		t.Fatalf("missing template payload = %v", err)
+	}
+	if err := assertWireFacts(e, []WireFactInput{TemplateFact("sensor", map[string]WireValue{"id": {Kind: "bad"}})}); !errors.Is(err, errUnknownWireValueKind) {
+		t.Fatalf("bad template slot = %v", err)
+	}
+	if err := assertWireFacts(&Engine{}, []WireFactInput{TemplateFact("sensor", map[string]WireValue{"id": IntValue(1)})}); err == nil {
+		t.Fatal("template assertion through nil engine should fail")
+	}
+	if err := assertWireFacts(e, []WireFactInput{{Kind: WireFactKind("bogus")}}); !errors.Is(err, errUnsupportedFactKind) {
+		t.Fatalf("unsupported fact kind = %v", err)
+	}
+
+	mgr, err := NewManager(WithSource(`(deftemplate sensor (slot id))`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, mgr)
+	if _, err := mgr.EvaluateNative(context.Background(), &EvaluateNativeRequest{
+		Facts: []NativeFactInput{{TemplateName: "sensor", Slots: map[string]any{"id": struct{}{}}}},
+	}); !errors.Is(err, errUnsupportedWireConversionType) {
+		t.Fatalf("bad native slot = %v", err)
+	}
+	if _, err := mgr.EvaluateNative(context.Background(), &EvaluateNativeRequest{
+		Facts: []NativeFactInput{{Relation: "x", Fields: []any{struct{}{}}}},
+	}); !errors.Is(err, errUnsupportedWireConversionType) {
+		t.Fatalf("bad native field = %v", err)
+	}
+
+	if _, err := mgr.Evaluate(context.Background(), &EvaluateRequest{
+		Facts: []WireFactInput{{Kind: WireFactKindOrdered}},
+	}); !errors.Is(err, errOrderedFactPayloadMissing) {
+		t.Fatalf("Evaluate bad wire fact = %v", err)
+	}
+
+	stderrMgr, err := NewManager(WithSource(`(defrule warn => (printout stderr "warn" crlf))`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, stderrMgr)
+	result, err := stderrMgr.Evaluate(context.Background(), &EvaluateRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Output["stderr"] != "warn\n" {
+		t.Fatalf("stderr output = %q, want warn", result.Output["stderr"])
+	}
+
+	if _, err := buildEvaluateResult(&Engine{}, &RunResult{}); err == nil {
+		t.Fatal("buildEvaluateResult should fail when Facts fails")
+	}
+}
+
+func TestManualPinnedEngineCancellationAndSerializationFile(t *testing.T) {
+	// PinnedEngine should forward file serialization and respect cancellation
+	// while waiting for an already-dispatched worker operation to finish.
+	p, err := NewPinnedEngine(WithSource(`(defrule r => (assert (ok)))`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, p)
+
+	path := t.TempDir() + "/snapshot.bin"
+	if err := p.SerializeToFile(path, FormatBincode); err != nil {
+		t.Fatalf("SerializeToFile failed: %v", err)
+	}
+	if err := p.Do(nil, func(*Engine) error { return nil }); !errors.Is(err, errNilContext) {
+		t.Fatalf("PinnedEngine.Do nil context = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	release := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- p.Do(ctx, func(*Engine) error {
+			close(started)
+			<-release
+			return nil
+		})
+	}()
+	<-started
+	cancel()
+	err = <-errCh
+	close(release)
+	if err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("PinnedEngine.Do canceled while waiting = %v", err)
+	}
+
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Do(context.Background(), func(*Engine) error { return nil }); !errors.Is(err, errPinnedEngineClosed) {
+		t.Fatalf("PinnedEngine.Do after close = %v", err)
+	}
+
+	blocked := &PinnedEngine{
+		requests: make(chan pinnedRequest),
+		done:     make(chan struct{}),
+	}
+	blockedCtx, blockedCancel := context.WithCancel(context.Background())
+	blockedErr := make(chan error, 1)
+	go func() {
+		blockedErr <- blocked.tryEnqueue(blockedCtx, pinnedRequest{resp: make(chan error, 1)})
+	}()
+	blockedCancel()
+	if err := <-blockedErr; err == nil || !errors.Is(err, context.Canceled) {
+		t.Fatalf("blocked tryEnqueue canceled before dispatch = %v", err)
+	}
+}
+
+func TestManualEngineSourceConfigWrongThreadCloseAndDiagnostics(t *testing.T) {
+	// These examples cover source+config construction, Engine.Close's
+	// thread-affinity error, and the simple diagnostic iterator success path.
+	lockThread(t)
+
+	e, err := NewEngine(
+		WithSource(`(defrule r => (assert (ok)))`),
+		WithStrategy(StrategyBreadth),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, e)
+
+	wrongThread := make(chan error, 1)
+	go func() {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		wrongThread <- e.Close()
+	}()
+	if err := <-wrongThread; !errors.Is(err, ErrThreadViolation) {
+		t.Fatalf("wrong-thread Close = %v", err)
+	}
+
+	diag, err := NewEngine(WithSource(`(defrule boom => (/ 1 0))`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, diag)
+	_, _ = diag.Run(context.Background())
+	count := 0
+	for range diag.DiagnosticIter() {
+		count++
+		break
+	}
+	for _, err := range diag.DiagnosticIterE() {
+		if err != nil {
+			t.Fatalf("DiagnosticIterE unexpected error: %v", err)
+		}
+		break
+	}
+}
+
+func TestManualFinalizerAndBuildFactsHelpers(t *testing.T) {
+	// The named finalizer keeps GC cleanup testable without waiting for the
+	// runtime, and buildFacts centralizes ID-to-fact error handling.
+	finalizeEngine(&Engine{closed: true})
+	finalizeEngine(&Engine{})
+
+	lockThread(t)
+	e, err := NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, e)
+	if _, err := e.buildFacts([]uint64{999}); err == nil {
+		t.Fatal("buildFacts should fail when an ID cannot be resolved")
+	}
+}
+
+func TestManualHookedNewEngineNativeFallbacks(t *testing.T) {
+	// These branches defend against native constructors reporting success while
+	// returning a nil handle. Hooks make those impossible native states explicit.
+	t.Run("snapshot nil handle", func(t *testing.T) {
+		withFFIHooks(t)
+		ffiEngineDeserializeAs = func([]byte, ffi.SerializationFormat) (ffi.EngineHandle, ffi.ErrorCode) {
+			return nil, ffi.ErrOK
+		}
+		_, err := NewEngine(WithSnapshot([]byte("snapshot"), FormatBincode))
+		if err == nil || !strings.Contains(err.Error(), "snapshot") {
+			t.Fatalf("snapshot nil handle error = %v", err)
+		}
+	})
+
+	t.Run("source nil handle empty native error", func(t *testing.T) {
+		withFFIHooks(t)
+		ffiEngineNewWithSource = func(string) ffi.EngineHandle { return nil }
+		ffiLastErrorGlobal = func() string { return "" }
+		_, err := NewEngine(WithSource("(defrule r =>)"))
+		if err == nil || !strings.Contains(err.Error(), "failed to create engine from source") {
+			t.Fatalf("source nil handle error = %v", err)
+		}
+	})
+
+	t.Run("configured nil handle", func(t *testing.T) {
+		withFFIHooks(t)
+		ffiEngineNewWithConfig = func(*ffi.Config) ffi.EngineHandle { return nil }
+		_, err := NewEngine(WithStrategy(StrategyBreadth))
+		if err == nil || !strings.Contains(err.Error(), "failed to create engine") {
+			t.Fatalf("configured nil handle error = %v", err)
+		}
+	})
+}
+
+func TestManualHookedRunEdgeBranches(t *testing.T) {
+	// The real FFI should respect batch limits and host integer bounds. These
+	// hooks prove the Go wrapper still handles violations predictably.
+	t.Run("cancelable loop stops when previous batch over-fired", func(t *testing.T) {
+		withFFIHooks(t)
+		calls := 0
+		ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+			calls++
+			return 2, ffi.HaltReason(999), ffi.ErrOK
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		result, err := (&Engine{}).RunWithLimit(ctx, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.RulesFired != 2 || result.HaltReason != HaltLimitReached || calls != 1 {
+			t.Fatalf("over-fired result = %+v after %d calls", result, calls)
+		}
+	})
+
+	t.Run("cancelable fired count overflow", func(t *testing.T) {
+		withFFIHooks(t)
+		maxInt := uint64(^uint(0) >> 1)
+		ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+			return maxInt + 1, ffi.HaltReasonAgendaEmpty, ffi.ErrOK
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_, err := (&Engine{}).RunWithLimit(ctx, 0)
+		if !errors.Is(err, errIntOverflow) {
+			t.Fatalf("cancelable overflow error = %v", err)
+		}
+	})
+
+	t.Run("direct fired count overflow", func(t *testing.T) {
+		withFFIHooks(t)
+		maxInt := uint64(^uint(0) >> 1)
+		ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+			return maxInt + 1, ffi.HaltReasonAgendaEmpty, ffi.ErrOK
+		}
+
+		_, err := (&Engine{}).Run(context.Background())
+		if !errors.Is(err, errIntOverflow) {
+			t.Fatalf("direct overflow error = %v", err)
+		}
+	})
+}
+
+func TestManualHookedIntrospectionAndIteratorErrors(t *testing.T) {
+	// The simple introspection APIs stop on mid-stream native errors, while E
+	// variants and E iterators expose the error. Hooks simulate that mid-stream.
+	withFFIHooks(t)
+	e := &Engine{}
+
+	ffiEngineFactIDs = func(ffi.EngineHandle) ([]uint64, ffi.ErrorCode) {
+		return []uint64{1}, ffi.ErrOK
+	}
+	ffiEngineGetFactType = func(ffi.EngineHandle, uint64) (ffi.FactType, ffi.ErrorCode) {
+		return 0, ffi.ErrNotFound
+	}
+	for range e.FactIter() {
+		t.Fatal("FactIter should stop when buildFact fails")
+	}
+	for _, err := range e.FactIterE() {
+		if err == nil {
+			t.Fatal("FactIterE should yield buildFact error")
+		}
+	}
+
+	ffiEngineRuleCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
+	ffiEngineRuleInfo = func(ffi.EngineHandle, uintptr) (string, int32, ffi.ErrorCode) {
+		return "", 0, ffi.ErrRuntimeError
+	}
+	if got := e.Rules(); len(got) != 0 {
+		t.Fatalf("Rules after item error = %v, want empty", got)
+	}
+	if _, err := e.RulesE(); err == nil {
+		t.Fatal("RulesE should return item error")
+	}
+	for range e.RuleIter() {
+		t.Fatal("RuleIter should stop on item error")
+	}
+	for _, err := range e.RuleIterE() {
+		if err == nil {
+			t.Fatal("RuleIterE should yield item error")
+		}
+	}
+
+	ffiEngineTemplateCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
+	ffiEngineTemplateName = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
+		return "", ffi.ErrRuntimeError
+	}
+	if got := e.Templates(); len(got) != 0 {
+		t.Fatalf("Templates after item error = %v, want empty", got)
+	}
+	if _, err := e.TemplatesE(); err == nil {
+		t.Fatal("TemplatesE should return item error")
+	}
+	for range e.TemplateIter() {
+		t.Fatal("TemplateIter should stop on item error")
+	}
+	for _, err := range e.TemplateIterE() {
+		if err == nil {
+			t.Fatal("TemplateIterE should yield item error")
+		}
+	}
+
+	ffiEngineFocusStackDepth = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
+	ffiEngineFocusStackEntry = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
+		return "", ffi.ErrRuntimeError
+	}
+	if got := e.FocusStack(); len(got) != 0 {
+		t.Fatalf("FocusStack after item error = %v, want empty", got)
+	}
+	if _, err := e.FocusStackE(); err == nil {
+		t.Fatal("FocusStackE should return item error")
+	}
+
+	ffiEngineActionDiagnosticCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
+	ffiEngineActionDiagnosticCopy = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
+		return "", ffi.ErrRuntimeError
+	}
+	if got := e.Diagnostics(); len(got) != 0 {
+		t.Fatalf("Diagnostics after item error = %v, want empty", got)
+	}
+	if _, err := e.DiagnosticsE(); err == nil {
+		t.Fatal("DiagnosticsE should return item error")
+	}
+	for range e.DiagnosticIter() {
+		t.Fatal("DiagnosticIter should stop on item error")
+	}
+	for _, err := range e.DiagnosticIterE() {
+		if err == nil {
+			t.Fatal("DiagnosticIterE should yield item error")
+		}
+	}
+}
+
+func installOrderedBuildFactHooks() {
+	ffiEngineGetFactType = func(ffi.EngineHandle, uint64) (ffi.FactType, ffi.ErrorCode) {
+		return ffi.FactTypeOrdered, ffi.ErrOK
+	}
+	ffiEngineGetFactFieldCount = func(ffi.EngineHandle, uint64) (uintptr, ffi.ErrorCode) {
+		return 1, ffi.ErrOK
+	}
+	ffiEngineGetFactField = func(ffi.EngineHandle, uint64, uintptr) (ffi.Value, ffi.ErrorCode) {
+		return ffi.ValueInteger(1), ffi.ErrOK
+	}
+	ffiEngineGetFactRelation = func(ffi.EngineHandle, uint64) (string, ffi.ErrorCode) {
+		return "rel", ffi.ErrOK
+	}
+}
+
+func installTemplateBuildFactHooks() {
+	ffiEngineGetFactType = func(ffi.EngineHandle, uint64) (ffi.FactType, ffi.ErrorCode) {
+		return ffi.FactTypeTemplate, ffi.ErrOK
+	}
+	ffiEngineGetFactFieldCount = func(ffi.EngineHandle, uint64) (uintptr, ffi.ErrorCode) {
+		return 1, ffi.ErrOK
+	}
+	ffiEngineGetFactField = func(ffi.EngineHandle, uint64, uintptr) (ffi.Value, ffi.ErrorCode) {
+		return ffi.ValueInteger(1), ffi.ErrOK
+	}
+	ffiEngineGetFactTemplateName = func(ffi.EngineHandle, uint64) (string, ffi.ErrorCode) {
+		return "tmpl", ffi.ErrOK
+	}
+	ffiEngineTemplateSlotCount = func(ffi.EngineHandle, string) (uintptr, ffi.ErrorCode) {
+		return 1, ffi.ErrOK
+	}
+	ffiEngineTemplateSlotName = func(ffi.EngineHandle, string, uintptr) (string, ffi.ErrorCode) {
+		return "slot", ffi.ErrOK
+	}
+}
+
+func TestManualHookedBuildFactErrors(t *testing.T) {
+	// buildFact composes multiple native lookups. Each subtest proves a later
+	// lookup failure is wrapped instead of returning a partially corrupted Fact.
+	cases := []struct {
+		name  string
+		setup func()
+		want  string
+	}{
+		{
+			name: "field count error",
+			setup: func() {
+				installOrderedBuildFactHooks()
+				ffiEngineGetFactFieldCount = func(ffi.EngineHandle, uint64) (uintptr, ffi.ErrorCode) {
+					return 0, ffi.ErrRuntimeError
+				}
+			},
+		},
+		{
+			name: "field error",
+			setup: func() {
+				installOrderedBuildFactHooks()
+				ffiEngineGetFactField = func(ffi.EngineHandle, uint64, uintptr) (ffi.Value, ffi.ErrorCode) {
+					return ffi.Value{}, ffi.ErrRuntimeError
+				}
+			},
+		},
+		{
+			name: "template name error",
+			setup: func() {
+				installTemplateBuildFactHooks()
+				ffiEngineGetFactTemplateName = func(ffi.EngineHandle, uint64) (string, ffi.ErrorCode) {
+					return "", ffi.ErrRuntimeError
+				}
+			},
+		},
+		{
+			name: "slot count error",
+			setup: func() {
+				installTemplateBuildFactHooks()
+				ffiEngineTemplateSlotCount = func(ffi.EngineHandle, string) (uintptr, ffi.ErrorCode) {
+					return 0, ffi.ErrRuntimeError
+				}
+			},
+			want: "slot count",
+		},
+		{
+			name: "slot name error",
+			setup: func() {
+				installTemplateBuildFactHooks()
+				ffiEngineTemplateSlotName = func(ffi.EngineHandle, string, uintptr) (string, ffi.ErrorCode) {
+					return "", ffi.ErrRuntimeError
+				}
+			},
+			want: "slot name",
+		},
+		{
+			name: "relation error",
+			setup: func() {
+				installOrderedBuildFactHooks()
+				ffiEngineGetFactRelation = func(ffi.EngineHandle, uint64) (string, ffi.ErrorCode) {
+					return "", ffi.ErrRuntimeError
+				}
+			},
+			want: "relation",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withFFIHooks(t)
+			tc.setup()
+			_, err := (&Engine{}).buildFact(1)
+			if err == nil {
+				t.Fatal("expected buildFact error")
+			}
+			if tc.want != "" && !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("buildFact error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestManualHookedEvaluateAndPinnedEdges(t *testing.T) {
+	// Evaluate's closure is normally backed by a healthy worker engine. Hooks
+	// let us cover reset, run, and result-conversion failures deterministically.
+	t.Run("reset failure", func(t *testing.T) {
+		withFFIHooks(t)
+		ffiEngineReset = func(ffi.EngineHandle) ffi.ErrorCode { return ffi.ErrRuntimeError }
+		mgr, err := NewManager()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer mustClose(t, mgr)
+		if _, err := mgr.Evaluate(context.Background(), &EvaluateRequest{}); err == nil {
+			t.Fatal("Evaluate should fail when Reset fails")
+		}
+	})
+
+	t.Run("run failure", func(t *testing.T) {
+		withFFIHooks(t)
+		ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+			return 0, 0, ffi.ErrRuntimeError
+		}
+		mgr, err := NewManager()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer mustClose(t, mgr)
+		if _, err := mgr.Evaluate(context.Background(), &EvaluateRequest{}); err == nil {
+			t.Fatal("Evaluate should fail when Run fails")
+		}
+	})
+
+	t.Run("wire conversion failure", func(t *testing.T) {
+		withFFIHooks(t)
+		factsToWire = func([]Fact) ([]WireFact, error) { return nil, errUnsupportedWireConversionType }
+		e, err := NewEngine()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer mustClose(t, e)
+		if _, err := buildEvaluateResult(e, &RunResult{}); err == nil {
+			t.Fatal("buildEvaluateResult should fail when factsToWire fails")
+		}
+	})
+
+	t.Run("pinned select cancellation", func(t *testing.T) {
+		withFFIHooks(t)
+		done := make(chan struct{})
+		close(done)
+		p := &PinnedEngine{requests: make(chan pinnedRequest), done: make(chan struct{})}
+		err := p.tryEnqueue(doneOnlyContext{done: done}, pinnedRequest{resp: make(chan error, 1)})
+		if err == nil {
+			t.Fatal("tryEnqueue should return an error from ctx.Done")
+		}
+	})
+}
+
+func TestPropertyConfigurationHelpers(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(0, 1<<31-1).Draw(t, "max_call_depth")
+		got, err := intToUintptr(n)
+		if err != nil {
+			t.Fatalf("non-negative depth rejected: %v", err)
+		}
+		if got != uintptr(n) {
+			t.Fatalf("intToUintptr(%d) = %d", n, got)
+		}
+
+		enc := rapid.SampledFrom([]Encoding{
+			EncodingASCII,
+			EncodingUTF8,
+			EncodingASCIISymbolsUTF8Strings,
+		}).Draw(t, "encoding")
+		if _, err := toFFIStringEncoding(enc); err != nil {
+			t.Fatalf("valid encoding rejected: %v", err)
+		}
+
+		strategy := rapid.SampledFrom([]Strategy{
+			StrategyDepth,
+			StrategyBreadth,
+			StrategyLEX,
+			StrategyMEA,
+		}).Draw(t, "strategy")
+		if _, err := toFFIConflictStrategy(strategy); err != nil {
+			t.Fatalf("valid strategy rejected: %v", err)
+		}
+
+		if _, err := intToUintptr(-1); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("negative max call depth error = %v", err)
+		}
+		if _, err := toFFIStringEncoding(Encoding(rapid.IntRange(100, 200).Draw(t, "bad_encoding"))); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("invalid encoding error = %v", err)
+		}
+		if _, err := toFFIConflictStrategy(Strategy(rapid.IntRange(100, 200).Draw(t, "bad_strategy"))); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("invalid strategy error = %v", err)
+		}
+		if _, err := formatToFFI(Format(rapid.IntRange(100, 200).Draw(t, "bad_format"))); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("invalid format error = %v", err)
+		}
+		if _, err := NewEngine(WithEncoding(Encoding(rapid.IntRange(100, 200).Draw(t, "engine_bad_encoding")))); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("NewEngine invalid encoding error = %v", err)
+		}
+		if _, err := NewEngine(WithStrategy(Strategy(rapid.IntRange(100, 200).Draw(t, "engine_bad_strategy")))); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("NewEngine invalid strategy error = %v", err)
+		}
+		if _, err := NewEngine(WithMaxCallDepth(-1)); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("NewEngine invalid call depth error = %v", err)
+		}
+		if _, err := NewCoordinator(nil, Threads(0)); !errors.Is(err, errInvalidThreadCount) {
+			t.Fatalf("invalid coordinator thread count error = %v", err)
+		}
+		if got := (roundRobinPolicy{}).PickWorker(RouteHint{}, 0, rapid.Uint64().Draw(t, "counter")); got != 0 {
+			t.Fatalf("roundRobinPolicy empty pool = %d, want 0", got)
+		}
+	})
+}
+
+func TestPropertyWireConversionErrorSurfaces(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		kind := WireValueKind(rapid.String().Filter(func(s string) bool {
+			switch WireValueKind(s) {
+			case WireValueVoid, WireValueInteger, WireValueFloat, WireValueSymbol, WireValueString, WireValueMultifield:
+				return false
+			default:
+				return true
+			}
+		}).Draw(t, "kind"))
+		_, err := WireToNativeValue(WireValue{Kind: kind})
+		if !errors.Is(err, errUnknownWireValueKind) {
+			t.Fatalf("unknown kind %q error = %v", kind, err)
+		}
+	})
+}
+
+func TestPropertyHookedNewEngineFallbacks(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		resetFFIHooks()
+		defer resetFFIHooks()
+
+		scenario := rapid.SampledFrom([]string{"snapshot", "source", "config"}).Draw(t, "scenario")
+		switch scenario {
+		case "snapshot":
+			ffiEngineDeserializeAs = func([]byte, ffi.SerializationFormat) (ffi.EngineHandle, ffi.ErrorCode) {
+				return nil, ffi.ErrOK
+			}
+			_, err := NewEngine(WithSnapshot([]byte("snapshot"), FormatBincode))
+			if err == nil {
+				t.Fatal("snapshot nil handle should fail")
+			}
+		case "source":
+			ffiEngineNewWithSource = func(string) ffi.EngineHandle { return nil }
+			ffiLastErrorGlobal = func() string { return "" }
+			_, err := NewEngine(WithSource("(defrule r =>)"))
+			if err == nil {
+				t.Fatal("source nil handle should fail")
+			}
+		case "config":
+			ffiEngineNewWithConfig = func(*ffi.Config) ffi.EngineHandle { return nil }
+			_, err := NewEngine(WithStrategy(StrategyBreadth))
+			if err == nil {
+				t.Fatal("configured nil handle should fail")
+			}
+		}
+	})
+}
+
+func TestPropertyHookedRunEdges(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		resetFFIHooks()
+		defer resetFFIHooks()
+
+		scenario := rapid.SampledFrom([]string{"overfire", "cancelable_overflow", "direct_overflow"}).Draw(t, "scenario")
+		maxInt := uint64(^uint(0) >> 1)
+		switch scenario {
+		case "overfire":
+			fired := rapid.Uint64Range(2, 20).Draw(t, "fired")
+			ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+				return fired, ffi.HaltReason(999), ffi.ErrOK
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			result, err := (&Engine{}).RunWithLimit(ctx, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.RulesFired != int(fired) || result.HaltReason != HaltLimitReached {
+				t.Fatalf("overfire result = %+v, fired %d", result, fired)
+			}
+		case "cancelable_overflow":
+			ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+				return maxInt + 1, ffi.HaltReasonAgendaEmpty, ffi.ErrOK
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			_, err := (&Engine{}).RunWithLimit(ctx, 0)
+			if !errors.Is(err, errIntOverflow) {
+				t.Fatalf("cancelable overflow error = %v", err)
+			}
+		case "direct_overflow":
+			ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+				return maxInt + 1, ffi.HaltReasonAgendaEmpty, ffi.ErrOK
+			}
+			_, err := (&Engine{}).Run(context.Background())
+			if !errors.Is(err, errIntOverflow) {
+				t.Fatalf("direct overflow error = %v", err)
+			}
+		}
+	})
+}
+
+func TestPropertyHookedIntrospectionErrors(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		resetFFIHooks()
+		defer resetFFIHooks()
+
+		e := &Engine{}
+		scenario := rapid.SampledFrom([]string{"fact", "rule", "template", "focus", "diagnostic"}).Draw(t, "scenario")
+		switch scenario {
+		case "fact":
+			ffiEngineFactIDs = func(ffi.EngineHandle) ([]uint64, ffi.ErrorCode) {
+				return []uint64{rapid.Uint64().Draw(t, "fact_id")}, ffi.ErrOK
+			}
+			ffiEngineGetFactType = func(ffi.EngineHandle, uint64) (ffi.FactType, ffi.ErrorCode) {
+				return 0, ffi.ErrNotFound
+			}
+			for range e.FactIter() {
+				t.Fatal("FactIter should stop on buildFact error")
+			}
+			for _, err := range e.FactIterE() {
+				if err == nil {
+					t.Fatal("FactIterE should yield buildFact error")
+				}
+			}
+		case "rule":
+			ffiEngineRuleCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
+			ffiEngineRuleInfo = func(ffi.EngineHandle, uintptr) (string, int32, ffi.ErrorCode) {
+				return "", 0, ffi.ErrRuntimeError
+			}
+			if len(e.Rules()) != 0 {
+				t.Fatal("Rules should return partial empty slice on item error")
+			}
+			if _, err := e.RulesE(); err == nil {
+				t.Fatal("RulesE should return item error")
+			}
+		case "template":
+			ffiEngineTemplateCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
+			ffiEngineTemplateName = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
+				return "", ffi.ErrRuntimeError
+			}
+			if len(e.Templates()) != 0 {
+				t.Fatal("Templates should return partial empty slice on item error")
+			}
+			if _, err := e.TemplatesE(); err == nil {
+				t.Fatal("TemplatesE should return item error")
+			}
+		case "focus":
+			ffiEngineFocusStackDepth = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
+			ffiEngineFocusStackEntry = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
+				return "", ffi.ErrRuntimeError
+			}
+			if len(e.FocusStack()) != 0 {
+				t.Fatal("FocusStack should return partial empty slice on item error")
+			}
+			if _, err := e.FocusStackE(); err == nil {
+				t.Fatal("FocusStackE should return item error")
+			}
+		case "diagnostic":
+			ffiEngineActionDiagnosticCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
+			ffiEngineActionDiagnosticCopy = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
+				return "", ffi.ErrRuntimeError
+			}
+			if len(e.Diagnostics()) != 0 {
+				t.Fatal("Diagnostics should return partial empty slice on item error")
+			}
+			if _, err := e.DiagnosticsE(); err == nil {
+				t.Fatal("DiagnosticsE should return item error")
+			}
+		}
+	})
+}
+
+func TestPropertyHookedBuildFactErrors(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		resetFFIHooks()
+		defer resetFFIHooks()
+
+		scenario := rapid.SampledFrom([]string{
+			"field_count", "field", "template_name", "slot_count", "slot_name", "relation",
+		}).Draw(t, "scenario")
+		switch scenario {
+		case "field_count":
+			installOrderedBuildFactHooks()
+			ffiEngineGetFactFieldCount = func(ffi.EngineHandle, uint64) (uintptr, ffi.ErrorCode) {
+				return 0, ffi.ErrRuntimeError
+			}
+		case "field":
+			installOrderedBuildFactHooks()
+			ffiEngineGetFactField = func(ffi.EngineHandle, uint64, uintptr) (ffi.Value, ffi.ErrorCode) {
+				return ffi.Value{}, ffi.ErrRuntimeError
+			}
+		case "template_name":
+			installTemplateBuildFactHooks()
+			ffiEngineGetFactTemplateName = func(ffi.EngineHandle, uint64) (string, ffi.ErrorCode) {
+				return "", ffi.ErrRuntimeError
+			}
+		case "slot_count":
+			installTemplateBuildFactHooks()
+			ffiEngineTemplateSlotCount = func(ffi.EngineHandle, string) (uintptr, ffi.ErrorCode) {
+				return 0, ffi.ErrRuntimeError
+			}
+		case "slot_name":
+			installTemplateBuildFactHooks()
+			ffiEngineTemplateSlotName = func(ffi.EngineHandle, string, uintptr) (string, ffi.ErrorCode) {
+				return "", ffi.ErrRuntimeError
+			}
+		case "relation":
+			installOrderedBuildFactHooks()
+			ffiEngineGetFactRelation = func(ffi.EngineHandle, uint64) (string, ffi.ErrorCode) {
+				return "", ffi.ErrRuntimeError
+			}
+		}
+		if _, err := (&Engine{}).buildFact(rapid.Uint64().Draw(t, "fact_id")); err == nil {
+			t.Fatal("buildFact should fail for injected native lookup error")
+		}
+	})
+}
+
+func TestPropertyHookedEvaluateAndPinnedEdges(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		resetFFIHooks()
+		defer resetFFIHooks()
+
+		scenario := rapid.SampledFrom([]string{"reset", "run", "wire", "pinned"}).Draw(t, "scenario")
+		switch scenario {
+		case "reset":
+			ffiEngineReset = func(ffi.EngineHandle) ffi.ErrorCode { return ffi.ErrRuntimeError }
+			mgr, err := NewManager()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = mgr.Close() }()
+			if _, err := mgr.Evaluate(context.Background(), &EvaluateRequest{}); err == nil {
+				t.Fatal("Evaluate should fail when Reset fails")
+			}
+		case "run":
+			ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+				return 0, 0, ffi.ErrRuntimeError
+			}
+			mgr, err := NewManager()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = mgr.Close() }()
+			if _, err := mgr.Evaluate(context.Background(), &EvaluateRequest{}); err == nil {
+				t.Fatal("Evaluate should fail when Run fails")
+			}
+		case "wire":
+			factsToWire = func([]Fact) ([]WireFact, error) { return nil, errUnsupportedWireConversionType }
+			e, err := NewEngine()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = e.Close() }()
+			if _, err := buildEvaluateResult(e, &RunResult{}); err == nil {
+				t.Fatal("buildEvaluateResult should fail when factsToWire fails")
+			}
+		case "pinned":
+			done := make(chan struct{})
+			close(done)
+			p := &PinnedEngine{requests: make(chan pinnedRequest), done: make(chan struct{})}
+			if err := p.tryEnqueue(doneOnlyContext{done: done}, pinnedRequest{resp: make(chan error, 1)}); err == nil {
+				t.Fatal("tryEnqueue should fail when Done is selected")
+			}
+		}
+	})
+}
+
+func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
+	lockThread(t)
+
+	tmpDir := t.TempDir()
+	source := `
+		(defglobal ?*threshold* = 10)
+		(deftemplate sensor (slot id (type INTEGER)) (slot value (type FLOAT)))
+		(defrule bootstrap => (assert (booted)))
+		(defrule color-seen (color ?c) => (assert (matched ?c)) (printout t ?c crlf))
+		(defrule sensor-seen (sensor (id ?id) (value ?v)) => (assert (observed ?id)))
+	`
+
+	rapid.Check(t, func(rt *rapid.T) {
+		id := rapid.Int64Range(1, 1000).Draw(rt, "id")
+		value := rapid.Float64Range(0.1, 1000.0).Draw(rt, "value")
+		policyIndex := rapid.IntRange(-8, 8).Draw(rt, "policy_index")
+		format := rapid.SampledFrom([]Format{
+			FormatBincode,
+			FormatJSON,
+			FormatCBOR,
+			FormatMessagePack,
+			FormatPostcard,
+		}).Draw(rt, "format")
+
+		e, err := NewEngine(
+			WithSource(source),
+			WithEncoding(EncodingUTF8),
+			WithStrategy(StrategyDepth),
+			WithMaxCallDepth(512),
+		)
+		if err != nil {
+			rt.Fatal(err)
+		}
+		defer func() { _ = e.Close() }()
+
+		if err := e.Load(`(defrule loaded => (assert (loaded)))`); err != nil {
+			rt.Fatal(err)
+		}
+		if err := e.Reset(); err != nil {
+			rt.Fatal(err)
+		}
+		if fired, err := e.Step(); err != nil {
+			rt.Fatal(err)
+		} else if fired == nil {
+			rt.Fatal("expected a bootstrap rule to fire")
+		}
+
+		colorID, err := e.AssertString("(assert (color red))")
+		if err != nil {
+			rt.Fatal(err)
+		}
+		dataID, err := e.AssertFact("data", id, Symbol("ok"))
+		if err != nil {
+			rt.Fatal(err)
+		}
+		sensorID, err := e.AssertTemplate("sensor", map[string]any{"id": id, "value": value})
+		if err != nil {
+			rt.Fatal(err)
+		}
+		if _, err := e.GetFact(sensorID); err != nil {
+			rt.Fatal(err)
+		}
+		if facts, err := e.Facts(); err != nil || len(facts) == 0 {
+			rt.Fatalf("Facts = (%v, %v), want facts", facts, err)
+		}
+		if facts, err := e.FindFacts("data"); err != nil || len(facts) == 0 {
+			rt.Fatalf("FindFacts(data) = (%v, %v), want facts", facts, err)
+		}
+		if count, err := e.FactCount(); err != nil || count == 0 {
+			rt.Fatalf("FactCount = (%d, %v), want positive", count, err)
+		}
+
+		_ = e.Rules()
+		_, _ = e.RulesE()
+		for range e.RuleIter() {
+		}
+		for _, err := range e.RuleIterE() {
+			if err != nil {
+				rt.Fatal(err)
+			}
+		}
+		_ = e.Templates()
+		_, _ = e.TemplatesE()
+		for range e.TemplateIter() {
+		}
+		for _, err := range e.TemplateIterE() {
+			if err != nil {
+				rt.Fatal(err)
+			}
+		}
+		_, _ = e.GetGlobal("threshold")
+		_ = e.CurrentModule()
+		_, _ = e.CurrentModuleE()
+		_, _ = e.Focus()
+		_, _, _ = e.FocusE()
+		_ = e.FocusStack()
+		_, _ = e.FocusStackE()
+		_ = e.AgendaSize()
+		_, _ = e.AgendaSizeE()
+		_ = e.IsHalted()
+		_, _ = e.IsHaltedE()
+		_ = e.Diagnostics()
+		_, _ = e.DiagnosticsE()
+		for range e.DiagnosticIter() {
+		}
+		for _, err := range e.DiagnosticIterE() {
+			if err != nil {
+				rt.Fatal(err)
+			}
+		}
+		e.ClearDiagnostics()
+		e.PushInput("unused")
+		for range e.FactIter() {
+		}
+		for _, err := range e.FactIterE() {
+			if err != nil {
+				rt.Fatal(err)
+			}
+		}
+
+		runResult, err := e.RunWithLimit(context.Background(), 1)
+		if err != nil {
+			rt.Fatal(err)
+		}
+		if runResult.RulesFired < 0 {
+			rt.Fatal("negative rules fired")
+		}
+		if _, err := e.Run(context.Background()); err != nil {
+			rt.Fatal(err)
+		}
+		_, _ = e.GetOutput("t")
+		e.ClearOutput("t")
+
+		data, err := e.Serialize(format)
+		if err != nil {
+			rt.Fatal(err)
+		}
+		restored, err := NewEngine(WithSnapshot(data, format))
+		if err != nil {
+			rt.Fatal(err)
+		}
+		_ = restored.Close()
+		path := tmpDir + "/engine-surface.bin"
+		if err := e.SerializeToFile(path, format); err != nil {
+			rt.Fatal(err)
+		}
+		fromFile, err := NewEngineFromFile(path, format)
+		if err != nil {
+			rt.Fatal(err)
+		}
+		_ = fromFile.Close()
+
+		if err := e.Retract(colorID); err != nil {
+			rt.Fatal(err)
+		}
+		if err := e.Retract(dataID); err != nil {
+			rt.Fatal(err)
+		}
+		e.Halt()
+		e.Clear()
+		_ = HaltAgendaEmpty.String()
+		_ = HaltLimitReached.String()
+		_ = HaltRequested.String()
+		_ = HaltReason(99).String()
+
+		mgr, err := NewManager(WithSource(source))
+		if err != nil {
+			rt.Fatal(err)
+		}
+		defer func() { _ = mgr.Close() }()
+		req := &EvaluateRequest{Facts: []WireFactInput{
+			OrderedFact("color", SymbolValue("blue"), StringValue("label"), MultifieldValue(IntValue(id))),
+			TemplateFact("sensor", map[string]WireValue{"id": IntValue(id), "value": FloatValue(value)}),
+		}}
+		if _, err := mgr.Evaluate(context.Background(), req); err != nil {
+			rt.Fatal(err)
+		}
+		req.Limit = 1
+		if _, err := mgr.Evaluate(context.Background(), req); err != nil {
+			rt.Fatal(err)
+		}
+		if _, err := mgr.EvaluateNative(context.Background(), &EvaluateNativeRequest{Facts: []NativeFactInput{
+			{Relation: "color", Fields: []any{Symbol("green")}},
+			{TemplateName: "sensor", Slots: map[string]any{"id": id, "value": value}},
+		}}); err != nil {
+			rt.Fatal(err)
+		}
+
+		coord, err := NewCoordinator(
+			[]EngineSpec{{Name: "sweep", Options: []EngineOption{WithSource(source)}}},
+			Threads(rapid.IntRange(1, 3).Draw(rt, "threads")),
+			WithDispatchPolicy(fixedIndexPolicy{index: policyIndex}),
+			WithLogger(slog.Default()),
+			WithTracerProvider(nil),
+			WithMeterProvider(nil),
+		)
+		if err != nil {
+			rt.Fatal(err)
+		}
+		defer func() { _ = coord.Close() }()
+		cm, err := coord.Manager("sweep")
+		if err != nil {
+			rt.Fatal(err)
+		}
+		if err := cm.Do(context.Background(), func(engine *Engine) error {
+			_, err := engine.Run(context.Background())
+			return err
+		}); err != nil {
+			rt.Fatal(err)
+		}
+
+		p, err := NewPinnedEngine(WithSource(source))
+		if err != nil {
+			rt.Fatal(err)
+		}
+		defer func() { _ = p.Close() }()
+		if err := p.Load(`(defrule pinned-loaded => (assert (pinned-loaded)))`); err != nil {
+			rt.Fatal(err)
+		}
+		if err := p.Reset(); err != nil {
+			rt.Fatal(err)
+		}
+		_, _ = p.Step()
+		pColorID, err := p.AssertString("(assert (color purple))")
+		if err != nil {
+			rt.Fatal(err)
+		}
+		if _, err := p.AssertFact("data", id); err != nil {
+			rt.Fatal(err)
+		}
+		pSensorID, err := p.AssertTemplate("sensor", map[string]any{"id": id, "value": value})
+		if err != nil {
+			rt.Fatal(err)
+		}
+		if _, err := p.GetFact(pSensorID); err != nil {
+			rt.Fatal(err)
+		}
+		_, _ = p.Facts()
+		_, _ = p.FindFacts("data")
+		_, _ = p.FactCount()
+		_, _ = p.RunWithLimit(context.Background(), 1)
+		_, _ = p.Run(context.Background())
+		_, _ = p.Serialize(format)
+		if err := p.SerializeToFile(tmpDir+"/pinned-surface.bin", format); err != nil {
+			rt.Fatal(err)
+		}
+		_ = p.Rules()
+		_ = p.Templates()
+		_, _ = p.GetGlobal("threshold")
+		_ = p.CurrentModule()
+		_, _ = p.Focus()
+		_ = p.FocusStack()
+		_ = p.AgendaSize()
+		_ = p.IsHalted()
+		_, _ = p.GetOutput("t")
+		p.ClearOutput("t")
+		p.PushInput("unused")
+		_ = p.Diagnostics()
+		p.ClearDiagnostics()
+		if err := p.Retract(pColorID); err != nil {
+			rt.Fatal(err)
+		}
+		p.Halt()
+		p.Clear()
+	})
+}
+
+func TestPropertyErrorSentinelsAndFFIValueConversions(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		text := rapid.String().Draw(t, "text")
+		i := rapid.Int64().Draw(t, "integer")
+		f := rapid.Float64().Filter(func(v float64) bool { return !math.IsNaN(v) }).Draw(t, "float")
+
+		for _, tc := range []struct {
+			code   ffi.ErrorCode
+			target error
+		}{
+			{ffi.ErrParseError, ErrParse},
+			{ffi.ErrCompileError, ErrCompile},
+			{ffi.ErrRuntimeError, ErrRuntime},
+			{ffi.ErrNotFound, ErrNotFound},
+			{ffi.ErrIOError, ErrIO},
+			{ffi.ErrSerializationError, ErrSerialization},
+			{ffi.ErrThreadViolation, ErrThreadViolation},
+			{ffi.ErrInvalidArgument, ErrInvalidArgument},
+		} {
+			if err := errorFromFFI(tc.code, nil); !errors.Is(err, tc.target) {
+				t.Fatalf("errorFromFFI(%d) = %v, want %v", tc.code, err, tc.target)
+			}
+		}
+		if err := errorFromFFI(ffi.ErrOK, nil); err != nil {
+			t.Fatalf("ErrOK translated to %v", err)
+		}
+		if err := errorFromFFI(ffi.ErrorCode(999), nil); err == nil || err.Error() == "" {
+			t.Fatalf("unknown FFI error translated to %v", err)
+		}
+
+		values := []any{
+			int(i),
+			i,
+			int32(i),
+			f,
+			float32(f),
+			Symbol(text),
+			text,
+			true,
+			false,
+			nil,
+			[]any{i, Symbol(text), text},
+		}
+		for _, value := range values {
+			fv, err := goToFFIValue(value)
+			if err != nil {
+				t.Fatalf("goToFFIValue(%T) failed: %v", value, err)
+			}
+			_ = ffiValueToGo(&fv)
+			ffi.ValueFree(&fv)
+		}
+		if _, err := goToFFIValue(struct{}{}); !errors.Is(err, errUnsupportedGoTypeForFFI) {
+			t.Fatalf("unsupported FFI value error = %v", err)
+		}
+		if _, err := goToFFIValue([]any{struct{}{}}); !errors.Is(err, errUnsupportedGoTypeForFFI) {
+			t.Fatalf("unsupported nested FFI value error = %v", err)
+		}
+
+		var external ffi.Value
+		*(*ffi.ValueType)(unsafe.Pointer(&external)) = ffi.ValueTypeExternalAddress
+		if _, ok := ffiValueToGo(&external).(unsafe.Pointer); !ok {
+			t.Fatal("external FFI value did not convert to unsafe.Pointer")
+		}
+		var unknown ffi.Value
+		*(*ffi.ValueType)(unsafe.Pointer(&unknown)) = ffi.ValueType(999)
+		if got := ffiValueToGo(&unknown); got != nil {
+			t.Fatalf("unknown FFI value = %v, want nil", got)
+		}
+
+		nativeCases := []any{
+			int(i),
+			int32(i),
+			i,
+			float32(f),
+			f,
+			Symbol(text),
+			text,
+			true,
+			false,
+			nil,
+			[]any{i, Symbol(text), text},
+		}
+		for _, value := range nativeCases {
+			wire, err := NativeToWireValue(value)
+			if err != nil {
+				t.Fatalf("NativeToWireValue(%T) failed: %v", value, err)
+			}
+			if _, err := WireToNativeValue(wire); err != nil {
+				t.Fatalf("WireToNativeValue(%v) failed: %v", wire, err)
+			}
+		}
+		if _, err := NativeToWireValue(struct{}{}); !errors.Is(err, errUnsupportedWireConversionType) {
+			t.Fatalf("unsupported native wire conversion error = %v", err)
+		}
+		if _, err := NativeToWireValue([]any{struct{}{}}); !errors.Is(err, errUnsupportedWireConversionType) {
+			t.Fatalf("unsupported nested native wire conversion error = %v", err)
+		}
+		if _, err := WireSliceToNative([]WireValue{{Kind: WireValueKind("bad")}}); !errors.Is(err, errUnknownWireValueKind) {
+			t.Fatalf("bad wire slice conversion error = %v", err)
+		}
+		if _, err := WireMapToNative(map[string]WireValue{"x": {Kind: WireValueKind("bad")}}); !errors.Is(err, errUnknownWireValueKind) {
+			t.Fatalf("bad wire map conversion error = %v", err)
+		}
+		if _, err := FactToWire(Fact{Type: FactOrdered, Fields: []any{struct{}{}}}); !errors.Is(err, errUnsupportedWireConversionType) {
+			t.Fatalf("bad ordered fact conversion error = %v", err)
+		}
+		if _, err := FactToWire(Fact{Type: FactTemplate, Slots: map[string]any{"x": struct{}{}}}); !errors.Is(err, errUnsupportedWireConversionType) {
+			t.Fatalf("bad template fact conversion error = %v", err)
+		}
+		if _, err := FactsToWire([]Fact{{Type: FactOrdered, Fields: []any{struct{}{}}}}); !errors.Is(err, errUnsupportedWireConversionType) {
+			t.Fatalf("bad facts conversion error = %v", err)
+		}
+	})
+}
+
+func TestPropertyHookedMutationAndAccessorErrors(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		resetFFIHooks()
+		defer resetFFIHooks()
+
+		e := &Engine{}
+		scenario := rapid.SampledFrom([]string{
+			"finalizer",
+			"close",
+			"load",
+			"assert_string",
+			"assert_ordered",
+			"assert_template",
+			"retract",
+			"fact_ids",
+			"find_fact_ids",
+			"fact_count",
+			"step",
+			"serialize",
+			"get_global",
+			"current_module",
+			"focus",
+			"agenda",
+			"is_halted",
+			"diagnostics",
+		}).Draw(t, "scenario")
+		switch scenario {
+		case "finalizer":
+			calls := 0
+			ffiEngineFreeUnchecked = func(ffi.EngineHandle) ffi.ErrorCode {
+				calls++
+				return ffi.ErrOK
+			}
+			finalizeEngine(&Engine{})
+			finalizeEngine(&Engine{closed: true})
+			if calls != 1 {
+				t.Fatalf("finalizer free calls = %d, want 1", calls)
+			}
+		case "close":
+			ffiEngineFree = func(ffi.EngineHandle) ffi.ErrorCode { return ffi.ErrRuntimeError }
+			if err := e.Close(); err == nil {
+				t.Fatal("Close should surface native free errors")
+			}
+		case "load":
+			ffiEngineLoadString = func(ffi.EngineHandle, string) ffi.ErrorCode { return ffi.ErrRuntimeError }
+			if err := e.Load("bad"); err == nil {
+				t.Fatal("Load should surface native errors")
+			}
+		case "assert_string":
+			ffiEngineAssertString = func(ffi.EngineHandle, string) (uint64, ffi.ErrorCode) {
+				return 0, ffi.ErrRuntimeError
+			}
+			if _, err := e.AssertString("(x)"); err == nil {
+				t.Fatal("AssertString should surface native errors")
+			}
+		case "assert_ordered":
+			ffiEngineAssertOrdered = func(ffi.EngineHandle, string, []ffi.Value) (uint64, ffi.ErrorCode) {
+				return 0, ffi.ErrRuntimeError
+			}
+			if _, err := e.AssertFact("x", int64(1)); err == nil {
+				t.Fatal("AssertFact should surface native errors")
+			}
+		case "assert_template":
+			ffiEngineAssertTemplate = func(ffi.EngineHandle, string, []string, []ffi.Value) (uint64, ffi.ErrorCode) {
+				return 0, ffi.ErrRuntimeError
+			}
+			if _, err := e.AssertTemplate("x", map[string]any{"slot": int64(1)}); err == nil {
+				t.Fatal("AssertTemplate should surface native errors")
+			}
+		case "retract":
+			ffiEngineRetract = func(ffi.EngineHandle, uint64) ffi.ErrorCode { return ffi.ErrRuntimeError }
+			if err := e.Retract(rapid.Uint64().Draw(t, "fact_id")); err == nil {
+				t.Fatal("Retract should surface native errors")
+			}
+		case "fact_ids":
+			ffiEngineFactIDs = func(ffi.EngineHandle) ([]uint64, ffi.ErrorCode) { return nil, ffi.ErrRuntimeError }
+			if _, err := e.Facts(); err == nil {
+				t.Fatal("Facts should surface native errors")
+			}
+		case "find_fact_ids":
+			ffiEngineFindFactIDs = func(ffi.EngineHandle, string) ([]uint64, ffi.ErrorCode) {
+				return nil, ffi.ErrRuntimeError
+			}
+			if _, err := e.FindFacts("x"); err == nil {
+				t.Fatal("FindFacts should surface native errors")
+			}
+		case "fact_count":
+			ffiEngineFactCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 0, ffi.ErrRuntimeError }
+			if _, err := e.FactCount(); err == nil {
+				t.Fatal("FactCount should surface native errors")
+			}
+		case "step":
+			ffiEngineStep = func(ffi.EngineHandle) (int32, ffi.ErrorCode) { return 0, ffi.ErrRuntimeError }
+			if _, err := e.Step(); err == nil {
+				t.Fatal("Step should surface native errors")
+			}
+		case "serialize":
+			ffiEngineSerializeAs = func(ffi.EngineHandle, ffi.SerializationFormat) ([]byte, ffi.ErrorCode) {
+				return nil, ffi.ErrRuntimeError
+			}
+			if _, err := e.Serialize(FormatBincode); err == nil {
+				t.Fatal("Serialize should surface native errors")
+			}
+		case "get_global":
+			ffiEngineGetGlobal = func(ffi.EngineHandle, string) (ffi.Value, ffi.ErrorCode) {
+				return ffi.Value{}, ffi.ErrRuntimeError
+			}
+			if _, err := e.GetGlobal("x"); err == nil {
+				t.Fatal("GetGlobal should surface native errors")
+			}
+		case "current_module":
+			ffiEngineCurrentModule = func(ffi.EngineHandle) (string, ffi.ErrorCode) { return "", ffi.ErrRuntimeError }
+			if got := e.CurrentModule(); got != "" {
+				t.Fatalf("CurrentModule error result = %q, want empty", got)
+			}
+			if _, err := e.CurrentModuleE(); err == nil {
+				t.Fatal("CurrentModuleE should surface native errors")
+			}
+		case "focus":
+			ffiEngineGetFocus = func(ffi.EngineHandle) (string, ffi.ErrorCode) { return "", ffi.ErrRuntimeError }
+			if name, ok := e.Focus(); name != "" || ok {
+				t.Fatalf("Focus error result = (%q, %v), want empty false", name, ok)
+			}
+			if _, _, err := e.FocusE(); err == nil {
+				t.Fatal("FocusE should surface native errors")
+			}
+		case "agenda":
+			ffiEngineAgendaCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 0, ffi.ErrRuntimeError }
+			if got := e.AgendaSize(); got != 0 {
+				t.Fatalf("AgendaSize error result = %d, want 0", got)
+			}
+			if _, err := e.AgendaSizeE(); err == nil {
+				t.Fatal("AgendaSizeE should surface native errors")
+			}
+		case "is_halted":
+			ffiEngineIsHalted = func(ffi.EngineHandle) (bool, ffi.ErrorCode) { return false, ffi.ErrRuntimeError }
+			if got := e.IsHalted(); got {
+				t.Fatal("IsHalted error result = true, want false")
+			}
+			if _, err := e.IsHaltedE(); err == nil {
+				t.Fatal("IsHaltedE should surface native errors")
+			}
+		case "diagnostics":
+			ffiEngineActionDiagnosticCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) {
+				return 0, ffi.ErrRuntimeError
+			}
+			if got := e.Diagnostics(); got != nil {
+				t.Fatalf("Diagnostics error result = %v, want nil", got)
+			}
+			if _, err := e.DiagnosticsE(); err == nil {
+				t.Fatal("DiagnosticsE should surface native errors")
+			}
+		}
+	})
+}

--- a/bindings/go/coverage_edge_test.go
+++ b/bindings/go/coverage_edge_test.go
@@ -341,15 +341,14 @@ func TestManualNilEngineErrorBranches(t *testing.T) {
 	if _, err := e.FactCount(); err == nil {
 		t.Fatal("FactCount: expected error")
 	}
-	if _, err := e.RunWithLimit(nil, 0); !errors.Is(err, errNilContext) {
+	var nilCtx context.Context
+	if _, err := e.RunWithLimit(nilCtx, 0); !errors.Is(err, errNilContext) {
 		t.Fatalf("nil context should fail with errNilContext, got %v", err)
 	}
 	if _, err := e.Run(context.Background()); err == nil {
 		t.Fatal("Run: expected error")
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	if _, err := e.RunWithLimit(ctx, 1); err == nil {
+	if _, err := e.RunWithLimit(t.Context(), 1); err == nil {
 		t.Fatal("RunWithLimit cancelable context: expected error")
 	}
 	if _, err := e.Step(); err == nil {
@@ -580,7 +579,8 @@ func TestManualCoordinatorWorkerAndManagerErrorBranches(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mustClose(t, mgr)
-	if err := mgr.Do(nil, func(*Engine) error { return nil }); !errors.Is(err, errNilContext) {
+	var nilMgrCtx context.Context
+	if err := mgr.Do(nilMgrCtx, func(*Engine) error { return nil }); !errors.Is(err, errNilContext) {
 		t.Fatalf("Do nil context = %v", err)
 	}
 	if _, err := mgr.Evaluate(context.Background(), nil); !errors.Is(err, errNilEvaluateRequest) {
@@ -688,7 +688,8 @@ func TestManualPinnedEngineCancellationAndSerializationFile(t *testing.T) {
 	if err := p.SerializeToFile(path, FormatBincode); err != nil {
 		t.Fatalf("SerializeToFile failed: %v", err)
 	}
-	if err := p.Do(nil, func(*Engine) error { return nil }); !errors.Is(err, errNilContext) {
+	var nilPinnedCtx context.Context
+	if err := p.Do(nilPinnedCtx, func(*Engine) error { return nil }); !errors.Is(err, errNilContext) {
 		t.Fatalf("PinnedEngine.Do nil context = %v", err)
 	}
 
@@ -768,6 +769,9 @@ func TestManualEngineSourceConfigWrongThreadCloseAndDiagnostics(t *testing.T) {
 		count++
 		break
 	}
+	if count == 0 {
+		t.Fatal("DiagnosticIter yielded no diagnostics from a divide-by-zero rule")
+	}
 	for _, err := range diag.DiagnosticIterE() {
 		if err != nil {
 			t.Fatalf("DiagnosticIterE unexpected error: %v", err)
@@ -838,9 +842,7 @@ func TestManualHookedRunEdgeBranches(t *testing.T) {
 			return 2, ffi.HaltReason(999), ffi.ErrOK
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		result, err := (&Engine{}).RunWithLimit(ctx, 1)
+		result, err := (&Engine{}).RunWithLimit(t.Context(), 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -856,9 +858,7 @@ func TestManualHookedRunEdgeBranches(t *testing.T) {
 			return maxInt + 1, ffi.HaltReasonAgendaEmpty, ffi.ErrOK
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		_, err := (&Engine{}).RunWithLimit(ctx, 0)
+		_, err := (&Engine{}).RunWithLimit(t.Context(), 0)
 		if !errors.Is(err, errIntOverflow) {
 			t.Fatalf("cancelable overflow error = %v", err)
 		}
@@ -1270,6 +1270,7 @@ func TestPropertyHookedRunEdges(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			//nolint:gosec // fired is drawn from rapid.Uint64Range(2, 20), safely fits in int
 			if result.RulesFired != int(fired) || result.HaltReason != HaltLimitReached {
 				t.Fatalf("overfire result = %+v, fired %d", result, fired)
 			}
@@ -1536,7 +1537,7 @@ func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
 
 		_ = e.Rules()
 		_, _ = e.RulesE()
-		for range e.RuleIter() {
+		for range e.RuleIter() { //nolint:revive // exhaust iterator without inspection to exercise the surface
 		}
 		for _, err := range e.RuleIterE() {
 			if err != nil {
@@ -1545,7 +1546,7 @@ func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
 		}
 		_ = e.Templates()
 		_, _ = e.TemplatesE()
-		for range e.TemplateIter() {
+		for range e.TemplateIter() { //nolint:revive // exhaust iterator without inspection to exercise the surface
 		}
 		for _, err := range e.TemplateIterE() {
 			if err != nil {
@@ -1565,7 +1566,7 @@ func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
 		_, _ = e.IsHaltedE()
 		_ = e.Diagnostics()
 		_, _ = e.DiagnosticsE()
-		for range e.DiagnosticIter() {
+		for range e.DiagnosticIter() { //nolint:revive // exhaust iterator without inspection to exercise the surface
 		}
 		for _, err := range e.DiagnosticIterE() {
 			if err != nil {
@@ -1733,6 +1734,7 @@ func TestPropertyErrorSentinelsAndFFIValueConversions(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		text := rapid.String().Draw(t, "text")
 		i := rapid.Int64().Draw(t, "integer")
+		i32 := rapid.Int32().Draw(t, "integer32")
 		f := rapid.Float64().Filter(func(v float64) bool { return !math.IsNaN(v) }).Draw(t, "float")
 
 		for _, tc := range []struct {
@@ -1762,7 +1764,7 @@ func TestPropertyErrorSentinelsAndFFIValueConversions(t *testing.T) {
 		values := []any{
 			int(i),
 			i,
-			int32(i),
+			i32,
 			f,
 			float32(f),
 			Symbol(text),
@@ -1800,7 +1802,7 @@ func TestPropertyErrorSentinelsAndFFIValueConversions(t *testing.T) {
 
 		nativeCases := []any{
 			int(i),
-			int32(i),
+			i32,
 			i,
 			float32(f),
 			f,

--- a/bindings/go/coverage_edge_test.go
+++ b/bindings/go/coverage_edge_test.go
@@ -1323,7 +1323,13 @@ func TestPropertyWireConversionErrorSurfaces(t *testing.T) {
 	})
 }
 
-func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
+// TestPropertyEngineSurfaceSweep fuzzes the raw Engine API surface and the
+// serialize/restore round-trip across every format. It deliberately does NOT
+// spin up Manager/Coordinator/PinnedEngine per iteration — those wrappers each
+// start OS-thread-locked workers, and creating them 100x amplifies
+// thread-affinity churn for no extra signal (their surface is covered once by
+// TestManagerCoordinatorPinnedSurface and by their dedicated test files).
+func TestPropertyEngineSurfaceSweep(t *testing.T) {
 	lockThread(t)
 
 	tmpDir := t.TempDir()
@@ -1338,7 +1344,6 @@ func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		id := rapid.Int64Range(1, 1000).Draw(rt, "id")
 		value := rapid.Float64Range(0.1, 1000.0).Draw(rt, "value")
-		policyIndex := rapid.IntRange(-8, 8).Draw(rt, "policy_index")
 		format := rapid.SampledFrom([]Format{
 			FormatBincode,
 			FormatJSON,
@@ -1499,107 +1504,132 @@ func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
 		_ = HaltLimitReached.String()
 		_ = HaltRequested.String()
 		_ = HaltReason(99).String()
-
-		mgr, err := NewManager(WithSource(source))
-		if err != nil {
-			rt.Fatal(err)
-		}
-		defer func() { _ = mgr.Close() }()
-		req := &EvaluateRequest{Facts: []WireFactInput{
-			OrderedFact("color", SymbolValue("blue"), StringValue("label"), MultifieldValue(IntValue(id))),
-			TemplateFact("sensor", map[string]WireValue{"id": IntValue(id), "value": FloatValue(value)}),
-		}}
-		if _, err := mgr.Evaluate(context.Background(), req); err != nil {
-			rt.Fatal(err)
-		}
-		req.Limit = 1
-		if _, err := mgr.Evaluate(context.Background(), req); err != nil {
-			rt.Fatal(err)
-		}
-		if _, err := mgr.EvaluateNative(context.Background(), &EvaluateNativeRequest{Facts: []NativeFactInput{
-			{Relation: "color", Fields: []any{Symbol("green")}},
-			{TemplateName: "sensor", Slots: map[string]any{"id": id, "value": value}},
-		}}); err != nil {
-			rt.Fatal(err)
-		}
-
-		coord, err := NewCoordinator(
-			[]EngineSpec{{Name: "sweep", Options: []EngineOption{WithSource(source)}}},
-			Threads(rapid.IntRange(1, 3).Draw(rt, "threads")),
-			WithDispatchPolicy(fixedIndexPolicy{index: policyIndex}),
-			WithLogger(slog.New(slog.DiscardHandler)),
-			WithTracerProvider(nil),
-			WithMeterProvider(nil),
-		)
-		if err != nil {
-			rt.Fatal(err)
-		}
-		defer func() { _ = coord.Close() }()
-		cm, err := coord.Manager("sweep")
-		if err != nil {
-			rt.Fatal(err)
-		}
-		if err := cm.Do(context.Background(), func(engine *Engine) error {
-			_, err := engine.Run(context.Background())
-			return err
-		}); err != nil {
-			rt.Fatal(err)
-		}
-
-		p, err := NewPinnedEngine(WithSource(source))
-		if err != nil {
-			rt.Fatal(err)
-		}
-		defer func() { _ = p.Close() }()
-		if err := p.Load(`(defrule pinned-loaded => (assert (pinned-loaded)))`); err != nil {
-			rt.Fatal(err)
-		}
-		if err := p.Reset(); err != nil {
-			rt.Fatal(err)
-		}
-		_, _ = p.Step()
-		pColorID, err := p.AssertString("(assert (color purple))")
-		if err != nil {
-			rt.Fatal(err)
-		}
-		if _, err := p.AssertFact("data", id); err != nil {
-			rt.Fatal(err)
-		}
-		pSensorID, err := p.AssertTemplate("sensor", map[string]any{"id": id, "value": value})
-		if err != nil {
-			rt.Fatal(err)
-		}
-		if _, err := p.GetFact(pSensorID); err != nil {
-			rt.Fatal(err)
-		}
-		_, _ = p.Facts()
-		_, _ = p.FindFacts("data")
-		_, _ = p.FactCount()
-		_, _ = p.RunWithLimit(context.Background(), 1)
-		_, _ = p.Run(context.Background())
-		_, _ = p.Serialize(format)
-		if err := p.SerializeToFile(tmpDir+"/pinned-surface.bin", format); err != nil {
-			rt.Fatal(err)
-		}
-		_ = p.Rules()
-		_ = p.Templates()
-		_, _ = p.GetGlobal("threshold")
-		_ = p.CurrentModule()
-		_, _ = p.Focus()
-		_ = p.FocusStack()
-		_ = p.AgendaSize()
-		_ = p.IsHalted()
-		_, _ = p.GetOutput("t")
-		p.ClearOutput("t")
-		p.PushInput("unused")
-		_ = p.Diagnostics()
-		p.ClearDiagnostics()
-		if err := p.Retract(pColorID); err != nil {
-			rt.Fatal(err)
-		}
-		p.Halt()
-		p.Clear()
 	})
+}
+
+// TestManagerCoordinatorPinnedSurface exercises the Manager, Coordinator, and
+// PinnedEngine wrapper surfaces once with fixed inputs. It is deliberately not
+// a rapid property: these wrappers each start OS-thread-locked worker
+// goroutines, so running them under a 100-iteration property needlessly churns
+// OS threads (an affinity-flake amplifier) without exercising new behavior.
+// Concurrency correctness lives in manager_test.go / pinned_engine_test.go /
+// property_test.go; this test just walks the broad accessor surface.
+func TestManagerCoordinatorPinnedSurface(t *testing.T) {
+	const (
+		id     = int64(42)
+		value  = 3.14
+		format = FormatBincode
+		// Negative index exercises the ((idx % n) + n) % n clamp in pickWorker.
+		policyIndex = -1
+	)
+	tmpDir := t.TempDir()
+	source := `
+		(defglobal ?*threshold* = 10)
+		(deftemplate sensor (slot id (type INTEGER)) (slot value (type FLOAT)))
+		(defrule bootstrap => (assert (booted)))
+		(defrule color-seen (color ?c) => (assert (matched ?c)) (printout t ?c crlf))
+		(defrule sensor-seen (sensor (id ?id) (value ?v)) => (assert (observed ?id)))
+	`
+
+	mgr, err := NewManager(WithSource(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = mgr.Close() }()
+	req := &EvaluateRequest{Facts: []WireFactInput{
+		OrderedFact("color", SymbolValue("blue"), StringValue("label"), MultifieldValue(IntValue(id))),
+		TemplateFact("sensor", map[string]WireValue{"id": IntValue(id), "value": FloatValue(value)}),
+	}}
+	if _, err := mgr.Evaluate(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	req.Limit = 1
+	if _, err := mgr.Evaluate(context.Background(), req); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mgr.EvaluateNative(context.Background(), &EvaluateNativeRequest{Facts: []NativeFactInput{
+		{Relation: "color", Fields: []any{Symbol("green")}},
+		{TemplateName: "sensor", Slots: map[string]any{"id": id, "value": value}},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	coord, err := NewCoordinator(
+		[]EngineSpec{{Name: "sweep", Options: []EngineOption{WithSource(source)}}},
+		Threads(2),
+		WithDispatchPolicy(fixedIndexPolicy{index: policyIndex}),
+		WithLogger(slog.New(slog.DiscardHandler)),
+		WithTracerProvider(nil),
+		WithMeterProvider(nil),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = coord.Close() }()
+	cm, err := coord.Manager("sweep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cm.Do(context.Background(), func(engine *Engine) error {
+		_, err := engine.Run(context.Background())
+		return err
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := NewPinnedEngine(WithSource(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Close() }()
+	if err := p.Load(`(defrule pinned-loaded => (assert (pinned-loaded)))`); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Reset(); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = p.Step()
+	pColorID, err := p.AssertString("(assert (color purple))")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.AssertFact("data", id); err != nil {
+		t.Fatal(err)
+	}
+	pSensorID, err := p.AssertTemplate("sensor", map[string]any{"id": id, "value": value})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.GetFact(pSensorID); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = p.Facts()
+	_, _ = p.FindFacts("data")
+	_, _ = p.FactCount()
+	_, _ = p.RunWithLimit(context.Background(), 1)
+	_, _ = p.Run(context.Background())
+	_, _ = p.Serialize(format)
+	if err := p.SerializeToFile(tmpDir+"/pinned-surface.bin", format); err != nil {
+		t.Fatal(err)
+	}
+	_ = p.Rules()
+	_ = p.Templates()
+	_, _ = p.GetGlobal("threshold")
+	_ = p.CurrentModule()
+	_, _ = p.Focus()
+	_ = p.FocusStack()
+	_ = p.AgendaSize()
+	_ = p.IsHalted()
+	_, _ = p.GetOutput("t")
+	p.ClearOutput("t")
+	p.PushInput("unused")
+	_ = p.Diagnostics()
+	p.ClearDiagnostics()
+	if err := p.Retract(pColorID); err != nil {
+		t.Fatal(err)
+	}
+	p.Halt()
+	p.Clear()
 }
 
 func TestPropertyErrorSentinelsAndFFIValueConversions(t *testing.T) {

--- a/bindings/go/coverage_edge_test.go
+++ b/bindings/go/coverage_edge_test.go
@@ -203,6 +203,18 @@ func TestManualErrorTypesAndTranslations(t *testing.T) {
 	if err := errorFromFFI(ffi.ErrNullPointer, nil); err == nil || !strings.Contains(err.Error(), "error code") {
 		t.Fatalf("unknown FFI error should use generic fallback, got %v", err)
 	}
+
+	// The errors.Is sentinel match must be backed by the documented concrete
+	// type carrying the originating FFI code, not just any error.
+	var re *RuntimeError
+	if err := errorFromFFI(ffi.ErrRuntimeError, nil); !errors.As(err, &re) || re.Code != int(ffi.ErrRuntimeError) {
+		t.Fatalf("errorFromFFI(runtime) = %#v, want *RuntimeError with code %d", re, int(ffi.ErrRuntimeError))
+	}
+	// The generic fallback is a plain *FerricError that still propagates the code.
+	var fe *FerricError
+	if err := errorFromFFI(ffi.ErrNullPointer, nil); !errors.As(err, &fe) || fe.Code != int(ffi.ErrNullPointer) {
+		t.Fatalf("errorFromFFI(null) = %#v, want *FerricError with code %d", fe, int(ffi.ErrNullPointer))
+	}
 }
 
 func TestManualWireConversionEdges(t *testing.T) {
@@ -291,6 +303,20 @@ func TestManualFFIValueConversionEdges(t *testing.T) {
 		t.Fatalf("unsupported Go value should fail, got %v", err)
 	}
 
+	// Verify the documented cleanup actually runs: the elements converted
+	// before an unsupported one must each be freed exactly once.
+	t.Run("multifield error frees converted elements", func(t *testing.T) {
+		withFFIHooks(t)
+		freed := 0
+		ffiValueFree = func(*ffi.Value) { freed++ }
+		if _, err := goToFFIValue([]any{"a", "b", struct{}{}}); !errors.Is(err, errUnsupportedGoTypeForFFI) {
+			t.Fatalf("expected unsupported error, got %v", err)
+		}
+		if freed != 2 {
+			t.Fatalf("freed %d converted elements, want 2", freed)
+		}
+	})
+
 	var external ffi.Value
 	*(*ffi.ValueType)(unsafe.Pointer(&external)) = ffi.ValueTypeExternalAddress //nolint:gosec // intentional unsafe write of opaque ffi.Value type tag to exercise the discriminator branch
 	if got, ok := ffiValueToGo(&external).(unsafe.Pointer); !ok || got != nil {
@@ -317,6 +343,12 @@ func TestManualNilEngineErrorBranches(t *testing.T) {
 
 	if err := e.Close(); err != nil {
 		t.Fatalf("Close on a nil handle should remain idempotent, got %v", err)
+	}
+	// Representative check that the nil-handle path surfaces the native
+	// null-pointer code as a typed *FerricError, not just "some error".
+	var fe *FerricError
+	if err := e.Load(`(defrule r =>)`); !errors.As(err, &fe) || fe.Code != int(ffi.ErrNullPointer) {
+		t.Fatalf("Load on nil handle = %#v, want *FerricError code %d", fe, int(ffi.ErrNullPointer))
 	}
 	assertErr("Load", e.Load(`(defrule r =>)`))
 	if _, err := e.AssertString("(assert (x))"); err == nil {
@@ -806,8 +838,9 @@ func TestManualHookedNewEngineNativeFallbacks(t *testing.T) {
 			return nil, ffi.ErrOK
 		}
 		_, err := NewEngine(WithSnapshot([]byte("snapshot"), FormatBincode))
-		if err == nil || !strings.Contains(err.Error(), "snapshot") {
-			t.Fatalf("snapshot nil handle error = %v", err)
+		var fe *FerricError
+		if !errors.As(err, &fe) || !strings.Contains(err.Error(), "snapshot") {
+			t.Fatalf("snapshot nil handle error = %v, want *FerricError mentioning snapshot", err)
 		}
 	})
 
@@ -816,8 +849,23 @@ func TestManualHookedNewEngineNativeFallbacks(t *testing.T) {
 		ffiEngineNewWithSource = func(string) ffi.EngineHandle { return nil }
 		ffiLastErrorGlobal = func() string { return "" }
 		_, err := NewEngine(WithSource("(defrule r =>)"))
-		if err == nil || !strings.Contains(err.Error(), "failed to create engine from source") {
-			t.Fatalf("source nil handle error = %v", err)
+		// A nil handle from a source build is reported as a parse failure.
+		var pe *ParseError
+		if !errors.As(err, &pe) || !errors.Is(err, ErrParse) ||
+			!strings.Contains(err.Error(), "failed to create engine from source") {
+			t.Fatalf("source nil handle error = %v, want *ParseError fallback message", err)
+		}
+	})
+
+	t.Run("source nil handle prefers native message", func(t *testing.T) {
+		withFFIHooks(t)
+		ffiEngineNewWithSource = func(string) ffi.EngineHandle { return nil }
+		ffiLastErrorGlobal = func() string { return "native parse boom" }
+		_, err := NewEngine(WithSource("(defrule r =>)"))
+		// When the native error channel has a message, it is preferred over the
+		// generic fallback.
+		if !errors.Is(err, ErrParse) || !strings.Contains(err.Error(), "native parse boom") {
+			t.Fatalf("source nil handle error = %v, want native message preferred", err)
 		}
 	})
 
@@ -825,8 +873,9 @@ func TestManualHookedNewEngineNativeFallbacks(t *testing.T) {
 		withFFIHooks(t)
 		ffiEngineNewWithConfig = func(*ffi.Config) ffi.EngineHandle { return nil }
 		_, err := NewEngine(WithStrategy(StrategyBreadth))
-		if err == nil || !strings.Contains(err.Error(), "failed to create engine") {
-			t.Fatalf("configured nil handle error = %v", err)
+		var fe *FerricError
+		if !errors.As(err, &fe) || !strings.Contains(err.Error(), "failed to create engine") {
+			t.Fatalf("configured nil handle error = %v, want *FerricError", err)
 		}
 	})
 }
@@ -968,6 +1017,59 @@ func TestManualHookedIntrospectionAndIteratorErrors(t *testing.T) {
 	}
 }
 
+// TestManualHookedIntrospectionKeepsItemsBeforeError pins the partial-result
+// contract that the item-0-fails cases above cannot: when a mid-stream item
+// (here index 1 of 2) fails, the simple accessors break and return the items
+// collected *before* the failure rather than discarding them or returning nil.
+func TestManualHookedIntrospectionKeepsItemsBeforeError(t *testing.T) {
+	withFFIHooks(t)
+	e := &Engine{}
+
+	ffiEngineRuleCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 2, ffi.ErrOK }
+	ffiEngineRuleInfo = func(_ ffi.EngineHandle, i uintptr) (string, int32, ffi.ErrorCode) {
+		if i == 0 {
+			return "r0", 7, ffi.ErrOK
+		}
+		return "", 0, ffi.ErrRuntimeError
+	}
+	if got := e.Rules(); len(got) != 1 || got[0].Name != "r0" {
+		t.Fatalf("Rules after item-1 error = %v, want [r0]", got)
+	}
+
+	ffiEngineTemplateCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 2, ffi.ErrOK }
+	ffiEngineTemplateName = func(_ ffi.EngineHandle, i uintptr) (string, ffi.ErrorCode) {
+		if i == 0 {
+			return "t0", ffi.ErrOK
+		}
+		return "", ffi.ErrRuntimeError
+	}
+	if got := e.Templates(); len(got) != 1 || got[0] != "t0" {
+		t.Fatalf("Templates after item-1 error = %v, want [t0]", got)
+	}
+
+	ffiEngineFocusStackDepth = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 2, ffi.ErrOK }
+	ffiEngineFocusStackEntry = func(_ ffi.EngineHandle, i uintptr) (string, ffi.ErrorCode) {
+		if i == 0 {
+			return "MAIN", ffi.ErrOK
+		}
+		return "", ffi.ErrRuntimeError
+	}
+	if got := e.FocusStack(); len(got) != 1 || got[0] != "MAIN" {
+		t.Fatalf("FocusStack after item-1 error = %v, want [MAIN]", got)
+	}
+
+	ffiEngineActionDiagnosticCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 2, ffi.ErrOK }
+	ffiEngineActionDiagnosticCopy = func(_ ffi.EngineHandle, i uintptr) (string, ffi.ErrorCode) {
+		if i == 0 {
+			return "d0", ffi.ErrOK
+		}
+		return "", ffi.ErrRuntimeError
+	}
+	if got := e.Diagnostics(); len(got) != 1 || got[0] != "d0" {
+		t.Fatalf("Diagnostics after item-1 error = %v, want [d0]", got)
+	}
+}
+
 func installOrderedBuildFactHooks() {
 	ffiEngineGetFactType = func(ffi.EngineHandle, uint64) (ffi.FactType, ffi.ErrorCode) {
 		return ffi.FactTypeOrdered, ffi.ErrOK
@@ -1076,8 +1178,10 @@ func TestManualHookedBuildFactErrors(t *testing.T) {
 			withFFIHooks(t)
 			tc.setup()
 			_, err := (&Engine{}).buildFact(1)
-			if err == nil {
-				t.Fatal("expected buildFact error")
+			// Every lookup failure must preserve the underlying native code
+			// (ErrRuntime) through any fmt.Errorf wrapping buildFact adds.
+			if !errors.Is(err, ErrRuntime) {
+				t.Fatalf("buildFact error = %v, want ErrRuntime", err)
 			}
 			if tc.want != "" && !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("buildFact error = %v, want substring %q", err, tc.want)
@@ -1144,7 +1248,7 @@ func TestManualHookedEvaluateAndPinnedEdges(t *testing.T) {
 
 func TestPropertyConfigurationHelpers(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		n := rapid.IntRange(0, 1<<31-1).Draw(t, "max_call_depth")
+		n := rapid.IntRange(0, math.MaxInt).Draw(t, "max_call_depth")
 		got, err := intToUintptr(n)
 		if err != nil {
 			t.Fatalf("non-negative depth rejected: %v", err)

--- a/bindings/go/coverage_edge_test.go
+++ b/bindings/go/coverage_edge_test.go
@@ -1219,250 +1219,6 @@ func TestPropertyWireConversionErrorSurfaces(t *testing.T) {
 	})
 }
 
-func TestPropertyHookedNewEngineFallbacks(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		resetFFIHooks()
-		defer resetFFIHooks()
-
-		scenario := rapid.SampledFrom([]string{"snapshot", "source", "config"}).Draw(t, "scenario")
-		switch scenario {
-		case "snapshot":
-			ffiEngineDeserializeAs = func([]byte, ffi.SerializationFormat) (ffi.EngineHandle, ffi.ErrorCode) {
-				return nil, ffi.ErrOK
-			}
-			_, err := NewEngine(WithSnapshot([]byte("snapshot"), FormatBincode))
-			if err == nil {
-				t.Fatal("snapshot nil handle should fail")
-			}
-		case "source":
-			ffiEngineNewWithSource = func(string) ffi.EngineHandle { return nil }
-			ffiLastErrorGlobal = func() string { return "" }
-			_, err := NewEngine(WithSource("(defrule r =>)"))
-			if err == nil {
-				t.Fatal("source nil handle should fail")
-			}
-		case "config":
-			ffiEngineNewWithConfig = func(*ffi.Config) ffi.EngineHandle { return nil }
-			_, err := NewEngine(WithStrategy(StrategyBreadth))
-			if err == nil {
-				t.Fatal("configured nil handle should fail")
-			}
-		}
-	})
-}
-
-func TestPropertyHookedRunEdges(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		resetFFIHooks()
-		defer resetFFIHooks()
-
-		scenario := rapid.SampledFrom([]string{"overfire", "cancelable_overflow", "direct_overflow"}).Draw(t, "scenario")
-		maxInt := uint64(^uint(0) >> 1)
-		switch scenario {
-		case "overfire":
-			fired := rapid.Uint64Range(2, 20).Draw(t, "fired")
-			ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
-				return fired, ffi.HaltReason(999), ffi.ErrOK
-			}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			result, err := (&Engine{}).RunWithLimit(ctx, 1)
-			if err != nil {
-				t.Fatal(err)
-			}
-			//nolint:gosec // fired is drawn from rapid.Uint64Range(2, 20), safely fits in int
-			if result.RulesFired != int(fired) || result.HaltReason != HaltLimitReached {
-				t.Fatalf("overfire result = %+v, fired %d", result, fired)
-			}
-		case "cancelable_overflow":
-			ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
-				return maxInt + 1, ffi.HaltReasonAgendaEmpty, ffi.ErrOK
-			}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			_, err := (&Engine{}).RunWithLimit(ctx, 0)
-			if !errors.Is(err, errIntOverflow) {
-				t.Fatalf("cancelable overflow error = %v", err)
-			}
-		case "direct_overflow":
-			ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
-				return maxInt + 1, ffi.HaltReasonAgendaEmpty, ffi.ErrOK
-			}
-			_, err := (&Engine{}).Run(context.Background())
-			if !errors.Is(err, errIntOverflow) {
-				t.Fatalf("direct overflow error = %v", err)
-			}
-		}
-	})
-}
-
-func TestPropertyHookedIntrospectionErrors(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		resetFFIHooks()
-		defer resetFFIHooks()
-
-		e := &Engine{}
-		scenario := rapid.SampledFrom([]string{"fact", "rule", "template", "focus", "diagnostic"}).Draw(t, "scenario")
-		switch scenario {
-		case "fact":
-			ffiEngineFactIDs = func(ffi.EngineHandle) ([]uint64, ffi.ErrorCode) {
-				return []uint64{rapid.Uint64().Draw(t, "fact_id")}, ffi.ErrOK
-			}
-			ffiEngineGetFactType = func(ffi.EngineHandle, uint64) (ffi.FactType, ffi.ErrorCode) {
-				return 0, ffi.ErrNotFound
-			}
-			for range e.FactIter() {
-				t.Fatal("FactIter should stop on buildFact error")
-			}
-			for _, err := range e.FactIterE() {
-				if err == nil {
-					t.Fatal("FactIterE should yield buildFact error")
-				}
-			}
-		case "rule":
-			ffiEngineRuleCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
-			ffiEngineRuleInfo = func(ffi.EngineHandle, uintptr) (string, int32, ffi.ErrorCode) {
-				return "", 0, ffi.ErrRuntimeError
-			}
-			if len(e.Rules()) != 0 {
-				t.Fatal("Rules should return partial empty slice on item error")
-			}
-			if _, err := e.RulesE(); err == nil {
-				t.Fatal("RulesE should return item error")
-			}
-		case "template":
-			ffiEngineTemplateCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
-			ffiEngineTemplateName = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
-				return "", ffi.ErrRuntimeError
-			}
-			if len(e.Templates()) != 0 {
-				t.Fatal("Templates should return partial empty slice on item error")
-			}
-			if _, err := e.TemplatesE(); err == nil {
-				t.Fatal("TemplatesE should return item error")
-			}
-		case "focus":
-			ffiEngineFocusStackDepth = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
-			ffiEngineFocusStackEntry = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
-				return "", ffi.ErrRuntimeError
-			}
-			if len(e.FocusStack()) != 0 {
-				t.Fatal("FocusStack should return partial empty slice on item error")
-			}
-			if _, err := e.FocusStackE(); err == nil {
-				t.Fatal("FocusStackE should return item error")
-			}
-		case "diagnostic":
-			ffiEngineActionDiagnosticCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 1, ffi.ErrOK }
-			ffiEngineActionDiagnosticCopy = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
-				return "", ffi.ErrRuntimeError
-			}
-			if len(e.Diagnostics()) != 0 {
-				t.Fatal("Diagnostics should return partial empty slice on item error")
-			}
-			if _, err := e.DiagnosticsE(); err == nil {
-				t.Fatal("DiagnosticsE should return item error")
-			}
-		}
-	})
-}
-
-func TestPropertyHookedBuildFactErrors(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		resetFFIHooks()
-		defer resetFFIHooks()
-
-		scenario := rapid.SampledFrom([]string{
-			"field_count", "field", "template_name", "slot_count", "slot_name", "relation",
-		}).Draw(t, "scenario")
-		switch scenario {
-		case "field_count":
-			installOrderedBuildFactHooks()
-			ffiEngineGetFactFieldCount = func(ffi.EngineHandle, uint64) (uintptr, ffi.ErrorCode) {
-				return 0, ffi.ErrRuntimeError
-			}
-		case "field":
-			installOrderedBuildFactHooks()
-			ffiEngineGetFactField = func(ffi.EngineHandle, uint64, uintptr) (ffi.Value, ffi.ErrorCode) {
-				return ffi.Value{}, ffi.ErrRuntimeError
-			}
-		case "template_name":
-			installTemplateBuildFactHooks()
-			ffiEngineGetFactTemplateName = func(ffi.EngineHandle, uint64) (string, ffi.ErrorCode) {
-				return "", ffi.ErrRuntimeError
-			}
-		case "slot_count":
-			installTemplateBuildFactHooks()
-			ffiEngineTemplateSlotCount = func(ffi.EngineHandle, string) (uintptr, ffi.ErrorCode) {
-				return 0, ffi.ErrRuntimeError
-			}
-		case "slot_name":
-			installTemplateBuildFactHooks()
-			ffiEngineTemplateSlotName = func(ffi.EngineHandle, string, uintptr) (string, ffi.ErrorCode) {
-				return "", ffi.ErrRuntimeError
-			}
-		case "relation":
-			installOrderedBuildFactHooks()
-			ffiEngineGetFactRelation = func(ffi.EngineHandle, uint64) (string, ffi.ErrorCode) {
-				return "", ffi.ErrRuntimeError
-			}
-		}
-		if _, err := (&Engine{}).buildFact(rapid.Uint64().Draw(t, "fact_id")); err == nil {
-			t.Fatal("buildFact should fail for injected native lookup error")
-		}
-	})
-}
-
-func TestPropertyHookedEvaluateAndPinnedEdges(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		resetFFIHooks()
-		defer resetFFIHooks()
-
-		scenario := rapid.SampledFrom([]string{"reset", "run", "wire", "pinned"}).Draw(t, "scenario")
-		switch scenario {
-		case "reset":
-			ffiEngineReset = func(ffi.EngineHandle) ffi.ErrorCode { return ffi.ErrRuntimeError }
-			mgr, err := NewManager()
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() { _ = mgr.Close() }()
-			if _, err := mgr.Evaluate(context.Background(), &EvaluateRequest{}); err == nil {
-				t.Fatal("Evaluate should fail when Reset fails")
-			}
-		case "run":
-			ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
-				return 0, 0, ffi.ErrRuntimeError
-			}
-			mgr, err := NewManager()
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() { _ = mgr.Close() }()
-			if _, err := mgr.Evaluate(context.Background(), &EvaluateRequest{}); err == nil {
-				t.Fatal("Evaluate should fail when Run fails")
-			}
-		case "wire":
-			factsToWire = func([]Fact) ([]WireFact, error) { return nil, errUnsupportedWireConversionType }
-			e, err := NewEngine()
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer func() { _ = e.Close() }()
-			if _, err := buildEvaluateResult(e, &RunResult{}); err == nil {
-				t.Fatal("buildEvaluateResult should fail when factsToWire fails")
-			}
-		case "pinned":
-			done := make(chan struct{})
-			close(done)
-			p := &PinnedEngine{requests: make(chan pinnedRequest), done: make(chan struct{})}
-			if err := p.tryEnqueue(doneOnlyContext{done: done}, pinnedRequest{resp: make(chan error, 1)}); err == nil {
-				t.Fatal("tryEnqueue should fail when Done is selected")
-			}
-		}
-	})
-}
-
 func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
 	lockThread(t)
 
@@ -1522,8 +1278,16 @@ func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
 		if err != nil {
 			rt.Fatal(err)
 		}
-		if _, err := e.GetFact(sensorID); err != nil {
+		sensorFact, err := e.GetFact(sensorID)
+		if err != nil {
 			rt.Fatal(err)
+		}
+		// The drawn slot values must round-trip back through GetFact.
+		if got, ok := sensorFact.Slots["id"].(int64); !ok || got != id {
+			rt.Fatalf("sensor.id slot = %v, want %d", sensorFact.Slots["id"], id)
+		}
+		if got, ok := sensorFact.Slots["value"].(float64); !ok || got != value {
+			rt.Fatalf("sensor.value slot = %v, want %v", sensorFact.Slots["value"], value)
 		}
 		if facts, err := e.Facts(); err != nil || len(facts) == 0 {
 			rt.Fatalf("Facts = (%v, %v), want facts", facts, err)
@@ -1583,12 +1347,8 @@ func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
 			}
 		}
 
-		runResult, err := e.RunWithLimit(context.Background(), 1)
-		if err != nil {
+		if _, err := e.RunWithLimit(context.Background(), 1); err != nil {
 			rt.Fatal(err)
-		}
-		if runResult.RulesFired < 0 {
-			rt.Fatal("negative rules fired")
 		}
 		if _, err := e.Run(context.Background()); err != nil {
 			rt.Fatal(err)
@@ -1600,9 +1360,17 @@ func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
 		if err != nil {
 			rt.Fatal(err)
 		}
+		wantCount, err := e.FactCount()
+		if err != nil {
+			rt.Fatal(err)
+		}
 		restored, err := NewEngine(WithSnapshot(data, format))
 		if err != nil {
 			rt.Fatal(err)
+		}
+		// A restored snapshot must reproduce the original engine's fact set.
+		if gotCount, err := restored.FactCount(); err != nil || gotCount != wantCount {
+			rt.Fatalf("restored FactCount = (%d, %v), want %d", gotCount, err, wantCount)
 		}
 		_ = restored.Close()
 		path := tmpDir + "/engine-surface.bin"
@@ -1655,7 +1423,7 @@ func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
 			[]EngineSpec{{Name: "sweep", Options: []EngineOption{WithSource(source)}}},
 			Threads(rapid.IntRange(1, 3).Draw(rt, "threads")),
 			WithDispatchPolicy(fixedIndexPolicy{index: policyIndex}),
-			WithLogger(slog.Default()),
+			WithLogger(slog.New(slog.DiscardHandler)),
 			WithTracerProvider(nil),
 			WithMeterProvider(nil),
 		)
@@ -1846,158 +1614,265 @@ func TestPropertyErrorSentinelsAndFFIValueConversions(t *testing.T) {
 	})
 }
 
-func TestPropertyHookedMutationAndAccessorErrors(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		resetFFIHooks()
-		defer resetFFIHooks()
+// TestManualFinalizerFreesLiveSkipsClosed pins the non-obvious finalizer
+// invariant directly (rather than as 1 of N random branches): a live engine is
+// freed exactly once, and an already-closed engine is skipped.
+func TestManualFinalizerFreesLiveSkipsClosed(t *testing.T) {
+	withFFIHooks(t)
+	calls := 0
+	ffiEngineFreeUnchecked = func(ffi.EngineHandle) ffi.ErrorCode {
+		calls++
+		return ffi.ErrOK
+	}
+	finalizeEngine(&Engine{})             // live engine: frees once
+	finalizeEngine(&Engine{closed: true}) // already closed: skipped
+	if calls != 1 {
+		t.Fatalf("finalizer free calls = %d, want 1", calls)
+	}
+}
 
-		e := &Engine{}
-		scenario := rapid.SampledFrom([]string{
-			"finalizer",
-			"close",
-			"load",
-			"assert_string",
-			"assert_ordered",
-			"assert_template",
-			"retract",
-			"fact_ids",
-			"find_fact_ids",
-			"fact_count",
-			"step",
-			"serialize",
-			"get_global",
-			"current_module",
-			"focus",
-			"agenda",
-			"is_halted",
-			"diagnostics",
-		}).Draw(t, "scenario")
-		switch scenario {
-		case "finalizer":
-			calls := 0
-			ffiEngineFreeUnchecked = func(ffi.EngineHandle) ffi.ErrorCode {
-				calls++
-				return ffi.ErrOK
-			}
-			finalizeEngine(&Engine{})
-			finalizeEngine(&Engine{closed: true})
-			if calls != 1 {
-				t.Fatalf("finalizer free calls = %d, want 1", calls)
-			}
-		case "close":
-			ffiEngineFree = func(ffi.EngineHandle) ffi.ErrorCode { return ffi.ErrRuntimeError }
-			if err := e.Close(); err == nil {
-				t.Fatal("Close should surface native free errors")
-			}
-		case "load":
-			ffiEngineLoadString = func(ffi.EngineHandle, string) ffi.ErrorCode { return ffi.ErrRuntimeError }
-			if err := e.Load("bad"); err == nil {
-				t.Fatal("Load should surface native errors")
-			}
-		case "assert_string":
-			ffiEngineAssertString = func(ffi.EngineHandle, string) (uint64, ffi.ErrorCode) {
-				return 0, ffi.ErrRuntimeError
-			}
-			if _, err := e.AssertString("(x)"); err == nil {
-				t.Fatal("AssertString should surface native errors")
-			}
-		case "assert_ordered":
-			ffiEngineAssertOrdered = func(ffi.EngineHandle, string, []ffi.Value) (uint64, ffi.ErrorCode) {
-				return 0, ffi.ErrRuntimeError
-			}
-			if _, err := e.AssertFact("x", int64(1)); err == nil {
-				t.Fatal("AssertFact should surface native errors")
-			}
-		case "assert_template":
-			ffiEngineAssertTemplate = func(ffi.EngineHandle, string, []string, []ffi.Value) (uint64, ffi.ErrorCode) {
-				return 0, ffi.ErrRuntimeError
-			}
-			if _, err := e.AssertTemplate("x", map[string]any{"slot": int64(1)}); err == nil {
-				t.Fatal("AssertTemplate should surface native errors")
-			}
-		case "retract":
-			ffiEngineRetract = func(ffi.EngineHandle, uint64) ffi.ErrorCode { return ffi.ErrRuntimeError }
-			if err := e.Retract(rapid.Uint64().Draw(t, "fact_id")); err == nil {
-				t.Fatal("Retract should surface native errors")
-			}
-		case "fact_ids":
-			ffiEngineFactIDs = func(ffi.EngineHandle) ([]uint64, ffi.ErrorCode) { return nil, ffi.ErrRuntimeError }
-			if _, err := e.Facts(); err == nil {
-				t.Fatal("Facts should surface native errors")
-			}
-		case "find_fact_ids":
-			ffiEngineFindFactIDs = func(ffi.EngineHandle, string) ([]uint64, ffi.ErrorCode) {
-				return nil, ffi.ErrRuntimeError
-			}
-			if _, err := e.FindFacts("x"); err == nil {
-				t.Fatal("FindFacts should surface native errors")
-			}
-		case "fact_count":
-			ffiEngineFactCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 0, ffi.ErrRuntimeError }
-			if _, err := e.FactCount(); err == nil {
-				t.Fatal("FactCount should surface native errors")
-			}
-		case "step":
-			ffiEngineStep = func(ffi.EngineHandle) (int32, ffi.ErrorCode) { return 0, ffi.ErrRuntimeError }
-			if _, err := e.Step(); err == nil {
-				t.Fatal("Step should surface native errors")
-			}
-		case "serialize":
-			ffiEngineSerializeAs = func(ffi.EngineHandle, ffi.SerializationFormat) ([]byte, ffi.ErrorCode) {
-				return nil, ffi.ErrRuntimeError
-			}
-			if _, err := e.Serialize(FormatBincode); err == nil {
-				t.Fatal("Serialize should surface native errors")
-			}
-		case "get_global":
-			ffiEngineGetGlobal = func(ffi.EngineHandle, string) (ffi.Value, ffi.ErrorCode) {
-				return ffi.Value{}, ffi.ErrRuntimeError
-			}
-			if _, err := e.GetGlobal("x"); err == nil {
-				t.Fatal("GetGlobal should surface native errors")
-			}
-		case "current_module":
-			ffiEngineCurrentModule = func(ffi.EngineHandle) (string, ffi.ErrorCode) { return "", ffi.ErrRuntimeError }
-			if got := e.CurrentModule(); got != "" {
-				t.Fatalf("CurrentModule error result = %q, want empty", got)
-			}
-			if _, err := e.CurrentModuleE(); err == nil {
-				t.Fatal("CurrentModuleE should surface native errors")
-			}
-		case "focus":
-			ffiEngineGetFocus = func(ffi.EngineHandle) (string, ffi.ErrorCode) { return "", ffi.ErrRuntimeError }
-			if name, ok := e.Focus(); name != "" || ok {
-				t.Fatalf("Focus error result = (%q, %v), want empty false", name, ok)
-			}
-			if _, _, err := e.FocusE(); err == nil {
-				t.Fatal("FocusE should surface native errors")
-			}
-		case "agenda":
-			ffiEngineAgendaCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 0, ffi.ErrRuntimeError }
-			if got := e.AgendaSize(); got != 0 {
-				t.Fatalf("AgendaSize error result = %d, want 0", got)
-			}
-			if _, err := e.AgendaSizeE(); err == nil {
-				t.Fatal("AgendaSizeE should surface native errors")
-			}
-		case "is_halted":
-			ffiEngineIsHalted = func(ffi.EngineHandle) (bool, ffi.ErrorCode) { return false, ffi.ErrRuntimeError }
-			if got := e.IsHalted(); got {
-				t.Fatal("IsHalted error result = true, want false")
-			}
-			if _, err := e.IsHaltedE(); err == nil {
-				t.Fatal("IsHaltedE should surface native errors")
-			}
-		case "diagnostics":
-			ffiEngineActionDiagnosticCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) {
-				return 0, ffi.ErrRuntimeError
-			}
-			if got := e.Diagnostics(); got != nil {
-				t.Fatalf("Diagnostics error result = %v, want nil", got)
-			}
-			if _, err := e.DiagnosticsE(); err == nil {
-				t.Fatal("DiagnosticsE should surface native errors")
-			}
-		}
-	})
+// TestManualHookedMutationAndAccessorErrors verifies that each Engine method
+// translates an injected native ErrRuntimeError into the ErrRuntime sentinel
+// (mutators and E-accessors) and returns its documented zero value for the
+// non-erroring accessors. Asserting errors.Is(ErrRuntime) — not merely err !=
+// nil — proves the FFI error code is actually carried through, not swallowed
+// or replaced by an unrelated error.
+func TestManualHookedMutationAndAccessorErrors(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func()
+		check func(t *testing.T, e *Engine)
+	}{
+		{
+			name:  "close",
+			setup: func() { ffiEngineFree = func(ffi.EngineHandle) ffi.ErrorCode { return ffi.ErrRuntimeError } },
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if err := e.Close(); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("Close err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "load",
+			setup: func() {
+				ffiEngineLoadString = func(ffi.EngineHandle, string) ffi.ErrorCode { return ffi.ErrRuntimeError }
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if err := e.Load("bad"); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("Load err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "assert_string",
+			setup: func() {
+				ffiEngineAssertString = func(ffi.EngineHandle, string) (uint64, ffi.ErrorCode) { return 0, ffi.ErrRuntimeError }
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if _, err := e.AssertString("(x)"); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("AssertString err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "assert_ordered",
+			setup: func() {
+				ffiEngineAssertOrdered = func(ffi.EngineHandle, string, []ffi.Value) (uint64, ffi.ErrorCode) {
+					return 0, ffi.ErrRuntimeError
+				}
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if _, err := e.AssertFact("x", int64(1)); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("AssertFact err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "assert_template",
+			setup: func() {
+				ffiEngineAssertTemplate = func(ffi.EngineHandle, string, []string, []ffi.Value) (uint64, ffi.ErrorCode) {
+					return 0, ffi.ErrRuntimeError
+				}
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if _, err := e.AssertTemplate("x", map[string]any{"slot": int64(1)}); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("AssertTemplate err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name:  "retract",
+			setup: func() { ffiEngineRetract = func(ffi.EngineHandle, uint64) ffi.ErrorCode { return ffi.ErrRuntimeError } },
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if err := e.Retract(1); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("Retract err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "fact_ids",
+			setup: func() {
+				ffiEngineFactIDs = func(ffi.EngineHandle) ([]uint64, ffi.ErrorCode) { return nil, ffi.ErrRuntimeError }
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if _, err := e.Facts(); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("Facts err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "find_fact_ids",
+			setup: func() {
+				ffiEngineFindFactIDs = func(ffi.EngineHandle, string) ([]uint64, ffi.ErrorCode) { return nil, ffi.ErrRuntimeError }
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if _, err := e.FindFacts("x"); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("FindFacts err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "fact_count",
+			setup: func() {
+				ffiEngineFactCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 0, ffi.ErrRuntimeError }
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if _, err := e.FactCount(); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("FactCount err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "step",
+			setup: func() {
+				ffiEngineStep = func(ffi.EngineHandle) (int32, ffi.ErrorCode) { return 0, ffi.ErrRuntimeError }
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if _, err := e.Step(); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("Step err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "serialize",
+			setup: func() {
+				ffiEngineSerializeAs = func(ffi.EngineHandle, ffi.SerializationFormat) ([]byte, ffi.ErrorCode) {
+					return nil, ffi.ErrRuntimeError
+				}
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if _, err := e.Serialize(FormatBincode); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("Serialize err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "get_global",
+			setup: func() {
+				ffiEngineGetGlobal = func(ffi.EngineHandle, string) (ffi.Value, ffi.ErrorCode) {
+					return ffi.Value{}, ffi.ErrRuntimeError
+				}
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if _, err := e.GetGlobal("x"); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("GetGlobal err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "current_module",
+			setup: func() {
+				ffiEngineCurrentModule = func(ffi.EngineHandle) (string, ffi.ErrorCode) { return "", ffi.ErrRuntimeError }
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if got := e.CurrentModule(); got != "" {
+					t.Fatalf("CurrentModule = %q, want empty", got)
+				}
+				if _, err := e.CurrentModuleE(); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("CurrentModuleE err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "focus",
+			setup: func() {
+				ffiEngineGetFocus = func(ffi.EngineHandle) (string, ffi.ErrorCode) { return "", ffi.ErrRuntimeError }
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if name, ok := e.Focus(); name != "" || ok {
+					t.Fatalf("Focus = (%q, %v), want empty false", name, ok)
+				}
+				if _, _, err := e.FocusE(); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("FocusE err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "agenda",
+			setup: func() {
+				ffiEngineAgendaCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 0, ffi.ErrRuntimeError }
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if got := e.AgendaSize(); got != 0 {
+					t.Fatalf("AgendaSize = %d, want 0", got)
+				}
+				if _, err := e.AgendaSizeE(); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("AgendaSizeE err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "is_halted",
+			setup: func() {
+				ffiEngineIsHalted = func(ffi.EngineHandle) (bool, ffi.ErrorCode) { return false, ffi.ErrRuntimeError }
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if got := e.IsHalted(); got {
+					t.Fatalf("IsHalted = true, want false")
+				}
+				if _, err := e.IsHaltedE(); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("IsHaltedE err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+		{
+			name: "diagnostics",
+			setup: func() {
+				ffiEngineActionDiagnosticCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) { return 0, ffi.ErrRuntimeError }
+			},
+			check: func(t *testing.T, e *Engine) {
+				t.Helper()
+				if got := e.Diagnostics(); got != nil {
+					t.Fatalf("Diagnostics = %v, want nil", got)
+				}
+				if _, err := e.DiagnosticsE(); !errors.Is(err, ErrRuntime) {
+					t.Fatalf("DiagnosticsE err = %v, want ErrRuntime", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withFFIHooks(t)
+			tc.setup()
+			tc.check(t, &Engine{})
+		})
+	}
 }

--- a/bindings/go/coverage_edge_test.go
+++ b/bindings/go/coverage_edge_test.go
@@ -292,13 +292,13 @@ func TestManualFFIValueConversionEdges(t *testing.T) {
 	}
 
 	var external ffi.Value
-	*(*ffi.ValueType)(unsafe.Pointer(&external)) = ffi.ValueTypeExternalAddress
+	*(*ffi.ValueType)(unsafe.Pointer(&external)) = ffi.ValueTypeExternalAddress //nolint:gosec // intentional unsafe write of opaque ffi.Value type tag to exercise the discriminator branch
 	if got, ok := ffiValueToGo(&external).(unsafe.Pointer); !ok || got != nil {
 		t.Fatalf("zero external pointer = (%T, %v), want nil unsafe.Pointer", got, got)
 	}
 
 	var unknown ffi.Value
-	*(*ffi.ValueType)(unsafe.Pointer(&unknown)) = ffi.ValueType(9999)
+	*(*ffi.ValueType)(unsafe.Pointer(&unknown)) = ffi.ValueType(9999) //nolint:gosec // intentional unsafe write of opaque ffi.Value type tag to exercise the unknown-type branch
 	if got := ffiValueToGo(&unknown); got != nil {
 		t.Fatalf("unknown value type = %v, want nil", got)
 	}
@@ -1575,7 +1575,7 @@ func TestPropertyEngineManagerAndPinnedSurfaceSweep(t *testing.T) {
 		}
 		e.ClearDiagnostics()
 		e.PushInput("unused")
-		for range e.FactIter() {
+		for range e.FactIter() { //nolint:revive // exhaust iterator without inspection to exercise the surface
 		}
 		for _, err := range e.FactIterE() {
 			if err != nil {
@@ -1790,12 +1790,12 @@ func TestPropertyErrorSentinelsAndFFIValueConversions(t *testing.T) {
 		}
 
 		var external ffi.Value
-		*(*ffi.ValueType)(unsafe.Pointer(&external)) = ffi.ValueTypeExternalAddress
+		*(*ffi.ValueType)(unsafe.Pointer(&external)) = ffi.ValueTypeExternalAddress //nolint:gosec // intentional unsafe write of opaque ffi.Value type tag to exercise the discriminator branch
 		if _, ok := ffiValueToGo(&external).(unsafe.Pointer); !ok {
 			t.Fatal("external FFI value did not convert to unsafe.Pointer")
 		}
 		var unknown ffi.Value
-		*(*ffi.ValueType)(unsafe.Pointer(&unknown)) = ffi.ValueType(999)
+		*(*ffi.ValueType)(unsafe.Pointer(&unknown)) = ffi.ValueType(999) //nolint:gosec // intentional unsafe write of opaque ffi.Value type tag to exercise the unknown-type branch
 		if got := ffiValueToGo(&unknown); got != nil {
 			t.Fatalf("unknown FFI value = %v, want nil", got)
 		}

--- a/bindings/go/engine.go
+++ b/bindings/go/engine.go
@@ -44,7 +44,7 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 			return nil, err
 		}
 		var rc ffi.ErrorCode
-		h, rc = ffi.EngineDeserializeAs(cfg.snapshot, ffiFormat)
+		h, rc = ffiEngineDeserializeAs(cfg.snapshot, ffiFormat)
 		if rc != ffi.ErrOK {
 			return nil, errorFromFFI(rc, nil)
 		}
@@ -59,12 +59,12 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 
 		if cfg.source != "" {
 			if cfg.strategy != 0 || cfg.encoding != 0 || cfg.maxCallDepth != 256 {
-				h = ffi.EngineNewWithSourceConfig(cfg.source, config)
+				h = ffiEngineNewWithSourceConfig(cfg.source, config)
 			} else {
-				h = ffi.EngineNewWithSource(cfg.source)
+				h = ffiEngineNewWithSource(cfg.source)
 			}
 			if h == nil {
-				msg := ffi.LastErrorGlobal()
+				msg := ffiLastErrorGlobal()
 				if msg == "" {
 					msg = "failed to create engine from source"
 				}
@@ -72,9 +72,9 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 			}
 		} else {
 			if cfg.strategy != 0 || cfg.encoding != 0 || cfg.maxCallDepth != 256 {
-				h = ffi.EngineNewWithConfig(config)
+				h = ffiEngineNewWithConfig(config)
 			} else {
-				h = ffi.EngineNew()
+				h = ffiEngineNew()
 			}
 			if h == nil {
 				return nil, &FerricError{Message: "failed to create engine"}
@@ -83,12 +83,14 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 	}
 
 	e := &Engine{handle: h}
-	runtime.SetFinalizer(e, func(e *Engine) {
-		if !e.closed {
-			ffi.EngineFreeUnchecked(e.handle)
-		}
-	})
+	runtime.SetFinalizer(e, finalizeEngine)
 	return e, nil
+}
+
+func finalizeEngine(e *Engine) {
+	if !e.closed {
+		ffiEngineFreeUnchecked(e.handle)
+	}
 }
 
 // NewEngineFromFile creates a new engine by deserializing a snapshot from the
@@ -184,7 +186,7 @@ func (e *Engine) Close() error {
 	if e.closed {
 		return nil
 	}
-	rc := ffi.EngineFree(e.handle)
+	rc := ffiEngineFree(e.handle)
 	if rc != ffi.ErrOK {
 		// Leave closed=false and finalizer intact so the caller
 		// can retry or the finalizer can still clean up.
@@ -199,7 +201,7 @@ func (e *Engine) Close() error {
 
 // Load loads CLIPS source into the engine.
 func (e *Engine) Load(source string) error {
-	rc := ffi.EngineLoadString(e.handle, source)
+	rc := ffiEngineLoadString(e.handle, source)
 	if rc != ffi.ErrOK {
 		return errorFromFFI(rc, e.handle)
 	}
@@ -211,7 +213,7 @@ func (e *Engine) Load(source string) error {
 // AssertString asserts a fact from a CLIPS source string
 // (e.g., "(assert (color red))").
 func (e *Engine) AssertString(source string) (uint64, error) {
-	id, rc := ffi.EngineAssertString(e.handle, source)
+	id, rc := ffiEngineAssertString(e.handle, source)
 	if rc != ffi.ErrOK {
 		return 0, errorFromFFI(rc, e.handle)
 	}
@@ -223,7 +225,7 @@ func (e *Engine) AssertFact(relation string, fields ...any) (uint64, error) {
 	vals := make([]ffi.Value, len(fields))
 	defer func() {
 		for i := range vals {
-			ffi.ValueFree(&vals[i])
+			ffiValueFree(&vals[i])
 		}
 	}()
 	for i, f := range fields {
@@ -234,7 +236,7 @@ func (e *Engine) AssertFact(relation string, fields ...any) (uint64, error) {
 		vals[i] = v
 	}
 
-	id, rc := ffi.EngineAssertOrdered(e.handle, relation, vals)
+	id, rc := ffiEngineAssertOrdered(e.handle, relation, vals)
 	if rc != ffi.ErrOK {
 		return 0, errorFromFFI(rc, e.handle)
 	}
@@ -247,7 +249,7 @@ func (e *Engine) AssertTemplate(templateName string, slots map[string]any) (uint
 	vals := make([]ffi.Value, 0, len(slots))
 	defer func() {
 		for i := range vals {
-			ffi.ValueFree(&vals[i])
+			ffiValueFree(&vals[i])
 		}
 	}()
 	for k, v := range slots {
@@ -259,7 +261,7 @@ func (e *Engine) AssertTemplate(templateName string, slots map[string]any) (uint
 		vals = append(vals, fv)
 	}
 
-	id, rc := ffi.EngineAssertTemplate(e.handle, templateName, names, vals)
+	id, rc := ffiEngineAssertTemplate(e.handle, templateName, names, vals)
 	if rc != ffi.ErrOK {
 		return 0, errorFromFFI(rc, e.handle)
 	}
@@ -268,7 +270,7 @@ func (e *Engine) AssertTemplate(templateName string, slots map[string]any) (uint
 
 // Retract removes a fact by its ID.
 func (e *Engine) Retract(factID uint64) error {
-	rc := ffi.EngineRetract(e.handle, factID)
+	rc := ffiEngineRetract(e.handle, factID)
 	if rc != ffi.ErrOK {
 		return errorFromFFI(rc, e.handle)
 	}
@@ -282,10 +284,14 @@ func (e *Engine) GetFact(factID uint64) (*Fact, error) {
 
 // Facts returns snapshots of all user-visible facts.
 func (e *Engine) Facts() ([]Fact, error) {
-	ids, rc := ffi.EngineFactIDs(e.handle)
+	ids, rc := ffiEngineFactIDs(e.handle)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
+	return e.buildFacts(ids)
+}
+
+func (e *Engine) buildFacts(ids []uint64) ([]Fact, error) {
 	facts := make([]Fact, 0, len(ids))
 	for _, id := range ids {
 		f, err := e.buildFact(id)
@@ -299,24 +305,16 @@ func (e *Engine) Facts() ([]Fact, error) {
 
 // FindFacts returns snapshots of facts matching the given relation name.
 func (e *Engine) FindFacts(relation string) ([]Fact, error) {
-	ids, rc := ffi.EngineFindFactIDs(e.handle, relation)
+	ids, rc := ffiEngineFindFactIDs(e.handle, relation)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
-	facts := make([]Fact, 0, len(ids))
-	for _, id := range ids {
-		f, err := e.buildFact(id)
-		if err != nil {
-			return nil, err
-		}
-		facts = append(facts, *f)
-	}
-	return facts, nil
+	return e.buildFacts(ids)
 }
 
 // FactCount returns the number of user-visible facts.
 func (e *Engine) FactCount() (int, error) {
-	count, rc := ffi.EngineFactCount(e.handle)
+	count, rc := ffiEngineFactCount(e.handle)
 	if rc != ffi.ErrOK {
 		return 0, errorFromFFI(rc, e.handle)
 	}
@@ -367,7 +365,7 @@ func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error
 			}
 		}
 
-		fired, reason, rc := ffi.EngineRunEx(e.handle, batch)
+		fired, reason, rc := ffiEngineRunEx(e.handle, batch)
 		if rc != ffi.ErrOK {
 			return &RunResult{RulesFired: totalFired}, errorFromFFI(rc, e.handle)
 		}
@@ -393,7 +391,7 @@ func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error
 }
 
 func (e *Engine) runDirect(limit int64) (*RunResult, error) {
-	fired, reason, rc := ffi.EngineRunEx(e.handle, limit)
+	fired, reason, rc := ffiEngineRunEx(e.handle, limit)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
@@ -416,7 +414,7 @@ func (e *Engine) runDirect(limit int64) (*RunResult, error) {
 // Step executes a single rule firing.
 // Returns nil if the agenda is empty.
 func (e *Engine) Step() (*FiredRule, error) {
-	status, rc := ffi.EngineStep(e.handle)
+	status, rc := ffiEngineStep(e.handle)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
@@ -429,12 +427,12 @@ func (e *Engine) Step() (*FiredRule, error) {
 
 // Halt requests the engine to halt.
 func (e *Engine) Halt() {
-	ffi.EngineHalt(e.handle)
+	ffiEngineHalt(e.handle)
 }
 
 // Reset resets the engine to its initial state (facts cleared, rules kept).
 func (e *Engine) Reset() error {
-	rc := ffi.EngineReset(e.handle)
+	rc := ffiEngineReset(e.handle)
 	if rc != ffi.ErrOK {
 		return errorFromFFI(rc, e.handle)
 	}
@@ -443,7 +441,7 @@ func (e *Engine) Reset() error {
 
 // Clear removes all rules, facts, templates, etc. from the engine.
 func (e *Engine) Clear() {
-	ffi.EngineClear(e.handle)
+	ffiEngineClear(e.handle)
 }
 
 // Serialize produces a snapshot of the engine's current state using the
@@ -454,7 +452,7 @@ func (e *Engine) Serialize(format Format) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, rc := ffi.EngineSerializeAs(e.handle, ffiFormat)
+	data, rc := ffiEngineSerializeAs(e.handle, ffiFormat)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
@@ -478,13 +476,13 @@ func (e *Engine) SerializeToFile(path string, format Format) error {
 
 // Rules returns information about all registered rules.
 func (e *Engine) Rules() []RuleInfo {
-	count, rc := ffi.EngineRuleCount(e.handle)
+	count, rc := ffiEngineRuleCount(e.handle)
 	if rc != ffi.ErrOK {
 		return nil
 	}
 	rules := make([]RuleInfo, 0, count)
 	for i := range count {
-		name, salience, rc := ffi.EngineRuleInfo(e.handle, i)
+		name, salience, rc := ffiEngineRuleInfo(e.handle, i)
 		if rc != ffi.ErrOK {
 			break
 		}
@@ -495,13 +493,13 @@ func (e *Engine) Rules() []RuleInfo {
 
 // Templates returns the names of all registered templates.
 func (e *Engine) Templates() []string {
-	count, rc := ffi.EngineTemplateCount(e.handle)
+	count, rc := ffiEngineTemplateCount(e.handle)
 	if rc != ffi.ErrOK {
 		return nil
 	}
 	names := make([]string, 0, count)
 	for i := range count {
-		name, rc := ffi.EngineTemplateName(e.handle, i)
+		name, rc := ffiEngineTemplateName(e.handle, i)
 		if rc != ffi.ErrOK {
 			break
 		}
@@ -513,7 +511,7 @@ func (e *Engine) Templates() []string {
 // GetGlobal retrieves a global variable's value by name.
 // The name should not include the ?* prefix/suffix.
 func (e *Engine) GetGlobal(name string) (any, error) {
-	val, rc := ffi.EngineGetGlobal(e.handle, name)
+	val, rc := ffiEngineGetGlobal(e.handle, name)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
@@ -523,7 +521,7 @@ func (e *Engine) GetGlobal(name string) (any, error) {
 
 // CurrentModule returns the name of the current module.
 func (e *Engine) CurrentModule() string {
-	name, rc := ffi.EngineCurrentModule(e.handle)
+	name, rc := ffiEngineCurrentModule(e.handle)
 	if rc != ffi.ErrOK {
 		return ""
 	}
@@ -533,7 +531,7 @@ func (e *Engine) CurrentModule() string {
 // Focus returns the module at the top of the focus stack.
 // Returns empty string and false if the focus stack is empty.
 func (e *Engine) Focus() (string, bool) {
-	name, rc := ffi.EngineGetFocus(e.handle)
+	name, rc := ffiEngineGetFocus(e.handle)
 	if rc != ffi.ErrOK {
 		return "", false
 	}
@@ -542,13 +540,13 @@ func (e *Engine) Focus() (string, bool) {
 
 // FocusStack returns the focus stack entries from bottom to top.
 func (e *Engine) FocusStack() []string {
-	depth, rc := ffi.EngineFocusStackDepth(e.handle)
+	depth, rc := ffiEngineFocusStackDepth(e.handle)
 	if rc != ffi.ErrOK {
 		return nil
 	}
 	stack := make([]string, 0, depth)
 	for i := range depth {
-		name, rc := ffi.EngineFocusStackEntry(e.handle, i)
+		name, rc := ffiEngineFocusStackEntry(e.handle, i)
 		if rc != ffi.ErrOK {
 			break
 		}
@@ -559,7 +557,7 @@ func (e *Engine) FocusStack() []string {
 
 // AgendaSize returns the number of activations on the agenda.
 func (e *Engine) AgendaSize() int {
-	count, rc := ffi.EngineAgendaCount(e.handle)
+	count, rc := ffiEngineAgendaCount(e.handle)
 	if rc != ffi.ErrOK {
 		return 0
 	}
@@ -568,7 +566,7 @@ func (e *Engine) AgendaSize() int {
 
 // IsHalted returns true if the engine is halted.
 func (e *Engine) IsHalted() bool {
-	halted, rc := ffi.EngineIsHalted(e.handle)
+	halted, rc := ffiEngineIsHalted(e.handle)
 	if rc != ffi.ErrOK {
 		return false
 	}
@@ -580,30 +578,30 @@ func (e *Engine) IsHalted() bool {
 // GetOutput retrieves captured output for a named channel.
 // Returns the output string and true, or empty string and false if no output.
 func (e *Engine) GetOutput(channel string) (string, bool) {
-	return ffi.EngineGetOutput(e.handle, channel)
+	return ffiEngineGetOutput(e.handle, channel)
 }
 
 // ClearOutput clears a specific output channel.
 func (e *Engine) ClearOutput(channel string) {
-	ffi.EngineClearOutput(e.handle, channel)
+	ffiEngineClearOutput(e.handle, channel)
 }
 
 // PushInput pushes an input line for read/readline.
 func (e *Engine) PushInput(line string) {
-	ffi.EnginePushInput(e.handle, line)
+	ffiEnginePushInput(e.handle, line)
 }
 
 // --- Diagnostics ---
 
 // Diagnostics returns all action diagnostic messages from recent execution.
 func (e *Engine) Diagnostics() []string {
-	count, rc := ffi.EngineActionDiagnosticCount(e.handle)
+	count, rc := ffiEngineActionDiagnosticCount(e.handle)
 	if rc != ffi.ErrOK {
 		return nil
 	}
 	diags := make([]string, 0, count)
 	for i := range count {
-		msg, rc := ffi.EngineActionDiagnosticCopy(e.handle, i)
+		msg, rc := ffiEngineActionDiagnosticCopy(e.handle, i)
 		if rc != ffi.ErrOK {
 			break
 		}
@@ -614,7 +612,7 @@ func (e *Engine) Diagnostics() []string {
 
 // ClearDiagnostics clears all stored action diagnostics.
 func (e *Engine) ClearDiagnostics() {
-	ffi.EngineClearActionDiagnostics(e.handle)
+	ffiEngineClearActionDiagnostics(e.handle)
 }
 
 // ---------------------------------------------------------------------------
@@ -623,13 +621,13 @@ func (e *Engine) ClearDiagnostics() {
 
 // RulesE returns information about all registered rules, or an error.
 func (e *Engine) RulesE() ([]RuleInfo, error) {
-	count, rc := ffi.EngineRuleCount(e.handle)
+	count, rc := ffiEngineRuleCount(e.handle)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
 	rules := make([]RuleInfo, 0, count)
 	for i := range count {
-		name, salience, rc := ffi.EngineRuleInfo(e.handle, i)
+		name, salience, rc := ffiEngineRuleInfo(e.handle, i)
 		if rc != ffi.ErrOK {
 			return nil, errorFromFFI(rc, e.handle)
 		}
@@ -640,13 +638,13 @@ func (e *Engine) RulesE() ([]RuleInfo, error) {
 
 // TemplatesE returns the names of all registered templates, or an error.
 func (e *Engine) TemplatesE() ([]string, error) {
-	count, rc := ffi.EngineTemplateCount(e.handle)
+	count, rc := ffiEngineTemplateCount(e.handle)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
 	names := make([]string, 0, count)
 	for i := range count {
-		name, rc := ffi.EngineTemplateName(e.handle, i)
+		name, rc := ffiEngineTemplateName(e.handle, i)
 		if rc != ffi.ErrOK {
 			return nil, errorFromFFI(rc, e.handle)
 		}
@@ -657,13 +655,13 @@ func (e *Engine) TemplatesE() ([]string, error) {
 
 // DiagnosticsE returns all action diagnostic messages, or an error.
 func (e *Engine) DiagnosticsE() ([]string, error) {
-	count, rc := ffi.EngineActionDiagnosticCount(e.handle)
+	count, rc := ffiEngineActionDiagnosticCount(e.handle)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
 	diags := make([]string, 0, count)
 	for i := range count {
-		msg, rc := ffi.EngineActionDiagnosticCopy(e.handle, i)
+		msg, rc := ffiEngineActionDiagnosticCopy(e.handle, i)
 		if rc != ffi.ErrOK {
 			return nil, errorFromFFI(rc, e.handle)
 		}
@@ -674,7 +672,7 @@ func (e *Engine) DiagnosticsE() ([]string, error) {
 
 // CurrentModuleE returns the name of the current module, or an error.
 func (e *Engine) CurrentModuleE() (string, error) {
-	name, rc := ffi.EngineCurrentModule(e.handle)
+	name, rc := ffiEngineCurrentModule(e.handle)
 	if rc != ffi.ErrOK {
 		return "", errorFromFFI(rc, e.handle)
 	}
@@ -685,7 +683,7 @@ func (e *Engine) CurrentModuleE() (string, error) {
 // Returns ("", false, nil) when the result cannot be distinguished from
 // an empty stack without an error; callers should check the bool first.
 func (e *Engine) FocusE() (string, bool, error) {
-	name, rc := ffi.EngineGetFocus(e.handle)
+	name, rc := ffiEngineGetFocus(e.handle)
 	if rc != ffi.ErrOK {
 		return "", false, errorFromFFI(rc, e.handle)
 	}
@@ -694,13 +692,13 @@ func (e *Engine) FocusE() (string, bool, error) {
 
 // FocusStackE returns the focus stack entries from bottom to top, or an error.
 func (e *Engine) FocusStackE() ([]string, error) {
-	depth, rc := ffi.EngineFocusStackDepth(e.handle)
+	depth, rc := ffiEngineFocusStackDepth(e.handle)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
 	stack := make([]string, 0, depth)
 	for i := range depth {
-		name, rc := ffi.EngineFocusStackEntry(e.handle, i)
+		name, rc := ffiEngineFocusStackEntry(e.handle, i)
 		if rc != ffi.ErrOK {
 			return nil, errorFromFFI(rc, e.handle)
 		}
@@ -711,7 +709,7 @@ func (e *Engine) FocusStackE() ([]string, error) {
 
 // AgendaSizeE returns the number of activations on the agenda, or an error.
 func (e *Engine) AgendaSizeE() (int, error) {
-	count, rc := ffi.EngineAgendaCount(e.handle)
+	count, rc := ffiEngineAgendaCount(e.handle)
 	if rc != ffi.ErrOK {
 		return 0, errorFromFFI(rc, e.handle)
 	}
@@ -720,7 +718,7 @@ func (e *Engine) AgendaSizeE() (int, error) {
 
 // IsHaltedE returns whether the engine is halted, or an error.
 func (e *Engine) IsHaltedE() (bool, error) {
-	halted, rc := ffi.EngineIsHalted(e.handle)
+	halted, rc := ffiEngineIsHalted(e.handle)
 	if rc != ffi.ErrOK {
 		return false, errorFromFFI(rc, e.handle)
 	}
@@ -730,19 +728,19 @@ func (e *Engine) IsHaltedE() (bool, error) {
 // --- Internal: fact building ---
 
 func (e *Engine) buildFact(factID uint64) (*Fact, error) {
-	ft, rc := ffi.EngineGetFactType(e.handle, factID)
+	ft, rc := ffiEngineGetFactType(e.handle, factID)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
 
-	fieldCount, rc := ffi.EngineGetFactFieldCount(e.handle, factID)
+	fieldCount, rc := ffiEngineGetFactFieldCount(e.handle, factID)
 	if rc != ffi.ErrOK {
 		return nil, errorFromFFI(rc, e.handle)
 	}
 
 	fields := make([]any, fieldCount)
 	for i := range fieldCount {
-		val, rc := ffi.EngineGetFactField(e.handle, factID, i)
+		val, rc := ffiEngineGetFactField(e.handle, factID, i)
 		if rc != ffi.ErrOK {
 			return nil, errorFromFFI(rc, e.handle)
 		}
@@ -756,21 +754,21 @@ func (e *Engine) buildFact(factID uint64) (*Fact, error) {
 
 	if ft == ffi.FactTypeTemplate {
 		fact.Type = FactTemplate
-		name, rc := ffi.EngineGetFactTemplateName(e.handle, factID)
+		name, rc := ffiEngineGetFactTemplateName(e.handle, factID)
 		if rc != ffi.ErrOK {
 			return nil, errorFromFFI(rc, e.handle)
 		}
 		fact.TemplateName = name
 
 		// Build slot map by querying template slot names.
-		slotCount, rc := ffi.EngineTemplateSlotCount(e.handle, name)
+		slotCount, rc := ffiEngineTemplateSlotCount(e.handle, name)
 		if rc != ffi.ErrOK {
 			return nil, fmt.Errorf("ferric: failed to get slot count for template %q: %w", name, errorFromFFI(rc, e.handle))
 		}
 		if slotCount > 0 {
 			fact.Slots = make(map[string]any, slotCount)
 			for i := range slotCount {
-				slotName, rc := ffi.EngineTemplateSlotName(e.handle, name, i)
+				slotName, rc := ffiEngineTemplateSlotName(e.handle, name, i)
 				if rc != ffi.ErrOK {
 					return nil, fmt.Errorf("ferric: failed to get slot name %d for template %q: %w", i, name, errorFromFFI(rc, e.handle))
 				}
@@ -781,7 +779,7 @@ func (e *Engine) buildFact(factID uint64) (*Fact, error) {
 		}
 	} else {
 		fact.Type = FactOrdered
-		rel, rc := ffi.EngineGetFactRelation(e.handle, factID)
+		rel, rc := ffiEngineGetFactRelation(e.handle, factID)
 		if rc != ffi.ErrOK {
 			return nil, fmt.Errorf("ferric: failed to get relation for fact %d: %w", factID, errorFromFFI(rc, e.handle))
 		}

--- a/bindings/go/ffi_hooks.go
+++ b/bindings/go/ffi_hooks.go
@@ -1,0 +1,56 @@
+//nolint:gochecknoglobals // Package-level FFI hooks let tests simulate native edge cases deterministically.
+package ferric
+
+import "github.com/prb/ferric-rules/bindings/go/internal/ffi"
+
+var (
+	ffiEngineNew                    = ffi.EngineNew
+	ffiEngineNewWithConfig          = ffi.EngineNewWithConfig
+	ffiEngineNewWithSource          = ffi.EngineNewWithSource
+	ffiEngineNewWithSourceConfig    = ffi.EngineNewWithSourceConfig
+	ffiEngineDeserializeAs          = ffi.EngineDeserializeAs
+	ffiLastErrorGlobal              = ffi.LastErrorGlobal
+	ffiEngineFree                   = ffi.EngineFree
+	ffiEngineFreeUnchecked          = ffi.EngineFreeUnchecked
+	ffiEngineLoadString             = ffi.EngineLoadString
+	ffiEngineAssertString           = ffi.EngineAssertString
+	ffiEngineAssertOrdered          = ffi.EngineAssertOrdered
+	ffiEngineAssertTemplate         = ffi.EngineAssertTemplate
+	ffiEngineRetract                = ffi.EngineRetract
+	ffiEngineFactIDs                = ffi.EngineFactIDs
+	ffiEngineFindFactIDs            = ffi.EngineFindFactIDs
+	ffiEngineFactCount              = ffi.EngineFactCount
+	ffiEngineRunEx                  = ffi.EngineRunEx
+	ffiEngineStep                   = ffi.EngineStep
+	ffiEngineHalt                   = ffi.EngineHalt
+	ffiEngineReset                  = ffi.EngineReset
+	ffiEngineClear                  = ffi.EngineClear
+	ffiEngineSerializeAs            = ffi.EngineSerializeAs
+	ffiEngineRuleCount              = ffi.EngineRuleCount
+	ffiEngineRuleInfo               = ffi.EngineRuleInfo
+	ffiEngineTemplateCount          = ffi.EngineTemplateCount
+	ffiEngineTemplateName           = ffi.EngineTemplateName
+	ffiEngineGetGlobal              = ffi.EngineGetGlobal
+	ffiEngineCurrentModule          = ffi.EngineCurrentModule
+	ffiEngineGetFocus               = ffi.EngineGetFocus
+	ffiEngineFocusStackDepth        = ffi.EngineFocusStackDepth
+	ffiEngineFocusStackEntry        = ffi.EngineFocusStackEntry
+	ffiEngineAgendaCount            = ffi.EngineAgendaCount
+	ffiEngineIsHalted               = ffi.EngineIsHalted
+	ffiEngineGetOutput              = ffi.EngineGetOutput
+	ffiEngineClearOutput            = ffi.EngineClearOutput
+	ffiEnginePushInput              = ffi.EnginePushInput
+	ffiEngineActionDiagnosticCount  = ffi.EngineActionDiagnosticCount
+	ffiEngineActionDiagnosticCopy   = ffi.EngineActionDiagnosticCopy
+	ffiEngineClearActionDiagnostics = ffi.EngineClearActionDiagnostics
+	ffiEngineGetFactType            = ffi.EngineGetFactType
+	ffiEngineGetFactFieldCount      = ffi.EngineGetFactFieldCount
+	ffiEngineGetFactField           = ffi.EngineGetFactField
+	ffiEngineGetFactTemplateName    = ffi.EngineGetFactTemplateName
+	ffiEngineTemplateSlotCount      = ffi.EngineTemplateSlotCount
+	ffiEngineTemplateSlotName       = ffi.EngineTemplateSlotName
+	ffiEngineGetFactRelation        = ffi.EngineGetFactRelation
+	ffiValueFree                    = ffi.ValueFree
+)
+
+var factsToWire = FactsToWire

--- a/bindings/go/internal/ffi/coverage_edge_test.go
+++ b/bindings/go/internal/ffi/coverage_edge_test.go
@@ -333,6 +333,51 @@ func TestManualStringFromTwoCallBranches(t *testing.T) {
 	}); rc != ErrOK || got != "" {
 		t.Fatalf("zero-length post-copy = (%q, %d), want empty OK", got, rc)
 	}
+
+	// Shrink: the second call reports fewer bytes than the first reserved; the
+	// helper must return exactly the bytes the second call actually wrote.
+	calls = 0
+	if got, rc := stringFromTwoCall(func(buf []byte) (uintptr, ErrorCode) {
+		calls++
+		if calls == 1 {
+			return 5, ErrOK
+		}
+		copy(buf, []byte{'h', 'i', 0})
+		return 3, ErrOK
+	}); rc != ErrOK || got != "hi" {
+		t.Fatalf("shrink-to-nonzero = (%q, %d), want \"hi\"", got, rc)
+	}
+
+	// Buffer-length contract: the second call must receive a buffer sized to
+	// the count the first call reported.
+	calls = 0
+	seenLen := -1
+	if got, rc := stringFromTwoCall(func(buf []byte) (uintptr, ErrorCode) {
+		calls++
+		if calls == 1 {
+			return 4, ErrOK
+		}
+		seenLen = len(buf)
+		copy(buf, []byte{'a', 'b', 'c', 0})
+		return 4, ErrOK
+	}); rc != ErrOK || got != "abc" || seenLen != 4 {
+		t.Fatalf("buffer-length contract = (%q, %d, len=%d), want (\"abc\", OK, 4)", got, rc, seenLen)
+	}
+
+	// Grow: if the second call reports MORE than the first reserved (only
+	// reachable under concurrent mutation, which the wrappers do not permit),
+	// the helper must clamp to the buffer rather than panic on buf[:needed-1].
+	calls = 0
+	if got, rc := stringFromTwoCall(func(buf []byte) (uintptr, ErrorCode) {
+		calls++
+		if calls == 1 {
+			return 2, ErrOK
+		}
+		copy(buf, []byte{'a', 'b'})
+		return 5, ErrOK
+	}); rc != ErrOK || got != "a" {
+		t.Fatalf("grow clamp = (%q, %d), want \"a\" without panic", got, rc)
+	}
 }
 
 func TestManualUint64IDsFromTwoCallBranches(t *testing.T) {
@@ -372,6 +417,48 @@ func TestManualUint64IDsFromTwoCallBranches(t *testing.T) {
 	}); rc != ErrOK || len(got) != 3 || got[0] != 7 || got[2] != 9 {
 		t.Fatalf("filled ids = (%v, %d), want [7 8 9] OK", got, rc)
 	}
+
+	// Shrink: the second call reports fewer ids than the first reserved.
+	calls = 0
+	if got, rc := uint64IDsFromTwoCall(func(dst []uint64) (uintptr, ErrorCode) {
+		calls++
+		if calls == 1 {
+			return 5, ErrOK
+		}
+		copy(dst, []uint64{1, 2})
+		return 2, ErrOK
+	}); rc != ErrOK || len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("shrink-to-nonzero = (%v, %d), want [1 2]", got, rc)
+	}
+
+	// Buffer-length contract: the fill buffer must be sized to the first count.
+	calls = 0
+	seenLen := -1
+	if got, rc := uint64IDsFromTwoCall(func(dst []uint64) (uintptr, ErrorCode) {
+		calls++
+		if calls == 1 {
+			return 3, ErrOK
+		}
+		seenLen = len(dst)
+		copy(dst, []uint64{4, 5, 6})
+		return 3, ErrOK
+	}); rc != ErrOK || len(got) != 3 || seenLen != 3 {
+		t.Fatalf("buffer-length contract = (%v, %d, len=%d), want (3 ids, OK, 3)", got, rc, seenLen)
+	}
+
+	// Grow: a second count larger than the first must clamp to the buffer
+	// rather than panic on result[:count].
+	calls = 0
+	if got, rc := uint64IDsFromTwoCall(func(dst []uint64) (uintptr, ErrorCode) {
+		calls++
+		if calls == 1 {
+			return 2, ErrOK
+		}
+		copy(dst, []uint64{1, 2})
+		return 5, ErrOK
+	}); rc != ErrOK || len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("grow clamp = (%v, %d), want [1 2] without panic", got, rc)
+	}
 }
 
 func TestPropertyValueScalarAccessors(t *testing.T) {
@@ -404,33 +491,6 @@ func TestPropertyValueScalarAccessors(t *testing.T) {
 	})
 }
 
-func TestPropertySerializationWrappersRoundTrip(t *testing.T) {
-	lockThread(t)
-
-	rapid.Check(t, func(t *rapid.T) {
-		format := rapid.SampledFrom(ffiFormats()).Draw(t, "format")
-		h := EngineNewWithSource(`(defrule r => (assert (ok)))`)
-		if h == nil {
-			t.Fatal("EngineNewWithSource returned nil")
-		}
-		data, rc := EngineSerializeAs(h, format)
-		if rc != ErrOK {
-			t.Fatalf("EngineSerializeAs returned %d", rc)
-		}
-		if rc := EngineFree(h); rc != ErrOK {
-			t.Fatalf("EngineFree returned %d", rc)
-		}
-
-		restored, rc := EngineDeserializeAs(data, format)
-		if rc != ErrOK || restored == nil {
-			t.Fatalf("EngineDeserializeAs = (%v, %d), want handle OK", restored, rc)
-		}
-		if rc := EngineFree(restored); rc != ErrOK {
-			t.Fatalf("EngineFree restored returned %d", rc)
-		}
-	})
-}
-
 func TestPropertyCopyAndFreeBytes(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		src := rapid.SliceOfN(rapid.Uint8(), 0, 32).Draw(t, "bytes")
@@ -455,116 +515,93 @@ func TestPropertyCopyAndFreeBytes(t *testing.T) {
 	})
 }
 
+// TestPropertyStringFromTwoCall fuzzes the relationship between the size the
+// first FFI call advertises and the length the second call reports. They may
+// match, shrink, or (pathologically, under concurrent mutation the wrappers
+// forbid) grow. The invariant: the second call always receives a buffer sized
+// to the first count, the result is clamped to that buffer and never panics,
+// and after stripping the NUL terminator its length is min(first,second)-1
+// (or 0 when that is non-positive). Error/empty branches are covered by the
+// manual table; this test owns the size-relationship contract.
 func TestPropertyStringFromTwoCall(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		scenario := rapid.SampledFrom([]string{"ok", "empty", "first_error", "second_error", "zero_after_copy"}).Draw(t, "scenario")
-		switch scenario {
-		case "ok":
-			s := rapid.String().Filter(func(v string) bool {
-				for _, r := range v {
-					if r == 0 {
-						return false
-					}
-				}
-				return true
-			}).Draw(t, "string")
-			calls := 0
-			got, rc := stringFromTwoCall(func(buf []byte) (uintptr, ErrorCode) {
-				calls++
-				if calls == 1 {
-					return uintptr(len(s) + 1), ErrOK
-				}
-				copy(buf, append([]byte(s), 0))
-				return uintptr(len(s) + 1), ErrOK
-			})
-			if rc != ErrOK || got != s {
-				t.Fatalf("stringFromTwoCall = (%q, %d), want %q OK", got, rc, s)
+		firstN := rapid.IntRange(1, 16).Draw(t, "firstN")
+		secondN := rapid.IntRange(0, 24).Draw(t, "secondN")
+
+		eff := min(secondN, firstN)
+
+		calls := 0
+		got, rc := stringFromTwoCall(func(buf []byte) (uintptr, ErrorCode) {
+			calls++
+			if calls == 1 {
+				return uintptr(firstN), ErrOK
 			}
-		case "empty":
-			got, rc := stringFromTwoCall(func([]byte) (uintptr, ErrorCode) { return 0, ErrOK })
-			if rc != ErrOK || got != "" {
-				t.Fatalf("empty stringFromTwoCall = (%q, %d)", got, rc)
+			if len(buf) != firstN {
+				t.Fatalf("second buffer len = %d, want first count %d", len(buf), firstN)
 			}
-		case "first_error":
-			_, rc := stringFromTwoCall(func([]byte) (uintptr, ErrorCode) { return 0, ErrRuntimeError })
-			if rc != ErrRuntimeError {
-				t.Fatalf("first error rc = %d", rc)
+			for i := range buf {
+				buf[i] = 'x'
 			}
-		case "second_error":
-			calls := 0
-			_, rc := stringFromTwoCall(func([]byte) (uintptr, ErrorCode) {
-				calls++
-				if calls == 1 {
-					return 1, ErrOK
-				}
-				return 1, ErrBufferTooSmall
-			})
-			if rc != ErrBufferTooSmall {
-				t.Fatalf("second error rc = %d", rc)
+			if eff > 0 {
+				buf[eff-1] = 0 // NUL terminator inside the clamped length
 			}
-		case "zero_after_copy":
-			calls := 0
-			got, rc := stringFromTwoCall(func(buf []byte) (uintptr, ErrorCode) {
-				calls++
-				if calls == 1 {
-					return 1, ErrOK
-				}
-				if len(buf) > 0 {
-					buf[0] = 0
-				}
-				return 0, ErrOK
-			})
-			if rc != ErrOK || got != "" {
-				t.Fatalf("zero-after-copy string = (%q, %d)", got, rc)
+			return uintptr(secondN), ErrOK
+		})
+		if rc != ErrOK {
+			t.Fatalf("size property rc = %d (firstN=%d secondN=%d)", rc, firstN, secondN)
+		}
+
+		wantLen := 0
+		if eff > 0 {
+			wantLen = eff - 1
+		}
+		if len(got) != wantLen {
+			t.Fatalf("len = %d, want %d (firstN=%d secondN=%d)", len(got), wantLen, firstN, secondN)
+		}
+		for i := range len(got) {
+			if got[i] != 'x' {
+				t.Fatalf("byte %d = %q, want 'x'", i, got[i])
 			}
 		}
 	})
 }
 
+// TestPropertyUint64IDsFromTwoCall fuzzes the first-vs-second count
+// relationship (match/shrink/grow). The invariant: the fill buffer is sized to
+// the first count, the result is clamped to min(first,second) ids (never
+// panicking on the reslice), and the ids returned are exactly those written.
+// Error/empty branches are covered by the manual table.
 func TestPropertyUint64IDsFromTwoCall(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		scenario := rapid.SampledFrom([]string{"ok", "empty", "first_error", "second_error"}).Draw(t, "scenario")
-		switch scenario {
-		case "ok":
-			want := rapid.SliceOfN(rapid.Uint64(), 1, 16).Draw(t, "ids")
-			calls := 0
-			got, rc := uint64IDsFromTwoCall(func(dst []uint64) (uintptr, ErrorCode) {
-				calls++
-				if calls == 1 {
-					return uintptr(len(want)), ErrOK
-				}
-				copy(dst, want)
-				return uintptr(len(want)), ErrOK
-			})
-			if rc != ErrOK || len(got) != len(want) {
-				t.Fatalf("ids result = (%v, %d), want %v OK", got, rc, want)
+		firstN := rapid.IntRange(1, 16).Draw(t, "firstN")
+		secondN := rapid.IntRange(0, 24).Draw(t, "secondN")
+		base := rapid.Uint64().Draw(t, "base")
+
+		eff := min(secondN, firstN)
+
+		calls := 0
+		got, rc := uint64IDsFromTwoCall(func(dst []uint64) (uintptr, ErrorCode) {
+			calls++
+			if calls == 1 {
+				return uintptr(firstN), ErrOK
 			}
-			for i := range want {
-				if got[i] != want[i] {
-					t.Fatalf("ids[%d] = %d, want %d", i, got[i], want[i])
-				}
+			if len(dst) != firstN {
+				t.Fatalf("second buffer len = %d, want first count %d", len(dst), firstN)
 			}
-		case "empty":
-			got, rc := uint64IDsFromTwoCall(func([]uint64) (uintptr, ErrorCode) { return 0, ErrOK })
-			if rc != ErrOK || got != nil {
-				t.Fatalf("empty ids = (%v, %d)", got, rc)
+			for i := range dst {
+				dst[i] = base + uint64(i)
 			}
-		case "first_error":
-			_, rc := uint64IDsFromTwoCall(func([]uint64) (uintptr, ErrorCode) { return 0, ErrRuntimeError })
-			if rc != ErrRuntimeError {
-				t.Fatalf("first error rc = %d", rc)
-			}
-		case "second_error":
-			calls := 0
-			_, rc := uint64IDsFromTwoCall(func([]uint64) (uintptr, ErrorCode) {
-				calls++
-				if calls == 1 {
-					return 1, ErrOK
-				}
-				return 1, ErrBufferTooSmall
-			})
-			if rc != ErrBufferTooSmall {
-				t.Fatalf("second error rc = %d", rc)
+			return uintptr(secondN), ErrOK
+		})
+		if rc != ErrOK {
+			t.Fatalf("size property rc = %d (firstN=%d secondN=%d)", rc, firstN, secondN)
+		}
+		if len(got) != eff {
+			t.Fatalf("len = %d, want %d (firstN=%d secondN=%d)", len(got), eff, firstN, secondN)
+		}
+		for i := range got {
+			if got[i] != base+uint64(i) {
+				t.Fatalf("id[%d] = %d, want %d", i, got[i], base+uint64(i))
 			}
 		}
 	})

--- a/bindings/go/internal/ffi/coverage_edge_test.go
+++ b/bindings/go/internal/ffi/coverage_edge_test.go
@@ -1,0 +1,830 @@
+//nolint:funlen,gocyclo,maintidx // Coverage edge tests intentionally enumerate related FFI branches together.
+package ffi
+
+import (
+	"bytes"
+	"math"
+	"testing"
+	"unsafe"
+
+	"pgregory.net/rapid"
+)
+
+func ffiFormats() []SerializationFormat {
+	return []SerializationFormat{
+		FormatBincode,
+		FormatJSON,
+		FormatCBOR,
+		FormatMessagePack,
+		FormatPostcard,
+	}
+}
+
+func TestManualValueAccessorsAndConstructors(t *testing.T) {
+	// The accessor helpers are the only safe way for the outer Go package to
+	// inspect cgo-owned FerricValue fields. This covers each public value shape.
+	integer := ValueInteger(-42)
+	if ValueGetType(&integer) != ValueTypeInteger || ValueGetInteger(&integer) != -42 {
+		t.Fatalf("integer accessor mismatch")
+	}
+
+	float := ValueFloat(1.25)
+	if ValueGetType(&float) != ValueTypeFloat || ValueGetFloat(&float) != 1.25 {
+		t.Fatalf("float accessor mismatch")
+	}
+
+	void := ValueVoid()
+	if ValueGetType(&void) != ValueTypeVoid {
+		t.Fatalf("void accessor mismatch")
+	}
+	if got := ValueGetStringPtr(&void); got != "" {
+		t.Fatalf("nil string pointer = %q, want empty", got)
+	}
+
+	symbol := ValueSymbol("sym")
+	if ValueGetType(&symbol) != ValueTypeSymbol || ValueGetStringPtr(&symbol) != "sym" {
+		t.Fatalf("symbol accessor mismatch")
+	}
+	ValueFree(&symbol)
+
+	str := ValueString("hello")
+	if ValueGetType(&str) != ValueTypeString || ValueGetStringPtr(&str) != "hello" {
+		t.Fatalf("string accessor mismatch")
+	}
+	ValueFree(&str)
+
+	multifield := ValueMultifield([]Value{
+		ValueInteger(1),
+		ValueString("nested"),
+	})
+	if ValueGetType(&multifield) != ValueTypeMultifield {
+		t.Fatalf("multifield type mismatch")
+	}
+	if got := ValueGetMultifieldLen(&multifield); got != 2 {
+		t.Fatalf("multifield length = %d, want 2", got)
+	}
+	if elem := ValueGetMultifieldElement(&multifield, 1); ValueGetStringPtr(&elem) != "nested" {
+		t.Fatalf("multifield element mismatch")
+	}
+	ValueFree(&multifield)
+
+	emptyMultifield := ValueMultifield(nil)
+	if ValueGetType(&emptyMultifield) != ValueTypeMultifield || ValueGetMultifieldLen(&emptyMultifield) != 0 {
+		t.Fatalf("empty multifield accessor mismatch")
+	}
+	ValueFree(&emptyMultifield)
+
+	marker := 7
+	var external Value
+	external.value_type = ValueTypeExternalAddress
+	external.external_pointer = unsafe.Pointer(&marker)
+	if got := ValueGetExternalPointer(&external); got != unsafe.Pointer(&marker) {
+		t.Fatalf("external pointer = %v, want %v", got, unsafe.Pointer(&marker))
+	}
+
+	cfg := MakeConfig(StringEncodingUTF8, ConflictStrategyLEX, 512)
+	if cfg == nil {
+		t.Fatal("MakeConfig returned nil")
+	}
+
+	StringFree(nil)
+	ValueArrayFree(nil, 0)
+}
+
+func TestManualConfigConstructorsOutputDiagnosticsAndErrors(t *testing.T) {
+	// These examples exercise FFI constructors and mutable side channels that
+	// the high-level package usually reaches indirectly.
+	lockThread(t)
+
+	cfg := MakeConfig(StringEncodingUTF8, ConflictStrategyDepth, 256)
+	h := EngineNewWithConfig(cfg)
+	if h == nil {
+		t.Fatal("EngineNewWithConfig returned nil")
+	}
+	if rc := EngineFree(h); rc != ErrOK {
+		t.Fatalf("EngineFree returned %d", rc)
+	}
+
+	h = EngineNewWithSourceConfig(`(defrule hello => (printout t "hi" crlf))`, cfg)
+	if h == nil {
+		t.Fatal("EngineNewWithSourceConfig returned nil")
+	}
+	defer EngineFree(h)
+
+	fired, reason, rc := EngineRunEx(h, -1)
+	if rc != ErrOK || fired != 1 || reason != HaltReasonAgendaEmpty {
+		t.Fatalf("run = (%d, %d, %d), want one agenda-empty firing", fired, reason, rc)
+	}
+	if out, ok := EngineGetOutput(h, "t"); !ok || out != "hi\n" {
+		t.Fatalf("stdout = (%q, %v), want hi", out, ok)
+	}
+	if rc := EngineClearOutput(h, "t"); rc != ErrOK {
+		t.Fatalf("EngineClearOutput returned %d", rc)
+	}
+	if out, ok := EngineGetOutput(h, "t"); ok || out != "" {
+		t.Fatalf("cleared stdout = (%q, %v), want empty false", out, ok)
+	}
+
+	diag := EngineNewWithSource(`(defrule boom => (/ 1 0))`)
+	if diag == nil {
+		t.Fatal("diagnostic engine returned nil")
+	}
+	defer EngineFree(diag)
+	_, _, _ = EngineRunEx(diag, -1)
+	count, rc := EngineActionDiagnosticCount(diag)
+	if rc != ErrOK {
+		t.Fatalf("EngineActionDiagnosticCount returned %d", rc)
+	}
+	for i := range count {
+		if _, rc := EngineActionDiagnosticCopy(diag, i); rc != ErrOK {
+			t.Fatalf("EngineActionDiagnosticCopy(%d) returned %d", i, rc)
+		}
+	}
+	if rc := EngineClearActionDiagnostics(diag); rc != ErrOK {
+		t.Fatalf("EngineClearActionDiagnostics returned %d", rc)
+	}
+
+	introspect := EngineNewWithSource(`(deftemplate sensor (slot id))`)
+	if introspect == nil {
+		t.Fatal("introspection engine returned nil")
+	}
+	defer EngineFree(introspect)
+	name, rc := EngineTemplateName(introspect, 0)
+	if rc != ErrOK || name != "sensor" {
+		t.Fatalf("EngineTemplateName = (%q, %d), want sensor OK", name, rc)
+	}
+
+	if rc := EngineLoadString(introspect, "(defrule bad"); rc == ErrOK {
+		t.Fatal("invalid source should fail")
+	}
+	if _, rc := EngineLastErrorCopy(introspect); rc != ErrOK {
+		t.Fatalf("EngineLastErrorCopy returned %d", rc)
+	}
+	EngineClearError(introspect)
+	if msg := EngineLastError(introspect); msg != "" {
+		t.Fatalf("cleared engine error = %q, want empty", msg)
+	}
+
+	invalid := EngineNewWithSource("(defrule bad")
+	if invalid != nil {
+		_ = EngineFree(invalid)
+		t.Fatal("invalid source unexpectedly created an engine")
+	}
+	if _, rc := LastErrorGlobalCopy(); rc != ErrOK {
+		t.Fatalf("LastErrorGlobalCopy returned %d", rc)
+	}
+	ClearErrorGlobal()
+	if msg := LastErrorGlobal(); msg != "" {
+		t.Fatalf("cleared global error = %q, want empty", msg)
+	}
+}
+
+func TestManualFactIDWrapperEdges(t *testing.T) {
+	// Fact ID wrappers use a two-call C buffer pattern. Empty, nil-handle, and
+	// populated calls prove the Go wrapper handles all caller-visible outcomes.
+	lockThread(t)
+
+	if ids, rc := EngineFactIDs(nil); rc == ErrOK || ids != nil {
+		t.Fatalf("EngineFactIDs nil = (%v, %d), want nil error", ids, rc)
+	}
+	if ids, rc := EngineFindFactIDs(nil, "x"); rc == ErrOK || ids != nil {
+		t.Fatalf("EngineFindFactIDs nil = (%v, %d), want nil error", ids, rc)
+	}
+
+	h := EngineNew()
+	if h == nil {
+		t.Fatal("EngineNew returned nil")
+	}
+	defer EngineFree(h)
+	if rc := EngineReset(h); rc != ErrOK {
+		t.Fatalf("EngineReset returned %d", rc)
+	}
+	if ids, rc := EngineFactIDs(h); rc != ErrOK || len(ids) != 0 {
+		t.Fatalf("empty EngineFactIDs = (%v, %d), want empty OK", ids, rc)
+	}
+	if ids, rc := EngineFindFactIDs(h, "missing"); rc != ErrOK || len(ids) != 0 {
+		t.Fatalf("empty EngineFindFactIDs = (%v, %d), want empty OK", ids, rc)
+	}
+	if _, rc := EngineAssertString(h, "(assert (color red))"); rc != ErrOK {
+		t.Fatalf("EngineAssertString returned %d", rc)
+	}
+	if ids, rc := EngineFactIDs(h); rc != ErrOK || len(ids) != 1 {
+		t.Fatalf("populated EngineFactIDs = (%v, %d), want one OK", ids, rc)
+	}
+	if ids, rc := EngineFindFactIDs(h, "color"); rc != ErrOK || len(ids) != 1 {
+		t.Fatalf("populated EngineFindFactIDs = (%v, %d), want one OK", ids, rc)
+	}
+}
+
+func TestManualSerializationWrappers(t *testing.T) {
+	// Direct serde tests keep the internal FFI wrappers covered independently
+	// from the higher-level Engine.Serialize tests in the parent package.
+	lockThread(t)
+
+	for _, format := range ffiFormats() {
+		h := EngineNewWithSource(`(defrule r => (assert (ok)))`)
+		if h == nil {
+			t.Fatal("EngineNewWithSource returned nil")
+		}
+
+		data, rc := EngineSerializeAs(h, format)
+		if rc != ErrOK {
+			t.Fatalf("EngineSerializeAs(%d) returned %d", format, rc)
+		}
+		if len(data) == 0 {
+			t.Fatalf("EngineSerializeAs(%d) returned empty data", format)
+		}
+		if rc := EngineFree(h); rc != ErrOK {
+			t.Fatalf("EngineFree returned %d", rc)
+		}
+
+		restored, rc := EngineDeserializeAs(data, format)
+		if rc != ErrOK || restored == nil {
+			t.Fatalf("EngineDeserializeAs(%d) = (%v, %d), want handle OK", format, restored, rc)
+		}
+		if rc := EngineFree(restored); rc != ErrOK {
+			t.Fatalf("EngineFree restored returned %d", rc)
+		}
+	}
+
+	if data, rc := EngineSerializeAs(nil, FormatBincode); rc == ErrOK || data != nil {
+		t.Fatalf("EngineSerializeAs nil = (%v, %d), want nil error", data, rc)
+	}
+	if h, rc := EngineDeserializeAs(nil, FormatBincode); rc != ErrInvalidArgument || h != nil {
+		t.Fatalf("EngineDeserializeAs empty = (%v, %d), want invalid argument", h, rc)
+	}
+	if h, rc := EngineDeserializeAs([]byte("not a snapshot"), FormatJSON); rc == ErrOK || h != nil {
+		t.Fatalf("EngineDeserializeAs invalid = (%v, %d), want nil error", h, rc)
+	}
+}
+
+func TestManualCopyAndFreeBytesBranches(t *testing.T) {
+	// Serialization copies Rust-owned bytes and must always invoke the provided
+	// free callback, including the zero-length edge case.
+	freed := false
+	if got := copyAndFreeBytes(nil, 0, func() { freed = true }); got != nil || !freed {
+		t.Fatalf("zero copy = (%v, freed=%v), want nil freed", got, freed)
+	}
+
+	src := []byte{1, 2, 3}
+	freed = false
+	got := copyAndFreeBytes(unsafe.Pointer(&src[0]), uintptr(len(src)), func() { freed = true })
+	if !freed || len(got) != len(src) || got[0] != 1 || got[2] != 3 {
+		t.Fatalf("copy = (%v, freed=%v), want copied bytes freed", got, freed)
+	}
+	src[0] = 9
+	if got[0] != 1 {
+		t.Fatalf("copy must be Go-owned, got mutated first byte %d", got[0])
+	}
+}
+
+func TestManualStringFromTwoCallBranches(t *testing.T) {
+	// The pure helper under getStringWith owns the allocation and error handling
+	// contract for all string-copy FFI wrappers.
+	if got, rc := stringFromTwoCall(func(_ []byte) (uintptr, ErrorCode) {
+		return 0, ErrRuntimeError
+	}); rc != ErrRuntimeError || got != "" {
+		t.Fatalf("first-call failure = (%q, %d), want runtime error", got, rc)
+	}
+
+	if got, rc := stringFromTwoCall(func(_ []byte) (uintptr, ErrorCode) {
+		return 0, ErrOK
+	}); rc != ErrOK || got != "" {
+		t.Fatalf("empty result = (%q, %d), want empty OK", got, rc)
+	}
+
+	calls := 0
+	if got, rc := stringFromTwoCall(func(_ []byte) (uintptr, ErrorCode) {
+		calls++
+		if calls == 1 {
+			return 2, ErrOK
+		}
+		return 2, ErrBufferTooSmall
+	}); rc != ErrBufferTooSmall || got != "" {
+		t.Fatalf("second-call failure = (%q, %d), want buffer-too-small", got, rc)
+	}
+
+	calls = 0
+	if got, rc := stringFromTwoCall(func(buf []byte) (uintptr, ErrorCode) {
+		calls++
+		if calls == 1 {
+			return 3, ErrOK
+		}
+		copy(buf, []byte{'o', 'k', 0})
+		return 3, ErrOK
+	}); rc != ErrOK || got != "ok" {
+		t.Fatalf("copied string = (%q, %d), want ok", got, rc)
+	}
+
+	calls = 0
+	if got, rc := stringFromTwoCall(func(buf []byte) (uintptr, ErrorCode) {
+		calls++
+		if calls == 1 {
+			return 1, ErrOK
+		}
+		if len(buf) > 0 {
+			buf[0] = 0
+		}
+		return 0, ErrOK
+	}); rc != ErrOK || got != "" {
+		t.Fatalf("zero-length post-copy = (%q, %d), want empty OK", got, rc)
+	}
+}
+
+func TestManualUint64IDsFromTwoCallBranches(t *testing.T) {
+	// Fact ID wrappers share this helper, so fake callbacks cover the count
+	// query, empty result, second-call failure, and successful fill branches.
+	if got, rc := uint64IDsFromTwoCall(func(_ []uint64) (uintptr, ErrorCode) {
+		return 0, ErrRuntimeError
+	}); rc != ErrRuntimeError || got != nil {
+		t.Fatalf("first-call failure = (%v, %d), want nil runtime error", got, rc)
+	}
+
+	if got, rc := uint64IDsFromTwoCall(func(_ []uint64) (uintptr, ErrorCode) {
+		return 0, ErrOK
+	}); rc != ErrOK || got != nil {
+		t.Fatalf("empty ids = (%v, %d), want nil OK", got, rc)
+	}
+
+	calls := 0
+	if got, rc := uint64IDsFromTwoCall(func(_ []uint64) (uintptr, ErrorCode) {
+		calls++
+		if calls == 1 {
+			return 2, ErrOK
+		}
+		return 2, ErrBufferTooSmall
+	}); rc != ErrBufferTooSmall || got != nil {
+		t.Fatalf("second-call failure = (%v, %d), want nil buffer-too-small", got, rc)
+	}
+
+	calls = 0
+	if got, rc := uint64IDsFromTwoCall(func(dst []uint64) (uintptr, ErrorCode) {
+		calls++
+		if calls == 1 {
+			return 3, ErrOK
+		}
+		copy(dst, []uint64{7, 8, 9})
+		return 3, ErrOK
+	}); rc != ErrOK || len(got) != 3 || got[0] != 7 || got[2] != 9 {
+		t.Fatalf("filled ids = (%v, %d), want [7 8 9] OK", got, rc)
+	}
+}
+
+func TestPropertyValueScalarAccessors(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		i := rapid.Int64().Draw(t, "integer")
+		iv := ValueInteger(i)
+		if ValueGetType(&iv) != ValueTypeInteger || ValueGetInteger(&iv) != i {
+			t.Fatalf("integer value/accessor mismatch")
+		}
+
+		f := rapid.Float64().Filter(func(v float64) bool { return !math.IsNaN(v) }).Draw(t, "float")
+		fv := ValueFloat(f)
+		if ValueGetType(&fv) != ValueTypeFloat || ValueGetFloat(&fv) != f {
+			t.Fatalf("float value/accessor mismatch")
+		}
+
+		s := rapid.String().Filter(func(v string) bool {
+			for _, r := range v {
+				if r == 0 {
+					return false
+				}
+			}
+			return true
+		}).Draw(t, "string")
+		sv := ValueString(s)
+		if ValueGetType(&sv) != ValueTypeString || ValueGetStringPtr(&sv) != s {
+			t.Fatalf("string value/accessor mismatch")
+		}
+		ValueFree(&sv)
+	})
+}
+
+func TestPropertySerializationWrappersRoundTrip(t *testing.T) {
+	lockThread(t)
+
+	rapid.Check(t, func(t *rapid.T) {
+		format := rapid.SampledFrom(ffiFormats()).Draw(t, "format")
+		h := EngineNewWithSource(`(defrule r => (assert (ok)))`)
+		if h == nil {
+			t.Fatal("EngineNewWithSource returned nil")
+		}
+		data, rc := EngineSerializeAs(h, format)
+		if rc != ErrOK {
+			t.Fatalf("EngineSerializeAs returned %d", rc)
+		}
+		if rc := EngineFree(h); rc != ErrOK {
+			t.Fatalf("EngineFree returned %d", rc)
+		}
+
+		restored, rc := EngineDeserializeAs(data, format)
+		if rc != ErrOK || restored == nil {
+			t.Fatalf("EngineDeserializeAs = (%v, %d), want handle OK", restored, rc)
+		}
+		if rc := EngineFree(restored); rc != ErrOK {
+			t.Fatalf("EngineFree restored returned %d", rc)
+		}
+	})
+}
+
+func TestPropertyCopyAndFreeBytes(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		src := rapid.SliceOfN(rapid.Uint8(), 0, 32).Draw(t, "bytes")
+		freed := false
+		var ptr unsafe.Pointer
+		if len(src) > 0 {
+			ptr = unsafe.Pointer(&src[0])
+		}
+		got := copyAndFreeBytes(ptr, uintptr(len(src)), func() { freed = true })
+		if !freed {
+			t.Fatal("copyAndFreeBytes must always call free")
+		}
+		if !bytes.Equal(got, src) {
+			t.Fatalf("copied bytes = %v, want %v", got, src)
+		}
+		if len(src) > 0 {
+			src[0] ^= 0xff
+			if got[0] == src[0] {
+				t.Fatal("copyAndFreeBytes must return Go-owned bytes")
+			}
+		}
+	})
+}
+
+func TestPropertyStringFromTwoCall(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		scenario := rapid.SampledFrom([]string{"ok", "empty", "first_error", "second_error", "zero_after_copy"}).Draw(t, "scenario")
+		switch scenario {
+		case "ok":
+			s := rapid.String().Filter(func(v string) bool {
+				for _, r := range v {
+					if r == 0 {
+						return false
+					}
+				}
+				return true
+			}).Draw(t, "string")
+			calls := 0
+			got, rc := stringFromTwoCall(func(buf []byte) (uintptr, ErrorCode) {
+				calls++
+				if calls == 1 {
+					return uintptr(len(s) + 1), ErrOK
+				}
+				copy(buf, append([]byte(s), 0))
+				return uintptr(len(s) + 1), ErrOK
+			})
+			if rc != ErrOK || got != s {
+				t.Fatalf("stringFromTwoCall = (%q, %d), want %q OK", got, rc, s)
+			}
+		case "empty":
+			got, rc := stringFromTwoCall(func([]byte) (uintptr, ErrorCode) { return 0, ErrOK })
+			if rc != ErrOK || got != "" {
+				t.Fatalf("empty stringFromTwoCall = (%q, %d)", got, rc)
+			}
+		case "first_error":
+			_, rc := stringFromTwoCall(func([]byte) (uintptr, ErrorCode) { return 0, ErrRuntimeError })
+			if rc != ErrRuntimeError {
+				t.Fatalf("first error rc = %d", rc)
+			}
+		case "second_error":
+			calls := 0
+			_, rc := stringFromTwoCall(func([]byte) (uintptr, ErrorCode) {
+				calls++
+				if calls == 1 {
+					return 1, ErrOK
+				}
+				return 1, ErrBufferTooSmall
+			})
+			if rc != ErrBufferTooSmall {
+				t.Fatalf("second error rc = %d", rc)
+			}
+		case "zero_after_copy":
+			calls := 0
+			got, rc := stringFromTwoCall(func(buf []byte) (uintptr, ErrorCode) {
+				calls++
+				if calls == 1 {
+					return 1, ErrOK
+				}
+				if len(buf) > 0 {
+					buf[0] = 0
+				}
+				return 0, ErrOK
+			})
+			if rc != ErrOK || got != "" {
+				t.Fatalf("zero-after-copy string = (%q, %d)", got, rc)
+			}
+		}
+	})
+}
+
+func TestPropertyUint64IDsFromTwoCall(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		scenario := rapid.SampledFrom([]string{"ok", "empty", "first_error", "second_error"}).Draw(t, "scenario")
+		switch scenario {
+		case "ok":
+			want := rapid.SliceOfN(rapid.Uint64(), 1, 16).Draw(t, "ids")
+			calls := 0
+			got, rc := uint64IDsFromTwoCall(func(dst []uint64) (uintptr, ErrorCode) {
+				calls++
+				if calls == 1 {
+					return uintptr(len(want)), ErrOK
+				}
+				copy(dst, want)
+				return uintptr(len(want)), ErrOK
+			})
+			if rc != ErrOK || len(got) != len(want) {
+				t.Fatalf("ids result = (%v, %d), want %v OK", got, rc, want)
+			}
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("ids[%d] = %d, want %d", i, got[i], want[i])
+				}
+			}
+		case "empty":
+			got, rc := uint64IDsFromTwoCall(func([]uint64) (uintptr, ErrorCode) { return 0, ErrOK })
+			if rc != ErrOK || got != nil {
+				t.Fatalf("empty ids = (%v, %d)", got, rc)
+			}
+		case "first_error":
+			_, rc := uint64IDsFromTwoCall(func([]uint64) (uintptr, ErrorCode) { return 0, ErrRuntimeError })
+			if rc != ErrRuntimeError {
+				t.Fatalf("first error rc = %d", rc)
+			}
+		case "second_error":
+			calls := 0
+			_, rc := uint64IDsFromTwoCall(func([]uint64) (uintptr, ErrorCode) {
+				calls++
+				if calls == 1 {
+					return 1, ErrOK
+				}
+				return 1, ErrBufferTooSmall
+			})
+			if rc != ErrBufferTooSmall {
+				t.Fatalf("second error rc = %d", rc)
+			}
+		}
+	})
+}
+
+func TestPropertyNativeFFISurfaceSweep(t *testing.T) {
+	lockThread(t)
+
+	source := `
+		(defglobal ?*threshold* = 10)
+		(deftemplate sensor (slot id (type INTEGER)) (slot value (type FLOAT)))
+		(defrule bootstrap => (assert (booted)))
+		(defrule color-seen (color ?c) => (assert (matched ?c)) (printout t ?c crlf))
+		(defrule sensor-seen (sensor (id ?id) (value ?v)) => (assert (observed ?id)))
+	`
+
+	rapid.Check(t, func(rt *rapid.T) {
+		id := rapid.Int64Range(1, 1000).Draw(rt, "id")
+		value := rapid.Float64Range(0.1, 1000.0).Draw(rt, "value")
+		format := rapid.SampledFrom(ffiFormats()).Draw(rt, "format")
+
+		cfg := MakeConfig(StringEncodingUTF8, ConflictStrategyDepth, 512)
+		if cfg == nil {
+			rt.Fatal("MakeConfig returned nil")
+		}
+		if h := EngineNew(); h == nil {
+			rt.Fatal("EngineNew returned nil")
+		} else if rc := EngineFreeUnchecked(h); rc != ErrOK {
+			rt.Fatalf("EngineFreeUnchecked returned %d", rc)
+		}
+		if h := EngineNewWithConfig(cfg); h == nil {
+			rt.Fatal("EngineNewWithConfig returned nil")
+		} else if rc := EngineFree(h); rc != ErrOK {
+			rt.Fatalf("EngineFree config handle returned %d", rc)
+		}
+		if h := EngineNewWithConfigHelper(StringEncodingASCII, ConflictStrategyBreadth, 256); h == nil {
+			rt.Fatal("EngineNewWithConfigHelper returned nil")
+		} else if rc := EngineFree(h); rc != ErrOK {
+			rt.Fatalf("EngineFree helper handle returned %d", rc)
+		}
+		if h := EngineNewWithSourceConfig(source, cfg); h == nil {
+			rt.Fatal("EngineNewWithSourceConfig returned nil")
+		} else if rc := EngineFree(h); rc != ErrOK {
+			rt.Fatalf("EngineFree source-config handle returned %d", rc)
+		}
+
+		h := EngineNewWithSource(source)
+		if h == nil {
+			rt.Fatal("EngineNewWithSource returned nil")
+		}
+		defer EngineFree(h)
+
+		if rc := EngineLoadString(h, `(defrule loaded => (assert (loaded)))`); rc != ErrOK {
+			rt.Fatalf("EngineLoadString returned %d", rc)
+		}
+		if rc := EngineReset(h); rc != ErrOK {
+			rt.Fatalf("EngineReset returned %d", rc)
+		}
+		if fired, rc := EngineStep(h); rc != ErrOK || fired == 0 {
+			rt.Fatalf("EngineStep = (%d, %d), want fired OK", fired, rc)
+		}
+
+		if factID, rc := EngineAssertString(h, "(assert (color red))"); rc != ErrOK || factID == 0 {
+			rt.Fatalf("EngineAssertString = (%d, %d), want id OK", factID, rc)
+		}
+		orderedVals := []Value{ValueInteger(id), ValueSymbol("ok")}
+		orderedID, rc := EngineAssertOrdered(h, "data", orderedVals)
+		for i := range orderedVals {
+			ValueFree(&orderedVals[i])
+		}
+		if rc != ErrOK || orderedID == 0 {
+			rt.Fatalf("EngineAssertOrdered = (%d, %d), want id OK", orderedID, rc)
+		}
+		templateVals := []Value{ValueInteger(id), ValueFloat(value)}
+		templateID, rc := EngineAssertTemplate(h, "sensor", []string{"id", "value"}, templateVals)
+		for i := range templateVals {
+			ValueFree(&templateVals[i])
+		}
+		if rc != ErrOK || templateID == 0 {
+			rt.Fatalf("EngineAssertTemplate = (%d, %d), want id OK", templateID, rc)
+		}
+
+		if count, rc := EngineFactCount(h); rc != ErrOK || count == 0 {
+			rt.Fatalf("EngineFactCount = (%d, %d), want positive OK", count, rc)
+		}
+		if ids, rc := EngineFactIDs(h); rc != ErrOK || len(ids) == 0 {
+			rt.Fatalf("EngineFactIDs = (%v, %d), want ids OK", ids, rc)
+		}
+		if ids, rc := EngineFindFactIDs(h, "data"); rc != ErrOK || len(ids) == 0 {
+			rt.Fatalf("EngineFindFactIDs = (%v, %d), want ids OK", ids, rc)
+		}
+		if factType, rc := EngineGetFactType(h, orderedID); rc != ErrOK || factType != FactTypeOrdered {
+			rt.Fatalf("EngineGetFactType ordered = (%d, %d)", factType, rc)
+		}
+		if relation, rc := EngineGetFactRelation(h, orderedID); rc != ErrOK || relation != "data" {
+			rt.Fatalf("EngineGetFactRelation = (%q, %d)", relation, rc)
+		}
+		if count, rc := EngineGetFactFieldCount(h, orderedID); rc != ErrOK || count == 0 {
+			rt.Fatalf("EngineGetFactFieldCount = (%d, %d)", count, rc)
+		}
+		if val, rc := EngineGetFactField(h, orderedID, 0); rc != ErrOK {
+			rt.Fatalf("EngineGetFactField returned %d", rc)
+		} else {
+			ValueFree(&val)
+		}
+		if factType, rc := EngineGetFactType(h, templateID); rc != ErrOK || factType != FactTypeTemplate {
+			rt.Fatalf("EngineGetFactType template = (%d, %d)", factType, rc)
+		}
+		if name, rc := EngineGetFactTemplateName(h, templateID); rc != ErrOK || name != "sensor" {
+			rt.Fatalf("EngineGetFactTemplateName = (%q, %d)", name, rc)
+		}
+		if val, rc := EngineGetFactSlotByName(h, templateID, "id"); rc != ErrOK {
+			rt.Fatalf("EngineGetFactSlotByName returned %d", rc)
+		} else {
+			ValueFree(&val)
+		}
+
+		if count, rc := EngineTemplateCount(h); rc != ErrOK || count == 0 {
+			rt.Fatalf("EngineTemplateCount = (%d, %d)", count, rc)
+		}
+		if name, rc := EngineTemplateName(h, 0); rc != ErrOK || name == "" {
+			rt.Fatalf("EngineTemplateName = (%q, %d)", name, rc)
+		}
+		if count, rc := EngineTemplateSlotCount(h, "sensor"); rc != ErrOK || count == 0 {
+			rt.Fatalf("EngineTemplateSlotCount = (%d, %d)", count, rc)
+		}
+		if name, rc := EngineTemplateSlotName(h, "sensor", 0); rc != ErrOK || name == "" {
+			rt.Fatalf("EngineTemplateSlotName = (%q, %d)", name, rc)
+		}
+		if count, rc := EngineRuleCount(h); rc != ErrOK || count == 0 {
+			rt.Fatalf("EngineRuleCount = (%d, %d)", count, rc)
+		}
+		if name, _, rc := EngineRuleInfo(h, 0); rc != ErrOK || name == "" {
+			rt.Fatalf("EngineRuleInfo = (%q, %d)", name, rc)
+		}
+		if count, rc := EngineModuleCount(h); rc != ErrOK || count == 0 {
+			rt.Fatalf("EngineModuleCount = (%d, %d)", count, rc)
+		}
+		if name, rc := EngineModuleName(h, 0); rc != ErrOK || name == "" {
+			rt.Fatalf("EngineModuleName = (%q, %d)", name, rc)
+		}
+		if name, rc := EngineCurrentModule(h); rc != ErrOK || name == "" {
+			rt.Fatalf("EngineCurrentModule = (%q, %d)", name, rc)
+		}
+		if depth, rc := EngineFocusStackDepth(h); rc != ErrOK {
+			rt.Fatalf("EngineFocusStackDepth returned %d", rc)
+		} else if depth > 0 {
+			if _, rc := EngineFocusStackEntry(h, 0); rc != ErrOK {
+				rt.Fatalf("EngineFocusStackEntry returned %d", rc)
+			}
+		}
+		if _, rc := EngineGetFocus(h); rc != ErrOK && rc != ErrNotFound {
+			rt.Fatalf("EngineGetFocus returned %d", rc)
+		}
+		if _, rc := EngineAgendaCount(h); rc != ErrOK {
+			rt.Fatalf("EngineAgendaCount returned %d", rc)
+		}
+
+		if fired, rc := EngineRun(h, 1); rc != ErrOK {
+			rt.Fatalf("EngineRun = (%d, %d)", fired, rc)
+		}
+		if fired, reason, rc := EngineRunEx(h, -1); rc != ErrOK {
+			rt.Fatalf("EngineRunEx = (%d, %d, %d)", fired, reason, rc)
+		}
+		if _, ok := EngineGetOutput(h, "t"); !ok {
+			rt.Fatal("EngineGetOutput missing stdout")
+		}
+		if rc := EngineClearOutput(h, "t"); rc != ErrOK {
+			rt.Fatalf("EngineClearOutput returned %d", rc)
+		}
+		if got, ok := EngineGetOutput(h, "missing"); ok || got != "" {
+			rt.Fatalf("EngineGetOutput missing = (%q, %v), want empty false", got, ok)
+		}
+		if rc := EnginePushInput(h, "unused"); rc != ErrOK {
+			rt.Fatalf("EnginePushInput returned %d", rc)
+		}
+		if val, rc := EngineGetGlobal(h, "threshold"); rc != ErrOK {
+			rt.Fatalf("EngineGetGlobal returned %d", rc)
+		} else {
+			ValueFree(&val)
+		}
+		if count, rc := EngineActionDiagnosticCount(h); rc != ErrOK {
+			rt.Fatalf("EngineActionDiagnosticCount returned %d", rc)
+		} else if count > 0 {
+			if _, rc := EngineActionDiagnosticCopy(h, 0); rc != ErrOK {
+				rt.Fatalf("EngineActionDiagnosticCopy returned %d", rc)
+			}
+		} else {
+			_, _ = EngineActionDiagnosticCopy(h, 0)
+		}
+		if rc := EngineClearActionDiagnostics(h); rc != ErrOK {
+			rt.Fatalf("EngineClearActionDiagnostics returned %d", rc)
+		}
+
+		data, rc := EngineSerializeAs(h, format)
+		if rc != ErrOK || len(data) == 0 {
+			rt.Fatalf("EngineSerializeAs = (%d bytes, %d), want data OK", len(data), rc)
+		}
+		if badData, rc := EngineSerializeAs(nil, format); rc == ErrOK || badData != nil {
+			rt.Fatalf("EngineSerializeAs nil = (%v, %d), want error", badData, rc)
+		}
+		if restored, rc := EngineDeserializeAs(data, format); rc != ErrOK || restored == nil {
+			rt.Fatalf("EngineDeserializeAs = (%v, %d), want handle OK", restored, rc)
+		} else if rc := EngineFree(restored); rc != ErrOK {
+			rt.Fatalf("EngineFree restored returned %d", rc)
+		}
+		if restored, rc := EngineDeserializeAs(nil, format); rc != ErrInvalidArgument || restored != nil {
+			rt.Fatalf("EngineDeserializeAs nil = (%v, %d), want invalid argument", restored, rc)
+		}
+		if restored, rc := EngineDeserializeAs([]byte("bad snapshot"), format); rc == ErrOK || restored != nil {
+			rt.Fatalf("EngineDeserializeAs invalid = (%v, %d), want error", restored, rc)
+		}
+
+		EngineHalt(h)
+		if halted, rc := EngineIsHalted(h); rc != ErrOK || !halted {
+			rt.Fatalf("EngineIsHalted = (%v, %d), want true OK", halted, rc)
+		}
+		_ = EngineLoadString(h, "(this is not valid CLIPS")
+		_ = EngineLastError(h)
+		if _, rc := EngineLastErrorCopy(h); rc != ErrOK && rc != ErrNotFound {
+			rt.Fatalf("EngineLastErrorCopy returned %d", rc)
+		}
+		if rc := EngineClearError(h); rc != ErrOK {
+			rt.Fatalf("EngineClearError returned %d", rc)
+		}
+		_ = LastErrorGlobal()
+		_ = EngineNewWithSource("(defrule bad")
+		_ = LastErrorGlobal()
+		if _, rc := LastErrorGlobalCopy(); rc != ErrOK && rc != ErrNotFound {
+			rt.Fatalf("LastErrorGlobalCopy returned %d", rc)
+		}
+		ClearErrorGlobal()
+
+		if rc := EngineRetract(h, orderedID); rc != ErrOK {
+			rt.Fatalf("EngineRetract ordered returned %d", rc)
+		}
+		if rc := EngineClear(h); rc != ErrOK {
+			rt.Fatalf("EngineClear returned %d", rc)
+		}
+
+		void := ValueVoid()
+		if got := ValueGetStringPtr(&void); got != "" {
+			rt.Fatalf("void string ptr = %q, want empty", got)
+		}
+		_ = ValueGetExternalPointer(&void)
+		emptyMulti := ValueMultifield(nil)
+		if ValueGetMultifieldLen(&emptyMulti) != 0 {
+			rt.Fatal("empty multifield length mismatch")
+		}
+		symbol := ValueSymbol("sym")
+		if ValueGetType(&symbol) != ValueTypeSymbol || ValueGetStringPtr(&symbol) != "sym" {
+			rt.Fatal("symbol accessor mismatch")
+		}
+		ValueFree(&symbol)
+		multi := ValueMultifield([]Value{ValueString("nested")})
+		if ValueGetMultifieldLen(&multi) != 1 {
+			rt.Fatal("multifield length mismatch")
+		}
+		elem := ValueGetMultifieldElement(&multi, 0)
+		if ValueGetStringPtr(&elem) != "nested" {
+			rt.Fatal("multifield element mismatch")
+		}
+		ValueFree(&multi)
+		StringFree(nil)
+		ValueArrayFree(nil, 0)
+	})
+}

--- a/bindings/go/internal/ffi/coverage_edge_test.go
+++ b/bindings/go/internal/ffi/coverage_edge_test.go
@@ -270,7 +270,7 @@ func TestManualCopyAndFreeBytesBranches(t *testing.T) {
 
 	src := []byte{1, 2, 3}
 	freed = false
-	got := copyAndFreeBytes(unsafe.Pointer(&src[0]), uintptr(len(src)), func() { freed = true })
+	got := copyAndFreeBytes(unsafe.Pointer(&src[0]), uintptr(len(src)), func() { freed = true }) //nolint:gosec // intentional &slice pointer to exercise copyAndFreeBytes' non-empty path
 	if !freed || len(got) != len(src) || got[0] != 1 || got[2] != 3 {
 		t.Fatalf("copy = (%v, freed=%v), want copied bytes freed", got, freed)
 	}
@@ -437,7 +437,7 @@ func TestPropertyCopyAndFreeBytes(t *testing.T) {
 		freed := false
 		var ptr unsafe.Pointer
 		if len(src) > 0 {
-			ptr = unsafe.Pointer(&src[0])
+			ptr = unsafe.Pointer(&src[0]) //nolint:gosec // intentional &slice pointer to exercise copyAndFreeBytes' non-empty path
 		}
 		got := copyAndFreeBytes(ptr, uintptr(len(src)), func() { freed = true })
 		if !freed {

--- a/bindings/go/internal/ffi/coverage_edge_test.go
+++ b/bindings/go/internal/ffi/coverage_edge_test.go
@@ -75,11 +75,12 @@ func TestManualValueAccessorsAndConstructors(t *testing.T) {
 	ValueFree(&emptyMultifield)
 
 	marker := 7
+	markerPtr := unsafe.Pointer(&marker) //nolint:gosec // intentional &local pointer used to round-trip an external address through the FFI accessor
 	var external Value
 	external.value_type = ValueTypeExternalAddress
-	external.external_pointer = unsafe.Pointer(&marker)
-	if got := ValueGetExternalPointer(&external); got != unsafe.Pointer(&marker) {
-		t.Fatalf("external pointer = %v, want %v", got, unsafe.Pointer(&marker))
+	external.external_pointer = markerPtr
+	if got := ValueGetExternalPointer(&external); got != markerPtr {
+		t.Fatalf("external pointer = %v, want %v", got, markerPtr)
 	}
 
 	cfg := MakeConfig(StringEncodingUTF8, ConflictStrategyLEX, 512)
@@ -130,6 +131,7 @@ func TestManualConfigConstructorsOutputDiagnosticsAndErrors(t *testing.T) {
 		t.Fatal("diagnostic engine returned nil")
 	}
 	defer EngineFree(diag)
+	//nolint:dogsled // run the engine purely to populate diagnostics; outcome is exercised separately above
 	_, _, _ = EngineRunEx(diag, -1)
 	count, rc := EngineActionDiagnosticCount(diag)
 	if rc != ErrOK {
@@ -272,7 +274,9 @@ func TestManualCopyAndFreeBytesBranches(t *testing.T) {
 	if !freed || len(got) != len(src) || got[0] != 1 || got[2] != 3 {
 		t.Fatalf("copy = (%v, freed=%v), want copied bytes freed", got, freed)
 	}
-	src[0] = 9
+	if len(src) > 0 {
+		src[0] = 9
+	}
 	if got[0] != 1 {
 		t.Fatalf("copy must be Go-owned, got mutated first byte %d", got[0])
 	}

--- a/bindings/go/internal/ffi/ffi.go
+++ b/bindings/go/internal/ffi/ffi.go
@@ -258,6 +258,13 @@ func uint64IDsFromTwoCall(query func(dst []uint64) (uintptr, ErrorCode)) ([]uint
 	if rc != ErrOK {
 		return nil, rc
 	}
+	// The query copies at most len(result) ids into the buffer. The second
+	// call normally reports the same count as the first (engine access is
+	// serialized between the two calls), but clamp defensively so a count
+	// that grew between calls truncates instead of panicking on the reslice.
+	if count > uintptr(len(result)) {
+		count = uintptr(len(result))
+	}
 	return result[:count], ErrOK
 }
 
@@ -655,6 +662,13 @@ func stringFromTwoCall(fn func(buf []byte) (uintptr, ErrorCode)) (string, ErrorC
 	needed, rc = fn(buf)
 	if rc != ErrOK {
 		return "", rc
+	}
+
+	// fn writes at most len(buf) bytes. The second call normally reports the
+	// same size as the first, but clamp defensively so a size that grew
+	// between the two calls truncates instead of panicking on buf[:needed-1].
+	if needed > uintptr(len(buf)) {
+		needed = uintptr(len(buf))
 	}
 
 	// Convert to Go string (exclude NUL terminator)

--- a/bindings/go/internal/ffi/ffi.go
+++ b/bindings/go/internal/ffi/ffi.go
@@ -209,27 +209,19 @@ func EngineFactCount(h EngineHandle) (uintptr, ErrorCode) {
 
 // EngineFactIDs retrieves all user-visible fact IDs.
 func EngineFactIDs(h EngineHandle) ([]uint64, ErrorCode) {
-	// Size query
-	var count C.uintptr_t
-	rc := ErrorCode(C.ferric_engine_fact_ids(h, nil, 0, &count))
-	if rc != ErrOK {
-		return nil, rc
-	}
-	if count == 0 {
-		return nil, ErrOK
-	}
-
-	ids := make([]C.uint64_t, count)
-	rc = ErrorCode(C.ferric_engine_fact_ids(h, &ids[0], count, &count))
-	if rc != ErrOK {
-		return nil, rc
-	}
-
-	result := make([]uint64, count)
-	for i := range count {
-		result[i] = uint64(ids[i])
-	}
-	return result, ErrOK
+	return uint64IDsFromTwoCall(func(dst []uint64) (uintptr, ErrorCode) {
+		var count C.uintptr_t
+		if dst == nil {
+			rc := ErrorCode(C.ferric_engine_fact_ids(h, nil, 0, &count))
+			return uintptr(count), rc
+		}
+		ids := make([]C.uint64_t, len(dst))
+		rc := ErrorCode(C.ferric_engine_fact_ids(h, &ids[0], C.uintptr_t(len(ids)), &count))
+		for i := uintptr(0); i < uintptr(count) && i < uintptr(len(dst)); i++ {
+			dst[i] = uint64(ids[i])
+		}
+		return uintptr(count), rc
+	})
 }
 
 // EngineFindFactIDs finds fact IDs by relation name.
@@ -237,9 +229,23 @@ func EngineFindFactIDs(h EngineHandle, relation string) ([]uint64, ErrorCode) {
 	crel := C.CString(relation)
 	defer C.free(unsafe.Pointer(crel))
 
-	// Size query
-	var count C.uintptr_t
-	rc := ErrorCode(C.ferric_engine_find_fact_ids(h, crel, nil, 0, &count))
+	return uint64IDsFromTwoCall(func(dst []uint64) (uintptr, ErrorCode) {
+		var count C.uintptr_t
+		if dst == nil {
+			rc := ErrorCode(C.ferric_engine_find_fact_ids(h, crel, nil, 0, &count))
+			return uintptr(count), rc
+		}
+		ids := make([]C.uint64_t, len(dst))
+		rc := ErrorCode(C.ferric_engine_find_fact_ids(h, crel, &ids[0], C.uintptr_t(len(ids)), &count))
+		for i := uintptr(0); i < uintptr(count) && i < uintptr(len(dst)); i++ {
+			dst[i] = uint64(ids[i])
+		}
+		return uintptr(count), rc
+	})
+}
+
+func uint64IDsFromTwoCall(query func(dst []uint64) (uintptr, ErrorCode)) ([]uint64, ErrorCode) {
+	count, rc := query(nil)
 	if rc != ErrOK {
 		return nil, rc
 	}
@@ -247,17 +253,12 @@ func EngineFindFactIDs(h EngineHandle, relation string) ([]uint64, ErrorCode) {
 		return nil, ErrOK
 	}
 
-	ids := make([]C.uint64_t, count)
-	rc = ErrorCode(C.ferric_engine_find_fact_ids(h, crel, &ids[0], count, &count))
+	result := make([]uint64, count)
+	count, rc = query(result)
 	if rc != ErrOK {
 		return nil, rc
 	}
-
-	result := make([]uint64, count)
-	for i := range count {
-		result[i] = uint64(ids[i])
-	}
-	return result, ErrOK
+	return result[:count], ErrOK
 }
 
 // EngineGetFactType returns the type (ordered vs template) of a fact.
@@ -629,9 +630,19 @@ func getString(fn func(buf *C.char, bufLen C.uintptr_t, outLen *C.uintptr_t) Err
 // Separated from getString to allow callers that need to capture extra
 // out-params from the same FFI call (e.g., EngineRuleInfo captures salience).
 func getStringWith(fn func(buf *C.char, bufLen C.uintptr_t, outLen *C.uintptr_t) ErrorCode) (string, ErrorCode) {
-	// Size query
-	var needed C.uintptr_t
-	rc := fn(nil, 0, &needed)
+	return stringFromTwoCall(func(buf []byte) (uintptr, ErrorCode) {
+		var needed C.uintptr_t
+		var ptr *C.char
+		if len(buf) > 0 {
+			ptr = (*C.char)(unsafe.Pointer(&buf[0]))
+		}
+		rc := fn(ptr, C.uintptr_t(len(buf)), &needed)
+		return uintptr(needed), rc
+	})
+}
+
+func stringFromTwoCall(fn func(buf []byte) (uintptr, ErrorCode)) (string, ErrorCode) {
+	needed, rc := fn(nil)
 	if rc != ErrOK {
 		return "", rc
 	}
@@ -641,7 +652,7 @@ func getStringWith(fn func(buf *C.char, bufLen C.uintptr_t, outLen *C.uintptr_t)
 
 	// Allocate and copy
 	buf := make([]byte, needed)
-	rc = fn((*C.char)(unsafe.Pointer(&buf[0])), C.uintptr_t(needed), &needed)
+	needed, rc = fn(buf)
 	if rc != ErrOK {
 		return "", rc
 	}

--- a/bindings/go/internal/ffi/serialization.go
+++ b/bindings/go/internal/ffi/serialization.go
@@ -20,18 +20,17 @@ func EngineSerializeAs(h EngineHandle, format SerializationFormat) ([]byte, Erro
 		return nil, rc
 	}
 
-	if length == 0 {
+	return copyAndFreeBytes(unsafe.Pointer(data), uintptr(length), func() {
 		C.ferric_bytes_free(data, length)
-		return nil, ErrOK
+	}), ErrOK
+}
+
+func copyAndFreeBytes(data unsafe.Pointer, length uintptr, free func()) []byte {
+	defer free()
+	if length == 0 {
+		return nil
 	}
-
-	// Copy the Rust-owned bytes into Go-managed memory.
-	goBytes := C.GoBytes(unsafe.Pointer(data), C.int(length))
-
-	// Free the Rust-allocated buffer.
-	C.ferric_bytes_free(data, length)
-
-	return goBytes, ErrOK
+	return C.GoBytes(data, C.int(length))
 }
 
 // EngineDeserializeAs creates an engine from previously serialized bytes

--- a/bindings/go/iterators.go
+++ b/bindings/go/iterators.go
@@ -10,7 +10,7 @@ import (
 // Each iteration yields a Fact snapshot. Stops early on error.
 func (e *Engine) FactIter() iter.Seq[Fact] {
 	return func(yield func(Fact) bool) {
-		ids, rc := ffi.EngineFactIDs(e.handle)
+		ids, rc := ffiEngineFactIDs(e.handle)
 		if rc != ffi.ErrOK {
 			return
 		}
@@ -29,12 +29,12 @@ func (e *Engine) FactIter() iter.Seq[Fact] {
 // RuleIter returns an iterator over all registered rules.
 func (e *Engine) RuleIter() iter.Seq[RuleInfo] {
 	return func(yield func(RuleInfo) bool) {
-		count, rc := ffi.EngineRuleCount(e.handle)
+		count, rc := ffiEngineRuleCount(e.handle)
 		if rc != ffi.ErrOK {
 			return
 		}
 		for i := range count {
-			name, salience, rc := ffi.EngineRuleInfo(e.handle, i)
+			name, salience, rc := ffiEngineRuleInfo(e.handle, i)
 			if rc != ffi.ErrOK {
 				return
 			}
@@ -48,12 +48,12 @@ func (e *Engine) RuleIter() iter.Seq[RuleInfo] {
 // TemplateIter returns an iterator over all registered template names.
 func (e *Engine) TemplateIter() iter.Seq[string] {
 	return func(yield func(string) bool) {
-		count, rc := ffi.EngineTemplateCount(e.handle)
+		count, rc := ffiEngineTemplateCount(e.handle)
 		if rc != ffi.ErrOK {
 			return
 		}
 		for i := range count {
-			name, rc := ffi.EngineTemplateName(e.handle, i)
+			name, rc := ffiEngineTemplateName(e.handle, i)
 			if rc != ffi.ErrOK {
 				return
 			}
@@ -67,12 +67,12 @@ func (e *Engine) TemplateIter() iter.Seq[string] {
 // DiagnosticIter returns an iterator over action diagnostic messages.
 func (e *Engine) DiagnosticIter() iter.Seq[string] {
 	return func(yield func(string) bool) {
-		count, rc := ffi.EngineActionDiagnosticCount(e.handle)
+		count, rc := ffiEngineActionDiagnosticCount(e.handle)
 		if rc != ffi.ErrOK {
 			return
 		}
 		for i := range count {
-			msg, rc := ffi.EngineActionDiagnosticCopy(e.handle, i)
+			msg, rc := ffiEngineActionDiagnosticCopy(e.handle, i)
 			if rc != ffi.ErrOK {
 				return
 			}
@@ -92,7 +92,7 @@ func (e *Engine) DiagnosticIter() iter.Seq[string] {
 // a final (Fact{}, err) is yielded and iteration stops.
 func (e *Engine) FactIterE() iter.Seq2[Fact, error] {
 	return func(yield func(Fact, error) bool) {
-		ids, rc := ffi.EngineFactIDs(e.handle)
+		ids, rc := ffiEngineFactIDs(e.handle)
 		if rc != ffi.ErrOK {
 			yield(Fact{}, errorFromFFI(rc, e.handle))
 			return
@@ -115,13 +115,13 @@ func (e *Engine) FactIterE() iter.Seq2[Fact, error] {
 // a final (RuleInfo{}, err) is yielded and iteration stops.
 func (e *Engine) RuleIterE() iter.Seq2[RuleInfo, error] {
 	return func(yield func(RuleInfo, error) bool) {
-		count, rc := ffi.EngineRuleCount(e.handle)
+		count, rc := ffiEngineRuleCount(e.handle)
 		if rc != ffi.ErrOK {
 			yield(RuleInfo{}, errorFromFFI(rc, e.handle))
 			return
 		}
 		for i := range count {
-			name, salience, rc := ffi.EngineRuleInfo(e.handle, i)
+			name, salience, rc := ffiEngineRuleInfo(e.handle, i)
 			if rc != ffi.ErrOK {
 				yield(RuleInfo{}, errorFromFFI(rc, e.handle))
 				return
@@ -138,13 +138,13 @@ func (e *Engine) RuleIterE() iter.Seq2[RuleInfo, error] {
 // error occurs, a final ("", err) is yielded and iteration stops.
 func (e *Engine) TemplateIterE() iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
-		count, rc := ffi.EngineTemplateCount(e.handle)
+		count, rc := ffiEngineTemplateCount(e.handle)
 		if rc != ffi.ErrOK {
 			yield("", errorFromFFI(rc, e.handle))
 			return
 		}
 		for i := range count {
-			name, rc := ffi.EngineTemplateName(e.handle, i)
+			name, rc := ffiEngineTemplateName(e.handle, i)
 			if rc != ffi.ErrOK {
 				yield("", errorFromFFI(rc, e.handle))
 				return
@@ -161,13 +161,13 @@ func (e *Engine) TemplateIterE() iter.Seq2[string, error] {
 // occurs, a final ("", err) is yielded and iteration stops.
 func (e *Engine) DiagnosticIterE() iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
-		count, rc := ffi.EngineActionDiagnosticCount(e.handle)
+		count, rc := ffiEngineActionDiagnosticCount(e.handle)
 		if rc != ffi.ErrOK {
 			yield("", errorFromFFI(rc, e.handle))
 			return
 		}
 		for i := range count {
-			msg, rc := ffi.EngineActionDiagnosticCopy(e.handle, i)
+			msg, rc := ffiEngineActionDiagnosticCopy(e.handle, i)
 			if rc != ffi.ErrOK {
 				yield("", errorFromFFI(rc, e.handle))
 				return

--- a/bindings/go/manager.go
+++ b/bindings/go/manager.go
@@ -347,9 +347,13 @@ type StandaloneManager struct {
 // NewManager creates a standalone Manager backed by a single dedicated thread.
 // For multiple engine types or higher concurrency, use NewCoordinator.
 func NewManager(opts ...EngineOption) (*StandaloneManager, error) {
-	coord, _ := NewCoordinator(
+	coord, err := NewCoordinator(
 		[]EngineSpec{{Name: "_default", Options: opts}},
 	)
+	if err != nil {
+		return nil, err
+	}
+	// "_default" was just registered above, so Manager cannot fail here.
 	mgr, _ := coord.Manager("_default")
 	return &StandaloneManager{coord: coord, Manager: mgr}, nil
 }

--- a/bindings/go/manager.go
+++ b/bindings/go/manager.go
@@ -61,8 +61,6 @@ func (m *Manager) tryEnqueue(ctx context.Context, w *worker, req workerRequest) 
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("ferric: request canceled before dispatch: %w", ctx.Err())
-	case <-m.coord.done:
-		return errCoordinatorClosed
 	case w.requests <- req:
 		return nil
 	}
@@ -71,6 +69,7 @@ func (m *Manager) tryEnqueue(ctx context.Context, w *worker, req workerRequest) 
 // Do dispatches a function to an engine of this Manager's type.
 // The function runs on a thread-locked worker goroutine. The Engine
 // must not be retained beyond the closure's return.
+//
 //nolint:nonamedreturns // named return needed for deferred observability recording.
 func (m *Manager) Do(ctx context.Context, fn func(*Engine) error) (retErr error) {
 	if ctx == nil {
@@ -219,7 +218,7 @@ func buildEvaluateResult(e *Engine, runResult *RunResult) (*EvaluateResult, erro
 	if err != nil {
 		return nil, err
 	}
-	wireFacts, err := FactsToWire(nativeFacts)
+	wireFacts, err := factsToWire(nativeFacts)
 	if err != nil {
 		return nil, err
 	}
@@ -348,12 +347,9 @@ type StandaloneManager struct {
 // NewManager creates a standalone Manager backed by a single dedicated thread.
 // For multiple engine types or higher concurrency, use NewCoordinator.
 func NewManager(opts ...EngineOption) (*StandaloneManager, error) {
-	coord, err := NewCoordinator(
+	coord, _ := NewCoordinator(
 		[]EngineSpec{{Name: "_default", Options: opts}},
 	)
-	if err != nil {
-		return nil, err
-	}
 	mgr, _ := coord.Manager("_default")
 	return &StandaloneManager{coord: coord, Manager: mgr}, nil
 }

--- a/bindings/go/pinned_engine.go
+++ b/bindings/go/pinned_engine.go
@@ -130,8 +130,6 @@ func (p *PinnedEngine) tryEnqueue(ctx context.Context, req pinnedRequest) error 
 	select {
 	case <-ctx.Done():
 		return fmt.Errorf("ferric: request canceled before dispatch: %w", ctx.Err())
-	case <-p.done:
-		return errPinnedEngineClosed
 	case p.requests <- req:
 		return nil
 	}

--- a/bindings/go/temporal/activity.go
+++ b/bindings/go/temporal/activity.go
@@ -5,7 +5,6 @@ package temporal
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	ferric "github.com/prb/ferric-rules/bindings/go"
@@ -29,13 +28,7 @@ func NewRulesActivity(specs []ferric.EngineSpec, opts ...ferric.CoordinatorOptio
 	}
 	managers := make(map[string]*ferric.Manager, len(specs))
 	for _, s := range specs {
-		mgr, err := coord.Manager(s.Name)
-		if err != nil {
-			if closeErr := coord.Close(); closeErr != nil {
-				return nil, fmt.Errorf("temporal: getting manager for %q: %w", s.Name, errors.Join(err, closeErr))
-			}
-			return nil, fmt.Errorf("temporal: getting manager for %q: %w", s.Name, err)
-		}
+		mgr, _ := coord.Manager(s.Name)
 		managers[s.Name] = mgr
 	}
 	return &RulesActivity{coord: coord, managers: managers}, nil
@@ -57,8 +50,5 @@ func (a *RulesActivity) Register(w worker.Worker) {
 
 // Close shuts down the Coordinator. Call from worker shutdown hook.
 func (a *RulesActivity) Close() error {
-	if err := a.coord.Close(); err != nil {
-		return fmt.Errorf("temporal: closing coordinator: %w", err)
-	}
-	return nil
+	return a.coord.Close()
 }

--- a/bindings/go/temporal/activity.go
+++ b/bindings/go/temporal/activity.go
@@ -5,6 +5,7 @@ package temporal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	ferric "github.com/prb/ferric-rules/bindings/go"
@@ -28,7 +29,13 @@ func NewRulesActivity(specs []ferric.EngineSpec, opts ...ferric.CoordinatorOptio
 	}
 	managers := make(map[string]*ferric.Manager, len(specs))
 	for _, s := range specs {
-		mgr, _ := coord.Manager(s.Name)
+		mgr, err := coord.Manager(s.Name)
+		if err != nil {
+			if closeErr := coord.Close(); closeErr != nil {
+				return nil, fmt.Errorf("temporal: getting manager for %q: %w", s.Name, errors.Join(err, closeErr))
+			}
+			return nil, fmt.Errorf("temporal: getting manager for %q: %w", s.Name, err)
+		}
 		managers[s.Name] = mgr
 	}
 	return &RulesActivity{coord: coord, managers: managers}, nil

--- a/bindings/go/temporal/activity.go
+++ b/bindings/go/temporal/activity.go
@@ -50,5 +50,8 @@ func (a *RulesActivity) Register(w worker.Worker) {
 
 // Close shuts down the Coordinator. Call from worker shutdown hook.
 func (a *RulesActivity) Close() error {
-	return a.coord.Close()
+	if err := a.coord.Close(); err != nil {
+		return fmt.Errorf("temporal: closing coordinator: %w", err)
+	}
+	return nil
 }

--- a/bindings/go/temporal/coverage_edge_test.go
+++ b/bindings/go/temporal/coverage_edge_test.go
@@ -1,0 +1,105 @@
+package temporal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	ferric "github.com/prb/ferric-rules/bindings/go"
+	"pgregory.net/rapid"
+)
+
+func TestManualRulesActivityErrorOptionsAndRegisteredClosure(t *testing.T) {
+	// Invalid coordinator options must surface through the Temporal constructor
+	// so a worker fails during setup instead of registering broken activities.
+	if _, err := NewRulesActivity(nil, ferric.Threads(0)); err == nil {
+		t.Fatal("expected invalid thread count error")
+	}
+
+	// ActivityOption currently stores pass-through coordinator options. Testing
+	// it directly documents the option contract even though construction accepts
+	// coordinator options for compatibility.
+	var cfg activityConfig
+	WithCoordinatorOptions(ferric.Threads(2), ferric.Threads(3))(&cfg)
+	if len(cfg.coordinatorOpts) != 2 {
+		t.Fatalf("coordinator option count = %d, want 2", len(cfg.coordinatorOpts))
+	}
+
+	ra, err := NewRulesActivity(
+		[]ferric.EngineSpec{
+			{Name: "risk", Options: []ferric.EngineOption{
+				ferric.WithSource(`(defrule r => (printout t "ok" crlf))`),
+			}},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, ra)
+
+	spy := &spyWorker{}
+	ra.Register(spy)
+	if len(spy.activities) != 1 {
+		t.Fatalf("registered activity count = %d, want 1", len(spy.activities))
+	}
+	fn, ok := spy.activities[0].fn.(func(context.Context, *ferric.EvaluateRequest) (*ferric.EvaluateResult, error))
+	if !ok {
+		t.Fatalf("registered function has unexpected type %T", spy.activities[0].fn)
+	}
+	result, err := fn(context.Background(), &ferric.EvaluateRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RulesFired != 1 || result.Output["stdout"] != "ok\n" {
+		t.Fatalf("activity result = %+v", result)
+	}
+}
+
+func TestPropertyRulesActivityRegistersGeneratedSpecs(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		count := rapid.IntRange(1, 4).Draw(t, "count")
+		threads := rapid.IntRange(1, 3).Draw(t, "threads")
+		var cfg activityConfig
+		WithCoordinatorOptions(ferric.Threads(threads))(&cfg)
+		if len(cfg.coordinatorOpts) != 1 {
+			t.Fatalf("coordinator option count = %d, want 1", len(cfg.coordinatorOpts))
+		}
+		if _, err := NewRulesActivity(nil, ferric.Threads(0)); err == nil {
+			t.Fatal("invalid coordinator option should fail construction")
+		}
+
+		specs := make([]ferric.EngineSpec, count)
+		for i := range specs {
+			specs[i] = ferric.EngineSpec{
+				Name: fmt.Sprintf("spec_%d", i),
+				Options: []ferric.EngineOption{
+					ferric.WithSource(`(defrule r => (assert (ok)))`),
+				},
+			}
+		}
+
+		ra, err := NewRulesActivity(specs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := ra.Close(); err != nil && !errors.Is(err, context.Canceled) {
+				t.Fatalf("close failed: %v", err)
+			}
+		}()
+
+		spy := &spyWorker{}
+		ra.Register(spy)
+		if len(spy.activities) != count {
+			t.Fatalf("registered %d activities, want %d", len(spy.activities), count)
+		}
+		fn, ok := spy.activities[0].fn.(func(context.Context, *ferric.EvaluateRequest) (*ferric.EvaluateResult, error))
+		if !ok {
+			t.Fatalf("registered function has unexpected type %T", spy.activities[0].fn)
+		}
+		if _, err := fn(context.Background(), &ferric.EvaluateRequest{}); err != nil {
+			t.Fatalf("registered function failed: %v", err)
+		}
+	})
+}

--- a/bindings/go/temporal/coverage_edge_test.go
+++ b/bindings/go/temporal/coverage_edge_test.go
@@ -2,12 +2,9 @@ package temporal
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"testing"
 
 	ferric "github.com/prb/ferric-rules/bindings/go"
-	"pgregory.net/rapid"
 )
 
 func TestManualRulesActivityErrorOptionsAndRegisteredClosure(t *testing.T) {
@@ -56,50 +53,44 @@ func TestManualRulesActivityErrorOptionsAndRegisteredClosure(t *testing.T) {
 	}
 }
 
-func TestPropertyRulesActivityRegistersGeneratedSpecs(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		count := rapid.IntRange(1, 4).Draw(t, "count")
-		threads := rapid.IntRange(1, 3).Draw(t, "threads")
-		var cfg activityConfig
-		WithCoordinatorOptions(ferric.Threads(threads))(&cfg)
-		if len(cfg.coordinatorOpts) != 1 {
-			t.Fatalf("coordinator option count = %d, want 1", len(cfg.coordinatorOpts))
-		}
-		if _, err := NewRulesActivity(nil, ferric.Threads(0)); err == nil {
-			t.Fatal("invalid coordinator option should fail construction")
-		}
+// TestManualRulesActivityRoutesEachSpecToOwnManager verifies that Register
+// builds a distinct closure per spec, each routed to that spec's own engine.
+// Existing tests (TestRegisterMultipleSpecs) only check activity names/count; a
+// regression that captured the same manager for every closure — or routed to
+// the wrong one — would pass those but fail here. Each spec prints a unique
+// token so the invoked closure's output identifies which engine actually ran.
+func TestManualRulesActivityRoutesEachSpecToOwnManager(t *testing.T) {
+	specs := []ferric.EngineSpec{
+		{Name: "alpha", Options: []ferric.EngineOption{ferric.WithSource(`(defrule a => (printout t "alpha" crlf))`)}},
+		{Name: "beta", Options: []ferric.EngineOption{ferric.WithSource(`(defrule b => (printout t "beta" crlf))`)}},
+	}
+	ra, err := NewRulesActivity(specs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, ra)
 
-		specs := make([]ferric.EngineSpec, count)
-		for i := range specs {
-			specs[i] = ferric.EngineSpec{
-				Name: fmt.Sprintf("spec_%d", i),
-				Options: []ferric.EngineOption{
-					ferric.WithSource(`(defrule r => (assert (ok)))`),
-				},
-			}
-		}
+	spy := &spyWorker{}
+	ra.Register(spy)
+	if len(spy.activities) != len(specs) {
+		t.Fatalf("registered %d activities, want %d", len(spy.activities), len(specs))
+	}
 
-		ra, err := NewRulesActivity(specs)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer func() {
-			if err := ra.Close(); err != nil && !errors.Is(err, context.Canceled) {
-				t.Fatalf("close failed: %v", err)
-			}
-		}()
-
-		spy := &spyWorker{}
-		ra.Register(spy)
-		if len(spy.activities) != count {
-			t.Fatalf("registered %d activities, want %d", len(spy.activities), count)
-		}
-		fn, ok := spy.activities[0].fn.(func(context.Context, *ferric.EvaluateRequest) (*ferric.EvaluateResult, error))
+	want := map[string]string{
+		"ferric.Evaluate.alpha": "alpha\n",
+		"ferric.Evaluate.beta":  "beta\n",
+	}
+	for _, a := range spy.activities {
+		fn, ok := a.fn.(func(context.Context, *ferric.EvaluateRequest) (*ferric.EvaluateResult, error))
 		if !ok {
-			t.Fatalf("registered function has unexpected type %T", spy.activities[0].fn)
+			t.Fatalf("activity %q has unexpected fn type %T", a.opts.Name, a.fn)
 		}
-		if _, err := fn(context.Background(), &ferric.EvaluateRequest{}); err != nil {
-			t.Fatalf("registered function failed: %v", err)
+		result, err := fn(context.Background(), &ferric.EvaluateRequest{})
+		if err != nil {
+			t.Fatalf("activity %q failed: %v", a.opts.Name, err)
 		}
-	})
+		if got := result.Output["stdout"]; got != want[a.opts.Name] {
+			t.Fatalf("activity %q stdout = %q, want %q", a.opts.Name, got, want[a.opts.Name])
+		}
+	}
 }

--- a/bindings/go/values.go
+++ b/bindings/go/values.go
@@ -45,8 +45,11 @@ func goToFFIValue(v any) (ffi.Value, error) {
 		for i, elem := range val {
 			ev, err := goToFFIValue(elem)
 			if err != nil {
+				// Free the elements converted before this failure. Goes through
+				// the ffiValueFree seam (as AssertFact/AssertTemplate do) so the
+				// cleanup is observable in tests.
 				for j := range i {
-					ffi.ValueFree(&elements[j])
+					ffiValueFree(&elements[j])
 				}
 				return ffi.Value{}, err
 			}

--- a/justfile
+++ b/justfile
@@ -336,7 +336,10 @@ test-go-stress count="10":
     cd bindings/go && go test -race -count={{count}} -v ./...
 
 # Version of golangci-lint to install when not already present.
-golangci_lint_version := "v2.8.0"
+# v2.12.x is the first line that runs under the Go 1.26 toolchain; v2.8.0
+# panics when loading 1.26 export data (CI itself runs Go 1.25, so it was
+# unaffected, but local 1.26 developers hit the crash on auto-install).
+golangci_lint_version := "v2.12.2"
 
 # Runs the golang-ci linter suite (auto-installs to ./bin/ if needed).
 run-golang-ci:


### PR DESCRIPTION
## Summary

- Adds ~2900 lines of coverage edge tests across three new files (`bindings/go/coverage_edge_test.go`, `bindings/go/internal/ffi/coverage_edge_test.go`, `bindings/go/temporal/coverage_edge_test.go`) exercising nil-context paths, iterator early breaks, hooked FFI fallbacks, build-fact error branches, cancellation/halt-reason flows, and serialization wrappers.
- Introduces `bindings/go/ffi_hooks.go`, a set of package-level swappable FFI function variables that let tests deterministically simulate native edge cases without invoking real CGO calls; `engine.go` and `iterators.go` are rewired to call through these hooks.
- Extracts shared FFI helpers (`uint64IDsFromTwoCall`, `stringFromTwoCall`, `copyAndFreeBytes`) and engine helpers (`buildFacts`, `finalizeEngine`) to reduce duplication between the size-query/payload-copy code paths.
- Simplifies `Manager` and `PinnedEngine` dispatch by dropping unreachable `select` branches and trims redundant error wrapping in `temporal/activity.go`.

## Test plan

- [x] `just test-go` (all Go binding tests pass, including the new coverage suites)
- [ ] CI Go Lint (v2.8.0) — verify on PR; cannot reproduce locally due to Go 1.25 vs 1.26 toolchain mismatch