### PR TITLE
Validate caller-provided FFI discriminants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,19 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - run: ./scripts/preflight.sh test
 
+  ffi-c-harness:
+    name: FFI C Harness (ASan/UBSan)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@just
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - run: just ffi-c-harness
+        env:
+          FERRIC_REQUIRE_SANITIZERS: "1"
+
   go-lint:
     name: Go Lint
     runs-on: ubuntu-latest

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -1627,7 +1627,7 @@ enum FerricError ferric_value_array_free(struct FerricValue *arr FERRIC_COUNTED_
  * at compile time for every consumer of this header.
  */
 
-#if defined(__cplusplus)
+#if defined(__cplusplus) && __cplusplus >= 201103L
   #define FERRIC_STATIC_ASSERT(COND, MSG) static_assert(COND, MSG)
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
   #define FERRIC_STATIC_ASSERT(COND, MSG) _Static_assert(COND, MSG)

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -190,17 +190,6 @@ typedef enum FerricError {
     FERRIC_ERROR_INTERNAL_ERROR = 99,
 } FerricError;
 
-// C-facing value type discriminant.
-typedef enum FerricValueType {
-    FERRIC_VALUE_TYPE_VOID = 0,
-    FERRIC_VALUE_TYPE_INTEGER = 1,
-    FERRIC_VALUE_TYPE_FLOAT = 2,
-    FERRIC_VALUE_TYPE_SYMBOL = 3,
-    FERRIC_VALUE_TYPE_STRING = 4,
-    FERRIC_VALUE_TYPE_MULTIFIELD = 5,
-    FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS = 6,
-} FerricValueType;
-
 // C-facing fact type discriminant.
 typedef enum FerricFactType {
     FERRIC_FACT_TYPE_ORDERED = 0,
@@ -228,6 +217,25 @@ typedef enum FerricConflictStrategy {
     FERRIC_CONFLICT_STRATEGY_LEX = 2,
     FERRIC_CONFLICT_STRATEGY_MEA = 3,
 } FerricConflictStrategy;
+
+// C-facing value type discriminant.
+//
+// Crosses the ABI as a raw `u32` (`FerricValue::value_type`), never as this
+// Rust enum: caller-populated memory is validated with [`Self::from_raw`] /
+// `TryFrom<u32>` before being interpreted, and unknown discriminants are
+// rejected with `FERRIC_ERROR_INVALID_ARGUMENT`.
+//
+// Stable numeric values — new variants may be added but existing values
+// must never change.
+typedef enum FerricValueType {
+    FERRIC_VALUE_TYPE_VOID = 0,
+    FERRIC_VALUE_TYPE_INTEGER = 1,
+    FERRIC_VALUE_TYPE_FLOAT = 2,
+    FERRIC_VALUE_TYPE_SYMBOL = 3,
+    FERRIC_VALUE_TYPE_STRING = 4,
+    FERRIC_VALUE_TYPE_MULTIFIELD = 5,
+    FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS = 6,
+} FerricValueType;
 
 #if defined(FERRIC_SERDE)
 // Serialization format selector for `ferric_engine_serialize_as` and
@@ -302,7 +310,13 @@ typedef struct FerricConfig {
 // | Multifield | `multifield_ptr` (owned), `multifield_len` |
 // | ExternalAddress | `external_type_id`, `external_pointer` |
 typedef struct FerricValue {
-    enum FerricValueType value_type;
+    // Raw `FerricValueType` discriminant.
+    //
+    // Every API that reads a caller-populated `FerricValue` validates this
+    // field before interpreting it; values outside the documented
+    // `FerricValueType` range are rejected with
+    // `FERRIC_ERROR_INVALID_ARGUMENT`.
+    uint32_t value_type;
     int64_t integer;
     double float_;
     char * FERRIC_NULL_TERMINATED string_ptr;
@@ -1565,24 +1579,172 @@ void ferric_string_free(char * FERRIC_NULL_TERMINATED ptr);
 
 // Free a `FerricValue` and its owned resources.
 //
-// Recursively frees owned strings and multifield arrays.
-// Null pointers are safely ignored.
+// Recursively frees owned strings and multifield arrays. Null pointers are
+// safely ignored and return `FERRIC_ERROR_OK`.
+//
+// If the value (or any nested multifield element) carries an unknown
+// `value_type` discriminant, returns `FERRIC_ERROR_INVALID_ARGUMENT` and
+// records a diagnostic in the global error channel. The unknown-tagged
+// value's payload fields are never interpreted (nothing of it is freed),
+// but all sibling values with known discriminants and every owned
+// containing multifield array are still released.
 //
 // # Safety
 //
 // - `value` must point to a valid `FerricValue` or be null.
 // - Any owned resources (`string_ptr`, `multifield_ptr`) must not have been freed already.
-void ferric_value_free(struct FerricValue *value);
+enum FerricError ferric_value_free(struct FerricValue *value);
 
 // Free an array of `FerricValue`s and all their owned resources.
 //
 // Frees each element's owned resources, then frees the array allocation.
-// Null pointers are safely ignored.
+// Null pointers are safely ignored and return `FERRIC_ERROR_OK`.
+//
+// If any element (or any nested multifield element) carries an unknown
+// `value_type` discriminant, returns `FERRIC_ERROR_INVALID_ARGUMENT` and
+// records a diagnostic in the global error channel. Unknown-tagged
+// elements' payload fields are never interpreted (nothing of them is
+// freed), but all elements with known discriminants and the array
+// allocation itself are still released.
 //
 // # Safety
 //
 // - `arr` must point to a contiguous array of `len` `FerricValue`s, or be null.
 // - The array must have been allocated by the FFI.
-void ferric_value_array_free(struct FerricValue *arr FERRIC_COUNTED_BY(len), uintptr_t len);
+enum FerricError ferric_value_array_free(struct FerricValue *arr FERRIC_COUNTED_BY(len), uintptr_t len);
+
+
+/*
+ * ============================================================
+ * ABI STATIC ASSERTIONS
+ * ============================================================
+ *
+ * Caller-populated discriminants cross this ABI as fixed-width
+ * 32-bit integers (never as C enum objects), and every accepting
+ * API validates them before interpretation: unknown values are
+ * rejected with FERRIC_ERROR_INVALID_ARGUMENT. The assertions
+ * below lock the field widths and the documented numeric values
+ * at compile time for every consumer of this header.
+ */
+
+#if defined(__cplusplus)
+  #define FERRIC_STATIC_ASSERT(COND, MSG) static_assert(COND, MSG)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+  #define FERRIC_STATIC_ASSERT(COND, MSG) _Static_assert(COND, MSG)
+#else
+  #define FERRIC_STATIC_ASSERT_CAT2(A, B) A##B
+  #define FERRIC_STATIC_ASSERT_CAT(A, B) FERRIC_STATIC_ASSERT_CAT2(A, B)
+  #define FERRIC_STATIC_ASSERT(COND, MSG) \
+      typedef char FERRIC_STATIC_ASSERT_CAT(ferric_static_assert_, __LINE__)[(COND) ? 1 : -1]
+#endif
+
+/* Discriminant field widths (all fixed at 32 bits). */
+FERRIC_STATIC_ASSERT(sizeof(((FerricValue *)0)->value_type) == 4,
+                     "FerricValue.value_type must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricValue *)0)->external_type_id) == 4,
+                     "FerricValue.external_type_id must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricConfig *)0)->string_encoding) == 4,
+                     "FerricConfig.string_encoding must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricConfig *)0)->strategy) == 4,
+                     "FerricConfig.strategy must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricPinnedEngineOptions *)0)->autorelease_policy) == 4,
+                     "FerricPinnedEngineOptions.autorelease_policy must be a 32-bit integer");
+
+/* C enum object widths for every enum crossing the ABI (as return values
+ * or out-parameters). Rust emits these as 32-bit values; a consumer
+ * compiled with -fshort-enums (or an equivalent packed-enum ABI) fails
+ * these assertions instead of silently miscompiling. */
+FERRIC_STATIC_ASSERT(sizeof(enum FerricError) == 4, "enum FerricError must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricValueType) == 4, "enum FerricValueType must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricStringEncoding) == 4,
+                     "enum FerricStringEncoding must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricConflictStrategy) == 4,
+                     "enum FerricConflictStrategy must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricFactType) == 4, "enum FerricFactType must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricHaltReason) == 4, "enum FerricHaltReason must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricPinnedAutoreleasePolicy) == 4,
+                     "enum FerricPinnedAutoreleasePolicy must be 32 bits");
+
+/* FerricValueType: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_VOID == 0, "FERRIC_VALUE_TYPE_VOID must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_INTEGER == 1, "FERRIC_VALUE_TYPE_INTEGER must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_FLOAT == 2, "FERRIC_VALUE_TYPE_FLOAT must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_SYMBOL == 3, "FERRIC_VALUE_TYPE_SYMBOL must be 3");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_STRING == 4, "FERRIC_VALUE_TYPE_STRING must be 4");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_MULTIFIELD == 5, "FERRIC_VALUE_TYPE_MULTIFIELD must be 5");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS == 6,
+                     "FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS must be 6");
+
+/* FerricStringEncoding: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_STRING_ENCODING_ASCII == 0, "FERRIC_STRING_ENCODING_ASCII must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_STRING_ENCODING_UTF8 == 1, "FERRIC_STRING_ENCODING_UTF8 must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS == 2,
+                     "FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS must be 2");
+
+/* FerricConflictStrategy: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_DEPTH == 0, "FERRIC_CONFLICT_STRATEGY_DEPTH must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_BREADTH == 1,
+                     "FERRIC_CONFLICT_STRATEGY_BREADTH must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_LEX == 2, "FERRIC_CONFLICT_STRATEGY_LEX must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_MEA == 3, "FERRIC_CONFLICT_STRATEGY_MEA must be 3");
+
+/* FerricFactType: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_FACT_TYPE_ORDERED == 0, "FERRIC_FACT_TYPE_ORDERED must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_FACT_TYPE_TEMPLATE == 1, "FERRIC_FACT_TYPE_TEMPLATE must be 1");
+
+/* FerricHaltReason: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_HALT_REASON_AGENDA_EMPTY == 0,
+                     "FERRIC_HALT_REASON_AGENDA_EMPTY must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_HALT_REASON_LIMIT_REACHED == 1,
+                     "FERRIC_HALT_REASON_LIMIT_REACHED must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_HALT_REASON_HALT_REQUESTED == 2,
+                     "FERRIC_HALT_REASON_HALT_REQUESTED must be 2");
+
+/* FerricPinnedAutoreleasePolicy: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_PINNED_AUTORELEASE_POLICY_NONE == 0,
+                     "FERRIC_PINNED_AUTORELEASE_POLICY_NONE must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM == 1,
+                     "FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH == 2,
+                     "FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH must be 2");
+
+/* FerricError: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_OK == 0, "FERRIC_ERROR_OK must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_NULL_POINTER == 1, "FERRIC_ERROR_NULL_POINTER must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_THREAD_VIOLATION == 2, "FERRIC_ERROR_THREAD_VIOLATION must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_NOT_FOUND == 3, "FERRIC_ERROR_NOT_FOUND must be 3");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PARSE_ERROR == 4, "FERRIC_ERROR_PARSE_ERROR must be 4");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_COMPILE_ERROR == 5, "FERRIC_ERROR_COMPILE_ERROR must be 5");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_RUNTIME_ERROR == 6, "FERRIC_ERROR_RUNTIME_ERROR must be 6");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_IO_ERROR == 7, "FERRIC_ERROR_IO_ERROR must be 7");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_BUFFER_TOO_SMALL == 8, "FERRIC_ERROR_BUFFER_TOO_SMALL must be 8");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_INVALID_ARGUMENT == 9, "FERRIC_ERROR_INVALID_ARGUMENT must be 9");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_SERIALIZATION_ERROR == 10,
+                     "FERRIC_ERROR_SERIALIZATION_ERROR must be 10");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_CLOSED == 11, "FERRIC_ERROR_PINNED_CLOSED must be 11");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_CANCELED == 12, "FERRIC_ERROR_PINNED_CANCELED must be 12");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_QUEUE_FULL == 13,
+                     "FERRIC_ERROR_PINNED_QUEUE_FULL must be 13");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_DISPATCH_FAILED == 14,
+                     "FERRIC_ERROR_PINNED_DISPATCH_FAILED must be 14");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_REENTRANT_CALL == 15,
+                     "FERRIC_ERROR_PINNED_REENTRANT_CALL must be 15");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_INTERNAL_ERROR == 99, "FERRIC_ERROR_INTERNAL_ERROR must be 99");
+
+#if defined(FERRIC_SERDE)
+/* FerricSerializationFormat: enum object width and stable numeric values. */
+FERRIC_STATIC_ASSERT(sizeof(enum FerricSerializationFormat) == 4,
+                     "enum FerricSerializationFormat must be 32 bits");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_BINCODE == 0,
+                     "FERRIC_SERIALIZATION_FORMAT_BINCODE must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_JSON == 1,
+                     "FERRIC_SERIALIZATION_FORMAT_JSON must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_CBOR == 2,
+                     "FERRIC_SERIALIZATION_FORMAT_CBOR must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK == 3,
+                     "FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK must be 3");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_POSTCARD == 4,
+                     "FERRIC_SERIALIZATION_FORMAT_POSTCARD must be 4");
+#endif
 
 #endif  /* FERRIC_H */

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -187,27 +187,27 @@ typedef enum FerricError {
     // A synchronous pinned call was attempted from that engine's worker thread.
     FERRIC_ERROR_PINNED_REENTRANT_CALL = 15,
     // Internal/unexpected error.
-    FERRIC_ERROR_INTERNAL_ERROR = 99,
+    FERRIC_ERROR_INTERNAL_ERROR = 99
 } FerricError;
 
 // C-facing fact type discriminant.
 typedef enum FerricFactType {
     FERRIC_FACT_TYPE_ORDERED = 0,
-    FERRIC_FACT_TYPE_TEMPLATE = 1,
+    FERRIC_FACT_TYPE_TEMPLATE = 1
 } FerricFactType;
 
 // C-facing halt reason returned by `ferric_engine_run_ex`.
 typedef enum FerricHaltReason {
     FERRIC_HALT_REASON_AGENDA_EMPTY = 0,
     FERRIC_HALT_REASON_LIMIT_REACHED = 1,
-    FERRIC_HALT_REASON_HALT_REQUESTED = 2,
+    FERRIC_HALT_REASON_HALT_REQUESTED = 2
 } FerricHaltReason;
 
 // C-facing string-encoding configuration for `FerricConfig`.
 typedef enum FerricStringEncoding {
     FERRIC_STRING_ENCODING_ASCII = 0,
     FERRIC_STRING_ENCODING_UTF8 = 1,
-    FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS = 2,
+    FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS = 2
 } FerricStringEncoding;
 
 // C-facing conflict-resolution strategy for `FerricConfig`.
