### PR TITLE
test: cover selector gate after blockers close

### DIFF
--- a/.selector-smoke/issue-230.txt
+++ b/.selector-smoke/issue-230.txt
@@ -1,0 +1,1 @@
+Temporary unmerged file used only to validate aggregate-gate closing-reference behavior.


### PR DESCRIPTION
Temporary unmerged selector smoke test. The gate blockers are now closed, so this closing relationship should validly cover the gate.

Closes #230

It will be closed without merge after validation.