### PR TITLE
[FR-CABI-002] Synchronize per-engine diagnostic snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,23 @@ jobs:
         env:
           FERRIC_REQUIRE_SANITIZERS: "1"
 
+  ffi-diagnostics-tsan:
+    name: FFI Diagnostics (ThreadSanitizer)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@just
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2025-11-04
+          components: rust-src
+      - run: sudo apt-get update && sudo apt-get install -y clang llvm
+      - run: just ffi-tsan-harness
+        env:
+          CC: clang
+          FERRIC_TSAN_TOOLCHAIN: nightly-2025-11-04
+
   go-lint:
     name: Go Lint
     runs-on: ubuntu-latest

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -5,16 +5,28 @@
  * THREAD SAFETY
  * ============================================================
  *
- * Engine handles (FerricEngine*) are bound to the thread that
- * created them. Every ferric_engine_* function validates thread
- * affinity before any state mutation.
+ * Raw engine handles (FerricEngine*) are bound to the thread that
+ * created them. Ordinary ferric_engine_* runtime accessors validate
+ * thread affinity before accessing runtime state.
  *
  * - Creating thread: all operations succeed normally.
- * - Other threads: operations return FERRIC_ERROR_THREAD_VIOLATION
- *   with a descriptive message in the global error channel.
- * - Exception: ferric_engine_last_error() and
- *   ferric_engine_last_error_copy() skip thread checks
- *   (diagnostic access should always work).
+ * - Other threads: ordinary runtime operations return
+ *   FERRIC_ERROR_THREAD_VIOLATION with a descriptive message in the
+ *   global error channel.
+ * - ferric_engine_last_error_copy() is synchronized and may run
+ *   concurrently from any thread. Each call copies one coherent
+ *   error snapshot.
+ * - ferric_engine_last_error() may be called from any thread, but
+ *   the returned borrowed pointer must not be used while another
+ *   borrowed read or engine destruction may occur. Use the copy API
+ *   when pointer-use windows could overlap.
+ * - ferric_engine_free_unchecked() is a destruction-only escape
+ *   hatch that deliberately skips affinity. Like all destruction,
+ *   it must not overlap any access to that engine.
+ * - Neither diagnostic reader may race with engine destruction.
+ * - Same-engine runtime reentry from a host callback fails with
+ *   FERRIC_ERROR_INTERNAL_ERROR. The last-error readers remain safe
+ *   to call from such callbacks.
  *
  * The global error functions (ferric_last_error_global, etc.)
  * use thread-local storage and are safe to call from any thread.
@@ -26,10 +38,12 @@
  * 1. Engine handles: Caller owns the handle returned by
  *    ferric_engine_new(). Must free with ferric_engine_free().
  *
- * 2. Borrowed string pointers: Pointers returned by
- *    ferric_last_error_global() and ferric_engine_last_error()
- *    are valid until the next FFI call that may modify that
- *    error channel. Do NOT free these pointers.
+ * 2. Borrowed error pointers: ferric_last_error_global() remains
+ *    valid until the next call that may modify that thread's global
+ *    error channel. ferric_engine_last_error() remains valid until
+ *    the next borrowed read on that engine or engine destruction;
+ *    error writers and the copy API do not invalidate it. Do NOT
+ *    free either pointer.
  *
  * 3. Owned string pointers: String fields in FerricValue
  *    (string_ptr for Symbol/String types) are heap-allocated.