@@ -215,7 +215,7 @@ typedef enum FerricConflictStrategy {
     FERRIC_CONFLICT_STRATEGY_DEPTH = 0,
     FERRIC_CONFLICT_STRATEGY_BREADTH = 1,
     FERRIC_CONFLICT_STRATEGY_LEX = 2,
-    FERRIC_CONFLICT_STRATEGY_MEA = 3,
+    FERRIC_CONFLICT_STRATEGY_MEA = 3
 } FerricConflictStrategy;
 
 // C-facing value type discriminant.
@@ -234,7 +234,7 @@ typedef enum FerricValueType {
     FERRIC_VALUE_TYPE_SYMBOL = 3,
     FERRIC_VALUE_TYPE_STRING = 4,
     FERRIC_VALUE_TYPE_MULTIFIELD = 5,
-    FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS = 6,
+    FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS = 6
 } FerricValueType;
 
 #if defined(FERRIC_SERDE)
@@ -250,7 +250,7 @@ typedef enum FerricSerializationFormat {
     // `MessagePack` (compact binary, JSON-like schema).
     FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK = 3,
     // Postcard (compact, `no_std`-friendly binary).
-    FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4,
+    FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4
 } FerricSerializationFormat;
 #endif
 
@@ -261,7 +261,7 @@ typedef enum FerricPinnedAutoreleasePolicy {
     // Install one pool per drained request.
     FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM = 1,
     // Install one pool per drained batch.
-    FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH = 2,
+    FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH = 2
 } FerricPinnedAutoreleasePolicy;
 
 // Opaque engine handle exposed to C.

--- a/bindings/go/internal/ffi/types.go
+++ b/bindings/go/internal/ffi/types.go
@@ -28,8 +28,9 @@ const (
 	ErrInternalError      ErrorCode = C.FERRIC_ERROR_INTERNAL_ERROR
 )
 
-// ValueType mirrors the C FerricValueType enum.
-type ValueType = C.enum_FerricValueType
+// ValueType mirrors FerricValue.value_type, which crosses the C ABI as a
+// fixed-width uint32_t carrying a FerricValueType discriminant (FR-CABI-001).
+type ValueType = C.uint32_t
 
 // ValueType values mirror C.FERRIC_VALUE_TYPE_*.
 const (

--- a/crates/ferric-ffi/build.rs
+++ b/crates/ferric-ffi/build.rs
@@ -162,7 +162,7 @@ const STATIC_ASSERTIONS: &str = r#"
  * at compile time for every consumer of this header.
  */
 
-#if defined(__cplusplus)
+#if defined(__cplusplus) && __cplusplus >= 201103L
   #define FERRIC_STATIC_ASSERT(COND, MSG) static_assert(COND, MSG)
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
   #define FERRIC_STATIC_ASSERT(COND, MSG) _Static_assert(COND, MSG)

--- a/crates/ferric-ffi/build.rs
+++ b/crates/ferric-ffi/build.rs
@@ -142,6 +142,148 @@ const BOUNDS_SAFETY_MACROS: &str = r"
 #endif
 ";
 
+/// Compile-time lock on ABI discriminant widths and numeric values.
+///
+/// Appended to the generated header immediately before the closing include
+/// guard. Discriminants cross the ABI as fixed-width 32-bit integers with
+/// the documented numeric values below; these assertions fail a consumer's
+/// build if the header ever drifts from that contract.
+const STATIC_ASSERTIONS: &str = r#"
+/*
+ * ============================================================
+ * ABI STATIC ASSERTIONS
+ * ============================================================
+ *
+ * Caller-populated discriminants cross this ABI as fixed-width
+ * 32-bit integers (never as C enum objects), and every accepting
+ * API validates them before interpretation: unknown values are
+ * rejected with FERRIC_ERROR_INVALID_ARGUMENT. The assertions
+ * below lock the field widths and the documented numeric values
+ * at compile time for every consumer of this header.
+ */
+
+#if defined(__cplusplus)
+  #define FERRIC_STATIC_ASSERT(COND, MSG) static_assert(COND, MSG)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+  #define FERRIC_STATIC_ASSERT(COND, MSG) _Static_assert(COND, MSG)
+#else
+  #define FERRIC_STATIC_ASSERT_CAT2(A, B) A##B
+  #define FERRIC_STATIC_ASSERT_CAT(A, B) FERRIC_STATIC_ASSERT_CAT2(A, B)
+  #define FERRIC_STATIC_ASSERT(COND, MSG) \
+      typedef char FERRIC_STATIC_ASSERT_CAT(ferric_static_assert_, __LINE__)[(COND) ? 1 : -1]
+#endif
+
+/* Discriminant field widths (all fixed at 32 bits). */
+FERRIC_STATIC_ASSERT(sizeof(((FerricValue *)0)->value_type) == 4,
+                     "FerricValue.value_type must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricValue *)0)->external_type_id) == 4,
+                     "FerricValue.external_type_id must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricConfig *)0)->string_encoding) == 4,
+                     "FerricConfig.string_encoding must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricConfig *)0)->strategy) == 4,
+                     "FerricConfig.strategy must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricPinnedEngineOptions *)0)->autorelease_policy) == 4,
+                     "FerricPinnedEngineOptions.autorelease_policy must be a 32-bit integer");
+
+/* C enum object widths for every enum crossing the ABI (as return values
+ * or out-parameters). Rust emits these as 32-bit values; a consumer
+ * compiled with -fshort-enums (or an equivalent packed-enum ABI) fails
+ * these assertions instead of silently miscompiling. */
+FERRIC_STATIC_ASSERT(sizeof(enum FerricError) == 4, "enum FerricError must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricValueType) == 4, "enum FerricValueType must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricStringEncoding) == 4,
+                     "enum FerricStringEncoding must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricConflictStrategy) == 4,
+                     "enum FerricConflictStrategy must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricFactType) == 4, "enum FerricFactType must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricHaltReason) == 4, "enum FerricHaltReason must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricPinnedAutoreleasePolicy) == 4,
+                     "enum FerricPinnedAutoreleasePolicy must be 32 bits");
+
+/* FerricValueType: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_VOID == 0, "FERRIC_VALUE_TYPE_VOID must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_INTEGER == 1, "FERRIC_VALUE_TYPE_INTEGER must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_FLOAT == 2, "FERRIC_VALUE_TYPE_FLOAT must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_SYMBOL == 3, "FERRIC_VALUE_TYPE_SYMBOL must be 3");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_STRING == 4, "FERRIC_VALUE_TYPE_STRING must be 4");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_MULTIFIELD == 5, "FERRIC_VALUE_TYPE_MULTIFIELD must be 5");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS == 6,
+                     "FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS must be 6");
+
+/* FerricStringEncoding: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_STRING_ENCODING_ASCII == 0, "FERRIC_STRING_ENCODING_ASCII must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_STRING_ENCODING_UTF8 == 1, "FERRIC_STRING_ENCODING_UTF8 must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS == 2,
+                     "FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS must be 2");
+
+/* FerricConflictStrategy: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_DEPTH == 0, "FERRIC_CONFLICT_STRATEGY_DEPTH must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_BREADTH == 1,
+                     "FERRIC_CONFLICT_STRATEGY_BREADTH must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_LEX == 2, "FERRIC_CONFLICT_STRATEGY_LEX must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_MEA == 3, "FERRIC_CONFLICT_STRATEGY_MEA must be 3");
+
+/* FerricFactType: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_FACT_TYPE_ORDERED == 0, "FERRIC_FACT_TYPE_ORDERED must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_FACT_TYPE_TEMPLATE == 1, "FERRIC_FACT_TYPE_TEMPLATE must be 1");
+
+/* FerricHaltReason: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_HALT_REASON_AGENDA_EMPTY == 0,
+                     "FERRIC_HALT_REASON_AGENDA_EMPTY must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_HALT_REASON_LIMIT_REACHED == 1,
+                     "FERRIC_HALT_REASON_LIMIT_REACHED must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_HALT_REASON_HALT_REQUESTED == 2,
+                     "FERRIC_HALT_REASON_HALT_REQUESTED must be 2");
+
+/* FerricPinnedAutoreleasePolicy: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_PINNED_AUTORELEASE_POLICY_NONE == 0,
+                     "FERRIC_PINNED_AUTORELEASE_POLICY_NONE must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM == 1,
+                     "FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH == 2,
+                     "FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH must be 2");
+
+/* FerricError: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_OK == 0, "FERRIC_ERROR_OK must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_NULL_POINTER == 1, "FERRIC_ERROR_NULL_POINTER must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_THREAD_VIOLATION == 2, "FERRIC_ERROR_THREAD_VIOLATION must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_NOT_FOUND == 3, "FERRIC_ERROR_NOT_FOUND must be 3");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PARSE_ERROR == 4, "FERRIC_ERROR_PARSE_ERROR must be 4");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_COMPILE_ERROR == 5, "FERRIC_ERROR_COMPILE_ERROR must be 5");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_RUNTIME_ERROR == 6, "FERRIC_ERROR_RUNTIME_ERROR must be 6");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_IO_ERROR == 7, "FERRIC_ERROR_IO_ERROR must be 7");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_BUFFER_TOO_SMALL == 8, "FERRIC_ERROR_BUFFER_TOO_SMALL must be 8");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_INVALID_ARGUMENT == 9, "FERRIC_ERROR_INVALID_ARGUMENT must be 9");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_SERIALIZATION_ERROR == 10,
+                     "FERRIC_ERROR_SERIALIZATION_ERROR must be 10");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_CLOSED == 11, "FERRIC_ERROR_PINNED_CLOSED must be 11");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_CANCELED == 12, "FERRIC_ERROR_PINNED_CANCELED must be 12");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_QUEUE_FULL == 13,
+                     "FERRIC_ERROR_PINNED_QUEUE_FULL must be 13");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_DISPATCH_FAILED == 14,
+                     "FERRIC_ERROR_PINNED_DISPATCH_FAILED must be 14");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_REENTRANT_CALL == 15,
+                     "FERRIC_ERROR_PINNED_REENTRANT_CALL must be 15");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_INTERNAL_ERROR == 99, "FERRIC_ERROR_INTERNAL_ERROR must be 99");
+
+#if defined(FERRIC_SERDE)
+/* FerricSerializationFormat: enum object width and stable numeric values. */
+FERRIC_STATIC_ASSERT(sizeof(enum FerricSerializationFormat) == 4,
+                     "enum FerricSerializationFormat must be 32 bits");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_BINCODE == 0,
+                     "FERRIC_SERIALIZATION_FORMAT_BINCODE must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_JSON == 1,
+                     "FERRIC_SERIALIZATION_FORMAT_JSON must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_CBOR == 2,
+                     "FERRIC_SERIALIZATION_FORMAT_CBOR must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK == 3,
+                     "FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK must be 3");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_POSTCARD == 4,
+                     "FERRIC_SERIALIZATION_FORMAT_POSTCARD must be 4");
+#endif
+
+"#;
+
 /// Deterministic annotation replacements applied to the cbindgen output.
 ///
 /// Each `(find, replace)` pair must match exactly once in the generated header.
@@ -410,6 +552,14 @@ fn main() {
         );
         header = header.replacen(find, replace, 1);
     }
+
+    // Append ABI static assertions immediately before the closing include
+    // guard so all asserted types are already declared.
+    let guard_close = "#endif  /* FERRIC_H */";
+    let guard_pos = header
+        .rfind(guard_close)
+        .expect("Could not find closing include guard in generated header");
+    header.insert_str(guard_pos, STATIC_ASSERTIONS);
 
     std::fs::write(format!("{crate_dir}/ferric.h"), header).expect("Failed to write ferric.h");
 }

