### PR TITLE
Retry transient CLIPS image builds in CI

### DIFF
--- a/.github/workflows/compat-compare.yml
+++ b/.github/workflows/compat-compare.yml
@@ -52,7 +52,22 @@ jobs:
       - uses: astral-sh/setup-uv@v5
 
       - name: Build CLIPS reference image
-        run: docker build -t ferric-rules/clips-reference:latest docker/clips-reference/
+        timeout-minutes: 10
+        run: |
+          for attempt in 1 2 3; do
+            if docker build -t ferric-rules/clips-reference:latest docker/clips-reference/; then
+              exit 0
+            fi
+
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "::error::Docker build failed after ${attempt} attempts"
+              exit 1
+            fi
+
+            retry_delay=$((attempt * 10))
+            echo "::warning::Docker build attempt ${attempt} failed; retrying in ${retry_delay} seconds"
+            sleep "$retry_delay"
+          done
 
       # ── Base branch assessment ─────────────────────────────────────────
       - name: Assess base branch

--- a/.github/workflows/compat-standalone.yml
+++ b/.github/workflows/compat-standalone.yml
@@ -34,7 +34,22 @@ jobs:
       - uses: astral-sh/setup-uv@v5
 
       - name: Build CLIPS reference image
-        run: docker build -t ferric-rules/clips-reference:latest docker/clips-reference/
+        timeout-minutes: 10
+        run: |
+          for attempt in 1 2 3; do
+            if docker build -t ferric-rules/clips-reference:latest docker/clips-reference/; then
+              exit 0
+            fi
+
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "::error::Docker build failed after ${attempt} attempts"
+              exit 1
+            fi
+
+            retry_delay=$((attempt * 10))
+            echo "::warning::Docker build attempt ${attempt} failed; retrying in ${retry_delay} seconds"
+            sleep "$retry_delay"
+          done
 
       - name: Build ferric
         run: cargo build --release -p ferric-cli


### PR DESCRIPTION
## Summary

- Retry CLIPS reference Docker builds up to three times with 10- and 20-second backoff in both comparison and standalone compatibility workflows.
- Cap each build step at 10 minutes and emit GitHub warnings or errors when retries occur or are exhausted.

This hardens CI against transient Docker Hub TCP timeouts like the one observed on PR #226, which occurred before any project code ran.

Validation: `actionlint`, mocked retry-success and retry-exhaustion paths, and `just preflight-pr`.