@@ -266,7 +280,15 @@ typedef enum FerricPinnedAutoreleasePolicy {
 
 // Opaque engine handle exposed to C.
 //
-// Contains the Rust [`Engine`] plus per-engine error state.
+// The runtime engine remains owner-thread-only. Per-engine error snapshots
+// are stored separately so the two last-error accessors can safely read them
+// from any thread.
+//
+// Production accessors never construct a Rust reference to this whole
+// structure. They project references to individual fields from the raw
+// handle, which permits an owner-thread `&mut Engine` to coexist with a
+// foreign-thread reference to the disjoint diagnostic mutex.
+//
 // C code receives `*mut FerricEngine` as an opaque pointer.
 typedef struct FerricEngine FerricEngine;
 
@@ -335,6 +357,10 @@ typedef struct FerricValue {
 //
 // Must return a pointer to at least `size` writable bytes, or null to
 // signal allocation failure.
+//
+// The callback may query the same raw engine's last-error channel. Other
+// same-engine runtime calls are rejected with `InternalError` while
+// serialization is active, and the callback must not free the engine.
 typedef uint8_t *(*FerricAllocFn)(uintptr_t size, void *context);
 #endif
 
@@ -415,8 +441,15 @@ enum FerricError ferric_engine_load_string(struct FerricEngine *engine, const ch
 
 // Retrieve the last per-engine error message.
 //
-// Returns a pointer to a NUL-terminated string, or null if no error
-// is stored. The pointer is valid until the next call on this engine.
+// Returns a pointer to a NUL-terminated string, or null if no error is
+// stored. This accessor may be called from any thread, including from a host
+// callback.
+//
+// The pointer is borrowed from the engine and may be invalidated by the next
+// call to `ferric_engine_last_error` on the same engine or by freeing the
+// engine. Do not dereference or otherwise use the pointer while another
+// borrowed read or engine destruction may occur. Use
+// `ferric_engine_last_error_copy` when pointer-use windows could overlap.
 //
 // # Safety
 //
@@ -426,8 +459,13 @@ const char * FERRIC_NULL_TERMINATED ferric_engine_last_error(const struct Ferric
 // Copy the per-engine error message into a caller-provided buffer.
 //
 // Same contract as `ferric_last_error_global_copy` but reads from the
-// per-engine error channel. Deliberately skips thread-affinity check
-// (diagnostic operation).
+// per-engine error channel. This accessor may be called concurrently from
+// any thread and from a host callback. Each invocation observes and copies
+// one coherent error snapshot.
+//
+// A size query and a later copy are separate snapshots. If the error changes
+// between those calls, the copy may return `BufferTooSmall` with the newer
+// required size; callers should resize and retry.
 //
 // ## Contract
 //

--- a/crates/ferric-ffi/build.rs
+++ b/crates/ferric-ffi/build.rs
@@ -8,16 +8,28 @@ pub const HEADER_PREAMBLE: &str = r"/*
  * THREAD SAFETY
  * ============================================================
  *
- * Engine handles (FerricEngine*) are bound to the thread that
- * created them. Every ferric_engine_* function validates thread
- * affinity before any state mutation.
+ * Raw engine handles (FerricEngine*) are bound to the thread that
+ * created them. Ordinary ferric_engine_* runtime accessors validate
+ * thread affinity before accessing runtime state.
  *
  * - Creating thread: all operations succeed normally.
- * - Other threads: operations return FERRIC_ERROR_THREAD_VIOLATION
- *   with a descriptive message in the global error channel.
- * - Exception: ferric_engine_last_error() and
- *   ferric_engine_last_error_copy() skip thread checks
- *   (diagnostic access should always work).
+ * - Other threads: ordinary runtime operations return
+ *   FERRIC_ERROR_THREAD_VIOLATION with a descriptive message in the
+ *   global error channel.
+ * - ferric_engine_last_error_copy() is synchronized and may run
+ *   concurrently from any thread. Each call copies one coherent
+ *   error snapshot.
+ * - ferric_engine_last_error() may be called from any thread, but
+ *   the returned borrowed pointer must not be used while another
+ *   borrowed read or engine destruction may occur. Use the copy API
+ *   when pointer-use windows could overlap.
+ * - ferric_engine_free_unchecked() is a destruction-only escape
+ *   hatch that deliberately skips affinity. Like all destruction,
+ *   it must not overlap any access to that engine.
+ * - Neither diagnostic reader may race with engine destruction.
+ * - Same-engine runtime reentry from a host callback fails with
+ *   FERRIC_ERROR_INTERNAL_ERROR. The last-error readers remain safe
+ *   to call from such callbacks.
  *
  * The global error functions (ferric_last_error_global, etc.)
  * use thread-local storage and are safe to call from any thread.
@@ -29,10 +41,12 @@ pub const HEADER_PREAMBLE: &str = r"/*
  * 1. Engine handles: Caller owns the handle returned by
  *    ferric_engine_new(). Must free with ferric_engine_free().
  *
- * 2. Borrowed string pointers: Pointers returned by
- *    ferric_last_error_global() and ferric_engine_last_error()
- *    are valid until the next FFI call that may modify that
- *    error channel. Do NOT free these pointers.
+ * 2. Borrowed error pointers: ferric_last_error_global() remains
+ *    valid until the next call that may modify that thread's global
+ *    error channel. ferric_engine_last_error() remains valid until
+ *    the next borrowed read on that engine or engine destruction;
+ *    error writers and the copy API do not invalidate it. Do NOT
+ *    free either pointer.
  *
  * 3. Owned string pointers: String fields in FerricValue
  *    (string_ptr for Symbol/String types) are heap-allocated.

--- a/crates/ferric-ffi/ferric.h
+++ b/crates/ferric-ffi/ferric.h
@@ -5,16 +5,28 @@
  * THREAD SAFETY
  * ============================================================
  *
- * Engine handles (FerricEngine*) are bound to the thread that
- * created them. Every ferric_engine_* function validates thread
- * affinity before any state mutation.
+ * Raw engine handles (FerricEngine*) are bound to the thread that
+ * created them. Ordinary ferric_engine_* runtime accessors validate
+ * thread affinity before accessing runtime state.
  *
  * - Creating thread: all operations succeed normally.
- * - Other threads: operations return FERRIC_ERROR_THREAD_VIOLATION
- *   with a descriptive message in the global error channel.
- * - Exception: ferric_engine_last_error() and
- *   ferric_engine_last_error_copy() skip thread checks
- *   (diagnostic access should always work).
+ * - Other threads: ordinary runtime operations return
+ *   FERRIC_ERROR_THREAD_VIOLATION with a descriptive message in the
+ *   global error channel.
+ * - ferric_engine_last_error_copy() is synchronized and may run
+ *   concurrently from any thread. Each call copies one coherent
+ *   error snapshot.
+ * - ferric_engine_last_error() may be called from any thread, but
+ *   the returned borrowed pointer must not be used while another
+ *   borrowed read or engine destruction may occur. Use the copy API
+ *   when pointer-use windows could overlap.
+ * - ferric_engine_free_unchecked() is a destruction-only escape
+ *   hatch that deliberately skips affinity. Like all destruction,
+ *   it must not overlap any access to that engine.
+ * - Neither diagnostic reader may race with engine destruction.
+ * - Same-engine runtime reentry from a host callback fails with
+ *   FERRIC_ERROR_INTERNAL_ERROR. The last-error readers remain safe
+ *   to call from such callbacks.
  *
  * The global error functions (ferric_last_error_global, etc.)
  * use thread-local storage and are safe to call from any thread.
@@ -26,10 +38,12 @@
  * 1. Engine handles: Caller owns the handle returned by
  *    ferric_engine_new(). Must free with ferric_engine_free().
  *
- * 2. Borrowed string pointers: Pointers returned by
- *    ferric_last_error_global() and ferric_engine_last_error()
- *    are valid until the next FFI call that may modify that
- *    error channel. Do NOT free these pointers.
+ * 2. Borrowed error pointers: ferric_last_error_global() remains
+ *    valid until the next call that may modify that thread's global
+ *    error channel. ferric_engine_last_error() remains valid until
+ *    the next borrowed read on that engine or engine destruction;
+ *    error writers and the copy API do not invalidate it. Do NOT
+ *    free either pointer.
  *
  * 3. Owned string pointers: String fields in FerricValue
  *    (string_ptr for Symbol/String types) are heap-allocated.
@@ -266,7 +280,15 @@ typedef enum FerricPinnedAutoreleasePolicy {
 
 // Opaque engine handle exposed to C.
 //
-// Contains the Rust [`Engine`] plus per-engine error state.
+// The runtime engine remains owner-thread-only. Per-engine error snapshots
+// are stored separately so the two last-error accessors can safely read them
+// from any thread.
+//
+// Production accessors never construct a Rust reference to this whole
+// structure. They project references to individual fields from the raw
+// handle, which permits an owner-thread `&mut Engine` to coexist with a
+// foreign-thread reference to the disjoint diagnostic mutex.
+//
 // C code receives `*mut FerricEngine` as an opaque pointer.
 typedef struct FerricEngine FerricEngine;
 
@@ -335,6 +357,10 @@ typedef struct FerricValue {
 //
 // Must return a pointer to at least `size` writable bytes, or null to
 // signal allocation failure.
+//
+// The callback may query the same raw engine's last-error channel. Other
+// same-engine runtime calls are rejected with `InternalError` while
+// serialization is active, and the callback must not free the engine.
 typedef uint8_t *(*FerricAllocFn)(uintptr_t size, void *context);
 #endif
 
@@ -415,8 +441,15 @@ enum FerricError ferric_engine_load_string(struct FerricEngine *engine, const ch
 
 // Retrieve the last per-engine error message.
 //
-// Returns a pointer to a NUL-terminated string, or null if no error
-// is stored. The pointer is valid until the next call on this engine.
+// Returns a pointer to a NUL-terminated string, or null if no error is
+// stored. This accessor may be called from any thread, including from a host
+// callback.
+//
+// The pointer is borrowed from the engine and may be invalidated by the next
+// call to `ferric_engine_last_error` on the same engine or by freeing the
+// engine. Do not dereference or otherwise use the pointer while another
+// borrowed read or engine destruction may occur. Use
+// `ferric_engine_last_error_copy` when pointer-use windows could overlap.
 //
 // # Safety
 //
@@ -426,8 +459,13 @@ const char * FERRIC_NULL_TERMINATED ferric_engine_last_error(const struct Ferric
 // Copy the per-engine error message into a caller-provided buffer.
 //
 // Same contract as `ferric_last_error_global_copy` but reads from the
-// per-engine error channel. Deliberately skips thread-affinity check
-// (diagnostic operation).
+// per-engine error channel. This accessor may be called concurrently from
+// any thread and from a host callback. Each invocation observes and copies
+// one coherent error snapshot.
+//
+// A size query and a later copy are separate snapshots. If the error changes
+// between those calls, the copy may return `BufferTooSmall` with the newer
+// required size; callers should resize and retry.
 //
 // ## Contract
 //

--- a/crates/ferric-ffi/src/engine.rs
+++ b/crates/ferric-ffi/src/engine.rs
@@ -2,12 +2,19 @@
 //!
 //! ## Thread Affinity Contract
 //!
-//! Every `ferric_engine_*` entry point validates that the calling thread
-//! matches the thread that created the engine. This check happens BEFORE
-//! any mutable borrow or state mutation.
+//! Runtime-facing `ferric_engine_*` entry points validate that the calling
+//! thread matches the thread that created the engine before projecting a
+//! reference to runtime state.
 //!
 //! - Thread violations return `FERRIC_ERROR_THREAD_VIOLATION` with a descriptive
 //!   message in the global error channel.
+//! - `ferric_engine_last_error_copy` provides synchronized, coherent snapshots
+//!   to any thread.
+//! - `ferric_engine_last_error` also skips affinity checks, but its returned
+//!   pointer must not be used while another borrowed read or engine free may
+//!   occur.
+//! - `ferric_engine_free_unchecked` deliberately skips affinity solely to
+//!   destroy the handle; it must not overlap any access to that engine.
 //!
 //! The internal `unsafe fn move_to_current_thread` is deliberately NOT
 //! exposed through the C API.
@@ -16,7 +23,10 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
-use std::ptr;
+use std::ptr::{self, NonNull};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, MutexGuard};
+use std::thread::ThreadId;
 
 use crate::types::{
     engine_config_from_ffi, ferric_to_value, value_to_ferric, FerricConfig, FerricFactType,
@@ -33,12 +43,52 @@ use ferric_runtime::{Engine, EngineConfig, InitError, RunLimit};
 
 /// Opaque engine handle exposed to C.
 ///
-/// Contains the Rust [`Engine`] plus per-engine error state.
+/// The runtime engine remains owner-thread-only. Per-engine error snapshots
+/// are stored separately so the two last-error accessors can safely read them
+/// from any thread.
+///
+/// Production accessors never construct a Rust reference to this whole
+/// structure. They project references to individual fields from the raw
+/// handle, which permits an owner-thread `&mut Engine` to coexist with a
+/// foreign-thread reference to the disjoint diagnostic mutex.
+///
 /// C code receives `*mut FerricEngine` as an opaque pointer.
 pub struct FerricEngine {
     pub(crate) engine: Engine,
-    pub(crate) error_state: EngineErrorState,
-    pub(crate) error_cstring: RefCell<Option<CString>>,
+    owner_thread: ThreadId,
+    call_active: AtomicBool,
+    diagnostics: Mutex<EngineDiagnostics>,
+}
+
+#[derive(Debug, Default)]
+struct EngineDiagnostics {
+    error_state: EngineErrorState,
+    borrowed_cstring: Option<CString>,
+}
+
+impl EngineDiagnostics {
+    fn new() -> Self {
+        Self {
+            error_state: EngineErrorState::new(),
+            borrowed_cstring: None,
+        }
+    }
+}
+
+impl FerricEngine {
+    fn new(engine: Engine) -> Self {
+        Self {
+            engine,
+            owner_thread: std::thread::current().id(),
+            call_active: AtomicBool::new(false),
+            diagnostics: Mutex::new(EngineDiagnostics::new()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_error_for_test(&self, message: String) {
+        lock_unpoisoned(&self.diagnostics).error_state.set(message);
+    }
 }
 
 thread_local! {
@@ -55,65 +105,152 @@ struct CachedOutputCString {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/// Validate a non-null engine pointer, returning a shared reference.
+/// Validate a non-null engine pointer without constructing a Rust reference.
 ///
-/// Sets global error on null pointer. Used for read-only operations
-/// and as the first step of the two-step borrow pattern.
-unsafe fn validate_engine_ptr<'a>(
-    engine: *const FerricEngine,
-) -> Result<&'a FerricEngine, FerricError> {
-    if engine.is_null() {
+/// A whole-handle reference would overlap owner-thread access to `engine` with
+/// foreign-thread diagnostic access. Callers must project only the field they
+/// need from the returned token.
+fn validate_engine_ptr(engine: *const FerricEngine) -> Result<NonNull<FerricEngine>, FerricError> {
+    NonNull::new(engine.cast_mut()).ok_or_else(|| {
         set_global_error("engine pointer is null".to_string());
-        return Err(FerricError::NullPointer);
-    }
-    Ok(&*engine)
+        FerricError::NullPointer
+    })
 }
 
-/// Validate a non-null engine pointer, returning a mutable reference.
-///
-/// Sets global error on null pointer. Used after thread-affinity check passes.
-unsafe fn validate_engine_ptr_mut<'a>(
-    engine: *mut FerricEngine,
-) -> Result<&'a mut FerricEngine, FerricError> {
-    if engine.is_null() {
-        set_global_error("engine pointer is null".to_string());
-        return Err(FerricError::NullPointer);
-    }
-    Ok(&mut *engine)
+fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
-/// Check thread affinity on the engine's inner runtime Engine.
+/// Project the immutable owner-thread field from an opaque handle.
 ///
-/// This is the canonical "step 1" of the two-step borrow pattern:
-/// obtain a shared reference, verify the thread, THEN proceed to mutable access.
-fn check_thread_affinity(handle: &FerricEngine) -> Result<(), FerricError> {
-    match handle.engine.check_thread_affinity() {
-        Ok(()) => Ok(()),
-        Err(ref err @ EngineError::WrongThread { .. }) => {
-            set_global_error(err.to_string());
-            Err(FerricError::ThreadViolation)
-        }
-        Err(ref err) => {
-            set_global_error(err.to_string());
-            Err(FerricError::InternalError)
+/// # Safety
+///
+/// `handle` must remain valid for the duration of the returned reference.
+unsafe fn owner_thread<'a>(handle: NonNull<FerricEngine>) -> &'a ThreadId {
+    &*std::ptr::addr_of!((*handle.as_ptr()).owner_thread)
+}
+
+/// Project the active-call flag from an opaque handle.
+///
+/// # Safety
+///
+/// `handle` must remain valid for the duration of the returned reference.
+unsafe fn call_active<'a>(handle: NonNull<FerricEngine>) -> &'a AtomicBool {
+    &*std::ptr::addr_of!((*handle.as_ptr()).call_active)
+}
+
+/// Project the synchronized diagnostic state from an opaque handle.
+///
+/// # Safety
+///
+/// `handle` must remain valid for the duration of the returned reference.
+unsafe fn diagnostics<'a>(handle: NonNull<FerricEngine>) -> &'a Mutex<EngineDiagnostics> {
+    &*std::ptr::addr_of!((*handle.as_ptr()).diagnostics)
+}
+
+/// Check thread affinity without touching the owner-thread-only runtime.
+///
+/// # Safety
+///
+/// `handle` must point to a live engine handle.
+unsafe fn check_thread_affinity(handle: NonNull<FerricEngine>) -> Result<(), FerricError> {
+    let creator = *owner_thread(handle);
+    let current = std::thread::current().id();
+    if current != creator {
+        let err = EngineError::WrongThread { creator, current };
+        set_global_error(err.to_string());
+        return Err(FerricError::ThreadViolation);
+    }
+    Ok(())
+}
+
+struct EngineCallGuard<'a> {
+    active: &'a AtomicBool,
+    release_on_drop: bool,
+}
+
+impl EngineCallGuard<'_> {
+    fn disarm(mut self) {
+        self.release_on_drop = false;
+    }
+}
+
+impl Drop for EngineCallGuard<'_> {
+    fn drop(&mut self) {
+        if self.release_on_drop {
+            self.active.store(false, Ordering::Release);
         }
     }
+}
+
+struct EngineWriteAccess<'a> {
+    engine: &'a mut Engine,
+    diagnostics: &'a Mutex<EngineDiagnostics>,
+    _guard: EngineCallGuard<'a>,
+}
+
+struct EngineReadAccess<'a> {
+    engine: &'a Engine,
+    _guard: EngineCallGuard<'a>,
+}
+
+/// Reject overlapping access to the owner-thread-only runtime.
+///
+/// This primarily protects against a host callback synchronously re-entering
+/// the same raw engine. Diagnostic-only access does not use this guard and is
+/// safe to perform reentrantly.
+///
+/// # Safety
+///
+/// `handle` must point to a live engine handle.
+unsafe fn enter_engine_call<'a>(
+    handle: NonNull<FerricEngine>,
+) -> Result<EngineCallGuard<'a>, FerricError> {
+    let active = call_active(handle);
+    if active
+        .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+        .is_err()
+    {
+        set_global_error(
+            "reentrant call on a raw engine is not supported; only per-engine error accessors may be called from a host callback"
+                .to_string(),
+        );
+        return Err(FerricError::InternalError);
+    }
+    Ok(EngineCallGuard {
+        active,
+        release_on_drop: true,
+    })
 }
 
 unsafe fn borrow_engine_mut<'a>(
     engine: *mut FerricEngine,
-) -> Result<&'a mut FerricEngine, FerricError> {
+) -> Result<EngineWriteAccess<'a>, FerricError> {
     let handle = validate_engine_ptr(engine)?;
     check_thread_affinity(handle)?;
-    validate_engine_ptr_mut(engine)
+    let guard = enter_engine_call(handle)?;
+    let runtime = &mut *std::ptr::addr_of_mut!((*handle.as_ptr()).engine);
+    let diagnostic_state = diagnostics(handle);
+    Ok(EngineWriteAccess {
+        engine: runtime,
+        diagnostics: diagnostic_state,
+        _guard: guard,
+    })
 }
 
 unsafe fn borrow_engine_checked<'a>(
     engine: *const FerricEngine,
-) -> Result<&'a FerricEngine, FerricError> {
+) -> Result<EngineReadAccess<'a>, FerricError> {
     let handle = validate_engine_ptr(engine)?;
     check_thread_affinity(handle)?;
-    Ok(handle)
+    let guard = enter_engine_call(handle)?;
+    let runtime = &*std::ptr::addr_of!((*handle.as_ptr()).engine);
+    Ok(EngineReadAccess {
+        engine: runtime,
+        _guard: guard,
+    })
 }
 
 unsafe fn c_str_to_str<'a>(ptr: *const c_char, label: &str) -> Result<&'a str, FerricError> {
@@ -129,20 +266,22 @@ unsafe fn c_str_to_str<'a>(ptr: *const c_char, label: &str) -> Result<&'a str, F
 }
 
 fn set_engine_error_message(
-    handle: &mut FerricEngine,
+    handle: &EngineWriteAccess<'_>,
     code: FerricError,
     message: String,
 ) -> FerricError {
-    handle.error_state.set(message.clone());
+    lock_unpoisoned(handle.diagnostics)
+        .error_state
+        .set(message.clone());
     set_global_error(message);
     code
 }
 
-fn set_engine_runtime_error(handle: &mut FerricEngine, err: &EngineError) -> FerricError {
+fn set_engine_runtime_error(handle: &EngineWriteAccess<'_>, err: &EngineError) -> FerricError {
     set_engine_error_message(handle, map_engine_error(err), err.to_string())
 }
 
-fn set_engine_load_error(handle: &mut FerricEngine, err: &LoadError) -> FerricError {
+fn set_engine_load_error(handle: &EngineWriteAccess<'_>, err: &LoadError) -> FerricError {
     set_engine_error_message(handle, map_load_error(err), err.to_string())
 }
 
@@ -237,12 +376,7 @@ pub unsafe extern "C" fn ferric_engine_new_with_config(
     };
 
     let engine = Engine::new(engine_config);
-    let handle = FerricEngine {
-        engine,
-        error_state: EngineErrorState::new(),
-        error_cstring: RefCell::new(None),
-    };
-    Box::into_raw(Box::new(handle))
+    Box::into_raw(Box::new(FerricEngine::new(engine)))
 }
 
 /// Free an engine handle.
@@ -260,10 +394,20 @@ pub unsafe extern "C" fn ferric_engine_free(engine: *mut FerricEngine) -> Ferric
     if engine.is_null() {
         return FerricError::Ok;
     }
-    let handle = &*engine;
+    let handle = match validate_engine_ptr(engine) {
+        Ok(handle) => handle,
+        Err(code) => return code,
+    };
     if let Err(code) = check_thread_affinity(handle) {
         return code;
     }
+    let guard = match enter_engine_call(handle) {
+        Ok(guard) => guard,
+        Err(code) => return code,
+    };
+    // The allocation is about to be destroyed, so the active flag must not be
+    // touched by the guard's destructor.
+    guard.disarm();
     drop(Box::from_raw(engine));
     FerricError::Ok
 }
@@ -295,10 +439,10 @@ pub unsafe extern "C" fn ferric_engine_load_string(
         Ok(_) => FerricError::Ok,
         Err(errors) => {
             if let Some(first) = errors.first() {
-                set_engine_load_error(handle, first)
+                set_engine_load_error(&handle, first)
             } else {
                 set_engine_error_message(
-                    handle,
+                    &handle,
                     FerricError::InternalError,
                     "internal error: load failed without diagnostics".to_string(),
                 )
@@ -309,26 +453,36 @@ pub unsafe extern "C" fn ferric_engine_load_string(
 
 /// Retrieve the last per-engine error message.
 ///
-/// Returns a pointer to a NUL-terminated string, or null if no error
-/// is stored. The pointer is valid until the next call on this engine.
+/// Returns a pointer to a NUL-terminated string, or null if no error is
+/// stored. This accessor may be called from any thread, including from a host
+/// callback.
+///
+/// The pointer is borrowed from the engine and may be invalidated by the next
+/// call to `ferric_engine_last_error` on the same engine or by freeing the
+/// engine. Do not dereference or otherwise use the pointer while another
+/// borrowed read or engine destruction may occur. Use
+/// `ferric_engine_last_error_copy` when pointer-use windows could overlap.
 ///
 /// # Safety
 ///
 /// - `engine` must be a valid engine pointer or null.
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_last_error(engine: *const FerricEngine) -> *const c_char {
-    // Deliberately skip thread-affinity check: reading the error message
-    // is a diagnostic operation that should always succeed.
+    // Deliberately skip thread-affinity and active-call checks. Error snapshots
+    // are synchronized separately and are safe to query reentrantly.
     let Ok(handle) = validate_engine_ptr(engine) else {
         return ptr::null();
     };
 
-    match handle.error_state.message() {
+    let mut state = lock_unpoisoned(diagnostics(handle));
+    let message = state.error_state.message().map(str::to_owned);
+    match message {
         Some(msg) => {
-            let cstring = CString::new(msg).unwrap_or_default();
-            let mut slot = handle.error_cstring.borrow_mut();
-            *slot = Some(cstring);
-            slot.as_ref().map_or(ptr::null(), |cs| cs.as_ptr())
+            state.borrowed_cstring = Some(CString::new(msg).unwrap_or_default());
+            state
+                .borrowed_cstring
+                .as_ref()
+                .map_or(ptr::null(), |cs| cs.as_ptr())
         }
         None => ptr::null(),
     }
@@ -337,8 +491,13 @@ pub unsafe extern "C" fn ferric_engine_last_error(engine: *const FerricEngine) -
 /// Copy the per-engine error message into a caller-provided buffer.
 ///
 /// Same contract as `ferric_last_error_global_copy` but reads from the
-/// per-engine error channel. Deliberately skips thread-affinity check
-/// (diagnostic operation).
+/// per-engine error channel. This accessor may be called concurrently from
+/// any thread and from a host callback. Each invocation observes and copies
+/// one coherent error snapshot.
+///
+/// A size query and a later copy are separate snapshots. If the error changes
+/// between those calls, the copy may return `BufferTooSmall` with the newer
+/// required size; callers should resize and retry.
 ///
 /// ## Contract
 ///
@@ -367,13 +526,14 @@ pub unsafe extern "C" fn ferric_engine_last_error_copy(
         return FerricError::InvalidArgument;
     }
     let handle = match validate_engine_ptr(engine) {
-        Ok(h) => h,
+        Ok(handle) => handle,
         Err(code) => {
             *out_len = 0;
             return code;
         }
     };
-    copy_error_to_buffer(handle.error_state.message(), buf, buf_len, out_len)
+    let state = lock_unpoisoned(diagnostics(handle));
+    copy_error_to_buffer(state.error_state.message(), buf, buf_len, out_len)
 }
 
 /// Clear the per-engine error state.
@@ -383,11 +543,14 @@ pub unsafe extern "C" fn ferric_engine_last_error_copy(
 /// - `engine` must be a valid engine pointer or null (null returns `NullPointer`).
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_clear_error(engine: *mut FerricEngine) -> FerricError {
-    let handle = match borrow_engine_mut(engine) {
-        Ok(h) => h,
+    let handle = match validate_engine_ptr(engine) {
+        Ok(handle) => handle,
         Err(code) => return code,
     };
-    handle.error_state.clear();
+    if let Err(code) = check_thread_affinity(handle) {
+        return code;
+    }
+    lock_unpoisoned(diagnostics(handle)).error_state.clear();
     FerricError::Ok
 }
 
@@ -405,7 +568,7 @@ pub unsafe extern "C" fn ferric_engine_reset(engine: *mut FerricEngine) -> Ferri
 
     match handle.engine.reset() {
         Ok(()) => FerricError::Ok,
-        Err(ref err) => set_engine_runtime_error(handle, err),
+        Err(ref err) => set_engine_runtime_error(&handle, err),
     }
 }
 
@@ -450,7 +613,7 @@ pub unsafe extern "C" fn ferric_engine_run(
             }
             FerricError::Ok
         }
-        Err(ref err) => set_engine_runtime_error(handle, err),
+        Err(ref err) => set_engine_runtime_error(&handle, err),
     }
 }
 
@@ -492,7 +655,7 @@ pub unsafe extern "C" fn ferric_engine_step(
             }
             FerricError::Ok
         }
-        Err(ref err) => set_engine_runtime_error(handle, err),
+        Err(ref err) => set_engine_runtime_error(&handle, err),
     }
 }
 
@@ -539,10 +702,10 @@ pub unsafe extern "C" fn ferric_engine_assert_string(
         }
         Err(errors) => {
             if let Some(first) = errors.first() {
-                set_engine_load_error(handle, first)
+                set_engine_load_error(&handle, first)
             } else {
                 set_engine_error_message(
-                    handle,
+                    &handle,
                     FerricError::InternalError,
                     "internal error: load failed without diagnostics".to_string(),
                 )
@@ -572,7 +735,7 @@ pub unsafe extern "C" fn ferric_engine_retract(
 
     match handle.engine.retract(fid) {
         Ok(()) => FerricError::Ok,
-        Err(ref err) => set_engine_runtime_error(handle, err),
+        Err(ref err) => set_engine_runtime_error(&handle, err),
     }
 }
 
@@ -727,7 +890,7 @@ pub unsafe extern "C" fn ferric_engine_fact_count(
     engine: *const FerricEngine,
     out_count: *mut usize,
 ) -> FerricError {
-    let handle = match validate_engine_ptr(engine) {
+    let handle = match borrow_engine_checked(engine) {
         Ok(h) => h,
         Err(code) => return code,
     };
@@ -760,7 +923,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_field_count(
     fact_id: u64,
     out_count: *mut usize,
 ) -> FerricError {
-    let handle = match validate_engine_ptr(engine) {
+    let handle = match borrow_engine_checked(engine) {
         Ok(h) => h,
         Err(code) => return code,
     };
@@ -809,7 +972,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_field(
     index: usize,
     out_value: *mut FerricValue,
 ) -> FerricError {
-    let handle = match validate_engine_ptr(engine) {
+    let handle = match borrow_engine_checked(engine) {
         Ok(h) => h,
         Err(code) => return code,
     };
@@ -829,7 +992,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_field(
                 Fact::Template(t) => t.slots.get(index),
             };
             if let Some(val) = field_value {
-                *out_value = value_to_ferric(val, &handle.engine);
+                *out_value = value_to_ferric(val, handle.engine);
                 FerricError::Ok
             } else {
                 set_global_error(format!("field index {index} out of bounds"));
@@ -880,7 +1043,7 @@ pub unsafe extern "C" fn ferric_engine_get_global(
     };
 
     if let Some(val) = handle.engine.get_global(name_str) {
-        *out_value = value_to_ferric(val, &handle.engine);
+        *out_value = value_to_ferric(val, handle.engine);
         FerricError::Ok
     } else {
         set_global_error(format!("global variable not found: {name_str}"));
@@ -1178,11 +1341,11 @@ pub unsafe extern "C" fn ferric_engine_assert_ordered(
     let mut values = Vec::with_capacity(field_count);
     for i in 0..field_count {
         let fv = &*fields.add(i);
-        match ferric_to_value(fv, &mut handle.engine) {
+        match ferric_to_value(fv, handle.engine) {
             Ok(v) => values.push(v),
             Err(msg) => {
                 return set_engine_error_message(
-                    handle,
+                    &handle,
                     FerricError::InvalidArgument,
                     format!("field {i}: {msg}"),
                 );
@@ -1197,7 +1360,7 @@ pub unsafe extern "C" fn ferric_engine_assert_ordered(
             }
             FerricError::Ok
         }
-        Err(ref err) => set_engine_runtime_error(handle, err),
+        Err(ref err) => set_engine_runtime_error(&handle, err),
     }
 }
 
@@ -1773,14 +1936,7 @@ pub unsafe extern "C" fn ferric_engine_new_with_source_config(
     };
 
     match Engine::with_rules_config(source_str, engine_config) {
-        Ok(engine) => {
-            let handle = FerricEngine {
-                engine,
-                error_state: EngineErrorState::new(),
-                error_cstring: RefCell::new(None),
-            };
-            Box::into_raw(Box::new(handle))
-        }
+        Ok(engine) => Box::into_raw(Box::new(FerricEngine::new(engine))),
         Err(err) => {
             set_global_error(match err {
                 InitError::Load(ref errors) => errors
@@ -1857,7 +2013,7 @@ pub unsafe extern "C" fn ferric_engine_run_ex(
             }
             FerricError::Ok
         }
-        Err(ref err) => set_engine_runtime_error(handle, err),
+        Err(ref err) => set_engine_runtime_error(&handle, err),
     }
 }
 
@@ -1927,11 +2083,11 @@ pub unsafe extern "C" fn ferric_engine_assert_template(
     let mut values = Vec::with_capacity(count);
     for i in 0..count {
         let fv = &*slot_values.add(i);
-        match ferric_to_value(fv, &mut handle.engine) {
+        match ferric_to_value(fv, handle.engine) {
             Ok(v) => values.push(v),
             Err(msg) => {
                 return set_engine_error_message(
-                    handle,
+                    &handle,
                     FerricError::InvalidArgument,
                     format!("slot_values[{i}]: {msg}"),
                 );
@@ -1948,7 +2104,7 @@ pub unsafe extern "C" fn ferric_engine_assert_template(
             }
             FerricError::Ok
         }
-        Err(ref err) => set_engine_runtime_error(handle, err),
+        Err(ref err) => set_engine_runtime_error(&handle, err),
     }
 }
 
@@ -1997,7 +2153,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_slot_by_name(
 
     match handle.engine.get_fact_slot_by_name(fid, name_str) {
         Ok(value) => {
-            *out_value = value_to_ferric(value, &handle.engine);
+            *out_value = value_to_ferric(value, handle.engine);
             FerricError::Ok
         }
         Err(ref err) => set_engine_error_global(err),
@@ -2026,6 +2182,15 @@ pub unsafe extern "C" fn ferric_engine_free_unchecked(engine: *mut FerricEngine)
     if engine.is_null() {
         return FerricError::Ok;
     }
+    let handle = match validate_engine_ptr(engine) {
+        Ok(handle) => handle,
+        Err(code) => return code,
+    };
+    let guard = match enter_engine_call(handle) {
+        Ok(guard) => guard,
+        Err(code) => return code,
+    };
+    guard.disarm();
     drop(Box::from_raw(engine));
     FerricError::Ok
 }
@@ -2086,6 +2251,10 @@ impl FerricSerializationFormat {
 ///
 /// Must return a pointer to at least `size` writable bytes, or null to
 /// signal allocation failure.
+///
+/// The callback may query the same raw engine's last-error channel. Other
+/// same-engine runtime calls are rejected with `InternalError` while
+/// serialization is active, and the callback must not free the engine.
 #[cfg(feature = "serde")]
 pub type FerricAllocFn =
     Option<unsafe extern "C" fn(size: usize, context: *mut std::ffi::c_void) -> *mut u8>;
@@ -2170,13 +2339,7 @@ unsafe fn deserialize_engine_impl(
         }
     };
 
-    let handle = FerricEngine {
-        engine,
-        error_state: EngineErrorState::new(),
-        error_cstring: RefCell::new(None),
-    };
-
-    *out_engine = Box::into_raw(Box::new(handle));
+    *out_engine = Box::into_raw(Box::new(FerricEngine::new(engine)));
     FerricError::Ok
 }
 

--- a/crates/ferric-ffi/src/lib.rs
+++ b/crates/ferric-ffi/src/lib.rs
@@ -11,15 +11,20 @@
 //!   module visibility/ambiguity failures, generic dispatch/conflict diagnostics)
 //!   are surfaced through FFI without reinterpretation or loss of source context.
 //!
-//! - **Thread affinity**: An engine handle is bound to its creating thread.
-//!   Every `ferric_engine_*` entry point validates thread affinity before any
-//!   mutable borrow or state mutation. The internal `unsafe fn move_to_current_thread`
-//!   is deliberately NOT exposed in the C API.
+//! - **Thread affinity**: A raw engine handle is bound to its creating thread.
+//!   Runtime operations validate affinity before accessing the engine. The
+//!   synchronized `ferric_engine_last_error_copy` accessor may run concurrently
+//!   from any thread; the borrowed `ferric_engine_last_error` accessor also
+//!   skips affinity but requires external serialization for pointer use. The
+//!   destruction-only `ferric_engine_free_unchecked` escape hatch also skips
+//!   affinity and must not overlap any access to the engine. The
+//!   internal `unsafe fn move_to_current_thread` is deliberately NOT exposed in
+//!   the C API.
 //!
 //! - **Ownership conventions**: Callers own handles returned by `_new` functions and
-//!   must free them with corresponding `_free` functions. String pointers returned by
-//!   error-retrieval APIs are valid only until the next call that may modify the
-//!   error channel.
+//!   must free them with corresponding `_free` functions. The borrowed raw-engine
+//!   error pointer remains valid until the next borrowed read on that engine or
+//!   engine destruction; concurrent consumers should use the copy API.
 //!
 //! - **Panic policy**: FFI builds use `panic = "abort"` profiles (`ffi-dev`,
 //!   `ffi-release`) so that Rust panics never unwind across the C ABI boundary.

--- a/crates/ferric-ffi/src/tests.rs
+++ b/crates/ferric-ffi/src/tests.rs
@@ -43,6 +43,9 @@ mod build_matrix;
 mod diagnostic_parity;
 
 #[cfg(test)]
+mod diagnostic_concurrency;
+
+#[cfg(test)]
 mod contract_lock;
 
 #[cfg(test)]

--- a/crates/ferric-ffi/src/tests/copy_error.rs
+++ b/crates/ferric-ffi/src/tests/copy_error.rs
@@ -293,7 +293,7 @@ fn engine_copy_size_query() {
     unsafe {
         let engine = ferric_engine_new();
         // Set the per-engine error directly (pub(crate) field accessible within crate).
-        (*engine).error_state.set(msg.to_string());
+        (*engine).set_error_for_test(msg.to_string());
 
         let mut out_len: usize = 0;
         let result = ferric_engine_last_error_copy(engine, std::ptr::null_mut(), 0, &mut out_len);
@@ -311,7 +311,7 @@ fn engine_copy_exact_fit() {
     let needed = msg.len() + 1;
     unsafe {
         let engine = ferric_engine_new();
-        (*engine).error_state.set(msg.to_string());
+        (*engine).set_error_for_test(msg.to_string());
 
         let mut buf = make_buf(needed);
         let mut out_len: usize = 0;
@@ -338,7 +338,7 @@ fn engine_copy_truncation() {
     let needed = msg.len() + 1;
     unsafe {
         let engine = ferric_engine_new();
-        (*engine).error_state.set(msg.to_string());
+        (*engine).set_error_for_test(msg.to_string());
 
         let mut buf = make_buf(buf_len);
         let mut out_len: usize = 0;

--- a/crates/ferric-ffi/src/tests/diagnostic_concurrency.rs
+++ b/crates/ferric-ffi/src/tests/diagnostic_concurrency.rs
@@ -1,0 +1,350 @@
+//! Concurrency and snapshot-ordering regressions for raw-engine diagnostics.
+
+use crate::engine::{
+    ferric_engine_action_diagnostic_count, ferric_engine_clear_error, ferric_engine_free,
+    ferric_engine_last_error, ferric_engine_last_error_copy, ferric_engine_new,
+    ferric_engine_retract, FerricEngine,
+};
+#[cfg(feature = "serde")]
+use crate::engine::{ferric_engine_reset, ferric_engine_serialize_bincode};
+use crate::error::FerricError;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::sync::{mpsc, Arc, Barrier};
+
+const STRESS_ROUNDS: usize = 10_000;
+
+unsafe fn copy_snapshot(engine: *const FerricEngine) -> Result<String, FerricError> {
+    let mut buffer = [0_u8; 512];
+    let mut written = 0;
+    let result = ferric_engine_last_error_copy(
+        engine,
+        buffer.as_mut_ptr().cast::<c_char>(),
+        buffer.len(),
+        &mut written,
+    );
+    if result != FerricError::Ok {
+        return Err(result);
+    }
+    assert!(written > 1);
+    assert!(written <= buffer.len());
+    assert_eq!(buffer[written - 1], 0);
+    Ok(CStr::from_ptr(buffer.as_ptr().cast::<c_char>())
+        .to_str()
+        .unwrap()
+        .to_string())
+}
+
+unsafe fn publish_missing_fact(engine: *mut FerricEngine, fact_id: u64) -> String {
+    assert_eq!(
+        ferric_engine_retract(engine, fact_id),
+        FerricError::NotFound
+    );
+    copy_snapshot(engine).unwrap()
+}
+
+unsafe fn validate_stress_snapshot(
+    engine: *const FerricEngine,
+    first: &str,
+    second: &str,
+) -> Result<(), String> {
+    let mut buffer = [0_u8; 512];
+    let mut written = 0;
+    let result = ferric_engine_last_error_copy(
+        engine,
+        buffer.as_mut_ptr().cast::<c_char>(),
+        buffer.len(),
+        &mut written,
+    );
+    if result != FerricError::Ok {
+        return Err(format!("diagnostic copy returned {result:?}"));
+    }
+    if written < 2 || written > buffer.len() || buffer[written - 1] != 0 {
+        return Err(format!(
+            "diagnostic copy returned invalid length or NUL: {written}"
+        ));
+    }
+    let message = &buffer[..written - 1];
+    if message != first.as_bytes() && message != second.as_bytes() {
+        return Err(format!(
+            "reader observed a torn or stale snapshot: {:?}",
+            String::from_utf8_lossy(message)
+        ));
+    }
+    Ok(())
+}
+
+#[test]
+fn ordered_snapshots_observe_published_transitions() {
+    enum Command {
+        Read,
+        Stop,
+    }
+
+    unsafe {
+        let engine = ferric_engine_new();
+        let first = publish_missing_fact(engine, u64::MAX);
+        let second = publish_missing_fact(engine, u64::MAX - 1);
+        assert_ne!(first, second);
+
+        let engine_addr = engine as usize;
+        let (command_tx, command_rx) = mpsc::channel();
+        let (snapshot_tx, snapshot_rx) = mpsc::channel();
+        let reader = std::thread::spawn(move || {
+            let engine = engine_addr as *const FerricEngine;
+            while let Ok(command) = command_rx.recv() {
+                match command {
+                    Command::Read => snapshot_tx.send(copy_snapshot(engine)).unwrap(),
+                    Command::Stop => break,
+                }
+            }
+        });
+
+        assert_eq!(
+            ferric_engine_retract(engine, u64::MAX),
+            FerricError::NotFound
+        );
+        command_tx.send(Command::Read).unwrap();
+        assert_eq!(snapshot_rx.recv().unwrap().unwrap(), first);
+
+        assert_eq!(
+            ferric_engine_retract(engine, u64::MAX - 1),
+            FerricError::NotFound
+        );
+        command_tx.send(Command::Read).unwrap();
+        assert_eq!(snapshot_rx.recv().unwrap().unwrap(), second);
+
+        assert_eq!(ferric_engine_clear_error(engine), FerricError::Ok);
+        command_tx.send(Command::Read).unwrap();
+        assert_eq!(snapshot_rx.recv().unwrap(), Err(FerricError::NotFound));
+
+        assert_eq!(
+            ferric_engine_retract(engine, u64::MAX),
+            FerricError::NotFound
+        );
+        command_tx.send(Command::Read).unwrap();
+        assert_eq!(snapshot_rx.recv().unwrap().unwrap(), first);
+
+        command_tx.send(Command::Stop).unwrap();
+        reader.join().unwrap();
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}
+
+#[test]
+fn copy_is_coherent_during_10_000_owner_mutations() {
+    unsafe {
+        let engine = ferric_engine_new();
+        let first = publish_missing_fact(engine, u64::MAX);
+        let second = publish_missing_fact(engine, u64::MAX - 1);
+        assert_ne!(first, second);
+        assert_eq!(
+            ferric_engine_retract(engine, u64::MAX),
+            FerricError::NotFound
+        );
+
+        let barrier = Arc::new(Barrier::new(2));
+        let reader_barrier = Arc::clone(&barrier);
+        let engine_addr = engine as usize;
+        let expected_first = first.clone();
+        let expected_second = second.clone();
+        let reader = std::thread::spawn(move || {
+            let engine = engine_addr as *const FerricEngine;
+            let mut failure = None;
+            for round in 0..STRESS_ROUNDS {
+                reader_barrier.wait();
+
+                if failure.is_none() {
+                    failure =
+                        validate_stress_snapshot(engine, &expected_first, &expected_second).err();
+                }
+                if failure.is_none() && round % 257 == 0 {
+                    let mut count = usize::MAX;
+                    let result = ferric_engine_action_diagnostic_count(engine, &mut count);
+                    if result != FerricError::ThreadViolation || count != usize::MAX {
+                        failure = Some(format!(
+                            "action diagnostics lost affinity: result={result:?}, count={count}"
+                        ));
+                    }
+                }
+                reader_barrier.wait();
+            }
+            failure
+        });
+
+        let mut owner_failure = None;
+        for round in 0..STRESS_ROUNDS {
+            barrier.wait();
+            let fact_id = if round % 2 == 0 {
+                u64::MAX - 1
+            } else {
+                u64::MAX
+            };
+            let result = ferric_engine_retract(engine, fact_id);
+            if owner_failure.is_none() && result != FerricError::NotFound {
+                owner_failure = Some(format!(
+                    "owner mutation returned {result:?} at round {round}"
+                ));
+            }
+            barrier.wait();
+        }
+
+        let reader_failure = reader.join().unwrap();
+        assert!(owner_failure.is_none(), "{owner_failure:?}");
+        assert!(reader_failure.is_none(), "{reader_failure:?}");
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}
+
+#[test]
+fn size_query_and_copy_are_independent_coherent_snapshots() {
+    unsafe {
+        let engine = ferric_engine_new();
+        let short = "short";
+        let long = "a much longer replacement diagnostic";
+        (*engine).set_error_for_test(short.to_string());
+
+        let mut short_size = 0;
+        assert_eq!(
+            ferric_engine_last_error_copy(engine, std::ptr::null_mut(), 0, &mut short_size),
+            FerricError::Ok
+        );
+        assert_eq!(short_size, short.len() + 1);
+
+        (*engine).set_error_for_test(long.to_string());
+        let mut small_buffer = vec![0_u8; short_size];
+        let mut required = 0;
+        assert_eq!(
+            ferric_engine_last_error_copy(
+                engine,
+                small_buffer.as_mut_ptr().cast::<c_char>(),
+                small_buffer.len(),
+                &mut required,
+            ),
+            FerricError::BufferTooSmall
+        );
+        assert_eq!(required, long.len() + 1);
+        assert_eq!(small_buffer[small_buffer.len() - 1], 0);
+        assert_eq!(
+            &small_buffer[..small_buffer.len() - 1],
+            &long.as_bytes()[..small_buffer.len() - 1]
+        );
+
+        let mut full_buffer = vec![0_u8; required];
+        let mut written = 0;
+        assert_eq!(
+            ferric_engine_last_error_copy(
+                engine,
+                full_buffer.as_mut_ptr().cast::<c_char>(),
+                full_buffer.len(),
+                &mut written,
+            ),
+            FerricError::Ok
+        );
+        assert_eq!(written, required);
+        assert_eq!(&full_buffer[..long.len()], long.as_bytes());
+        assert_eq!(full_buffer[long.len()], 0);
+
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}
+
+#[test]
+fn borrowed_pointer_survives_error_replacement_until_next_borrowed_read() {
+    unsafe {
+        let engine = ferric_engine_new();
+        (*engine).set_error_for_test("first snapshot".to_string());
+        let first = ferric_engine_last_error(engine);
+        assert!(!first.is_null());
+
+        (*engine).set_error_for_test("second snapshot".to_string());
+        assert_eq!(
+            copy_snapshot(engine).unwrap(),
+            "second snapshot",
+            "owned copies must see the current snapshot"
+        );
+        assert_eq!(
+            CStr::from_ptr(first).to_str().unwrap(),
+            "first snapshot",
+            "writers and owned copies must not invalidate the borrowed cache"
+        );
+
+        let second = ferric_engine_last_error(engine);
+        assert!(!second.is_null());
+        assert_eq!(CStr::from_ptr(second).to_str().unwrap(), "second snapshot");
+
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}
+
+#[cfg(feature = "serde")]
+struct ReentrantAllocatorContext {
+    engine: *mut FerricEngine,
+    storage: Vec<u8>,
+    diagnostic_result: FerricError,
+    diagnostic: String,
+    borrowed_diagnostic: String,
+    ordinary_call_result: FerricError,
+}
+
+#[cfg(feature = "serde")]
+unsafe extern "C" fn reentrant_allocator(size: usize, context: *mut std::ffi::c_void) -> *mut u8 {
+    let context = &mut *context.cast::<ReentrantAllocatorContext>();
+
+    context.diagnostic_result = match copy_snapshot(context.engine) {
+        Ok(message) => {
+            context.diagnostic = message;
+            FerricError::Ok
+        }
+        Err(code) => code,
+    };
+    let borrowed = ferric_engine_last_error(context.engine);
+    if !borrowed.is_null() {
+        context.borrowed_diagnostic = CStr::from_ptr(borrowed).to_string_lossy().into_owned();
+    }
+    context.ordinary_call_result = ferric_engine_reset(context.engine);
+    context.storage.resize(size, 0);
+    context.storage.as_mut_ptr()
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn allocator_callback_can_reenter_diagnostics_but_not_runtime() {
+    unsafe {
+        let engine = ferric_engine_new();
+        (*engine).set_error_for_test("callback snapshot".to_string());
+        let mut context = ReentrantAllocatorContext {
+            engine,
+            storage: Vec::new(),
+            diagnostic_result: FerricError::InternalError,
+            diagnostic: String::new(),
+            borrowed_diagnostic: String::new(),
+            ordinary_call_result: FerricError::Ok,
+        };
+        let mut data = std::ptr::null_mut();
+        let mut len = 0;
+
+        assert_eq!(
+            ferric_engine_serialize_bincode(
+                engine,
+                Some(reentrant_allocator),
+                std::ptr::addr_of_mut!(context).cast::<std::ffi::c_void>(),
+                &mut data,
+                &mut len,
+            ),
+            FerricError::Ok
+        );
+        assert_eq!(context.diagnostic_result, FerricError::Ok);
+        assert_eq!(context.diagnostic, "callback snapshot");
+        assert_eq!(context.borrowed_diagnostic, "callback snapshot");
+        assert_eq!(
+            context.ordinary_call_result,
+            FerricError::InternalError,
+            "same-engine runtime reentry must fail deterministically"
+        );
+        assert_eq!(data, context.storage.as_mut_ptr());
+        assert_eq!(len, context.storage.len());
+
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}

--- a/crates/ferric-ffi/src/tests/header.rs
+++ b/crates/ferric-ffi/src/tests/header.rs
@@ -28,6 +28,13 @@ fn read_ci_workflow() -> String {
         .unwrap_or_else(|_| panic!("CI workflow not found at {}", workflow_path.display()))
 }
 
+fn read_tsan_harness() -> String {
+    let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let script_path = crate_dir.join("../../scripts/ffi-tsan-harness.sh");
+    std::fs::read_to_string(&script_path)
+        .unwrap_or_else(|_| panic!("TSan harness not found at {}", script_path.display()))
+}
+
 #[test]
 fn header_has_include_guard() {
     let header = read_committed_header();
@@ -47,6 +54,26 @@ fn header_has_thread_safety_banner() {
     assert!(
         header.contains("FERRIC_ERROR_THREAD_VIOLATION"),
         "Thread-safety section must mention FERRIC_ERROR_THREAD_VIOLATION"
+    );
+    assert!(
+        header.contains("ferric_engine_last_error_copy() is synchronized"),
+        "Thread-safety section must promise synchronized owned snapshots"
+    );
+    assert!(
+        header.contains("returned borrowed pointer must not be used while another"),
+        "Thread-safety section must constrain borrowed-pointer use"
+    );
+    assert!(
+        header.contains("ferric_engine_free_unchecked() is a destruction-only escape"),
+        "Thread-safety section must document unchecked destruction"
+    );
+    assert!(
+        header.contains("Neither diagnostic reader may race with engine destruction"),
+        "Thread-safety section must forbid concurrent engine destruction"
+    );
+    assert!(
+        header.contains("Same-engine runtime reentry from a host callback fails"),
+        "Thread-safety section must document deterministic reentry rejection"
     );
 }
 
@@ -139,6 +166,37 @@ fn ci_checks_both_committed_headers_after_generation() {
         build_position < check_position,
         "CI must generate headers before checking them for drift"
     );
+}
+
+#[test]
+fn ci_runs_mixed_language_thread_sanitizer_harness() {
+    let workflow = read_ci_workflow();
+    assert!(
+        workflow.contains("FFI Diagnostics (ThreadSanitizer)"),
+        "CI must contain the raw-engine diagnostic TSan job"
+    );
+    assert!(
+        workflow.contains("just ffi-tsan-harness"),
+        "CI must run the mixed Rust/C TSan harness"
+    );
+}
+
+#[test]
+fn tsan_harness_instruments_rust_std_and_c() {
+    let script = read_tsan_harness();
+    for required in [
+        "-Zsanitizer=thread",
+        "-Zexternal-clangrt",
+        "-Zbuild-std=std,panic_abort",
+        "--crate-type staticlib",
+        "-fsanitize=thread",
+        "nm -u",
+    ] {
+        assert!(
+            script.contains(required),
+            "TSan harness is missing required mixed-language instrumentation: {required}"
+        );
+    }
 }
 
 #[test]

--- a/crates/ferric-ffi/src/tests/lifecycle.rs
+++ b/crates/ferric-ffi/src/tests/lifecycle.rs
@@ -218,7 +218,7 @@ fn thread_violation_from_other_thread_via_raw_pointer() {
 fn clear_error_rejects_other_thread_before_mutation() {
     unsafe {
         let engine = ferric_engine_new();
-        (*engine).error_state.set("sticky error".to_string());
+        (*engine).set_error_for_test("sticky error".to_string());
 
         let engine_addr = engine as usize;
         let result = std::thread::spawn(move || {
@@ -264,8 +264,8 @@ fn engine_last_error_pointer_storage_is_per_engine() {
     unsafe {
         let e1 = ferric_engine_new();
         let e2 = ferric_engine_new();
-        (*e1).error_state.set("engine one".to_string());
-        (*e2).error_state.set("engine two".to_string());
+        (*e1).set_error_for_test("engine one".to_string());
+        (*e2).set_error_for_test("engine two".to_string());
 
         let p1 = ferric_engine_last_error(e1);
         assert!(!p1.is_null());

--- a/crates/ferric-ffi/tests/c/diagnostic_concurrency.c
+++ b/crates/ferric-ffi/tests/c/diagnostic_concurrency.c
@@ -1,0 +1,233 @@
+/*
+ * diagnostic_concurrency.c — ThreadSanitizer regression for FR-CABI-002.
+ *
+ * The creator thread repeatedly replaces and clears a raw engine's error
+ * snapshot while foreign pthreads call both diagnostic accessors. Every owned
+ * copy must be either absent or one complete published snapshot. Borrowed
+ * pointers are deliberately not dereferenced because their public contract
+ * requires external serialization after the call returns.
+ *
+ * Both this harness and the Rust static library must be instrumented with
+ * ThreadSanitizer. Run through `just ffi-tsan-harness`.
+ */
+
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "ferric.h"
+
+#define READER_COUNT 2
+#define STRESS_ROUNDS 10000
+#define SNAPSHOT_CAPACITY 512
+
+typedef struct TestBarrier {
+    pthread_mutex_t mutex;
+    pthread_cond_t condition;
+    unsigned int threshold;
+    unsigned int waiting;
+    unsigned int generation;
+} TestBarrier;
+
+typedef struct ReaderContext {
+    const FerricEngine *engine;
+    TestBarrier *barrier;
+    const char *first;
+    const char *second;
+    int failures;
+} ReaderContext;
+
+static int barrier_init(TestBarrier *barrier, unsigned int threshold) {
+    if (pthread_mutex_init(&barrier->mutex, NULL) != 0) {
+        return 1;
+    }
+    if (pthread_cond_init(&barrier->condition, NULL) != 0) {
+        (void)pthread_mutex_destroy(&barrier->mutex);
+        return 1;
+    }
+    barrier->threshold = threshold;
+    barrier->waiting = 0;
+    barrier->generation = 0;
+    return 0;
+}
+
+static void barrier_wait(TestBarrier *barrier) {
+    (void)pthread_mutex_lock(&barrier->mutex);
+    unsigned int generation = barrier->generation;
+    barrier->waiting++;
+    if (barrier->waiting == barrier->threshold) {
+        barrier->waiting = 0;
+        barrier->generation++;
+        (void)pthread_cond_broadcast(&barrier->condition);
+    } else {
+        while (generation == barrier->generation) {
+            (void)pthread_cond_wait(&barrier->condition, &barrier->mutex);
+        }
+    }
+    (void)pthread_mutex_unlock(&barrier->mutex);
+}
+
+static void barrier_destroy(TestBarrier *barrier) {
+    (void)pthread_cond_destroy(&barrier->condition);
+    (void)pthread_mutex_destroy(&barrier->mutex);
+}
+
+static int copy_snapshot(const FerricEngine *engine, char *buffer,
+                         uintptr_t capacity, uintptr_t *written) {
+    FerricError result =
+        ferric_engine_last_error_copy(engine, buffer, capacity, written);
+    if (result != FERRIC_ERROR_OK) {
+        fprintf(stderr, "diagnostic copy failed with code %d\n", (int)result);
+        return 1;
+    }
+    if (*written < 2 || *written > capacity ||
+        buffer[*written - 1] != '\0') {
+        fprintf(stderr, "diagnostic copy returned an invalid length or NUL\n");
+        return 1;
+    }
+    return 0;
+}
+
+static void *diagnostic_reader(void *opaque) {
+    ReaderContext *context = (ReaderContext *)opaque;
+    char buffer[SNAPSHOT_CAPACITY];
+
+    for (int round = 0; round < STRESS_ROUNDS; round++) {
+        barrier_wait(context->barrier);
+
+        uintptr_t written = 0;
+        FerricError result = ferric_engine_last_error_copy(
+            context->engine, buffer, sizeof(buffer), &written);
+        if (result == FERRIC_ERROR_OK) {
+            if (written < 2 || written > sizeof(buffer) ||
+                buffer[written - 1] != '\0') {
+                fprintf(stderr,
+                        "reader observed invalid diagnostic length or NUL\n");
+                context->failures++;
+            } else if (strcmp(buffer, context->first) != 0 &&
+                       strcmp(buffer, context->second) != 0) {
+                fprintf(stderr, "reader observed torn snapshot: %s\n", buffer);
+                context->failures++;
+            }
+        } else if (result != FERRIC_ERROR_NOT_FOUND || written != 0) {
+            fprintf(stderr, "reader copy failed with code %d and length %zu\n",
+                    (int)result, (size_t)written);
+            context->failures++;
+        }
+
+        /*
+         * Exercise synchronization of the borrowed cache itself. Its returned
+         * pointer is intentionally discarded before the next competing call.
+         */
+        (void)ferric_engine_last_error(context->engine);
+
+        barrier_wait(context->barrier);
+    }
+    return NULL;
+}
+
+int main(void) {
+    int failures = 0;
+    FerricEngine *engine = ferric_engine_new();
+    if (engine == NULL) {
+        fprintf(stderr, "failed to create raw engine\n");
+        return 1;
+    }
+
+    char first[SNAPSHOT_CAPACITY] = {0};
+    char second[SNAPSHOT_CAPACITY] = {0};
+    uintptr_t written = 0;
+
+    if (ferric_engine_retract(engine, UINT64_MAX) !=
+            FERRIC_ERROR_NOT_FOUND ||
+        copy_snapshot(engine, first, sizeof(first), &written) != 0) {
+        fprintf(stderr, "failed to capture first baseline diagnostic\n");
+        failures++;
+    }
+    if (ferric_engine_retract(engine, UINT64_MAX - 1) !=
+            FERRIC_ERROR_NOT_FOUND ||
+        copy_snapshot(engine, second, sizeof(second), &written) != 0) {
+        fprintf(stderr, "failed to capture second baseline diagnostic\n");
+        failures++;
+    }
+    if (failures != 0) {
+        (void)ferric_engine_free(engine);
+        return 1;
+    }
+    if (strcmp(first, second) == 0) {
+        fprintf(stderr, "baseline diagnostics must be distinct\n");
+        (void)ferric_engine_free(engine);
+        return 1;
+    }
+
+    TestBarrier barrier;
+    if (barrier_init(&barrier, READER_COUNT + 1) != 0) {
+        fprintf(stderr, "failed to initialize pthread barrier\n");
+        (void)ferric_engine_free(engine);
+        return 1;
+    }
+
+    pthread_t readers[READER_COUNT];
+    ReaderContext contexts[READER_COUNT];
+    for (int index = 0; index < READER_COUNT; index++) {
+        contexts[index].engine = engine;
+        contexts[index].barrier = &barrier;
+        contexts[index].first = first;
+        contexts[index].second = second;
+        contexts[index].failures = 0;
+        if (pthread_create(&readers[index], NULL, diagnostic_reader,
+                           &contexts[index]) != 0) {
+            fprintf(stderr, "failed to create diagnostic reader\n");
+            return 1;
+        }
+    }
+
+    for (int round = 0; round < STRESS_ROUNDS; round++) {
+        barrier_wait(&barrier);
+
+        FerricError result;
+        if (round % 3 == 0) {
+            result = ferric_engine_clear_error(engine);
+            if (result != FERRIC_ERROR_OK) {
+                fprintf(stderr, "owner clear failed with code %d\n",
+                        (int)result);
+                failures++;
+            }
+        } else {
+            uint64_t fact_id = round % 2 == 0 ? UINT64_MAX : UINT64_MAX - 1;
+            result = ferric_engine_retract(engine, fact_id);
+            if (result != FERRIC_ERROR_NOT_FOUND) {
+                fprintf(stderr, "owner mutation failed with code %d\n",
+                        (int)result);
+                failures++;
+            }
+        }
+
+        barrier_wait(&barrier);
+    }
+
+    for (int index = 0; index < READER_COUNT; index++) {
+        if (pthread_join(readers[index], NULL) != 0) {
+            fprintf(stderr, "failed to join diagnostic reader\n");
+            failures++;
+        }
+        failures += contexts[index].failures;
+    }
+
+    barrier_destroy(&barrier);
+    if (ferric_engine_free(engine) != FERRIC_ERROR_OK) {
+        fprintf(stderr, "failed to free raw engine\n");
+        failures++;
+    }
+
+    if (failures != 0) {
+        fprintf(stderr, "diagnostic concurrency harness: %d failure(s)\n",
+                failures);
+        return 1;
+    }
+
+    printf("diagnostic concurrency harness: %d owner operations and %d reader operations passed\n",
+           STRESS_ROUNDS, STRESS_ROUNDS * READER_COUNT);
+    return 0;
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -761,11 +761,20 @@ ferric_engine_free(engine);
 
 Engine instances are bound to their creating thread (`!Send + !Sync`):
 
-- Every `ferric_engine_*` function validates thread affinity before mutation.
-- Wrong-thread calls return `FERRIC_ERROR_THREAD_VIOLATION` with no state
-  modified.
-- **Exceptions**: `ferric_engine_last_error` and `ferric_engine_last_error_copy`
-  skip thread checks (diagnostic access should always work).
+- Ordinary runtime-facing `ferric_engine_*` functions validate thread affinity
+  before accessing engine state.
+- Wrong-thread ordinary runtime calls return
+  `FERRIC_ERROR_THREAD_VIOLATION` with no state modified.
+- `ferric_engine_last_error_copy` is synchronized, may be called concurrently
+  from any thread, and copies one coherent snapshot per invocation.
+- `ferric_engine_last_error` may also be called from any thread. Its returned
+  pointer must not be used while another borrowed read or engine destruction
+  may occur; use the copy API when pointer-use windows could overlap.
+- `ferric_engine_free_unchecked` is a destruction-only escape hatch that skips
+  affinity. It must not overlap any access to the engine.
+- Same-engine runtime reentry from a host callback returns
+  `FERRIC_ERROR_INTERNAL_ERROR`. Last-error access remains safe in callbacks.
+- No engine accessor may race with engine destruction.
 
 Global error functions (`ferric_last_error_global`, etc.) use thread-local
 storage and are safe from any thread.
@@ -849,9 +858,11 @@ ferric_engine_clear_action_diagnostics(engine);
 | `ferric_value_free` | Free a `FerricValue` and its owned resources (recursive); returns `FERRIC_ERROR_INVALID_ARGUMENT` if any `value_type` tag is unknown (that value's payload is left untouched; known siblings and owned arrays are still freed) |
 | `ferric_value_array_free` | Free an array of `FerricValue`s; same unknown-tag contract as `ferric_value_free` |
 
-Borrowed pointers (from `ferric_engine_last_error`, `ferric_engine_get_output`)
-must **not** be freed by the caller and are valid only until the next FFI call
-that may modify that channel.
+Borrowed pointers must **not** be freed by the caller.
+`ferric_engine_last_error` remains valid until the next borrowed last-error
+read on that engine or engine destruction; error writers and the copy API do
+not invalidate it. `ferric_engine_get_output` remains valid until the next
+call that writes to that output channel.
 
 ### Panic Policy
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -163,7 +163,10 @@ Ferric uses byte-equality comparison with no Unicode normalization:
 If your application embeds CLIPS via its C API, Ferric provides a similar
 C FFI surface. Key differences:
 
-- Engine handles are thread-affine (must be used on the creating thread).
+- Engine runtime operations are thread-affine (must be used on the creating
+  thread). Per-engine last-error copies are synchronized across threads;
+  borrowed-pointer use must not overlap another borrowed read or destruction.
+  The destruction-only unchecked free skips affinity.
 - Error handling uses return codes + error channels (per-engine and global).
 - Include `ferric.h` and link against the Ferric shared library.
 

--- a/docs/phase6-baseline.md
+++ b/docs/phase6-baseline.md
@@ -120,8 +120,10 @@ C-ABI functions with opaque `FerricEngine*` handle:
 - `ferric_last_error_global` -- thread-local error (borrowed pointer, valid until next Ferric call)
 - `ferric_last_error_global_copy` -- thread-local error (copy-to-buffer)
 - `ferric_clear_error_global` -- clear thread-local error
-- `ferric_engine_last_error` -- per-engine error (borrowed pointer)
-- `ferric_engine_last_error_copy` -- per-engine error (copy-to-buffer)
+- `ferric_engine_last_error` -- synchronized per-engine error read (borrowed
+  pointer; serialize pointer use against another borrowed read)
+- `ferric_engine_last_error_copy` -- concurrent-safe coherent per-engine error
+  snapshot (copy-to-buffer)
 - `ferric_engine_clear_error` -- clear per-engine error
 
 **Action Diagnostics:**
@@ -136,9 +138,16 @@ C-ABI functions with opaque `FerricEngine*` handle:
 
 **Thread Affinity Contract:**
 - Engine instances are thread-affine (`!Send + !Sync`).
-- Every `ferric_engine_*` entry point checks thread affinity before mutation.
+- Runtime operations check thread affinity before accessing engine state.
 - Mismatch returns `FERRIC_ERROR_THREAD_VIOLATION` with no state modified.
-- Diagnostic read exceptions: `ferric_engine_last_error` and `ferric_engine_last_error_copy`.
+- `ferric_engine_last_error_copy` is a synchronized, coherent snapshot API
+  callable concurrently from any thread.
+- `ferric_engine_last_error` is callable from any thread, but borrowed-pointer
+  use must not overlap another borrowed read or engine destruction.
+- `ferric_engine_free_unchecked` skips affinity solely for destruction and must
+  not overlap any engine access.
+- Same-engine runtime reentry from host callbacks fails deterministically;
+  last-error access remains callback-safe.
 
 **FFI Panic Policy:**
 - Shipped FFI artifacts use `ffi-dev` / `ffi-release` profiles with `panic = "abort"`.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -101,8 +101,10 @@ profiles with `panic = abort`.
 - `tests.rs` + `src/tests/` — lifecycle, contract-lock, diagnostic-parity,
   error-model, execution, template-assertion, copy-error, build-matrix,
   ffi-expansion, values, header tests.
-- Thread-affinity invariant: engine handles bound to creating thread;
-  diagnostic readers skip the check.
+- Thread-affinity invariant: runtime state is owner-thread-only. Per-engine
+  last-error copies are synchronized across threads; borrowed last-error
+  pointer use must not overlap other borrowed reads or destruction. The
+  destruction-only unchecked free skips affinity but must not overlap access.
 
 ### `ferric-cli`
 

--- a/justfile
+++ b/justfile
@@ -75,6 +75,11 @@ test-ffi:
 ffi-c-harness:
     ./scripts/ffi-c-harness.sh
 
+# Run the mixed Rust/C pthread diagnostic harness under ThreadSanitizer
+# (x86_64 Linux; uses a pinned nightly to instrument Rust and std)
+ffi-tsan-harness:
+    ./scripts/ffi-tsan-harness.sh
+
 # Run tests for the facade crate
 test-ferric:
     cargo test -p ferric

--- a/scripts/ffi-tsan-harness.sh
+++ b/scripts/ffi-tsan-harness.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Build both sides of the raw-engine diagnostic concurrency harness with
+# ThreadSanitizer. This is intentionally separate from ffi-c-harness.sh:
+# ThreadSanitizer cannot be combined with AddressSanitizer/UBSan, and the Rust
+# static library (including std) must be instrumented for this check to be real.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+if [[ $(uname -s) != Linux || $(uname -m) != x86_64 ]]; then
+    echo "ffi-tsan-harness: requires x86_64 Linux" >&2
+    exit 1
+fi
+
+CC="${CC:-clang}"
+tsan_toolchain="${FERRIC_TSAN_TOOLCHAIN:-nightly-2025-11-04}"
+tsan_target="x86_64-unknown-linux-gnu"
+outdir="$root/target/ffi-tsan"
+staticlib="$outdir/$tsan_target/ffi-dev/libferric_ffi.a"
+binary="$outdir/diagnostic_concurrency"
+
+for command in "$CC" nm timeout; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "ffi-tsan-harness: required command not found: $command" >&2
+        exit 1
+    fi
+done
+
+CARGO_TARGET_DIR="$outdir" \
+RUSTFLAGS="-Zsanitizer=thread -Zexternal-clangrt -Cforce-frame-pointers=yes" \
+    cargo +"$tsan_toolchain" rustc \
+        --locked \
+        -Zbuild-std=std,panic_abort \
+        --target "$tsan_target" \
+        -p ferric-ffi \
+        --profile ffi-dev \
+        --crate-type staticlib
+
+if ! nm -u "$staticlib" | grep "__tsan_" >/dev/null; then
+    echo "ffi-tsan-harness: Rust static library has no TSan instrumentation" >&2
+    exit 1
+fi
+
+"$CC" -std=c11 -O1 -g -Wall -Wextra -Werror \
+    -fsanitize=thread -fno-omit-frame-pointer -pthread \
+    -I crates/ferric-ffi \
+    crates/ferric-ffi/tests/c/diagnostic_concurrency.c \
+    "$staticlib" \
+    -ldl -lm \
+    -o "$binary"
+
+TSAN_OPTIONS="halt_on_error=1:exitcode=66:detect_deadlocks=1" \
+    timeout 120s "$binary"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -29,6 +29,7 @@ run_clippy() {
 
 run_test() {
     cargo test --workspace --exclude ferric-python --exclude ferric-napi
+    cargo test -p ferric-ffi --features serde
 }
 
 command="${1:-all}"


### PR DESCRIPTION
Closes #86

## Scope

FR-CABI-002 separates owner-thread runtime state from a synchronized per-engine diagnostic channel. It makes owned last-error copies coherent and concurrent-safe without constructing overlapping whole-handle Rust references, preserves the documented borrowed-pointer API with a precise lifetime rule, rejects same-engine runtime reentry deterministically, and adds mixed Rust/C ThreadSanitizer coverage.

## Stack

- Immediate predecessor: none
- Earlier included PRs: none
- Required merge order: this PR only
- Tests require predecessor code: no
- Branch point: `4525d6dfa84f47d57c445feb66918e1ee55987b6`

## Red-before-fix evidence

In a detached worktree at the branch point, I built the original Rust library and this PR's C/pthread regression harness with mixed-language ThreadSanitizer instrumentation:

```sh
CARGO_TARGET_DIR=target/ffi-tsan-before \
RUSTFLAGS='-Zsanitizer=thread -Zexternal-clangrt -Cforce-frame-pointers=yes' \
  cargo +nightly rustc --locked -Zbuild-std=std,panic_abort \
  --target aarch64-apple-darwin -p ferric-ffi --profile ffi-dev \
  --crate-type staticlib

clang -std=c11 -O1 -g -Wall -Wextra -Werror \
  -fsanitize=thread -fno-omit-frame-pointer -pthread \
  -I crates/ferric-ffi diagnostic_concurrency.c \
  target/ffi-tsan-before/aarch64-apple-darwin/ffi-dev/libferric_ffi.a \
  -framework Security -framework CoreFoundation -lobjc \
  -o target/ffi-tsan-before/diagnostic_concurrency

TSAN_OPTIONS='halt_on_error=1:exitcode=66:detect_deadlocks=1' \
  target/ffi-tsan-before/diagnostic_concurrency
```

Result: exit 134. ThreadSanitizer reported a concrete data race in `RefCell<Option<CString>>::borrow_mut` inside `ferric_engine_last_error`, between the two `diagnostic_reader` pthreads.

## Validation

- `just preflight-pr` — passed
- `cargo test -p ferric-ffi --features serde` — 279 passed, 4 ignored
- native C/pthread regression harness — 10,000 owner operations and 20,000 reader operations passed
- mixed Rust/C ThreadSanitizer harness — 10,000 owner operations and 20,000 reader operations passed with no report
- GitHub `FFI Diagnostics (ThreadSanitizer)` check — passed on x86_64 Linux
- GitHub compatibility/performance assessments — passed
- isolated compatibility-timeout follow-up — the unchanged release CLI completed `constant-p-100.clp` successfully in five consecutive runs under the workflow timeout
- independent safety, contract, and test/sanitizer reviews — clean

## Acceptance criteria

- Documented cross-thread pattern is data-race-free: per-engine diagnostics and the borrowed CString cache share one mutex; the mixed-language TSan regression is green.
- Every owned-copy call is coherent: ordered transition, retry, and 10,000-round stress tests accept only complete snapshots.
- Borrow panics are removed: the old `RefCell` cache is replaced with mutex-protected state, and concurrent borrowed getter calls are exercised by C.
- Unsupported patterns fail deterministically: owner-thread runtime access is checked before projection, and same-engine callback reentry returns `FERRIC_ERROR_INTERNAL_ERROR` while diagnostic reads remain safe.
- Public contract is exact: both generated headers and compatibility/migration documentation cover owned-copy concurrency, borrowed-pointer use, unchecked destruction, reentry, and destruction serialization.

## Residual risks

Engine destruction remains externally serialized by contract: neither diagnostic accessor may race with destruction. Borrowed-pointer use must also be serialized against another borrowed read; callers needing overlapping use windows have the owned-copy API.