--- a/crates/ferric-ffi/build.rs
+++ b/crates/ferric-ffi/build.rs
@@ -532,6 +532,24 @@ fn main() {
     bindings.write(&mut buf);
     let mut header = String::from_utf8(buf).expect("cbindgen output was not valid UTF-8");
 
+    // Strip the trailing comma cbindgen emits after the last enum variant:
+    // strict C++98/03 (-pedantic-errors) rejects it. Applied line-wise so
+    // only a comma immediately preceding a closing brace is touched.
+    let mut lines: Vec<String> = header.lines().map(String::from).collect();
+    let mut stripped = 0;
+    for i in 0..lines.len().saturating_sub(1) {
+        if lines[i].ends_with(',') && lines[i + 1].trim_start().starts_with('}') {
+            lines[i].pop();
+            stripped += 1;
+        }
+    }
+    assert!(
+        stripped > 0,
+        "expected at least one trailing enum comma to strip; cbindgen output format changed"
+    );
+    header = lines.join("\n");
+    header.push('\n');
+
     // Inject bounds-safety macro definitions after the standard includes.
     let inject_marker = "#include <stdlib.h>";
     let inject_pos = header

--- a/crates/ferric-ffi/ferric.h
+++ b/crates/ferric-ffi/ferric.h
@@ -1627,7 +1627,7 @@ enum FerricError ferric_value_array_free(struct FerricValue *arr FERRIC_COUNTED_
  * at compile time for every consumer of this header.
  */
 
-#if defined(__cplusplus)
+#if defined(__cplusplus) && __cplusplus >= 201103L
   #define FERRIC_STATIC_ASSERT(COND, MSG) static_assert(COND, MSG)
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
   #define FERRIC_STATIC_ASSERT(COND, MSG) _Static_assert(COND, MSG)

--- a/crates/ferric-ffi/ferric.h
+++ b/crates/ferric-ffi/ferric.h
@@ -190,17 +190,6 @@ typedef enum FerricError {
     FERRIC_ERROR_INTERNAL_ERROR = 99,
 } FerricError;
 
-// C-facing value type discriminant.
-typedef enum FerricValueType {
-    FERRIC_VALUE_TYPE_VOID = 0,
-    FERRIC_VALUE_TYPE_INTEGER = 1,
-    FERRIC_VALUE_TYPE_FLOAT = 2,
-    FERRIC_VALUE_TYPE_SYMBOL = 3,
-    FERRIC_VALUE_TYPE_STRING = 4,
-    FERRIC_VALUE_TYPE_MULTIFIELD = 5,
-    FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS = 6,
-} FerricValueType;
-
 // C-facing fact type discriminant.
 typedef enum FerricFactType {
     FERRIC_FACT_TYPE_ORDERED = 0,
@@ -228,6 +217,25 @@ typedef enum FerricConflictStrategy {
     FERRIC_CONFLICT_STRATEGY_LEX = 2,
     FERRIC_CONFLICT_STRATEGY_MEA = 3,
 } FerricConflictStrategy;
+
+// C-facing value type discriminant.
+//
+// Crosses the ABI as a raw `u32` (`FerricValue::value_type`), never as this
+// Rust enum: caller-populated memory is validated with [`Self::from_raw`] /
+// `TryFrom<u32>` before being interpreted, and unknown discriminants are
+// rejected with `FERRIC_ERROR_INVALID_ARGUMENT`.
+//
+// Stable numeric values — new variants may be added but existing values
+// must never change.
+typedef enum FerricValueType {
+    FERRIC_VALUE_TYPE_VOID = 0,
+    FERRIC_VALUE_TYPE_INTEGER = 1,
+    FERRIC_VALUE_TYPE_FLOAT = 2,
+    FERRIC_VALUE_TYPE_SYMBOL = 3,
+    FERRIC_VALUE_TYPE_STRING = 4,
+    FERRIC_VALUE_TYPE_MULTIFIELD = 5,
+    FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS = 6,
+} FerricValueType;
 
 #if defined(FERRIC_SERDE)
 // Serialization format selector for `ferric_engine_serialize_as` and
@@ -302,7 +310,13 @@ typedef struct FerricConfig {
 // | Multifield | `multifield_ptr` (owned), `multifield_len` |
 // | ExternalAddress | `external_type_id`, `external_pointer` |
 typedef struct FerricValue {
-    enum FerricValueType value_type;
+    // Raw `FerricValueType` discriminant.
+    //
+    // Every API that reads a caller-populated `FerricValue` validates this
+    // field before interpreting it; values outside the documented
+    // `FerricValueType` range are rejected with
+    // `FERRIC_ERROR_INVALID_ARGUMENT`.
+    uint32_t value_type;
     int64_t integer;
     double float_;
     char * FERRIC_NULL_TERMINATED string_ptr;
@@ -1565,24 +1579,172 @@ void ferric_string_free(char * FERRIC_NULL_TERMINATED ptr);
 
 // Free a `FerricValue` and its owned resources.
 //
-// Recursively frees owned strings and multifield arrays.
-// Null pointers are safely ignored.
+// Recursively frees owned strings and multifield arrays. Null pointers are
+// safely ignored and return `FERRIC_ERROR_OK`.
+//
+// If the value (or any nested multifield element) carries an unknown
+// `value_type` discriminant, returns `FERRIC_ERROR_INVALID_ARGUMENT` and
+// records a diagnostic in the global error channel. The unknown-tagged
+// value's payload fields are never interpreted (nothing of it is freed),
+// but all sibling values with known discriminants and every owned
+// containing multifield array are still released.
 //
 // # Safety
 //
 // - `value` must point to a valid `FerricValue` or be null.
 // - Any owned resources (`string_ptr`, `multifield_ptr`) must not have been freed already.
-void ferric_value_free(struct FerricValue *value);
+enum FerricError ferric_value_free(struct FerricValue *value);
 
 // Free an array of `FerricValue`s and all their owned resources.
 //
 // Frees each element's owned resources, then frees the array allocation.
-// Null pointers are safely ignored.
+// Null pointers are safely ignored and return `FERRIC_ERROR_OK`.
+//
+// If any element (or any nested multifield element) carries an unknown
+// `value_type` discriminant, returns `FERRIC_ERROR_INVALID_ARGUMENT` and
+// records a diagnostic in the global error channel. Unknown-tagged
+// elements' payload fields are never interpreted (nothing of them is
+// freed), but all elements with known discriminants and the array
+// allocation itself are still released.
 //
 // # Safety
 //
 // - `arr` must point to a contiguous array of `len` `FerricValue`s, or be null.
 // - The array must have been allocated by the FFI.
-void ferric_value_array_free(struct FerricValue *arr FERRIC_COUNTED_BY(len), uintptr_t len);
+enum FerricError ferric_value_array_free(struct FerricValue *arr FERRIC_COUNTED_BY(len), uintptr_t len);
+
+
+/*
+ * ============================================================
+ * ABI STATIC ASSERTIONS
+ * ============================================================
+ *
+ * Caller-populated discriminants cross this ABI as fixed-width
+ * 32-bit integers (never as C enum objects), and every accepting
+ * API validates them before interpretation: unknown values are
+ * rejected with FERRIC_ERROR_INVALID_ARGUMENT. The assertions
+ * below lock the field widths and the documented numeric values
+ * at compile time for every consumer of this header.
+ */
+
+#if defined(__cplusplus)
+  #define FERRIC_STATIC_ASSERT(COND, MSG) static_assert(COND, MSG)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+  #define FERRIC_STATIC_ASSERT(COND, MSG) _Static_assert(COND, MSG)
+#else
+  #define FERRIC_STATIC_ASSERT_CAT2(A, B) A##B
+  #define FERRIC_STATIC_ASSERT_CAT(A, B) FERRIC_STATIC_ASSERT_CAT2(A, B)
+  #define FERRIC_STATIC_ASSERT(COND, MSG) \
+      typedef char FERRIC_STATIC_ASSERT_CAT(ferric_static_assert_, __LINE__)[(COND) ? 1 : -1]
+#endif
+
+/* Discriminant field widths (all fixed at 32 bits). */
+FERRIC_STATIC_ASSERT(sizeof(((FerricValue *)0)->value_type) == 4,
+                     "FerricValue.value_type must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricValue *)0)->external_type_id) == 4,
+                     "FerricValue.external_type_id must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricConfig *)0)->string_encoding) == 4,
+                     "FerricConfig.string_encoding must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricConfig *)0)->strategy) == 4,
+                     "FerricConfig.strategy must be a 32-bit integer");
+FERRIC_STATIC_ASSERT(sizeof(((FerricPinnedEngineOptions *)0)->autorelease_policy) == 4,
+                     "FerricPinnedEngineOptions.autorelease_policy must be a 32-bit integer");
+
+/* C enum object widths for every enum crossing the ABI (as return values
+ * or out-parameters). Rust emits these as 32-bit values; a consumer
+ * compiled with -fshort-enums (or an equivalent packed-enum ABI) fails
+ * these assertions instead of silently miscompiling. */
+FERRIC_STATIC_ASSERT(sizeof(enum FerricError) == 4, "enum FerricError must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricValueType) == 4, "enum FerricValueType must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricStringEncoding) == 4,
+                     "enum FerricStringEncoding must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricConflictStrategy) == 4,
+                     "enum FerricConflictStrategy must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricFactType) == 4, "enum FerricFactType must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricHaltReason) == 4, "enum FerricHaltReason must be 32 bits");
+FERRIC_STATIC_ASSERT(sizeof(enum FerricPinnedAutoreleasePolicy) == 4,
+                     "enum FerricPinnedAutoreleasePolicy must be 32 bits");
+
+/* FerricValueType: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_VOID == 0, "FERRIC_VALUE_TYPE_VOID must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_INTEGER == 1, "FERRIC_VALUE_TYPE_INTEGER must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_FLOAT == 2, "FERRIC_VALUE_TYPE_FLOAT must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_SYMBOL == 3, "FERRIC_VALUE_TYPE_SYMBOL must be 3");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_STRING == 4, "FERRIC_VALUE_TYPE_STRING must be 4");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_MULTIFIELD == 5, "FERRIC_VALUE_TYPE_MULTIFIELD must be 5");
+FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS == 6,
+                     "FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS must be 6");
+
+/* FerricStringEncoding: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_STRING_ENCODING_ASCII == 0, "FERRIC_STRING_ENCODING_ASCII must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_STRING_ENCODING_UTF8 == 1, "FERRIC_STRING_ENCODING_UTF8 must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS == 2,
+                     "FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS must be 2");
+
+/* FerricConflictStrategy: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_DEPTH == 0, "FERRIC_CONFLICT_STRATEGY_DEPTH must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_BREADTH == 1,
+                     "FERRIC_CONFLICT_STRATEGY_BREADTH must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_LEX == 2, "FERRIC_CONFLICT_STRATEGY_LEX must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_MEA == 3, "FERRIC_CONFLICT_STRATEGY_MEA must be 3");
+
+/* FerricFactType: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_FACT_TYPE_ORDERED == 0, "FERRIC_FACT_TYPE_ORDERED must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_FACT_TYPE_TEMPLATE == 1, "FERRIC_FACT_TYPE_TEMPLATE must be 1");
+
+/* FerricHaltReason: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_HALT_REASON_AGENDA_EMPTY == 0,
+                     "FERRIC_HALT_REASON_AGENDA_EMPTY must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_HALT_REASON_LIMIT_REACHED == 1,
+                     "FERRIC_HALT_REASON_LIMIT_REACHED must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_HALT_REASON_HALT_REQUESTED == 2,
+                     "FERRIC_HALT_REASON_HALT_REQUESTED must be 2");
+
+/* FerricPinnedAutoreleasePolicy: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_PINNED_AUTORELEASE_POLICY_NONE == 0,
+                     "FERRIC_PINNED_AUTORELEASE_POLICY_NONE must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM == 1,
+                     "FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH == 2,
+                     "FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH must be 2");
+
+/* FerricError: stable numeric values. */
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_OK == 0, "FERRIC_ERROR_OK must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_NULL_POINTER == 1, "FERRIC_ERROR_NULL_POINTER must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_THREAD_VIOLATION == 2, "FERRIC_ERROR_THREAD_VIOLATION must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_NOT_FOUND == 3, "FERRIC_ERROR_NOT_FOUND must be 3");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PARSE_ERROR == 4, "FERRIC_ERROR_PARSE_ERROR must be 4");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_COMPILE_ERROR == 5, "FERRIC_ERROR_COMPILE_ERROR must be 5");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_RUNTIME_ERROR == 6, "FERRIC_ERROR_RUNTIME_ERROR must be 6");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_IO_ERROR == 7, "FERRIC_ERROR_IO_ERROR must be 7");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_BUFFER_TOO_SMALL == 8, "FERRIC_ERROR_BUFFER_TOO_SMALL must be 8");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_INVALID_ARGUMENT == 9, "FERRIC_ERROR_INVALID_ARGUMENT must be 9");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_SERIALIZATION_ERROR == 10,
+                     "FERRIC_ERROR_SERIALIZATION_ERROR must be 10");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_CLOSED == 11, "FERRIC_ERROR_PINNED_CLOSED must be 11");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_CANCELED == 12, "FERRIC_ERROR_PINNED_CANCELED must be 12");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_QUEUE_FULL == 13,
+                     "FERRIC_ERROR_PINNED_QUEUE_FULL must be 13");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_DISPATCH_FAILED == 14,
+                     "FERRIC_ERROR_PINNED_DISPATCH_FAILED must be 14");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_PINNED_REENTRANT_CALL == 15,
+                     "FERRIC_ERROR_PINNED_REENTRANT_CALL must be 15");
+FERRIC_STATIC_ASSERT(FERRIC_ERROR_INTERNAL_ERROR == 99, "FERRIC_ERROR_INTERNAL_ERROR must be 99");
+
+#if defined(FERRIC_SERDE)
+/* FerricSerializationFormat: enum object width and stable numeric values. */
+FERRIC_STATIC_ASSERT(sizeof(enum FerricSerializationFormat) == 4,
+                     "enum FerricSerializationFormat must be 32 bits");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_BINCODE == 0,
+                     "FERRIC_SERIALIZATION_FORMAT_BINCODE must be 0");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_JSON == 1,
+                     "FERRIC_SERIALIZATION_FORMAT_JSON must be 1");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_CBOR == 2,
+                     "FERRIC_SERIALIZATION_FORMAT_CBOR must be 2");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK == 3,
+                     "FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK must be 3");
+FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_POSTCARD == 4,
+                     "FERRIC_SERIALIZATION_FORMAT_POSTCARD must be 4");
+#endif
 
 #endif  /* FERRIC_H */

--- a/crates/ferric-ffi/ferric.h
+++ b/crates/ferric-ffi/ferric.h
@@ -187,27 +187,27 @@ typedef enum FerricError {
     // A synchronous pinned call was attempted from that engine's worker thread.
     FERRIC_ERROR_PINNED_REENTRANT_CALL = 15,
     // Internal/unexpected error.
-    FERRIC_ERROR_INTERNAL_ERROR = 99,
+    FERRIC_ERROR_INTERNAL_ERROR = 99
 } FerricError;
 
 // C-facing fact type discriminant.
 typedef enum FerricFactType {
     FERRIC_FACT_TYPE_ORDERED = 0,
-    FERRIC_FACT_TYPE_TEMPLATE = 1,
+    FERRIC_FACT_TYPE_TEMPLATE = 1
 } FerricFactType;
 
 // C-facing halt reason returned by `ferric_engine_run_ex`.
 typedef enum FerricHaltReason {
     FERRIC_HALT_REASON_AGENDA_EMPTY = 0,
     FERRIC_HALT_REASON_LIMIT_REACHED = 1,
-    FERRIC_HALT_REASON_HALT_REQUESTED = 2,
+    FERRIC_HALT_REASON_HALT_REQUESTED = 2
 } FerricHaltReason;
 
 // C-facing string-encoding configuration for `FerricConfig`.
 typedef enum FerricStringEncoding {
     FERRIC_STRING_ENCODING_ASCII = 0,
     FERRIC_STRING_ENCODING_UTF8 = 1,
-    FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS = 2,
+    FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS = 2
 } FerricStringEncoding;
 
 // C-facing conflict-resolution strategy for `FerricConfig`.
@@ -215,7 +215,7 @@ typedef enum FerricConflictStrategy {
     FERRIC_CONFLICT_STRATEGY_DEPTH = 0,
     FERRIC_CONFLICT_STRATEGY_BREADTH = 1,
     FERRIC_CONFLICT_STRATEGY_LEX = 2,
-    FERRIC_CONFLICT_STRATEGY_MEA = 3,
+    FERRIC_CONFLICT_STRATEGY_MEA = 3
 } FerricConflictStrategy;
 
 // C-facing value type discriminant.
@@ -234,7 +234,7 @@ typedef enum FerricValueType {
     FERRIC_VALUE_TYPE_SYMBOL = 3,
     FERRIC_VALUE_TYPE_STRING = 4,
     FERRIC_VALUE_TYPE_MULTIFIELD = 5,
-    FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS = 6,
+    FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS = 6
 } FerricValueType;
 
 #if defined(FERRIC_SERDE)
@@ -250,7 +250,7 @@ typedef enum FerricSerializationFormat {
     // `MessagePack` (compact binary, JSON-like schema).
     FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK = 3,
     // Postcard (compact, `no_std`-friendly binary).
-    FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4,
+    FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4
 } FerricSerializationFormat;
 #endif
 
@@ -261,7 +261,7 @@ typedef enum FerricPinnedAutoreleasePolicy {
     // Install one pool per drained request.
     FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM = 1,
     // Install one pool per drained batch.
-    FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH = 2,
+    FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH = 2
 } FerricPinnedAutoreleasePolicy;
 
 // Opaque engine handle exposed to C.

--- a/crates/ferric-ffi/src/tests.rs
+++ b/crates/ferric-ffi/src/tests.rs
@@ -34,6 +34,9 @@ mod copy_error;
 mod values;
 
 #[cfg(test)]
+mod discriminant_validation;
+
+#[cfg(test)]
 mod build_matrix;
 
 #[cfg(test)]

--- a/crates/ferric-ffi/src/tests/contract_lock.rs
+++ b/crates/ferric-ffi/src/tests/contract_lock.rs
@@ -109,8 +109,8 @@ fn contract_lock_canonical_function_names_exist() {
 
     // value resource management
     let _: unsafe extern "C" fn(*mut c_char) = ferric_string_free;
-    let _: unsafe extern "C" fn(*mut FerricValue) = ferric_value_free;
-    let _: unsafe extern "C" fn(*mut FerricValue, usize) = ferric_value_array_free;
+    let _: unsafe extern "C" fn(*mut FerricValue) -> FerricError = ferric_value_free;
+    let _: unsafe extern "C" fn(*mut FerricValue, usize) -> FerricError = ferric_value_array_free;
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/ferric-ffi/src/tests/discriminant_validation.rs
+++ b/crates/ferric-ffi/src/tests/discriminant_validation.rs
@@ -1,0 +1,320 @@
+//! Regression tests for FR-CABI-001 (issue #85): caller-populated
+//! `FerricValue.value_type` discriminants cross the ABI as raw `u32` values
+//! and are validated before interpretation.
+//!
+//! Every API that reads a caller-populated `FerricValue` must reject unknown
+//! discriminants with `FerricError::InvalidArgument` — at top level and
+//! nested inside multifields — and the resource-freeing paths must never
+//! interpret an unknown tag. The companion C harness
+//! (`tests/c/discriminant_abuse.c`, run via `just ffi-c-harness`) exercises
+//! the same contract from a real C subprocess under ASan/UBSan.
+
+use std::ffi::CString;
+use std::ptr;
+
+use crate::engine::{
+    ferric_engine_assert_ordered, ferric_engine_assert_template, ferric_engine_fact_count,
+    ferric_engine_free, ferric_engine_load_string, ferric_engine_new, ferric_engine_reset,
+    FerricEngine,
+};
+use crate::error::FerricError;
+use crate::types::{
+    ferric_value_array_free, ferric_value_free, ferric_value_integer, FerricValue, FerricValueType,
+};
+
+/// Discriminants that must be rejected: the first out-of-range value,
+/// arbitrary garbage, and all-ones.
+const INVALID_TAGS: [u32; 4] = [7, 42, 0xDEAD_BEEF, u32::MAX];
+
+/// A `FerricValue` with an invalid discriminant and poisoned payload fields
+/// that must never be interpreted (dangling-looking pointers, huge length).
+fn poisoned_value(tag: u32) -> FerricValue {
+    FerricValue {
+        value_type: tag,
+        string_ptr: 0xDEAD_0001_usize as *mut _,
+        multifield_ptr: 0xDEAD_0002_usize as *mut FerricValue,
+        multifield_len: usize::MAX,
+        ..FerricValue::void()
+    }
+}
+
+unsafe fn new_engine_with_template() -> *mut FerricEngine {
+    let engine = ferric_engine_new();
+    let source =
+        CString::new("(deftemplate person (slot name) (slot age) (multislot tags))").unwrap();
+    assert_eq!(
+        ferric_engine_load_string(engine, source.as_ptr()),
+        FerricError::Ok
+    );
+    assert_eq!(ferric_engine_reset(engine), FerricError::Ok);
+    engine
+}
+
+/// Assert a valid fact to prove the engine survived a rejected call.
+unsafe fn assert_engine_usable(engine: *mut FerricEngine) {
+    let relation = CString::new("probe").unwrap();
+    let field = ferric_value_integer(1);
+    assert_eq!(
+        ferric_engine_assert_ordered(engine, relation.as_ptr(), &field, 1, ptr::null_mut()),
+        FerricError::Ok,
+        "engine must stay usable after a rejected discriminant"
+    );
+}
+
+#[test]
+fn value_type_raw_round_trip() {
+    for tag in 0..=6_u32 {
+        let vt = FerricValueType::from_raw(tag).expect("0..=6 must be valid discriminants");
+        assert_eq!(vt.as_raw(), tag);
+    }
+    for tag in INVALID_TAGS {
+        assert!(FerricValueType::from_raw(tag).is_none());
+        assert!(FerricValueType::try_from(tag).is_err());
+    }
+}
+
+#[test]
+fn assert_ordered_rejects_invalid_top_level_discriminant() {
+    unsafe {
+        let engine = new_engine_with_template();
+        let relation = CString::new("bad").unwrap();
+
+        for tag in INVALID_TAGS {
+            let bad = poisoned_value(tag);
+            let mut fact_id = 0_u64;
+            assert_eq!(
+                ferric_engine_assert_ordered(engine, relation.as_ptr(), &bad, 1, &mut fact_id),
+                FerricError::InvalidArgument,
+                "discriminant {tag} must be rejected"
+            );
+            assert_global_diag_names_tag(tag);
+            assert_engine_usable(engine);
+        }
+
+        // No `bad` fact must have been asserted (only the usable-probe facts).
+        let mut count = 0_usize;
+        assert_eq!(
+            ferric_engine_fact_count(engine, &mut count),
+            FerricError::Ok
+        );
+        assert_eq!(count, INVALID_TAGS.len());
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn assert_ordered_rejects_invalid_nested_discriminant() {
+    unsafe {
+        let engine = new_engine_with_template();
+        let relation = CString::new("bad").unwrap();
+
+        for tag in INVALID_TAGS {
+            let mut elems = [
+                ferric_value_integer(10),
+                poisoned_value(tag),
+                ferric_value_integer(20),
+            ];
+            let mf = FerricValue {
+                value_type: FerricValueType::Multifield.as_raw(),
+                multifield_ptr: elems.as_mut_ptr(),
+                multifield_len: elems.len(),
+                ..FerricValue::void()
+            };
+            assert_eq!(
+                ferric_engine_assert_ordered(engine, relation.as_ptr(), &mf, 1, ptr::null_mut()),
+                FerricError::InvalidArgument,
+                "nested discriminant {tag} must be rejected"
+            );
+            assert_global_diag_names_tag(tag);
+            assert_engine_usable(engine);
+        }
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn assert_ordered_rejects_invalid_doubly_nested_discriminant() {
+    unsafe {
+        let engine = new_engine_with_template();
+        let relation = CString::new("bad").unwrap();
+
+        let mut inner_bad = poisoned_value(0x00BA_DBAD);
+        let mut inner = FerricValue {
+            value_type: FerricValueType::Multifield.as_raw(),
+            multifield_ptr: &mut inner_bad,
+            multifield_len: 1,
+            ..FerricValue::void()
+        };
+        let outer = FerricValue {
+            value_type: FerricValueType::Multifield.as_raw(),
+            multifield_ptr: &mut inner,
+            multifield_len: 1,
+            ..FerricValue::void()
+        };
+        assert_eq!(
+            ferric_engine_assert_ordered(engine, relation.as_ptr(), &outer, 1, ptr::null_mut()),
+            FerricError::InvalidArgument
+        );
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn assert_template_rejects_invalid_discriminants() {
+    unsafe {
+        let engine = new_engine_with_template();
+        let template = CString::new("person").unwrap();
+        let age = CString::new("age").unwrap();
+        let tags = CString::new("tags").unwrap();
+
+        // Top-level slot value.
+        for tag in INVALID_TAGS {
+            let bad = poisoned_value(tag);
+            let names = [age.as_ptr()];
+            assert_eq!(
+                ferric_engine_assert_template(
+                    engine,
+                    template.as_ptr(),
+                    names.as_ptr(),
+                    &bad,
+                    1,
+                    ptr::null_mut(),
+                ),
+                FerricError::InvalidArgument,
+                "slot discriminant {tag} must be rejected"
+            );
+            assert_global_diag_names_tag(tag);
+        }
+
+        // Nested inside a multislot value.
+        let mut elems = [ferric_value_integer(1), poisoned_value(7)];
+        let mf = FerricValue {
+            value_type: FerricValueType::Multifield.as_raw(),
+            multifield_ptr: elems.as_mut_ptr(),
+            multifield_len: elems.len(),
+            ..FerricValue::void()
+        };
+        let names = [tags.as_ptr()];
+        assert_eq!(
+            ferric_engine_assert_template(
+                engine,
+                template.as_ptr(),
+                names.as_ptr(),
+                &mf,
+                1,
+                ptr::null_mut(),
+            ),
+            FerricError::InvalidArgument
+        );
+
+        assert_engine_usable(engine);
+        ferric_engine_free(engine);
+    }
+}
+
+/// Assert that the global error channel holds a diagnostic identifying the
+/// invalid raw discriminant `tag`.
+fn assert_global_diag_names_tag(tag: u32) {
+    crate::error::with_global_error(|msg| {
+        let msg = msg.expect("a diagnostic must be recorded in the global error channel");
+        let needle = format!("invalid value_type discriminant: {tag}");
+        assert!(
+            msg.contains(&needle),
+            "diagnostic must contain {needle:?}, got {msg:?}"
+        );
+    });
+}
+
+#[test]
+fn value_free_rejects_invalid_discriminant() {
+    unsafe {
+        // The poisoned payload pointers are not allocations; interpreting
+        // them would crash the test process (and abort under sanitizers).
+        for tag in INVALID_TAGS {
+            let mut bad = poisoned_value(tag);
+            assert_eq!(ferric_value_free(&mut bad), FerricError::InvalidArgument);
+            assert_global_diag_names_tag(tag);
+        }
+    }
+}
+
+#[test]
+fn value_free_null_and_valid_return_ok() {
+    unsafe {
+        assert_eq!(ferric_value_free(ptr::null_mut()), FerricError::Ok);
+        assert_eq!(ferric_value_array_free(ptr::null_mut(), 0), FerricError::Ok);
+        let mut ok = ferric_value_integer(5);
+        assert_eq!(ferric_value_free(&mut ok), FerricError::Ok);
+
+        let values = vec![ferric_value_integer(1), ferric_value_integer(2)];
+        let len = values.len();
+        let arr = Box::into_raw(values.into_boxed_slice()).cast::<FerricValue>();
+        assert_eq!(ferric_value_array_free(arr, len), FerricError::Ok);
+    }
+}
+
+#[test]
+fn value_array_free_rejects_but_frees_known_siblings() {
+    unsafe {
+        // Build an FFI-owned array the way `value_to_ferric` does, then
+        // corrupt one element's tag: the free path must report the invalid
+        // tag while still freeing known siblings (the boxed string below —
+        // a leak would be reported by leak-checking runs) and the array
+        // allocation itself.
+        let sibling = CString::new("owned-sibling").unwrap();
+        let values = vec![
+            FerricValue {
+                value_type: FerricValueType::String.as_raw(),
+                string_ptr: sibling.into_raw(),
+                ..FerricValue::void()
+            },
+            ferric_value_integer(2),
+        ];
+        let len = values.len();
+        let arr = Box::into_raw(values.into_boxed_slice()).cast::<FerricValue>();
+
+        (*arr.add(1)).value_type = 0xDEAD_BEEF;
+        (*arr.add(1)).string_ptr = 0xDEAD_0003_usize as *mut _;
+
+        assert_eq!(
+            ferric_value_array_free(arr, len),
+            FerricError::InvalidArgument
+        );
+        assert_global_diag_names_tag(0xDEAD_BEEF);
+    }
+}
+
+#[test]
+fn value_free_rejects_invalid_nested_tag_in_owned_multifield() {
+    unsafe {
+        // An FFI-owned multifield whose nested element tag is corrupted:
+        // ferric_value_free must return InvalidArgument, skip the corrupted
+        // element's payload, and still free the sibling and the array.
+        let sibling = CString::new("owned-nested-sibling").unwrap();
+        let elems = vec![
+            FerricValue {
+                value_type: FerricValueType::String.as_raw(),
+                string_ptr: sibling.into_raw(),
+                ..FerricValue::void()
+            },
+            ferric_value_integer(9),
+        ];
+        let len = elems.len();
+        let arr = Box::into_raw(elems.into_boxed_slice()).cast::<FerricValue>();
+        (*arr.add(1)).value_type = 999;
+        (*arr.add(1)).multifield_ptr = 0xDEAD_0004_usize as *mut FerricValue;
+        (*arr.add(1)).multifield_len = usize::MAX;
+
+        let mut mf = FerricValue {
+            value_type: FerricValueType::Multifield.as_raw(),
+            multifield_ptr: arr,
+            multifield_len: len,
+            ..FerricValue::void()
+        };
+        assert_eq!(ferric_value_free(&mut mf), FerricError::InvalidArgument);
+        assert_global_diag_names_tag(999);
+    }
+}

--- a/crates/ferric-ffi/src/tests/ffi_expansion.rs
+++ b/crates/ferric-ffi/src/tests/ffi_expansion.rs
@@ -608,7 +608,7 @@ fn assert_ordered_integer_fields() {
         let get_result =
             crate::engine::ferric_engine_get_fact_field(engine, out_fact_id, 0, &mut field_out);
         assert_eq!(get_result, FerricError::Ok);
-        assert_eq!(field_out.value_type, FerricValueType::Integer);
+        assert_eq!(field_out.value_type, FerricValueType::Integer.as_raw());
         assert_eq!(field_out.integer, 42);
 
         ferric_engine_free(engine);
@@ -723,7 +723,7 @@ fn assert_ordered_null_out_fact_id() {
 fn value_integer_constructor() {
     // ferric_value_integer produces a value with the correct type and numeric content.
     let v = ferric_value_integer(42);
-    assert_eq!(v.value_type, FerricValueType::Integer);
+    assert_eq!(v.value_type, FerricValueType::Integer.as_raw());
     assert_eq!(v.integer, 42);
     assert!(v.string_ptr.is_null());
     assert!(v.multifield_ptr.is_null());
@@ -733,7 +733,7 @@ fn value_integer_constructor() {
 fn value_float_constructor() {
     // ferric_value_float produces a value with the correct type and float content.
     let v = ferric_value_float(42.5);
-    assert_eq!(v.value_type, FerricValueType::Float);
+    assert_eq!(v.value_type, FerricValueType::Float.as_raw());
     assert!((v.float - 42.5_f64).abs() < 1e-9);
     assert!(v.string_ptr.is_null());
 }
@@ -745,7 +745,7 @@ fn value_symbol_constructor() {
         let name = CString::new("mySymbol").unwrap();
         let v = ferric_value_symbol(name.as_ptr());
 
-        assert_eq!(v.value_type, FerricValueType::Symbol);
+        assert_eq!(v.value_type, FerricValueType::Symbol.as_raw());
         assert!(!v.string_ptr.is_null(), "symbol must own a heap string");
         let s = CStr::from_ptr(v.string_ptr).to_str().unwrap();
         assert_eq!(s, "mySymbol");
@@ -761,7 +761,7 @@ fn value_string_constructor() {
         let raw = CString::new("hello, world").unwrap();
         let v = ferric_value_string(raw.as_ptr());
 
-        assert_eq!(v.value_type, FerricValueType::String);
+        assert_eq!(v.value_type, FerricValueType::String.as_raw());
         assert!(
             !v.string_ptr.is_null(),
             "string value must own a heap string"
@@ -777,7 +777,7 @@ fn value_string_constructor() {
 fn value_void_constructor() {
     // ferric_value_void produces a fully zeroed value of type Void.
     let v = ferric_value_void();
-    assert_eq!(v.value_type, FerricValueType::Void);
+    assert_eq!(v.value_type, FerricValueType::Void.as_raw());
     assert_eq!(v.integer, 0);
     assert!(v.float.abs() < f64::EPSILON);
     assert!(v.string_ptr.is_null());
@@ -791,7 +791,7 @@ fn value_symbol_null_returns_void() {
         let v = ferric_value_symbol(ptr::null());
         assert_eq!(
             v.value_type,
-            FerricValueType::Void,
+            FerricValueType::Void.as_raw(),
             "null symbol name must produce a Void value"
         );
         assert!(v.string_ptr.is_null());
@@ -805,7 +805,7 @@ fn value_string_null_returns_void() {
         let v = ferric_value_string(ptr::null());
         assert_eq!(
             v.value_type,
-            FerricValueType::Void,
+            FerricValueType::Void.as_raw(),
             "null string pointer must produce a Void value"
         );
         assert!(v.string_ptr.is_null());

--- a/crates/ferric-ffi/src/tests/header.rs
+++ b/crates/ferric-ffi/src/tests/header.rs
@@ -333,6 +333,17 @@ fn header_has_abi_static_assertions() {
 }
 
 #[test]
+fn header_enums_have_no_trailing_commas() {
+    // Strict C++98/03 (-pedantic-errors) rejects a trailing comma after the
+    // last enum variant; the generator strips the ones cbindgen emits.
+    let header = read_committed_header();
+    assert!(
+        !header.contains(",\n}"),
+        "committed header must not contain trailing commas before closing braces"
+    );
+}
+
+#[test]
 fn header_contains_ferric_engine_opaque() {
     let header = read_committed_header();
     // FerricEngine must appear as an opaque struct, not with its fields exposed

--- a/crates/ferric-ffi/src/tests/header.rs
+++ b/crates/ferric-ffi/src/tests/header.rs
@@ -258,6 +258,77 @@ fn header_contains_ferric_value_struct() {
 }
 
 #[test]
+fn header_value_type_is_fixed_width_integer() {
+    let header = read_committed_header();
+    assert!(
+        header.contains("uint32_t value_type;"),
+        "FerricValue.value_type must cross the ABI as uint32_t, not a C enum"
+    );
+    assert!(
+        !header.contains("enum FerricValueType value_type;"),
+        "FerricValue.value_type must not be typed as a C enum"
+    );
+}
+
+#[test]
+fn header_has_abi_static_assertions() {
+    let header = read_committed_header();
+    assert!(
+        header.contains("ABI STATIC ASSERTIONS"),
+        "Missing ABI STATIC ASSERTIONS section"
+    );
+    assert!(
+        header.contains("#define FERRIC_STATIC_ASSERT(COND, MSG)"),
+        "Missing FERRIC_STATIC_ASSERT macro definition"
+    );
+    // Width locks for every caller-populated discriminant field.
+    for field in [
+        "((FerricValue *)0)->value_type",
+        "((FerricValue *)0)->external_type_id",
+        "((FerricConfig *)0)->string_encoding",
+        "((FerricConfig *)0)->strategy",
+        "((FerricPinnedEngineOptions *)0)->autorelease_policy",
+    ] {
+        assert!(
+            header.contains(&format!("FERRIC_STATIC_ASSERT(sizeof({field}) == 4")),
+            "Missing width assertion for {field}"
+        );
+    }
+    // Enum object widths for every enum crossing the ABI (rejects
+    // -fshort-enums / packed-enum consumer ABIs at compile time).
+    for e in [
+        "FerricError",
+        "FerricValueType",
+        "FerricStringEncoding",
+        "FerricConflictStrategy",
+        "FerricFactType",
+        "FerricHaltReason",
+        "FerricPinnedAutoreleasePolicy",
+        "FerricSerializationFormat",
+    ] {
+        assert!(
+            header.contains(&format!("FERRIC_STATIC_ASSERT(sizeof(enum {e}) == 4")),
+            "Missing enum-width assertion for enum {e}"
+        );
+    }
+    // Documented numeric values for the ABI enums (spot-check boundaries).
+    for assertion in [
+        "FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_VOID == 0",
+        "FERRIC_STATIC_ASSERT(FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS == 6",
+        "FERRIC_STATIC_ASSERT(FERRIC_ERROR_INVALID_ARGUMENT == 9",
+        "FERRIC_STATIC_ASSERT(FERRIC_ERROR_INTERNAL_ERROR == 99",
+        "FERRIC_STATIC_ASSERT(FERRIC_STRING_ENCODING_ASCII == 0",
+        "FERRIC_STATIC_ASSERT(FERRIC_CONFLICT_STRATEGY_MEA == 3",
+        "FERRIC_STATIC_ASSERT(FERRIC_SERIALIZATION_FORMAT_POSTCARD == 4",
+    ] {
+        assert!(
+            header.contains(assertion),
+            "Missing numeric-value assertion: {assertion}"
+        );
+    }
+}
+
+#[test]
 fn header_contains_ferric_engine_opaque() {
     let header = read_committed_header();
     // FerricEngine must appear as an opaque struct, not with its fields exposed
@@ -407,13 +478,14 @@ fn header_contains_value_free_functions() {
         header.contains("ferric_string_free"),
         "Missing ferric_string_free"
     );
+    // Both value-free functions report invalid discriminants via FerricError.
     assert!(
-        header.contains("ferric_value_free"),
-        "Missing ferric_value_free"
+        header.contains("enum FerricError ferric_value_free("),
+        "ferric_value_free must return FerricError"
     );
     assert!(
-        header.contains("ferric_value_array_free"),
-        "Missing ferric_value_array_free"
+        header.contains("enum FerricError ferric_value_array_free("),
+        "ferric_value_array_free must return FerricError"
     );
 }
 

--- a/crates/ferric-ffi/src/tests/header.rs
+++ b/crates/ferric-ffi/src/tests/header.rs
@@ -281,6 +281,10 @@ fn header_has_abi_static_assertions() {
         header.contains("#define FERRIC_STATIC_ASSERT(COND, MSG)"),
         "Missing FERRIC_STATIC_ASSERT macro definition"
     );
+    assert!(
+        header.contains("#if defined(__cplusplus) && __cplusplus >= 201103L"),
+        "C++ static_assert must be gated on C++11 so older modes use the typedef fallback"
+    );
     // Width locks for every caller-populated discriminant field.
     for field in [
         "((FerricValue *)0)->value_type",

--- a/crates/ferric-ffi/src/tests/template_assertion.rs
+++ b/crates/ferric-ffi/src/tests/template_assertion.rs
@@ -119,14 +119,14 @@ fn assert_template_defaults_filled() {
         let mut age_val = FerricValue::void();
         let rc = ferric_engine_get_fact_field(engine, fact_id, 1, &mut age_val);
         assert_eq!(rc, FerricError::Ok);
-        assert_eq!(age_val.value_type, FerricValueType::Integer);
+        assert_eq!(age_val.value_type, FerricValueType::Integer.as_raw());
         assert_eq!(age_val.integer, 0);
 
         // active default is TRUE (a symbol)
         let mut active_val = FerricValue::void();
         let rc = ferric_engine_get_fact_field(engine, fact_id, 2, &mut active_val);
         assert_eq!(rc, FerricError::Ok);
-        assert_eq!(active_val.value_type, FerricValueType::Symbol);
+        assert_eq!(active_val.value_type, FerricValueType::Symbol.as_raw());
         let active_str = std::ffi::CStr::from_ptr(active_val.string_ptr)
             .to_str()
             .unwrap();
@@ -265,7 +265,7 @@ fn get_slot_by_name_basic() {
         let rc =
             ferric_engine_get_fact_slot_by_name(engine, fact_id, query_name.as_ptr(), &mut out_val);
         assert_eq!(rc, FerricError::Ok);
-        assert_eq!(out_val.value_type, FerricValueType::String);
+        assert_eq!(out_val.value_type, FerricValueType::String.as_raw());
         let name_str = std::ffi::CStr::from_ptr(out_val.string_ptr)
             .to_str()
             .unwrap();
@@ -278,7 +278,7 @@ fn get_slot_by_name_basic() {
         let rc =
             ferric_engine_get_fact_slot_by_name(engine, fact_id, query_age.as_ptr(), &mut out_val);
         assert_eq!(rc, FerricError::Ok);
-        assert_eq!(out_val.value_type, FerricValueType::Integer);
+        assert_eq!(out_val.value_type, FerricValueType::Integer.as_raw());
         assert_eq!(out_val.integer, 25);
 
         ferric_engine_free(engine);
@@ -456,7 +456,7 @@ fn assert_template_with_float_slot() {
         let mut out_val = FerricValue::void();
         let rc = ferric_engine_get_fact_slot_by_name(engine, fact_id, query.as_ptr(), &mut out_val);
         assert_eq!(rc, FerricError::Ok);
-        assert_eq!(out_val.value_type, FerricValueType::Float);
+        assert_eq!(out_val.value_type, FerricValueType::Float.as_raw());
         assert!((out_val.float - 98.6).abs() < f64::EPSILON);
 
         let query_unit = CString::new("unit").unwrap();
@@ -464,7 +464,7 @@ fn assert_template_with_float_slot() {
         let rc =
             ferric_engine_get_fact_slot_by_name(engine, fact_id, query_unit.as_ptr(), &mut out_val);
         assert_eq!(rc, FerricError::Ok);
-        assert_eq!(out_val.value_type, FerricValueType::Symbol);
+        assert_eq!(out_val.value_type, FerricValueType::Symbol.as_raw());
         let unit_str = std::ffi::CStr::from_ptr(out_val.string_ptr)
             .to_str()
             .unwrap();

--- a/crates/ferric-ffi/src/tests/values.rs
+++ b/crates/ferric-ffi/src/tests/values.rs
@@ -39,7 +39,7 @@ unsafe fn first_fact_id(handle: &FerricEngine) -> u64 {
 #[test]
 fn value_void_is_zeroed() {
     let v = FerricValue::void();
-    assert_eq!(v.value_type, FerricValueType::Void);
+    assert_eq!(v.value_type, FerricValueType::Void.as_raw());
     assert_eq!(v.integer, 0);
     assert!(v.float.abs() < f64::EPSILON);
     assert!(v.string_ptr.is_null());
@@ -73,7 +73,7 @@ fn value_integer_conversion() {
         // Field 0 is the integer value 42
         let result = ferric_engine_get_fact_field(engine, fid, 0, &mut out);
         assert_eq!(result, FerricError::Ok);
-        assert_eq!(out.value_type, FerricValueType::Integer);
+        assert_eq!(out.value_type, FerricValueType::Integer.as_raw());
         assert_eq!(out.integer, 42);
 
         ferric_engine_free(engine);
@@ -97,7 +97,7 @@ fn value_float_conversion() {
         let mut out = FerricValue::void();
         let result = ferric_engine_get_fact_field(engine, fid, 0, &mut out);
         assert_eq!(result, FerricError::Ok);
-        assert_eq!(out.value_type, FerricValueType::Float);
+        assert_eq!(out.value_type, FerricValueType::Float.as_raw());
         assert!((out.float - 98.6_f64).abs() < 1e-9);
 
         ferric_engine_free(engine);
@@ -122,7 +122,7 @@ fn value_symbol_conversion() {
         // Field 0 is the symbol `red`
         let result = ferric_engine_get_fact_field(engine, fid, 0, &mut out);
         assert_eq!(result, FerricError::Ok);
-        assert_eq!(out.value_type, FerricValueType::Symbol);
+        assert_eq!(out.value_type, FerricValueType::Symbol.as_raw());
         assert!(!out.string_ptr.is_null());
 
         let s = CStr::from_ptr(out.string_ptr).to_str().unwrap();
@@ -151,7 +151,7 @@ fn value_string_conversion() {
         // Field 0 is the string "hello world"
         let result = ferric_engine_get_fact_field(engine, fid, 0, &mut out);
         assert_eq!(result, FerricError::Ok);
-        assert_eq!(out.value_type, FerricValueType::String);
+        assert_eq!(out.value_type, FerricValueType::String.as_raw());
         assert!(!out.string_ptr.is_null());
 
         let s = CStr::from_ptr(out.string_ptr).to_str().unwrap();
@@ -176,14 +176,14 @@ fn string_free_null_is_safe() {
 #[test]
 fn value_free_null_is_safe() {
     unsafe {
-        ferric_value_free(ptr::null_mut());
+        assert_eq!(ferric_value_free(ptr::null_mut()), FerricError::Ok);
     }
 }
 
 #[test]
 fn value_array_free_null_is_safe() {
     unsafe {
-        ferric_value_array_free(ptr::null_mut(), 0);
+        assert_eq!(ferric_value_array_free(ptr::null_mut(), 0), FerricError::Ok);
     }
 }
 
@@ -204,10 +204,10 @@ fn value_free_releases_string() {
         let mut out = FerricValue::void();
         let result = ferric_engine_get_fact_field(engine, fid, 0, &mut out);
         assert_eq!(result, FerricError::Ok);
-        assert_eq!(out.value_type, FerricValueType::Symbol);
+        assert_eq!(out.value_type, FerricValueType::Symbol.as_raw());
 
         // Free via ferric_value_free — must not crash or leak
-        ferric_value_free(&mut out);
+        assert_eq!(ferric_value_free(&mut out), FerricError::Ok);
 
         ferric_engine_free(engine);
     }
@@ -406,7 +406,7 @@ fn get_global_value() {
         let mut out = FerricValue::void();
         let result = ferric_engine_get_global(engine, name.as_ptr(), &mut out);
         assert_eq!(result, FerricError::Ok);
-        assert_eq!(out.value_type, FerricValueType::Integer);
+        assert_eq!(out.value_type, FerricValueType::Integer.as_raw());
         assert_eq!(out.integer, 42);
 
         ferric_engine_free(engine);
@@ -453,7 +453,7 @@ fn full_assert_query_retract_cycle() {
             ferric_engine_get_fact_field(engine, fid, 0, &mut f0),
             FerricError::Ok
         );
-        assert_eq!(f0.value_type, FerricValueType::Symbol);
+        assert_eq!(f0.value_type, FerricValueType::Symbol.as_raw());
         let s = CStr::from_ptr(f0.string_ptr).to_str().unwrap();
         assert_eq!(s, "widget");
         ferric_string_free(f0.string_ptr);
@@ -464,7 +464,7 @@ fn full_assert_query_retract_cycle() {
             ferric_engine_get_fact_field(engine, fid, 1, &mut f1),
             FerricError::Ok
         );
-        assert_eq!(f1.value_type, FerricValueType::Integer);
+        assert_eq!(f1.value_type, FerricValueType::Integer.as_raw());
         assert_eq!(f1.integer, 99);
 
         // Retract the fact

--- a/crates/ferric-ffi/src/types.rs
+++ b/crates/ferric-ffi/src/types.rs
@@ -9,6 +9,8 @@ use std::ffi::CStr;
 use ferric_core::{ConflictResolutionStrategy, StringEncoding};
 use ferric_runtime::{Engine, EngineConfig, HaltReason};
 
+use crate::error::{set_global_error, FerricError};
+
 /// C-facing string-encoding configuration for `FerricConfig`.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -172,6 +174,14 @@ impl From<HaltReason> for FerricHaltReason {
 }
 
 /// C-facing value type discriminant.
+///
+/// Crosses the ABI as a raw `u32` (`FerricValue::value_type`), never as this
+/// Rust enum: caller-populated memory is validated with [`Self::from_raw`] /
+/// `TryFrom<u32>` before being interpreted, and unknown discriminants are
+/// rejected with `FERRIC_ERROR_INVALID_ARGUMENT`.
+///
+/// Stable numeric values — new variants may be added but existing values
+/// must never change.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FerricValueType {
@@ -182,6 +192,37 @@ pub enum FerricValueType {
     String = 4,
     Multifield = 5,
     ExternalAddress = 6,
+}
+
+impl FerricValueType {
+    /// Integer discriminant used in `FerricValue::value_type`.
+    #[must_use]
+    pub const fn as_raw(self) -> u32 {
+        self as u32
+    }
+
+    #[must_use]
+    pub const fn from_raw(raw: u32) -> Option<Self> {
+        match raw {
+            0 => Some(Self::Void),
+            1 => Some(Self::Integer),
+            2 => Some(Self::Float),
+            3 => Some(Self::Symbol),
+            4 => Some(Self::String),
+            5 => Some(Self::Multifield),
+            6 => Some(Self::ExternalAddress),
+            _ => None,
+        }
+    }
+}
+
+impl TryFrom<u32> for FerricValueType {
+    type Error = String;
+
+    fn try_from(raw: u32) -> Result<Self, Self::Error> {
+        Self::from_raw(raw)
+            .ok_or_else(|| format!("invalid value_type discriminant: {raw} (expected 0..=6)"))
+    }
 }
 
 /// C-facing value representation.
@@ -208,7 +249,13 @@ pub enum FerricValueType {
 /// | ExternalAddress | `external_type_id`, `external_pointer` |
 #[repr(C)]
 pub struct FerricValue {
-    pub value_type: FerricValueType,
+    /// Raw `FerricValueType` discriminant.
+    ///
+    /// Every API that reads a caller-populated `FerricValue` validates this
+    /// field before interpreting it; values outside the documented
+    /// `FerricValueType` range are rejected with
+    /// `FERRIC_ERROR_INVALID_ARGUMENT`.
+    pub value_type: u32,
     pub integer: i64,
     pub float: f64,
     pub string_ptr: *mut c_char,
@@ -223,7 +270,7 @@ impl FerricValue {
     #[must_use]
     pub const fn void() -> Self {
         Self {
-            value_type: FerricValueType::Void,
+            value_type: FerricValueType::Void.as_raw(),
             integer: 0,
             float: 0.0,
             string_ptr: ptr::null_mut(),
@@ -249,12 +296,12 @@ use ferric_core::Value;
 pub(crate) fn value_to_ferric(value: &Value, engine: &Engine) -> FerricValue {
     match value {
         Value::Integer(i) => FerricValue {
-            value_type: FerricValueType::Integer,
+            value_type: FerricValueType::Integer.as_raw(),
             integer: *i,
             ..FerricValue::void()
         },
         Value::Float(f) => FerricValue {
-            value_type: FerricValueType::Float,
+            value_type: FerricValueType::Float.as_raw(),
             float: *f,
             ..FerricValue::void()
         },
@@ -262,7 +309,7 @@ pub(crate) fn value_to_ferric(value: &Value, engine: &Engine) -> FerricValue {
             let name = engine.resolve_symbol(*sym).unwrap_or("<unknown>");
             let cstring = CString::new(name).unwrap_or_default();
             FerricValue {
-                value_type: FerricValueType::Symbol,
+                value_type: FerricValueType::Symbol.as_raw(),
                 string_ptr: cstring.into_raw(),
                 ..FerricValue::void()
             }
@@ -270,7 +317,7 @@ pub(crate) fn value_to_ferric(value: &Value, engine: &Engine) -> FerricValue {
         Value::String(s) => {
             let cstring = CString::new(s.as_str()).unwrap_or_default();
             FerricValue {
-                value_type: FerricValueType::String,
+                value_type: FerricValueType::String.as_raw(),
                 string_ptr: cstring.into_raw(),
                 ..FerricValue::void()
             }
@@ -286,14 +333,14 @@ pub(crate) fn value_to_ferric(value: &Value, engine: &Engine) -> FerricValue {
                 raw.cast::<FerricValue>()
             };
             FerricValue {
-                value_type: FerricValueType::Multifield,
+                value_type: FerricValueType::Multifield.as_raw(),
                 multifield_ptr: ptr,
                 multifield_len: len,
                 ..FerricValue::void()
             }
         }
         Value::ExternalAddress(ea) => FerricValue {
-            value_type: FerricValueType::ExternalAddress,
+            value_type: FerricValueType::ExternalAddress.as_raw(),
             external_type_id: ea.type_id.0,
             external_pointer: ea.pointer,
             ..FerricValue::void()
@@ -311,6 +358,10 @@ pub(crate) fn value_to_ferric(value: &Value, engine: &Engine) -> FerricValue {
 /// For Symbol and String types, the `string_ptr` is read as a NUL-terminated
 /// C string. For Symbol, the string is interned via the engine's symbol table.
 ///
+/// The raw `value_type` discriminant is validated before interpretation;
+/// unknown discriminants (including in nested multifield elements) produce an
+/// `Err`, which callers surface as `FERRIC_ERROR_INVALID_ARGUMENT`.
+///
 /// # Safety
 ///
 /// - `fv` must be a valid `FerricValue` with active fields matching `value_type`.
@@ -320,7 +371,7 @@ pub(crate) unsafe fn ferric_to_value(
     fv: &FerricValue,
     engine: &mut Engine,
 ) -> Result<Value, String> {
-    match fv.value_type {
+    match FerricValueType::try_from(fv.value_type)? {
         FerricValueType::Void => Ok(Value::Void),
         FerricValueType::Integer => Ok(Value::Integer(fv.integer)),
         FerricValueType::Float => Ok(Value::Float(fv.float)),
@@ -372,7 +423,7 @@ pub(crate) unsafe fn ferric_to_value(
 #[no_mangle]
 pub extern "C" fn ferric_value_integer(value: i64) -> FerricValue {
     FerricValue {
-        value_type: FerricValueType::Integer,
+        value_type: FerricValueType::Integer.as_raw(),
         integer: value,
         ..FerricValue::void()
     }
@@ -382,7 +433,7 @@ pub extern "C" fn ferric_value_integer(value: i64) -> FerricValue {
 #[no_mangle]
 pub extern "C" fn ferric_value_float(value: f64) -> FerricValue {
     FerricValue {
-        value_type: FerricValueType::Float,
+        value_type: FerricValueType::Float.as_raw(),
         float: value,
         ..FerricValue::void()
     }
@@ -404,7 +455,7 @@ pub unsafe extern "C" fn ferric_value_symbol(name: *const c_char) -> FerricValue
     let cstr = CStr::from_ptr(name);
     let cstring = CString::new(cstr.to_bytes()).unwrap_or_default();
     FerricValue {
-        value_type: FerricValueType::Symbol,
+        value_type: FerricValueType::Symbol.as_raw(),
         string_ptr: cstring.into_raw(),
         ..FerricValue::void()
     }
@@ -426,7 +477,7 @@ pub unsafe extern "C" fn ferric_value_string(s: *const c_char) -> FerricValue {
     let cstr = CStr::from_ptr(s);
     let cstring = CString::new(cstr.to_bytes()).unwrap_or_default();
     FerricValue {
-        value_type: FerricValueType::String,
+        value_type: FerricValueType::String.as_raw(),
         string_ptr: cstring.into_raw(),
         ..FerricValue::void()
     }
@@ -459,72 +510,124 @@ pub unsafe extern "C" fn ferric_string_free(ptr: *mut c_char) {
 
 /// Free a `FerricValue` and its owned resources.
 ///
-/// Recursively frees owned strings and multifield arrays.
-/// Null pointers are safely ignored.
+/// Recursively frees owned strings and multifield arrays. Null pointers are
+/// safely ignored and return `FERRIC_ERROR_OK`.
+///
+/// If the value (or any nested multifield element) carries an unknown
+/// `value_type` discriminant, returns `FERRIC_ERROR_INVALID_ARGUMENT` and
+/// records a diagnostic in the global error channel. The unknown-tagged
+/// value's payload fields are never interpreted (nothing of it is freed),
+/// but all sibling values with known discriminants and every owned
+/// containing multifield array are still released.
 ///
 /// # Safety
 ///
 /// - `value` must point to a valid `FerricValue` or be null.
 /// - Any owned resources (`string_ptr`, `multifield_ptr`) must not have been freed already.
 #[no_mangle]
-pub unsafe extern "C" fn ferric_value_free(value: *mut FerricValue) {
+pub unsafe extern "C" fn ferric_value_free(value: *mut FerricValue) -> FerricError {
     if value.is_null() {
-        return;
+        return FerricError::Ok;
     }
     let val = &*value;
-    free_value_resources(val);
+    report_free_result(free_value_resources(val))
 }
 
 /// Free an array of `FerricValue`s and all their owned resources.
 ///
 /// Frees each element's owned resources, then frees the array allocation.
-/// Null pointers are safely ignored.
+/// Null pointers are safely ignored and return `FERRIC_ERROR_OK`.
+///
+/// If any element (or any nested multifield element) carries an unknown
+/// `value_type` discriminant, returns `FERRIC_ERROR_INVALID_ARGUMENT` and
+/// records a diagnostic in the global error channel. Unknown-tagged
+/// elements' payload fields are never interpreted (nothing of them is
+/// freed), but all elements with known discriminants and the array
+/// allocation itself are still released.
 ///
 /// # Safety
 ///
 /// - `arr` must point to a contiguous array of `len` `FerricValue`s, or be null.
 /// - The array must have been allocated by the FFI.
 #[no_mangle]
-pub unsafe extern "C" fn ferric_value_array_free(arr: *mut FerricValue, len: usize) {
+pub unsafe extern "C" fn ferric_value_array_free(arr: *mut FerricValue, len: usize) -> FerricError {
     if arr.is_null() || len == 0 {
-        return;
+        return FerricError::Ok;
     }
-    // Free each element's owned resources
+    // Free each element's owned resources, retaining the first invalid tag.
+    let mut result = Ok(());
     for i in 0..len {
         let elem = &*arr.add(i);
-        free_value_resources(elem);
+        let elem_result = free_value_resources(elem);
+        if result.is_ok() {
+            result = elem_result;
+        }
     }
     // Free the array allocation itself
     let slice = std::slice::from_raw_parts_mut(arr, len);
     drop(Box::from_raw(slice as *mut [FerricValue]));
+    report_free_result(result)
+}
+
+/// Map a cleanup result to an FFI error code, storing any diagnostic in the
+/// global error channel.
+fn report_free_result(result: Result<(), String>) -> FerricError {
+    match result {
+        Ok(()) => FerricError::Ok,
+        Err(msg) => {
+            set_global_error(msg);
+            FerricError::InvalidArgument
+        }
+    }
 }
 
 /// Internal: free owned resources inside a `FerricValue` without freeing the struct itself.
+///
+/// The raw `value_type` discriminant is validated before interpretation. An
+/// unknown discriminant returns `Err` and frees nothing of that value: with
+/// an invalid tag there is no way to know which fields are active, so leaking
+/// any caller-supplied resources is preferred over interpreting arbitrary bit
+/// patterns (potential wild frees). Cleanup still proceeds for all sibling
+/// values with known discriminants and for the owned containing array; the
+/// first invalid tag encountered is retained in the returned diagnostic.
 ///
 /// # Safety
 ///
 /// - `val` must point to a valid `FerricValue`.
 /// - Any owned resources referenced by `val` must not have been freed already.
-unsafe fn free_value_resources(val: &FerricValue) {
-    match val.value_type {
-        FerricValueType::Symbol | FerricValueType::String => {
+unsafe fn free_value_resources(val: &FerricValue) -> Result<(), String> {
+    match FerricValueType::from_raw(val.value_type) {
+        Some(FerricValueType::Symbol | FerricValueType::String) => {
             if !val.string_ptr.is_null() {
                 drop(CString::from_raw(val.string_ptr));
             }
+            Ok(())
         }
-        FerricValueType::Multifield => {
+        Some(FerricValueType::Multifield) => {
+            let mut result = Ok(());
             if !val.multifield_ptr.is_null() && val.multifield_len > 0 {
                 for i in 0..val.multifield_len {
                     let elem = &*val.multifield_ptr.add(i);
-                    free_value_resources(elem);
+                    let elem_result = free_value_resources(elem);
+                    if result.is_ok() {
+                        result = elem_result;
+                    }
                 }
                 let slice = std::slice::from_raw_parts_mut(val.multifield_ptr, val.multifield_len);
                 drop(Box::from_raw(slice as *mut [FerricValue]));
             }
+            result
         }
-        FerricValueType::Void
-        | FerricValueType::Integer
-        | FerricValueType::Float
-        | FerricValueType::ExternalAddress => {}
+        Some(
+            FerricValueType::Void
+            | FerricValueType::Integer
+            | FerricValueType::Float
+            | FerricValueType::ExternalAddress,
+        ) => Ok(()),
+        None => Err(format!(
+            "cannot free value: invalid value_type discriminant: {} (expected 0..=6); \
+             its owned resources were not freed",
+            val.value_type
+        )),
     }
 }

--- a/crates/ferric-ffi/tests/c/discriminant_abuse.c
+++ b/crates/ferric-ffi/tests/c/discriminant_abuse.c
@@ -1,0 +1,402 @@
+/*
+ * discriminant_abuse.c — C-ABI regression harness for FR-CABI-001 (issue #85).
+ *
+ * Passes invalid `FerricValue.value_type` discriminants — top-level and
+ * nested inside multifields — to every API that accepts caller-populated
+ * FerricValues, and verifies:
+ *
+ *   1. Accepting APIs (ferric_engine_assert_ordered,
+ *      ferric_engine_assert_template) return FERRIC_ERROR_INVALID_ARGUMENT
+ *      for every unknown discriminant, at every nesting depth.
+ *   2. Resource-freeing paths (ferric_value_free) never interpret an
+ *      unknown discriminant: poison pointers stored alongside an invalid
+ *      tag must not be freed (ASan aborts on a wild free).
+ *   3. The engine stays usable after each rejection, and valid numeric
+ *      discriminants keep their existing meaning.
+ *
+ * Intended to run under AddressSanitizer + UndefinedBehaviorSanitizer via
+ * `just ffi-c-harness` (scripts/ffi-c-harness.sh). The harness exits
+ * non-zero on the first contract violation; a sanitizer abort also fails
+ * the run.
+ *
+ * Including ferric.h also compiles its ABI static assertions, which lock
+ * discriminant widths and numeric values at compile time.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "ferric.h"
+
+static int failures = 0;
+
+#define CHECK(cond, msg)                                              \
+    do {                                                              \
+        if (!(cond)) {                                                \
+            fprintf(stderr, "FAIL(%s:%d): %s\n", __FILE__, __LINE__,  \
+                    (msg));                                           \
+            failures++;                                               \
+        }                                                             \
+    } while (0)
+
+/* Discriminants that must be rejected: first invalid value, arbitrary
+ * garbage, and bit patterns that would be invalid Rust enum reprs. */
+static const uint32_t INVALID_TAGS[] = {7u, 42u, 0xDEADBEEFu, 0xFFFFFFFFu};
+static const size_t INVALID_TAG_COUNT =
+    sizeof(INVALID_TAGS) / sizeof(INVALID_TAGS[0]);
+
+/* The diagnostic must identify an invalid value_type discriminant and the
+ * raw decimal tag. Pre-fix code misclassified out-of-range tags as other
+ * value kinds (e.g. 999 as ExternalAddress) and could return
+ * INVALID_ARGUMENT with an unrelated message, so message content — not
+ * just the error code — is asserted. */
+static void check_diag_names_tag(const char *diag, uint32_t tag,
+                                 const char *ctx) {
+    char needle[64];
+    snprintf(needle, sizeof(needle), "invalid value_type discriminant: %u",
+             (unsigned)tag);
+    CHECK(diag != NULL && strstr(diag, needle) != NULL, ctx);
+}
+
+static void expect_engine_usable(FerricEngine *engine) {
+    FerricValue ok_field = ferric_value_integer(1);
+    uint64_t fact_id = 0;
+    FerricError err =
+        ferric_engine_assert_ordered(engine, "probe", &ok_field, 1, &fact_id);
+    CHECK(err == FERRIC_ERROR_OK, "engine must stay usable after rejection");
+    if (err == FERRIC_ERROR_OK) {
+        CHECK(ferric_engine_retract(engine, fact_id) == FERRIC_ERROR_OK,
+              "probe fact must be retractable");
+    }
+}
+
+static void test_assert_ordered_top_level(FerricEngine *engine) {
+    for (size_t i = 0; i < INVALID_TAG_COUNT; i++) {
+        FerricValue bad = ferric_value_void();
+        bad.value_type = INVALID_TAGS[i];
+        /* Poison the payload fields: they must never be interpreted. */
+        bad.string_ptr = (char *)&bad;
+        bad.multifield_ptr = (FerricValue *)&bad;
+        bad.multifield_len = SIZE_MAX;
+
+        uint64_t fact_id = 0;
+        FerricError err =
+            ferric_engine_assert_ordered(engine, "bad", &bad, 1, &fact_id);
+        CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+              "assert_ordered must reject an invalid top-level discriminant");
+        check_diag_names_tag(ferric_engine_last_error(engine), INVALID_TAGS[i],
+                             "ordered top-level diagnostic must name the tag");
+        expect_engine_usable(engine);
+    }
+}
+
+static void test_assert_ordered_nested(FerricEngine *engine) {
+    for (size_t i = 0; i < INVALID_TAG_COUNT; i++) {
+        FerricValue elems[3];
+        elems[0] = ferric_value_integer(10);
+        elems[1] = ferric_value_void();
+        elems[1].value_type = INVALID_TAGS[i];
+        elems[1].string_ptr = (char *)&elems[1];
+        elems[2] = ferric_value_float(2.5);
+
+        FerricValue mf = ferric_value_void();
+        mf.value_type = FERRIC_VALUE_TYPE_MULTIFIELD;
+        mf.multifield_ptr = elems;
+        mf.multifield_len = 3;
+
+        uint64_t fact_id = 0;
+        FerricError err =
+            ferric_engine_assert_ordered(engine, "bad", &mf, 1, &fact_id);
+        CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+              "assert_ordered must reject an invalid nested discriminant");
+        check_diag_names_tag(ferric_engine_last_error(engine), INVALID_TAGS[i],
+                             "ordered nested diagnostic must name the tag");
+        expect_engine_usable(engine);
+    }
+}
+
+static void test_assert_ordered_deeply_nested(FerricEngine *engine) {
+    FerricValue inner_bad = ferric_value_void();
+    inner_bad.value_type = 0xBADBADu;
+    inner_bad.multifield_ptr = &inner_bad;
+    inner_bad.multifield_len = SIZE_MAX;
+
+    FerricValue inner = ferric_value_void();
+    inner.value_type = FERRIC_VALUE_TYPE_MULTIFIELD;
+    inner.multifield_ptr = &inner_bad;
+    inner.multifield_len = 1;
+
+    FerricValue outer = ferric_value_void();
+    outer.value_type = FERRIC_VALUE_TYPE_MULTIFIELD;
+    outer.multifield_ptr = &inner;
+    outer.multifield_len = 1;
+
+    FerricError err =
+        ferric_engine_assert_ordered(engine, "bad", &outer, 1, NULL);
+    CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+          "assert_ordered must reject an invalid doubly-nested discriminant");
+    check_diag_names_tag(ferric_engine_last_error(engine), 0xBADBADu,
+                         "doubly-nested diagnostic must name the tag");
+    expect_engine_usable(engine);
+}
+
+static void test_assert_template(FerricEngine *engine) {
+    const char *slot_names[1] = {"age"};
+
+    for (size_t i = 0; i < INVALID_TAG_COUNT; i++) {
+        /* Top-level slot value with an invalid discriminant. */
+        FerricValue bad = ferric_value_void();
+        bad.value_type = INVALID_TAGS[i];
+        bad.string_ptr = (char *)&bad;
+
+        FerricError err = ferric_engine_assert_template(
+            engine, "person", slot_names, &bad, 1, NULL);
+        CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+              "assert_template must reject an invalid top-level discriminant");
+        check_diag_names_tag(ferric_engine_last_error(engine), INVALID_TAGS[i],
+                             "template top-level diagnostic must name the tag");
+        expect_engine_usable(engine);
+    }
+
+    /* Invalid discriminant nested inside a multislot value. */
+    const char *tag_slot[1] = {"tags"};
+    FerricValue elems[2];
+    elems[0] = ferric_value_integer(1);
+    elems[1] = ferric_value_void();
+    elems[1].value_type = 7u;
+    elems[1].string_ptr = (char *)&elems[1];
+
+    FerricValue mf = ferric_value_void();
+    mf.value_type = FERRIC_VALUE_TYPE_MULTIFIELD;
+    mf.multifield_ptr = elems;
+    mf.multifield_len = 2;
+
+    FerricError err = ferric_engine_assert_template(engine, "person", tag_slot,
+                                                    &mf, 1, NULL);
+    CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+          "assert_template must reject an invalid nested discriminant");
+    check_diag_names_tag(ferric_engine_last_error(engine), 7u,
+                         "template nested diagnostic must name the tag");
+    expect_engine_usable(engine);
+}
+
+static void test_value_free_invalid_tag(void) {
+    /* An invalid tag must free nothing: the poison pointers below are not
+     * heap allocations, so any attempt to interpret/free them aborts under
+     * ASan and corrupts memory without it. */
+    for (size_t i = 0; i < INVALID_TAG_COUNT; i++) {
+        char stack_buf[8] = "poison";
+        FerricValue bad = ferric_value_void();
+        bad.value_type = INVALID_TAGS[i];
+        bad.string_ptr = stack_buf;
+        bad.multifield_ptr = (FerricValue *)stack_buf;
+        bad.multifield_len = SIZE_MAX;
+
+        FerricError err = ferric_value_free(&bad);
+        CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+              "value_free must report an invalid top-level discriminant");
+        check_diag_names_tag(ferric_last_error_global(), INVALID_TAGS[i],
+                             "value_free diagnostic must name the tag");
+        CHECK(stack_buf[0] == 'p', "invalid-tag free must not touch payloads");
+    }
+}
+
+static void test_value_free_null_and_valid_return_ok(void) {
+    CHECK(ferric_value_free(NULL) == FERRIC_ERROR_OK,
+          "value_free(NULL) must return OK");
+    CHECK(ferric_value_array_free(NULL, 0) == FERRIC_ERROR_OK,
+          "value_array_free(NULL, 0) must return OK");
+    FerricValue sym = ferric_value_symbol("owned");
+    CHECK(ferric_value_free(&sym) == FERRIC_ERROR_OK,
+          "value_free of a valid value must return OK");
+}
+
+/* Assert a (sym 22) multislot fact and read the slot back, yielding an
+ * FFI-allocated multifield array: [Symbol(owned string), Integer].
+ * Returns 0 on failure. The caller owns *out and the fact `*fact_id`. */
+static int read_back_multislot(FerricEngine *engine, FerricValue *out,
+                               uint64_t *fact_id) {
+    const char *slot_names[1] = {"tags"};
+    FerricValue elems[2];
+    elems[0] = ferric_value_symbol("owned-sibling");
+    elems[1] = ferric_value_integer(22);
+    FerricValue mf = ferric_value_void();
+    mf.value_type = FERRIC_VALUE_TYPE_MULTIFIELD;
+    mf.multifield_ptr = elems;
+    mf.multifield_len = 2;
+
+    FerricError err = ferric_engine_assert_template(engine, "person",
+                                                    slot_names, &mf, 1,
+                                                    fact_id);
+    ferric_value_free(&elems[0]);
+    CHECK(err == FERRIC_ERROR_OK, "valid multislot assert must succeed");
+    if (err != FERRIC_ERROR_OK) {
+        return 0;
+    }
+
+    *out = ferric_value_void();
+    err = ferric_engine_get_fact_slot_by_name(engine, *fact_id, "tags", out);
+    CHECK(err == FERRIC_ERROR_OK, "multislot read-back must succeed");
+    if (err != FERRIC_ERROR_OK) {
+        return 0;
+    }
+    CHECK(out->value_type == FERRIC_VALUE_TYPE_MULTIFIELD &&
+              out->multifield_len == 2,
+          "read-back slot must be a 2-element multifield");
+    return out->value_type == FERRIC_VALUE_TYPE_MULTIFIELD &&
+           out->multifield_len == 2;
+}
+
+static void test_value_free_corrupted_nested_tag(FerricEngine *engine) {
+    /* Corrupt a nested tag inside a genuine FFI-allocated multifield, then
+     * free via ferric_value_free: it must report the invalid tag, skip the
+     * corrupted element's payload, and still free the owned sibling string
+     * and the containing array (a leaked sibling fails ASan leak checks). */
+    FerricValue out;
+    uint64_t fact_id = 0;
+    if (!read_back_multislot(engine, &out, &fact_id)) {
+        return;
+    }
+
+    /* Element 1 is an integer (owns nothing), so corrupting it leaks no
+     * memory while its poisoned payload must never be interpreted. */
+    out.multifield_ptr[1].value_type = 0xDEADBEEFu;
+    out.multifield_ptr[1].string_ptr = (char *)&out;
+
+    FerricError err = ferric_value_free(&out);
+    CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+          "value_free must report an invalid nested discriminant");
+    check_diag_names_tag(ferric_last_error_global(), 0xDEADBEEFu,
+                         "nested value_free diagnostic must name the tag");
+
+    CHECK(ferric_engine_retract(engine, fact_id) == FERRIC_ERROR_OK,
+          "fact must be retractable after free");
+}
+
+static void test_value_array_free_top_level_invalid(FerricEngine *engine) {
+    /* Corrupt a top-level element of an FFI-allocated array, then free the
+     * array directly via ferric_value_array_free: it must report the tag
+     * while freeing the known sibling string and the array allocation. */
+    FerricValue out;
+    uint64_t fact_id = 0;
+    if (!read_back_multislot(engine, &out, &fact_id)) {
+        return;
+    }
+
+    out.multifield_ptr[1].value_type = 999u;
+    out.multifield_ptr[1].string_ptr = (char *)&out;
+
+    FerricError err =
+        ferric_value_array_free(out.multifield_ptr, out.multifield_len);
+    CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+          "value_array_free must report an invalid top-level discriminant");
+    check_diag_names_tag(ferric_last_error_global(), 999u,
+                         "array_free diagnostic must name the tag");
+
+    CHECK(ferric_engine_retract(engine, fact_id) == FERRIC_ERROR_OK,
+          "fact must be retractable after array free");
+}
+
+static void test_value_array_free_nested_invalid(FerricEngine *engine) {
+    /* Nested case: graft one FFI-allocated array as a multifield element of
+     * another, corrupt an inner element, and free the outer array. The
+     * invalid inner tag must be reported while both arrays and the owned
+     * inner sibling string are still freed. */
+    FerricValue outer;
+    FerricValue inner;
+    uint64_t outer_fact = 0;
+    uint64_t inner_fact = 0;
+    if (!read_back_multislot(engine, &outer, &outer_fact) ||
+        !read_back_multislot(engine, &inner, &inner_fact)) {
+        return;
+    }
+
+    /* Corrupt the inner integer element, then graft the inner array in
+     * place of the outer integer element (which owns nothing). */
+    inner.multifield_ptr[1].value_type = 0xFFFFFFFFu;
+    outer.multifield_ptr[1] = inner;
+
+    FerricError err =
+        ferric_value_array_free(outer.multifield_ptr, outer.multifield_len);
+    CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+          "value_array_free must report an invalid nested discriminant");
+    check_diag_names_tag(ferric_last_error_global(), 0xFFFFFFFFu,
+                         "nested array_free diagnostic must name the tag");
+
+    CHECK(ferric_engine_retract(engine, outer_fact) == FERRIC_ERROR_OK &&
+              ferric_engine_retract(engine, inner_fact) == FERRIC_ERROR_OK,
+          "facts must be retractable after nested array free");
+}
+
+static void test_valid_values_preserve_meaning(FerricEngine *engine) {
+    FerricValue fields[4];
+    fields[0] = ferric_value_integer(7);
+    fields[1] = ferric_value_float(1.5);
+    fields[2] = ferric_value_symbol("sym");
+    fields[3] = ferric_value_string("str");
+
+    uint64_t fact_id = 0;
+    FerricError err =
+        ferric_engine_assert_ordered(engine, "mixed", fields, 4, &fact_id);
+    CHECK(err == FERRIC_ERROR_OK, "valid discriminants must still assert");
+    CHECK(ferric_value_free(&fields[2]) == FERRIC_ERROR_OK,
+          "freeing a valid symbol value must return OK");
+    CHECK(ferric_value_free(&fields[3]) == FERRIC_ERROR_OK,
+          "freeing a valid string value must return OK");
+    if (err != FERRIC_ERROR_OK) {
+        return;
+    }
+
+    static const uint32_t EXPECTED[4] = {
+        FERRIC_VALUE_TYPE_INTEGER,
+        FERRIC_VALUE_TYPE_FLOAT,
+        FERRIC_VALUE_TYPE_SYMBOL,
+        FERRIC_VALUE_TYPE_STRING,
+    };
+    for (uintptr_t i = 0; i < 4; i++) {
+        FerricValue out = ferric_value_void();
+        err = ferric_engine_get_fact_field(engine, fact_id, i, &out);
+        CHECK(err == FERRIC_ERROR_OK, "field read-back must succeed");
+        if (err == FERRIC_ERROR_OK) {
+            CHECK(out.value_type == EXPECTED[i],
+                  "read-back discriminant must preserve its meaning");
+            ferric_value_free(&out);
+        }
+    }
+}
+
+int main(void) {
+    FerricEngine *engine = ferric_engine_new();
+    CHECK(engine != NULL, "engine creation must succeed");
+    if (engine == NULL) {
+        return 1;
+    }
+
+    const char *tmpl =
+        "(deftemplate person (slot name) (slot age) (multislot tags))";
+    CHECK(ferric_engine_load_string(engine, tmpl) == FERRIC_ERROR_OK,
+          "template load must succeed");
+    CHECK(ferric_engine_reset(engine) == FERRIC_ERROR_OK,
+          "engine reset must succeed");
+
+    test_assert_ordered_top_level(engine);
+    test_assert_ordered_nested(engine);
+    test_assert_ordered_deeply_nested(engine);
+    test_assert_template(engine);
+    test_value_free_invalid_tag();
+    test_value_free_null_and_valid_return_ok();
+    test_value_free_corrupted_nested_tag(engine);
+    test_value_array_free_top_level_invalid(engine);
+    test_value_array_free_nested_invalid(engine);
+    test_valid_values_preserve_meaning(engine);
+
+    ferric_engine_free(engine);
+
+    if (failures == 0) {
+        printf("discriminant_abuse: all checks passed\n");
+        return 0;
+    }
+    fprintf(stderr, "discriminant_abuse: %d check(s) failed\n", failures);
+    return 1;
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -846,8 +846,8 @@ ferric_engine_clear_action_diagnostics(engine);
 | Function | Purpose |
 |----------|---------|
 | `ferric_string_free` | Free a Ferric-allocated C string |
-| `ferric_value_free` | Free a `FerricValue` and its owned resources (recursive) |
-| `ferric_value_array_free` | Free an array of `FerricValue`s |
+| `ferric_value_free` | Free a `FerricValue` and its owned resources (recursive); returns `FERRIC_ERROR_INVALID_ARGUMENT` if any `value_type` tag is unknown (that value's payload is left untouched; known siblings and owned arrays are still freed) |
+| `ferric_value_array_free` | Free an array of `FerricValue`s; same unknown-tag contract as `ferric_value_free` |
 
 Borrowed pointers (from `ferric_engine_last_error`, `ferric_engine_get_output`)
 must **not** be freed by the caller and are valid only until the next FFI call

--- a/justfile
+++ b/justfile
@@ -70,6 +70,11 @@ test-runtime:
 test-ffi:
     cargo test -p ferric-ffi
 
+# Build the FFI staticlib and run the C ABI discriminant-abuse harness
+# as a real C subprocess under ASan/UBSan (when the compiler supports them)
+ffi-c-harness:
+    ./scripts/ffi-c-harness.sh
+
 # Run tests for the facade crate
 test-ferric:
     cargo test -p ferric

--- a/scripts/ffi-c-harness.sh
+++ b/scripts/ffi-c-harness.sh
@@ -57,10 +57,32 @@ else
     echo "ffi-c-harness: compiler lacks -fshort-enums; skipping negative check" >&2
 fi
 
-# Pre-C++11 consumers must use the typedef-based static-assertion fallback.
-printf '#include "ferric.h"\nint main(){return 0;}\n' |
-    "$CXX" -std=c++98 -Wall -Wextra -Werror -DFERRIC_SERDE \
-        -fsyntax-only -I crates/ferric-ffi -x c++ -
+# Pre-C++11 consumers must use the typedef-based static-assertion fallback,
+# and the header must be strictly conforming (-pedantic-errors rejects
+# extensions such as trailing enum commas that C++98/03 do not allow).
+for cxx_std in c++98 c++03; do
+    printf '#include "ferric.h"\nint main(){return 0;}\n' |
+        "$CXX" -std="$cxx_std" -pedantic-errors -Wall -Wextra -Werror \
+            -DFERRIC_SERDE -fsyntax-only -I crates/ferric-ffi -x c++ -
+done
+
+# The typedef fallback must itself reject packed-enum ABIs: probe for
+# C++98 -fshort-enums support, then require the header to fail to compile.
+if echo 'int main(){return 0;}' |
+    "$CXX" -std=c++98 -fshort-enums -x c++ \
+        -o "$outdir/cxx98-short-enum-probe" - 2>/dev/null; then
+    rm -f "$outdir/cxx98-short-enum-probe"
+    if printf '#include "ferric.h"\nint main(){return 0;}\n' |
+        "$CXX" -std=c++98 -fshort-enums -DFERRIC_SERDE \
+            -fsyntax-only -I crates/ferric-ffi -x c++ - 2>/dev/null; then
+        echo "ffi-c-harness: ERROR: ferric.h compiled under C++98 -fshort-enums;" \
+            "typedef-fallback ABI assertions failed to fire" >&2
+        exit 1
+    fi
+    echo "ffi-c-harness: C++98 -fshort-enums correctly rejected by typedef fallback"
+else
+    echo "ffi-c-harness: compiler lacks C++98 -fshort-enums; skipping negative check" >&2
+fi
 
 "$CC" -std=c11 -Wall -Wextra -Werror "${san_flags[@]}" \
     -I crates/ferric-ffi \

--- a/scripts/ffi-c-harness.sh
+++ b/scripts/ffi-c-harness.sh
@@ -14,6 +14,7 @@ cd "$root"
 cargo build -p ferric-ffi --profile ffi-dev
 
 CC="${CC:-cc}"
+CXX="${CXX:-c++}"
 harness_src="crates/ferric-ffi/tests/c/discriminant_abuse.c"
 outdir="target/c-harness"
 mkdir -p "$outdir"
@@ -55,6 +56,11 @@ if echo 'int main(void){return 0;}' |
 else
     echo "ffi-c-harness: compiler lacks -fshort-enums; skipping negative check" >&2
 fi
+
+# Pre-C++11 consumers must use the typedef-based static-assertion fallback.
+printf '#include "ferric.h"\nint main(){return 0;}\n' |
+    "$CXX" -std=c++98 -Wall -Wextra -Werror -DFERRIC_SERDE \
+        -fsyntax-only -I crates/ferric-ffi -x c++ -
 
 "$CC" -std=c11 -Wall -Wextra -Werror "${san_flags[@]}" \
     -I crates/ferric-ffi \

--- a/scripts/ffi-c-harness.sh
+++ b/scripts/ffi-c-harness.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Build the ferric-ffi static library and run the C ABI discriminant-abuse
+# harness (crates/ferric-ffi/tests/c/) as a real C subprocess.
+#
+# The harness is compiled with AddressSanitizer + UndefinedBehaviorSanitizer
+# when the local C compiler supports them (falls back to plain compilation
+# otherwise). Set FERRIC_REQUIRE_SANITIZERS=1 to make missing sanitizer
+# support fatal, as CI does.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+cargo build -p ferric-ffi --profile ffi-dev
+
+CC="${CC:-cc}"
+harness_src="crates/ferric-ffi/tests/c/discriminant_abuse.c"
+outdir="target/c-harness"
+mkdir -p "$outdir"
+
+san_flags=("-fsanitize=address,undefined" "-fno-sanitize-recover=all")
+if ! echo 'int main(void){return 0;}' |
+    "$CC" "${san_flags[@]}" -x c -o "$outdir/san-probe" - 2>/dev/null; then
+    if [[ ${FERRIC_REQUIRE_SANITIZERS:-0} == 1 ]]; then
+        echo "ffi-c-harness: ERROR: compiler lacks required ASan/UBSan support" >&2
+        exit 1
+    fi
+    echo "ffi-c-harness: compiler lacks ASan/UBSan support; running unsanitized" >&2
+    san_flags=()
+fi
+rm -f "$outdir/san-probe"
+
+case "$(uname -s)" in
+Darwin)
+    platform_libs=(-framework Security -framework CoreFoundation -lobjc)
+    ;;
+*)
+    platform_libs=(-lpthread -ldl -lm)
+    ;;
+esac
+
+# Negative check: a consumer compiled with -fshort-enums (packed-enum ABI)
+# must be rejected by the header's enum-width static assertions, where the
+# compiler supports the flag.
+if echo 'int main(void){return 0;}' |
+    "$CC" -std=c11 -fshort-enums -x c -o "$outdir/short-enum-probe" - 2>/dev/null; then
+    rm -f "$outdir/short-enum-probe"
+    if printf '#include "ferric.h"\nint main(void){return 0;}\n' |
+        "$CC" -std=c11 -fshort-enums -fsyntax-only -I crates/ferric-ffi -x c - 2>/dev/null; then
+        echo "ffi-c-harness: ERROR: ferric.h compiled under -fshort-enums;" \
+            "enum ABI static assertions failed to fire" >&2
+        exit 1
+    fi
+    echo "ffi-c-harness: -fshort-enums correctly rejected by ABI static assertions"
+else
+    echo "ffi-c-harness: compiler lacks -fshort-enums; skipping negative check" >&2
+fi
+
+"$CC" -std=c11 -Wall -Wextra -Werror "${san_flags[@]}" \
+    -I crates/ferric-ffi \
+    -o "$outdir/discriminant_abuse" \
+    "$harness_src" \
+    target/ffi-dev/libferric_ffi.a \
+    "${platform_libs[@]}"
+
+"$outdir/discriminant_abuse"


### PR DESCRIPTION
Closes #85

## Summary

- Represent `FerricValue.value_type` as a fixed-width `u32`/`uint32_t` ABI field and validate it before any Rust enum interpretation.
- Reject unknown top-level and recursively nested tags with `FERRIC_ERROR_INVALID_ARGUMENT` in ordered/template assertions and both value-free APIs.
- Preserve safe cleanup by skipping unknowable invalid payloads while releasing known siblings and owned containing arrays.
- Generate compile-time ABI assertions for selector fields, enum widths, and stable numeric values; reject incompatible `-fshort-enums` consumers.
- Keep the Go binding and both committed headers synchronized.
- Add Rust regressions plus a real C subprocess harness under ASan/UBSan, wired into CI with sanitizer support required.

## Root cause

`FerricValue.value_type` was a public Rust `repr(C)` enum field populated by C callers. C permits arbitrary integer bit patterns in that storage, but Rust assumes every enum value is valid, so reading an unknown discriminant was undefined behavior before validation could occur. Nested multifields and resource cleanup recursively exposed the same problem.

## Compatibility and impact

The tag retains its existing four-byte width and numeric meanings (`0..=6`). Ordinary C callers can continue assigning the documented `FERRIC_VALUE_TYPE_*` constants. `ferric_value_free` and `ferric_value_array_free` now return `FerricError`; existing statement-style C calls and the Go wrappers may ignore the result, while callers using function pointers must update the declared return type.

## Validation

- `just preflight-pr`
- `cargo test -p ferric-ffi`
- `cargo test -p ferric-ffi --features serde`
- `FERRIC_REQUIRE_SANITIZERS=1 just ffi-c-harness`
- `cargo clippy -p ferric-ffi --all-targets --features serde -- -D warnings`
- `cargo fmt --all --check`
- Go build/tests and `golangci-lint`
- C99, C11 + serde, and C++17 header syntax checks
- `shellcheck scripts/ffi-c-harness.sh`
- `actionlint .github/workflows/ci.yml`
- Regenerated FFI headers remained byte-identical