### PR TITLE
[FR-CABI-008] Add Ferric-owned multifield copying

### DIFF
--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -45,27 +45,35 @@
  *    error writers and the copy API do not invalidate it. Do NOT
  *    free either pointer.
  *
- * 3. Owned string pointers: String fields in FerricValue
- *    (string_ptr for Symbol/String types) are heap-allocated.
- *    Free with ferric_string_free() or ferric_value_free().
+ * 3. Ferric-owned string pointers: String fields in values
+ *    returned by Ferric (string_ptr for Symbol/String types)
+ *    are heap-allocated. Free with ferric_string_free() or
+ *    ferric_value_free().
  *
- * 4. FerricValue ownership: Values returned through out-params
- *    (e.g., ferric_engine_get_fact_field) are caller-owned.
- *    Free with ferric_value_free() which recursively releases
- *    owned strings and multifield arrays.
+ * 4. Ferric-owned values: Values returned through out-params
+ *    (e.g., ferric_engine_get_fact_field and
+ *    ferric_value_multifield_copy) are caller-owned. Free with
+ *    ferric_value_free(), which recursively releases Ferric-owned
+ *    strings and multifield arrays.
  *
- * 5. Multifield arrays: FerricValue.multifield_ptr is a heap-
- *    allocated array. Free with ferric_value_array_free() or
- *    ferric_value_free() (which handles it recursively).
+ * 5. Borrowed value inputs: Value trees passed to structured
+ *    assertion APIs or ferric_value_multifield_copy() are borrowed
+ *    for that call. Ferric never retains or frees caller-provided
+ *    strings or arrays.
  *
- * 6. External address pointers: FerricValue.external_pointer
+ * 6. Multifield provenance: Only Ferric-owned arrays returned by
+ *    Ferric may be passed to ferric_value_array_free() or released
+ *    recursively with ferric_value_free(). Never pass stack or
+ *    foreign-allocated value trees to those cleanup APIs.
+ *
+ * 7. External address pointers: FerricValue.external_pointer
  *    is NOT owned by the FFI. Lifetime is caller-managed.
  *
- * 7. Output string pointers: ferric_engine_get_output() returns
+ * 8. Output string pointers: ferric_engine_get_output() returns
  *    a borrowed pointer valid until the next call that writes
  *    to that channel. Do NOT free.
  *
- * 8. Bounds annotations: Pointer parameters and struct fields
+ * 9. Bounds annotations: Pointer parameters and struct fields
  *    carry FERRIC_COUNTED_BY, FERRIC_SIZED_BY, and
  *    FERRIC_NULL_TERMINATED annotations when compiled with
  *    Clang -fbounds-safety. Define FERRIC_NO_BOUNDS_ANNOTATIONS
@@ -313,11 +321,16 @@ typedef struct FerricConfig {
 //
 // ## Ownership
 //
-// - `string_ptr`: when non-null, is a heap-allocated NUL-terminated string.
-//   The caller must free it with `ferric_string_free` or `ferric_value_free`.
-// - `multifield_ptr`: when non-null, is a heap-allocated array of `FerricValue`s.
-//   The caller must free it with `ferric_value_free` (which recursively frees elements)
-//   or `ferric_value_array_free`.
+// Ownership is contextual:
+//
+// - Values returned by Ferric APIs and constructors are Ferric-owned.
+//   Their non-null `string_ptr` and `multifield_ptr` fields must be released
+//   with `ferric_value_free` (or the matching type-specific Ferric free API).
+// - Values passed to structured assertion APIs or
+//   `ferric_value_multifield_copy` are borrowed for that call. Ferric neither
+//   retains nor frees any part of the caller-provided tree.
+// - Only Ferric-owned values and arrays may be passed to
+//   `ferric_value_free` and `ferric_value_array_free`.
 // - `external_pointer`: NOT owned by `FerricValue`. Lifetime is caller-managed.
 //
 // ## Active Fields by Type
@@ -327,9 +340,9 @@ typedef struct FerricConfig {
 // | Void | (none) |
 // | Integer | `integer` |
 // | Float | `float` |
-// | Symbol | `string_ptr` (owned) |
-// | String | `string_ptr` (owned) |
-// | Multifield | `multifield_ptr` (owned), `multifield_len` |
+// | Symbol | `string_ptr` |
+// | String | `string_ptr` |
+// | Multifield | `multifield_ptr`, `multifield_len` |
 // | ExternalAddress | `external_type_id`, `external_pointer` |
 typedef struct FerricValue {
     // Raw `FerricValueType` discriminant.
@@ -730,6 +743,12 @@ enum FerricError ferric_engine_get_fact_template_name(const struct FerricEngine 
 
 // Assert an ordered fact from structured values, bypassing CLIPS source parsing.
 //
+// `fields` and every active string or multifield reachable from it are
+// borrowed for the duration of this call. Ferric converts the values into
+// engine-owned runtime data and never retains or frees caller storage. The
+// complete input tree must remain readable and unchanged until the call
+// returns.
+//
 // # Safety
 //
 // - `engine` must be a valid engine pointer.
@@ -1000,6 +1019,10 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
 // `slot_names` and `slot_values` must each point to `count` elements.
 // Each `slot_names[i]` is a NUL-terminated C string naming a slot,
 // and `slot_values[i]` is the corresponding value for that slot.
+// Both arrays and every active string or multifield reachable from the slot
+// values are borrowed for the duration of this call. Ferric never retains or
+// frees caller storage. The complete input tree must remain readable and
+// unchanged until the call returns.
 //
 // # Safety
 //
@@ -1605,6 +1628,41 @@ struct FerricValue ferric_value_string(const char * FERRIC_NULL_TERMINATED s);
 // Create a void `FerricValue` with all fields zeroed/null.
 struct FerricValue ferric_value_void(void);
 
+// Deep-copy a borrowed array of values into one Ferric-owned multifield.
+//
+// The input array and its complete nested value tree are borrowed for the
+// duration of this call. Ferric never retains or frees caller-provided
+// arrays or strings. On success, `*out_value` owns independent copies of
+// every Symbol, String, and Multifield allocation and must be released with
+// `ferric_value_free`. External-address payload pointers are copied shallowly
+// and remain caller-owned.
+//
+// `elements == null` with `len == 0` constructs an empty multifield.
+// Unknown tags, null active string pointers, null non-empty multifield
+// pointers, cyclic or ancestor-overlapping array storage, and nesting deeper
+// than 128 levels return `FERRIC_ERROR_INVALID_ARGUMENT`. A null required
+// pointer returns `FERRIC_ERROR_NULL_POINTER`.
+//
+// When `out_value` is non-null, it is overwritten with Void before any input
+// validation and remains Void on every failure. Every partial Ferric-owned
+// copy is released before an error is returned.
+//
+// # Safety
+//
+// - `out_value` must point to writable storage for one `FerricValue`, must
+//   not overlap the borrowed input tree, and must not currently contain live
+//   Ferric-owned resources.
+// - If `len > 0`, `elements` must point to `len` aligned, initialized
+//   `FerricValue`s.
+// - Every active nested string pointer must address a NUL-terminated byte
+//   string, and every active nested multifield pointer must address its
+//   declared number of initialized `FerricValue`s.
+// - The complete input tree must remain readable and unchanged until this
+//   function returns.
+enum FerricError ferric_value_multifield_copy(const struct FerricValue *elements FERRIC_COUNTED_BY(len),
+                                              uintptr_t len,
+                                              struct FerricValue *out_value);
+
 // Free a heap-allocated C string returned by the FFI.
 //
 // Null pointers are safely ignored.
@@ -1630,6 +1688,8 @@ void ferric_string_free(char * FERRIC_NULL_TERMINATED ptr);
 // # Safety
 //
 // - `value` must point to a valid `FerricValue` or be null.
+// - Every recursively owned allocation must have Ferric provenance; borrowed
+//   or foreign-allocated value trees must not be passed to this function.
 // - Any owned resources (`string_ptr`, `multifield_ptr`) must not have been freed already.
 enum FerricError ferric_value_free(struct FerricValue *value);
 
@@ -1648,7 +1708,8 @@ enum FerricError ferric_value_free(struct FerricValue *value);
 // # Safety
 //
 // - `arr` must point to a contiguous array of `len` `FerricValue`s, or be null.
-// - The array must have been allocated by the FFI.
+// - The array and every recursively owned allocation must have been allocated
+//   by Ferric; borrowed or foreign-allocated arrays must not be passed here.
 enum FerricError ferric_value_array_free(struct FerricValue *arr FERRIC_COUNTED_BY(len), uintptr_t len);
 
 

--- a/crates/ferric-ffi/build.rs
+++ b/crates/ferric-ffi/build.rs
@@ -48,27 +48,35 @@ pub const HEADER_PREAMBLE: &str = r"/*
  *    error writers and the copy API do not invalidate it. Do NOT
  *    free either pointer.
  *
- * 3. Owned string pointers: String fields in FerricValue
- *    (string_ptr for Symbol/String types) are heap-allocated.
- *    Free with ferric_string_free() or ferric_value_free().
+ * 3. Ferric-owned string pointers: String fields in values
+ *    returned by Ferric (string_ptr for Symbol/String types)
+ *    are heap-allocated. Free with ferric_string_free() or
+ *    ferric_value_free().
  *
- * 4. FerricValue ownership: Values returned through out-params
- *    (e.g., ferric_engine_get_fact_field) are caller-owned.
- *    Free with ferric_value_free() which recursively releases
- *    owned strings and multifield arrays.
+ * 4. Ferric-owned values: Values returned through out-params
+ *    (e.g., ferric_engine_get_fact_field and
+ *    ferric_value_multifield_copy) are caller-owned. Free with
+ *    ferric_value_free(), which recursively releases Ferric-owned
+ *    strings and multifield arrays.
  *
- * 5. Multifield arrays: FerricValue.multifield_ptr is a heap-
- *    allocated array. Free with ferric_value_array_free() or
- *    ferric_value_free() (which handles it recursively).
+ * 5. Borrowed value inputs: Value trees passed to structured
+ *    assertion APIs or ferric_value_multifield_copy() are borrowed
+ *    for that call. Ferric never retains or frees caller-provided
+ *    strings or arrays.
  *
- * 6. External address pointers: FerricValue.external_pointer
+ * 6. Multifield provenance: Only Ferric-owned arrays returned by
+ *    Ferric may be passed to ferric_value_array_free() or released
+ *    recursively with ferric_value_free(). Never pass stack or
+ *    foreign-allocated value trees to those cleanup APIs.
+ *
+ * 7. External address pointers: FerricValue.external_pointer
  *    is NOT owned by the FFI. Lifetime is caller-managed.
  *
- * 7. Output string pointers: ferric_engine_get_output() returns
+ * 8. Output string pointers: ferric_engine_get_output() returns
  *    a borrowed pointer valid until the next call that writes
  *    to that channel. Do NOT free.
  *
- * 8. Bounds annotations: Pointer parameters and struct fields
+ * 9. Bounds annotations: Pointer parameters and struct fields
  *    carry FERRIC_COUNTED_BY, FERRIC_SIZED_BY, and
  *    FERRIC_NULL_TERMINATED annotations when compiled with
  *    Clang -fbounds-safety. Define FERRIC_NO_BOUNDS_ANNOTATIONS
@@ -413,6 +421,11 @@ const BOUNDS_ANNOTATIONS: &[(&str, &str)] = &[
     (
         "ferric_value_array_free(struct FerricValue *arr, uintptr_t len)",
         "ferric_value_array_free(struct FerricValue *arr FERRIC_COUNTED_BY(len), uintptr_t len)",
+    ),
+    // ferric_value_multifield_copy: elements is an array of len borrowed values.
+    (
+        "ferric_value_multifield_copy(const struct FerricValue *elements,\n                                              uintptr_t len,",
+        "ferric_value_multifield_copy(const struct FerricValue *elements FERRIC_COUNTED_BY(len),\n                                              uintptr_t len,",
     ),
     // ferric_last_error_global_copy: buf is a byte buffer of buf_len bytes.
     (

--- a/crates/ferric-ffi/ferric.h
+++ b/crates/ferric-ffi/ferric.h
@@ -45,27 +45,35 @@
  *    error writers and the copy API do not invalidate it. Do NOT
  *    free either pointer.
  *
- * 3. Owned string pointers: String fields in FerricValue
- *    (string_ptr for Symbol/String types) are heap-allocated.
- *    Free with ferric_string_free() or ferric_value_free().
+ * 3. Ferric-owned string pointers: String fields in values
+ *    returned by Ferric (string_ptr for Symbol/String types)
+ *    are heap-allocated. Free with ferric_string_free() or
+ *    ferric_value_free().
  *
- * 4. FerricValue ownership: Values returned through out-params
- *    (e.g., ferric_engine_get_fact_field) are caller-owned.
- *    Free with ferric_value_free() which recursively releases
- *    owned strings and multifield arrays.
+ * 4. Ferric-owned values: Values returned through out-params
+ *    (e.g., ferric_engine_get_fact_field and
+ *    ferric_value_multifield_copy) are caller-owned. Free with
+ *    ferric_value_free(), which recursively releases Ferric-owned
+ *    strings and multifield arrays.
  *
- * 5. Multifield arrays: FerricValue.multifield_ptr is a heap-
- *    allocated array. Free with ferric_value_array_free() or
- *    ferric_value_free() (which handles it recursively).
+ * 5. Borrowed value inputs: Value trees passed to structured
+ *    assertion APIs or ferric_value_multifield_copy() are borrowed
+ *    for that call. Ferric never retains or frees caller-provided
+ *    strings or arrays.
  *
- * 6. External address pointers: FerricValue.external_pointer
+ * 6. Multifield provenance: Only Ferric-owned arrays returned by
+ *    Ferric may be passed to ferric_value_array_free() or released
+ *    recursively with ferric_value_free(). Never pass stack or
+ *    foreign-allocated value trees to those cleanup APIs.
+ *
+ * 7. External address pointers: FerricValue.external_pointer
  *    is NOT owned by the FFI. Lifetime is caller-managed.
  *
- * 7. Output string pointers: ferric_engine_get_output() returns
+ * 8. Output string pointers: ferric_engine_get_output() returns
  *    a borrowed pointer valid until the next call that writes
  *    to that channel. Do NOT free.
  *
- * 8. Bounds annotations: Pointer parameters and struct fields
+ * 9. Bounds annotations: Pointer parameters and struct fields
  *    carry FERRIC_COUNTED_BY, FERRIC_SIZED_BY, and
  *    FERRIC_NULL_TERMINATED annotations when compiled with
  *    Clang -fbounds-safety. Define FERRIC_NO_BOUNDS_ANNOTATIONS
@@ -313,11 +321,16 @@ typedef struct FerricConfig {
 //
 // ## Ownership
 //
-// - `string_ptr`: when non-null, is a heap-allocated NUL-terminated string.
-//   The caller must free it with `ferric_string_free` or `ferric_value_free`.
-// - `multifield_ptr`: when non-null, is a heap-allocated array of `FerricValue`s.
-//   The caller must free it with `ferric_value_free` (which recursively frees elements)
-//   or `ferric_value_array_free`.
+// Ownership is contextual:
+//
+// - Values returned by Ferric APIs and constructors are Ferric-owned.
+//   Their non-null `string_ptr` and `multifield_ptr` fields must be released
+//   with `ferric_value_free` (or the matching type-specific Ferric free API).
+// - Values passed to structured assertion APIs or
+//   `ferric_value_multifield_copy` are borrowed for that call. Ferric neither
+//   retains nor frees any part of the caller-provided tree.
+// - Only Ferric-owned values and arrays may be passed to
+//   `ferric_value_free` and `ferric_value_array_free`.
 // - `external_pointer`: NOT owned by `FerricValue`. Lifetime is caller-managed.
 //
 // ## Active Fields by Type
@@ -327,9 +340,9 @@ typedef struct FerricConfig {
 // | Void | (none) |
 // | Integer | `integer` |
 // | Float | `float` |
-// | Symbol | `string_ptr` (owned) |
-// | String | `string_ptr` (owned) |
-// | Multifield | `multifield_ptr` (owned), `multifield_len` |
+// | Symbol | `string_ptr` |
+// | String | `string_ptr` |
+// | Multifield | `multifield_ptr`, `multifield_len` |
 // | ExternalAddress | `external_type_id`, `external_pointer` |
 typedef struct FerricValue {
     // Raw `FerricValueType` discriminant.
@@ -730,6 +743,12 @@ enum FerricError ferric_engine_get_fact_template_name(const struct FerricEngine 
 
 // Assert an ordered fact from structured values, bypassing CLIPS source parsing.
 //
+// `fields` and every active string or multifield reachable from it are
+// borrowed for the duration of this call. Ferric converts the values into
+// engine-owned runtime data and never retains or frees caller storage. The
+// complete input tree must remain readable and unchanged until the call
+// returns.
+//
 // # Safety
 //
 // - `engine` must be a valid engine pointer.
@@ -1000,6 +1019,10 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
 // `slot_names` and `slot_values` must each point to `count` elements.
 // Each `slot_names[i]` is a NUL-terminated C string naming a slot,
 // and `slot_values[i]` is the corresponding value for that slot.
+// Both arrays and every active string or multifield reachable from the slot
+// values are borrowed for the duration of this call. Ferric never retains or
+// frees caller storage. The complete input tree must remain readable and
+// unchanged until the call returns.
 //
 // # Safety
 //
@@ -1605,6 +1628,41 @@ struct FerricValue ferric_value_string(const char * FERRIC_NULL_TERMINATED s);
 // Create a void `FerricValue` with all fields zeroed/null.
 struct FerricValue ferric_value_void(void);
 
+// Deep-copy a borrowed array of values into one Ferric-owned multifield.
+//
+// The input array and its complete nested value tree are borrowed for the
+// duration of this call. Ferric never retains or frees caller-provided
+// arrays or strings. On success, `*out_value` owns independent copies of
+// every Symbol, String, and Multifield allocation and must be released with
+// `ferric_value_free`. External-address payload pointers are copied shallowly
+// and remain caller-owned.
+//
+// `elements == null` with `len == 0` constructs an empty multifield.
+// Unknown tags, null active string pointers, null non-empty multifield
+// pointers, cyclic or ancestor-overlapping array storage, and nesting deeper
+// than 128 levels return `FERRIC_ERROR_INVALID_ARGUMENT`. A null required
+// pointer returns `FERRIC_ERROR_NULL_POINTER`.
+//
+// When `out_value` is non-null, it is overwritten with Void before any input
+// validation and remains Void on every failure. Every partial Ferric-owned
+// copy is released before an error is returned.
+//
+// # Safety
+//
+// - `out_value` must point to writable storage for one `FerricValue`, must
+//   not overlap the borrowed input tree, and must not currently contain live
+//   Ferric-owned resources.
+// - If `len > 0`, `elements` must point to `len` aligned, initialized
+//   `FerricValue`s.
+// - Every active nested string pointer must address a NUL-terminated byte
+//   string, and every active nested multifield pointer must address its
+//   declared number of initialized `FerricValue`s.
+// - The complete input tree must remain readable and unchanged until this
+//   function returns.
+enum FerricError ferric_value_multifield_copy(const struct FerricValue *elements FERRIC_COUNTED_BY(len),
+                                              uintptr_t len,
+                                              struct FerricValue *out_value);
+
 // Free a heap-allocated C string returned by the FFI.
 //
 // Null pointers are safely ignored.
@@ -1630,6 +1688,8 @@ void ferric_string_free(char * FERRIC_NULL_TERMINATED ptr);
 // # Safety
 //
 // - `value` must point to a valid `FerricValue` or be null.
+// - Every recursively owned allocation must have Ferric provenance; borrowed
+//   or foreign-allocated value trees must not be passed to this function.
 // - Any owned resources (`string_ptr`, `multifield_ptr`) must not have been freed already.
 enum FerricError ferric_value_free(struct FerricValue *value);
 
@@ -1648,7 +1708,8 @@ enum FerricError ferric_value_free(struct FerricValue *value);
 // # Safety
 //
 // - `arr` must point to a contiguous array of `len` `FerricValue`s, or be null.
-// - The array must have been allocated by the FFI.
+// - The array and every recursively owned allocation must have been allocated
+//   by Ferric; borrowed or foreign-allocated arrays must not be passed here.
 enum FerricError ferric_value_array_free(struct FerricValue *arr FERRIC_COUNTED_BY(len), uintptr_t len);
 
 

--- a/crates/ferric-ffi/src/engine.rs
+++ b/crates/ferric-ffi/src/engine.rs
@@ -1307,6 +1307,12 @@ pub unsafe extern "C" fn ferric_engine_get_fact_template_name(
 
 /// Assert an ordered fact from structured values, bypassing CLIPS source parsing.
 ///
+/// `fields` and every active string or multifield reachable from it are
+/// borrowed for the duration of this call. Ferric converts the values into
+/// engine-owned runtime data and never retains or frees caller storage. The
+/// complete input tree must remain readable and unchanged until the call
+/// returns.
+///
 /// # Safety
 ///
 /// - `engine` must be a valid engine pointer.
@@ -2029,6 +2035,10 @@ pub unsafe extern "C" fn ferric_engine_run_ex(
 /// `slot_names` and `slot_values` must each point to `count` elements.
 /// Each `slot_names[i]` is a NUL-terminated C string naming a slot,
 /// and `slot_values[i]` is the corresponding value for that slot.
+/// Both arrays and every active string or multifield reachable from the slot
+/// values are borrowed for the duration of this call. Ferric never retains or
+/// frees caller storage. The complete input tree must remain readable and
+/// unchanged until the call returns.
 ///
 /// # Safety
 ///

--- a/crates/ferric-ffi/src/tests.rs
+++ b/crates/ferric-ffi/src/tests.rs
@@ -34,6 +34,9 @@ mod copy_error;
 mod values;
 
 #[cfg(test)]
+mod multifield_copy;
+
+#[cfg(test)]
 mod discriminant_validation;
 
 #[cfg(test)]

--- a/crates/ferric-ffi/src/tests/contract_lock.rs
+++ b/crates/ferric-ffi/src/tests/contract_lock.rs
@@ -21,8 +21,8 @@ use crate::error::{
     ferric_clear_error_global, ferric_last_error_global, ferric_last_error_global_copy, FerricError,
 };
 use crate::types::{
-    ferric_string_free, ferric_value_array_free, ferric_value_free, FerricConfig,
-    FerricConflictStrategy, FerricStringEncoding, FerricValue,
+    ferric_string_free, ferric_value_array_free, ferric_value_free, ferric_value_multifield_copy,
+    FerricConfig, FerricConflictStrategy, FerricStringEncoding, FerricValue,
 };
 use std::os::raw::c_char;
 
@@ -109,6 +109,8 @@ fn contract_lock_canonical_function_names_exist() {
 
     // value resource management
     let _: unsafe extern "C" fn(*mut c_char) = ferric_string_free;
+    let _: unsafe extern "C" fn(*const FerricValue, usize, *mut FerricValue) -> FerricError =
+        ferric_value_multifield_copy;
     let _: unsafe extern "C" fn(*mut FerricValue) -> FerricError = ferric_value_free;
     let _: unsafe extern "C" fn(*mut FerricValue, usize) -> FerricError = ferric_value_array_free;
 }

--- a/crates/ferric-ffi/src/tests/header.rs
+++ b/crates/ferric-ffi/src/tests/header.rs
@@ -21,6 +21,13 @@ fn read_committed_header() -> String {
     })
 }
 
+fn read_committed_go_header() -> String {
+    let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let header_path = crate_dir.join("../../bindings/go/internal/ffi/lib/ferric.h");
+    std::fs::read_to_string(&header_path)
+        .unwrap_or_else(|_| panic!("Go FFI header not found at {}", header_path.display()))
+}
+
 fn read_ci_workflow() -> String {
     let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let workflow_path = crate_dir.join("../../.github/workflows/ci.yml");
@@ -95,6 +102,23 @@ fn header_has_ownership_docs() {
     assert!(
         header.contains("ferric_value_free"),
         "Ownership docs must mention ferric_value_free"
+    );
+    assert!(
+        header.contains("Borrowed value inputs: Value trees passed to structured"),
+        "Ownership docs must identify structured value inputs as borrowed"
+    );
+    assert!(
+        header.contains("Never pass stack or\n *    foreign-allocated value trees"),
+        "Ownership docs must forbid freeing foreign value trees"
+    );
+}
+
+#[test]
+fn committed_ffi_headers_are_identical() {
+    assert_eq!(
+        read_committed_header(),
+        read_committed_go_header(),
+        "crate and Go binding copies of ferric.h must remain identical"
     );
 }
 
@@ -562,6 +586,32 @@ fn header_contains_value_free_functions() {
     );
 }
 
+#[test]
+fn header_contains_multifield_copy_contract() {
+    let header = read_committed_header();
+    assert!(
+        header.contains("enum FerricError ferric_value_multifield_copy("),
+        "Missing ferric_value_multifield_copy declaration"
+    );
+    assert!(
+        header.contains("*elements FERRIC_COUNTED_BY(len),"),
+        "multifield copy input must be annotated with FERRIC_COUNTED_BY(len)"
+    );
+    for required in [
+        "complete nested value tree are borrowed",
+        "Ferric never retains or frees caller-provided",
+        "External-address payload pointers are copied shallowly",
+        "remains Void on every failure",
+        "not overlap the borrowed input tree",
+        "foreign-allocated value trees must not be passed",
+    ] {
+        assert!(
+            header.contains(required),
+            "multifield ownership contract is missing: {required}"
+        );
+    }
+}
+
 // ── Bounds-safety annotation tests ─────────────────────────────────────
 
 #[test]
@@ -608,6 +658,12 @@ fn header_has_counted_by_and_sized_by_annotations() {
     assert!(
         header.contains("*arr FERRIC_COUNTED_BY(len)"),
         "Missing FERRIC_COUNTED_BY on ferric_value_array_free arr parameter"
+    );
+
+    // ferric_value_multifield_copy: elements counted_by len
+    assert!(
+        header.contains("*elements FERRIC_COUNTED_BY(len)"),
+        "Missing FERRIC_COUNTED_BY on ferric_value_multifield_copy elements"
     );
 
     // ferric_last_error_global_copy: buf sized_by buf_len

--- a/crates/ferric-ffi/src/tests/multifield_copy.rs
+++ b/crates/ferric-ffi/src/tests/multifield_copy.rs
@@ -1,0 +1,372 @@
+//! Regression tests for FR-CABI-008 (issue #87): borrowed foreign value trees
+//! are deep-copied into Ferric-owned multifields with explicit provenance.
+
+use std::ffi::CStr;
+use std::ptr;
+
+use crate::error::{ferric_last_error_global, FerricError};
+use crate::types::{
+    ferric_value_float, ferric_value_free, ferric_value_integer, ferric_value_multifield_copy,
+    FerricValue, FerricValueType,
+};
+
+fn borrowed_text(value_type: FerricValueType, bytes: &mut [u8]) -> FerricValue {
+    assert_eq!(
+        bytes.last(),
+        Some(&0),
+        "borrowed text must be NUL-terminated"
+    );
+    FerricValue {
+        value_type: value_type.as_raw(),
+        string_ptr: bytes.as_mut_ptr().cast(),
+        ..FerricValue::void()
+    }
+}
+
+fn borrowed_multifield(values: &mut [FerricValue]) -> FerricValue {
+    FerricValue {
+        value_type: FerricValueType::Multifield.as_raw(),
+        multifield_ptr: if values.is_empty() {
+            ptr::null_mut()
+        } else {
+            values.as_mut_ptr()
+        },
+        multifield_len: values.len(),
+        ..FerricValue::void()
+    }
+}
+
+fn external_address(type_id: u32, pointer: *mut std::ffi::c_void) -> FerricValue {
+    FerricValue {
+        value_type: FerricValueType::ExternalAddress.as_raw(),
+        external_type_id: type_id,
+        external_pointer: pointer,
+        ..FerricValue::void()
+    }
+}
+
+fn assert_void(value: &FerricValue) {
+    assert_eq!(value.value_type, FerricValueType::Void.as_raw());
+    assert_eq!(value.integer, 0);
+    assert_eq!(value.float.to_bits(), 0.0_f64.to_bits());
+    assert!(value.string_ptr.is_null());
+    assert!(value.multifield_ptr.is_null());
+    assert_eq!(value.multifield_len, 0);
+    assert_eq!(value.external_type_id, 0);
+    assert!(value.external_pointer.is_null());
+}
+
+unsafe fn multifield_elements(value: &FerricValue) -> &[FerricValue] {
+    assert_eq!(
+        value.value_type,
+        FerricValueType::Multifield.as_raw(),
+        "expected a multifield"
+    );
+    if value.multifield_len == 0 {
+        &[]
+    } else {
+        std::slice::from_raw_parts(value.multifield_ptr, value.multifield_len)
+    }
+}
+
+fn nested_integer_layers(multifield_levels: usize) -> Vec<Box<[FerricValue]>> {
+    let mut layers = Vec::<Box<[FerricValue]>>::with_capacity(multifield_levels + 1);
+    layers.push(vec![ferric_value_integer(1)].into_boxed_slice());
+    for _ in 0..multifield_levels {
+        let inner = layers
+            .last_mut()
+            .expect("at least one input layer")
+            .as_mut_ptr();
+        layers.push(
+            vec![FerricValue {
+                value_type: FerricValueType::Multifield.as_raw(),
+                multifield_ptr: inner,
+                multifield_len: 1,
+                ..FerricValue::void()
+            }]
+            .into_boxed_slice(),
+        );
+    }
+    layers
+}
+
+#[test]
+fn copy_constructs_empty_multifield_and_validates_required_pointers() {
+    unsafe {
+        let mut out = ferric_value_integer(91);
+        assert_eq!(
+            ferric_value_multifield_copy(ptr::null(), 0, &mut out),
+            FerricError::Ok
+        );
+        assert_eq!(out.value_type, FerricValueType::Multifield.as_raw());
+        assert!(out.multifield_ptr.is_null());
+        assert_eq!(out.multifield_len, 0);
+        assert_eq!(ferric_value_free(&mut out), FerricError::Ok);
+
+        assert_eq!(
+            ferric_value_multifield_copy(ptr::null(), 0, ptr::null_mut()),
+            FerricError::NullPointer
+        );
+
+        let mut out = FerricValue {
+            value_type: FerricValueType::Integer.as_raw(),
+            integer: 92,
+            float: 4.5,
+            string_ptr: 1_usize as *mut _,
+            multifield_ptr: 2_usize as *mut _,
+            multifield_len: 9,
+            external_type_id: 11,
+            external_pointer: 3_usize as *mut _,
+        };
+        assert_eq!(
+            ferric_value_multifield_copy(ptr::null(), 1, &mut out),
+            FerricError::NullPointer
+        );
+        assert_void(&out);
+    }
+}
+
+#[test]
+fn copy_deeply_owns_mixed_nested_tree_but_not_external_payload() {
+    unsafe {
+        let mut symbol = b"alpha\0".to_vec();
+        let mut string = b"hello\0".to_vec();
+        let mut non_utf8_symbol = vec![0xff, 0xfe, 0];
+        let mut external_payload = 77_i32;
+        let external_payload_ptr = ptr::addr_of_mut!(external_payload).cast::<std::ffi::c_void>();
+
+        let mut nested = [
+            borrowed_text(FerricValueType::Symbol, &mut non_utf8_symbol),
+            ferric_value_integer(1234),
+            ferric_value_float(2.5),
+        ];
+        let nested_source_ptr = nested.as_mut_ptr();
+        let mut source = [
+            ferric_value_integer(42),
+            ferric_value_float(3.25),
+            borrowed_text(FerricValueType::Symbol, &mut symbol),
+            borrowed_text(FerricValueType::String, &mut string),
+            borrowed_multifield(&mut nested),
+            external_address(19, external_payload_ptr),
+            FerricValue::void(),
+        ];
+        let source_ptr = source.as_mut_ptr();
+
+        let mut out = FerricValue::void();
+        assert_eq!(
+            ferric_value_multifield_copy(source.as_ptr(), source.len(), &mut out),
+            FerricError::Ok
+        );
+
+        let copied = multifield_elements(&out);
+        assert_eq!(copied.len(), source.len());
+        assert_ne!(out.multifield_ptr, source_ptr);
+        assert_ne!(copied[4].multifield_ptr, nested_source_ptr);
+        assert_ne!(copied[2].string_ptr.cast::<u8>(), symbol.as_mut_ptr());
+        assert_ne!(copied[3].string_ptr.cast::<u8>(), string.as_mut_ptr());
+        assert_ne!(
+            (*copied[4].multifield_ptr).string_ptr.cast::<u8>(),
+            non_utf8_symbol.as_mut_ptr()
+        );
+
+        source[0].integer = -1;
+        nested[1].integer = -2;
+        symbol[0] = b'X';
+        string[0] = b'Y';
+        non_utf8_symbol[0] = 1;
+        assert_eq!(source[0].integer, -1);
+        assert_eq!(nested[1].integer, -2);
+
+        let copied = multifield_elements(&out);
+        assert_eq!(copied[0].integer, 42);
+        assert_eq!(copied[1].float.to_bits(), 3.25_f64.to_bits());
+        assert_eq!(CStr::from_ptr(copied[2].string_ptr).to_bytes(), b"alpha");
+        assert_eq!(CStr::from_ptr(copied[3].string_ptr).to_bytes(), b"hello");
+        let copied_nested = multifield_elements(&copied[4]);
+        assert_eq!(
+            copied_nested[0].value_type,
+            FerricValueType::Symbol.as_raw()
+        );
+        assert_eq!(
+            CStr::from_ptr(copied_nested[0].string_ptr).to_bytes(),
+            [0xff, 0xfe]
+        );
+        assert_eq!(copied_nested[1].integer, 1234);
+        assert_eq!(copied_nested[2].float.to_bits(), 2.5_f64.to_bits());
+        assert_eq!(copied[5].external_type_id, 19);
+        assert_eq!(copied[5].external_pointer, external_payload_ptr);
+        assert_eq!(copied[6].value_type, FerricValueType::Void.as_raw());
+
+        assert_eq!(ferric_value_free(&mut out), FerricError::Ok);
+        assert_eq!(external_payload, 77);
+    }
+}
+
+#[test]
+fn copy_rejects_malformed_nested_inputs_and_leaves_void_output() {
+    unsafe {
+        let mut out = ferric_value_integer(1);
+        let invalid = FerricValue {
+            value_type: u32::MAX,
+            string_ptr: 1_usize as *mut _,
+            multifield_ptr: 2_usize as *mut _,
+            multifield_len: usize::MAX,
+            ..FerricValue::void()
+        };
+        assert_eq!(
+            ferric_value_multifield_copy(&invalid, 1, &mut out),
+            FerricError::InvalidArgument
+        );
+        assert_void(&out);
+        let diagnostic = CStr::from_ptr(ferric_last_error_global())
+            .to_string_lossy()
+            .into_owned();
+        assert!(
+            diagnostic.contains("invalid value_type discriminant"),
+            "unexpected diagnostic: {diagnostic}"
+        );
+
+        let null_string = FerricValue {
+            value_type: FerricValueType::String.as_raw(),
+            ..FerricValue::void()
+        };
+        out = ferric_value_integer(2);
+        assert_eq!(
+            ferric_value_multifield_copy(&null_string, 1, &mut out),
+            FerricError::InvalidArgument
+        );
+        assert_void(&out);
+
+        let null_nested = FerricValue {
+            value_type: FerricValueType::Multifield.as_raw(),
+            multifield_len: 1,
+            ..FerricValue::void()
+        };
+        out = ferric_value_integer(3);
+        assert_eq!(
+            ferric_value_multifield_copy(&null_nested, 1, &mut out),
+            FerricError::InvalidArgument
+        );
+        assert_void(&out);
+
+        let mut cycle = FerricValue::void();
+        cycle.value_type = FerricValueType::Multifield.as_raw();
+        cycle.multifield_ptr = &mut cycle;
+        cycle.multifield_len = 1;
+        out = ferric_value_integer(4);
+        assert_eq!(
+            ferric_value_multifield_copy(&cycle, 1, &mut out),
+            FerricError::InvalidArgument
+        );
+        assert_void(&out);
+
+        let mut overlap = [FerricValue::void(), ferric_value_integer(9)];
+        overlap[0].value_type = FerricValueType::Multifield.as_raw();
+        overlap[0].multifield_ptr = overlap.as_mut_ptr().add(1);
+        overlap[0].multifield_len = 1;
+        out = ferric_value_integer(5);
+        assert_eq!(
+            ferric_value_multifield_copy(overlap.as_ptr(), overlap.len(), &mut out),
+            FerricError::InvalidArgument
+        );
+        assert_void(&out);
+    }
+}
+
+#[test]
+fn copy_cleans_partial_nested_values_after_late_validation_failure() {
+    unsafe {
+        let mut first = b"first\0".to_vec();
+        let mut second = b"second\0".to_vec();
+        let mut third = b"third\0".to_vec();
+        let mut nested = [
+            borrowed_text(FerricValueType::Symbol, &mut second),
+            borrowed_text(FerricValueType::String, &mut third),
+            FerricValue {
+                value_type: 77,
+                ..FerricValue::void()
+            },
+        ];
+        let source = [
+            borrowed_text(FerricValueType::String, &mut first),
+            borrowed_multifield(&mut nested),
+        ];
+
+        for index in 0..64 {
+            let mut out = ferric_value_integer(index);
+            assert_eq!(
+                ferric_value_multifield_copy(source.as_ptr(), source.len(), &mut out),
+                FerricError::InvalidArgument
+            );
+            assert_void(&out);
+        }
+    }
+}
+
+#[test]
+fn copy_handles_large_borrowed_array_and_source_destruction() {
+    unsafe {
+        let mut text = b"borrowed-large\0".to_vec();
+        let mut source = Vec::with_capacity(1025);
+        for index in 0..1025 {
+            if index % 5 == 0 {
+                source.push(borrowed_text(FerricValueType::String, &mut text));
+            } else {
+                source.push(ferric_value_integer(index));
+            }
+        }
+
+        let mut out = FerricValue::void();
+        assert_eq!(
+            ferric_value_multifield_copy(source.as_ptr(), source.len(), &mut out),
+            FerricError::Ok
+        );
+        text[0] = b'X';
+        drop(source);
+
+        let copied = multifield_elements(&out);
+        assert_eq!(copied.len(), 1025);
+        assert_eq!(
+            CStr::from_ptr(copied[0].string_ptr).to_bytes(),
+            b"borrowed-large"
+        );
+        assert_eq!(copied[1024].integer, 1024);
+        assert_eq!(ferric_value_free(&mut out), FerricError::Ok);
+    }
+}
+
+#[test]
+fn copy_rejects_excessive_acyclic_nesting_before_recursive_free_is_unsafe() {
+    unsafe {
+        let accepted_layers = nested_integer_layers(128);
+        let accepted_outermost = accepted_layers.last().expect("outer input layer");
+        let mut accepted = FerricValue::void();
+        assert_eq!(
+            ferric_value_multifield_copy(
+                accepted_outermost.as_ptr(),
+                accepted_outermost.len(),
+                &mut accepted,
+            ),
+            FerricError::Ok
+        );
+        assert_eq!(ferric_value_free(&mut accepted), FerricError::Ok);
+
+        let rejected_layers = nested_integer_layers(129);
+        let rejected_outermost = rejected_layers.last().expect("outer input layer");
+        let mut out = ferric_value_integer(5);
+        assert_eq!(
+            ferric_value_multifield_copy(
+                rejected_outermost.as_ptr(),
+                rejected_outermost.len(),
+                &mut out,
+            ),
+            FerricError::InvalidArgument
+        );
+        assert_void(&out);
+        let diagnostic = CStr::from_ptr(ferric_last_error_global()).to_string_lossy();
+        assert!(
+            diagnostic.contains("nesting depth exceeds maximum of 128"),
+            "unexpected diagnostic: {diagnostic}"
+        );
+    }
+}

--- a/crates/ferric-ffi/src/types.rs
+++ b/crates/ferric-ffi/src/types.rs
@@ -229,11 +229,16 @@ impl TryFrom<u32> for FerricValueType {
 ///
 /// ## Ownership
 ///
-/// - `string_ptr`: when non-null, is a heap-allocated NUL-terminated string.
-///   The caller must free it with `ferric_string_free` or `ferric_value_free`.
-/// - `multifield_ptr`: when non-null, is a heap-allocated array of `FerricValue`s.
-///   The caller must free it with `ferric_value_free` (which recursively frees elements)
-///   or `ferric_value_array_free`.
+/// Ownership is contextual:
+///
+/// - Values returned by Ferric APIs and constructors are Ferric-owned.
+///   Their non-null `string_ptr` and `multifield_ptr` fields must be released
+///   with `ferric_value_free` (or the matching type-specific Ferric free API).
+/// - Values passed to structured assertion APIs or
+///   `ferric_value_multifield_copy` are borrowed for that call. Ferric neither
+///   retains nor frees any part of the caller-provided tree.
+/// - Only Ferric-owned values and arrays may be passed to
+///   `ferric_value_free` and `ferric_value_array_free`.
 /// - `external_pointer`: NOT owned by `FerricValue`. Lifetime is caller-managed.
 ///
 /// ## Active Fields by Type
@@ -243,9 +248,9 @@ impl TryFrom<u32> for FerricValueType {
 /// | Void | (none) |
 /// | Integer | `integer` |
 /// | Float | `float` |
-/// | Symbol | `string_ptr` (owned) |
-/// | String | `string_ptr` (owned) |
-/// | Multifield | `multifield_ptr` (owned), `multifield_len` |
+/// | Symbol | `string_ptr` |
+/// | String | `string_ptr` |
+/// | Multifield | `multifield_ptr`, `multifield_len` |
 /// | ExternalAddress | `external_type_id`, `external_pointer` |
 #[repr(C)]
 pub struct FerricValue {
@@ -278,6 +283,68 @@ impl FerricValue {
             multifield_len: 0,
             external_type_id: 0,
             external_pointer: ptr::null_mut(),
+        }
+    }
+}
+
+/// Maximum recursively nested multifield levels accepted by the copy
+/// constructor. This keeps both construction and the matching recursive free
+/// path within a bounded stack depth.
+const MAX_MULTIFIELD_COPY_DEPTH: usize = 128;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct BorrowedValueRange {
+    start: usize,
+    end: usize,
+}
+
+impl BorrowedValueRange {
+    fn overlaps(self, other: Self) -> bool {
+        self.start < other.end && other.start < self.end
+    }
+}
+
+/// RAII guard for Ferric-owned values that have not yet been transferred to a
+/// caller-visible multifield. A validation failure at any later element drops
+/// the guard and recursively releases every successful earlier copy.
+struct OwnedFerricValues(Vec<FerricValue>);
+
+impl OwnedFerricValues {
+    fn with_capacity(capacity: usize) -> Self {
+        Self(Vec::with_capacity(capacity))
+    }
+
+    fn push(&mut self, value: FerricValue) {
+        self.0.push(value);
+    }
+
+    fn into_multifield(mut self) -> FerricValue {
+        let values = std::mem::take(&mut self.0);
+        let len = values.len();
+        let multifield_ptr = if values.is_empty() {
+            ptr::null_mut()
+        } else {
+            Box::into_raw(values.into_boxed_slice()).cast::<FerricValue>()
+        };
+        FerricValue {
+            value_type: FerricValueType::Multifield.as_raw(),
+            multifield_ptr,
+            multifield_len: len,
+            ..FerricValue::void()
+        }
+    }
+}
+
+impl Drop for OwnedFerricValues {
+    fn drop(&mut self) {
+        for value in &self.0 {
+            // Values in this guard were constructed below and therefore have
+            // valid tags and exclusively Ferric-owned recursive resources.
+            let result = unsafe { free_value_resources(value) };
+            debug_assert!(
+                result.is_ok(),
+                "internally constructed FerricValue must be freeable: {result:?}"
+            );
         }
     }
 }
@@ -324,20 +391,7 @@ pub(crate) fn value_to_ferric(value: &Value, engine: &Engine) -> FerricValue {
         }
         Value::Multifield(mf) => {
             let values: Vec<FerricValue> = mf.iter().map(|v| value_to_ferric(v, engine)).collect();
-            let len = values.len();
-            let ptr = if values.is_empty() {
-                ptr::null_mut()
-            } else {
-                let boxed = values.into_boxed_slice();
-                let raw = Box::into_raw(boxed);
-                raw.cast::<FerricValue>()
-            };
-            FerricValue {
-                value_type: FerricValueType::Multifield.as_raw(),
-                multifield_ptr: ptr,
-                multifield_len: len,
-                ..FerricValue::void()
-            }
+            OwnedFerricValues(values).into_multifield()
         }
         Value::ExternalAddress(ea) => FerricValue {
             value_type: FerricValueType::ExternalAddress.as_raw(),
@@ -489,6 +543,194 @@ pub extern "C" fn ferric_value_void() -> FerricValue {
     FerricValue::void()
 }
 
+/// Deep-copy a borrowed array of values into one Ferric-owned multifield.
+///
+/// The input array and its complete nested value tree are borrowed for the
+/// duration of this call. Ferric never retains or frees caller-provided
+/// arrays or strings. On success, `*out_value` owns independent copies of
+/// every Symbol, String, and Multifield allocation and must be released with
+/// `ferric_value_free`. External-address payload pointers are copied shallowly
+/// and remain caller-owned.
+///
+/// `elements == null` with `len == 0` constructs an empty multifield.
+/// Unknown tags, null active string pointers, null non-empty multifield
+/// pointers, cyclic or ancestor-overlapping array storage, and nesting deeper
+/// than 128 levels return `FERRIC_ERROR_INVALID_ARGUMENT`. A null required
+/// pointer returns `FERRIC_ERROR_NULL_POINTER`.
+///
+/// When `out_value` is non-null, it is overwritten with Void before any input
+/// validation and remains Void on every failure. Every partial Ferric-owned
+/// copy is released before an error is returned.
+///
+/// # Safety
+///
+/// - `out_value` must point to writable storage for one `FerricValue`, must
+///   not overlap the borrowed input tree, and must not currently contain live
+///   Ferric-owned resources.
+/// - If `len > 0`, `elements` must point to `len` aligned, initialized
+///   `FerricValue`s.
+/// - Every active nested string pointer must address a NUL-terminated byte
+///   string, and every active nested multifield pointer must address its
+///   declared number of initialized `FerricValue`s.
+/// - The complete input tree must remain readable and unchanged until this
+///   function returns.
+#[no_mangle]
+pub unsafe extern "C" fn ferric_value_multifield_copy(
+    elements: *const FerricValue,
+    len: usize,
+    out_value: *mut FerricValue,
+) -> FerricError {
+    if out_value.is_null() {
+        return report_multifield_copy_error(FerricError::NullPointer, "out_value is null");
+    }
+    ptr::write(out_value, FerricValue::void());
+
+    if elements.is_null() && len > 0 {
+        return report_multifield_copy_error(
+            FerricError::NullPointer,
+            "elements is null with non-zero length",
+        );
+    }
+
+    let mut active_ranges = Vec::new();
+    match copy_borrowed_ferric_values(elements, len, 0, &mut active_ranges) {
+        Ok(values) => {
+            ptr::write(out_value, values.into_multifield());
+            FerricError::Ok
+        }
+        Err(message) => report_multifield_copy_error(FerricError::InvalidArgument, &message),
+    }
+}
+
+fn report_multifield_copy_error(code: FerricError, message: &str) -> FerricError {
+    set_global_error(format!("ferric_value_multifield_copy: {message}"));
+    code
+}
+
+fn borrowed_value_range(
+    elements: *const FerricValue,
+    len: usize,
+) -> Result<Option<BorrowedValueRange>, String> {
+    if len == 0 {
+        return Ok(None);
+    }
+    if elements.is_null() {
+        return Err("nested multifield pointer is null with non-zero length".to_string());
+    }
+
+    let start = elements as usize;
+    if start % std::mem::align_of::<FerricValue>() != 0 {
+        return Err("multifield pointer is not aligned for FerricValue".to_string());
+    }
+    let byte_len = len
+        .checked_mul(std::mem::size_of::<FerricValue>())
+        .filter(|size| isize::try_from(*size).is_ok())
+        .ok_or_else(|| "multifield length exceeds the addressable value-array bound".to_string())?;
+    let end = start
+        .checked_add(byte_len)
+        .ok_or_else(|| "multifield pointer range wraps the address space".to_string())?;
+    Ok(Some(BorrowedValueRange { start, end }))
+}
+
+/// Copy one borrowed value tree into a wholly Ferric-owned value.
+///
+/// # Safety
+///
+/// `value` and every active pointer reachable from it must satisfy the public
+/// copy constructor's safety contract.
+unsafe fn copy_borrowed_ferric_value(
+    value: &FerricValue,
+    depth: usize,
+    active_ranges: &mut Vec<BorrowedValueRange>,
+) -> Result<FerricValue, String> {
+    match FerricValueType::try_from(value.value_type)? {
+        FerricValueType::Void => Ok(FerricValue::void()),
+        FerricValueType::Integer => Ok(FerricValue {
+            value_type: FerricValueType::Integer.as_raw(),
+            integer: value.integer,
+            ..FerricValue::void()
+        }),
+        FerricValueType::Float => Ok(FerricValue {
+            value_type: FerricValueType::Float.as_raw(),
+            float: value.float,
+            ..FerricValue::void()
+        }),
+        FerricValueType::Symbol | FerricValueType::String => {
+            if value.string_ptr.is_null() {
+                return Err(format!(
+                    "{} string_ptr is null",
+                    if value.value_type == FerricValueType::Symbol.as_raw() {
+                        "symbol"
+                    } else {
+                        "string"
+                    }
+                ));
+            }
+            let copied = CStr::from_ptr(value.string_ptr).to_owned();
+            Ok(FerricValue {
+                value_type: value.value_type,
+                string_ptr: copied.into_raw(),
+                ..FerricValue::void()
+            })
+        }
+        FerricValueType::Multifield => copy_borrowed_ferric_values(
+            value.multifield_ptr,
+            value.multifield_len,
+            depth + 1,
+            active_ranges,
+        )
+        .map(OwnedFerricValues::into_multifield),
+        FerricValueType::ExternalAddress => Ok(FerricValue {
+            value_type: FerricValueType::ExternalAddress.as_raw(),
+            external_type_id: value.external_type_id,
+            external_pointer: value.external_pointer,
+            ..FerricValue::void()
+        }),
+    }
+}
+
+/// Copy a borrowed value array while rejecting cycles and bounding recursive
+/// construction/free depth.
+///
+/// # Safety
+///
+/// `elements` and all reachable active pointers must satisfy the public copy
+/// constructor's safety contract.
+unsafe fn copy_borrowed_ferric_values(
+    elements: *const FerricValue,
+    len: usize,
+    depth: usize,
+    active_ranges: &mut Vec<BorrowedValueRange>,
+) -> Result<OwnedFerricValues, String> {
+    if depth > MAX_MULTIFIELD_COPY_DEPTH {
+        return Err(format!(
+            "multifield nesting depth exceeds maximum of {MAX_MULTIFIELD_COPY_DEPTH}"
+        ));
+    }
+
+    let Some(range) = borrowed_value_range(elements, len)? else {
+        return Ok(OwnedFerricValues::with_capacity(0));
+    };
+    if active_ranges.iter().any(|active| range.overlaps(*active)) {
+        return Err(
+            "input contains cyclic or ancestor-overlapping multifield array storage".to_string(),
+        );
+    }
+
+    active_ranges.push(range);
+    let result = (|| {
+        let mut copied = OwnedFerricValues::with_capacity(len);
+        for index in 0..len {
+            let value = &*elements.add(index);
+            copied.push(copy_borrowed_ferric_value(value, depth, active_ranges)?);
+        }
+        Ok(copied)
+    })();
+    let popped = active_ranges.pop();
+    debug_assert_eq!(popped, Some(range));
+    result
+}
+
 // ---------------------------------------------------------------------------
 // C API: Resource management
 // ---------------------------------------------------------------------------
@@ -523,6 +765,8 @@ pub unsafe extern "C" fn ferric_string_free(ptr: *mut c_char) {
 /// # Safety
 ///
 /// - `value` must point to a valid `FerricValue` or be null.
+/// - Every recursively owned allocation must have Ferric provenance; borrowed
+///   or foreign-allocated value trees must not be passed to this function.
 /// - Any owned resources (`string_ptr`, `multifield_ptr`) must not have been freed already.
 #[no_mangle]
 pub unsafe extern "C" fn ferric_value_free(value: *mut FerricValue) -> FerricError {
@@ -548,7 +792,8 @@ pub unsafe extern "C" fn ferric_value_free(value: *mut FerricValue) -> FerricErr
 /// # Safety
 ///
 /// - `arr` must point to a contiguous array of `len` `FerricValue`s, or be null.
-/// - The array must have been allocated by the FFI.
+/// - The array and every recursively owned allocation must have been allocated
+///   by Ferric; borrowed or foreign-allocated arrays must not be passed here.
 #[no_mangle]
 pub unsafe extern "C" fn ferric_value_array_free(arr: *mut FerricValue, len: usize) -> FerricError {
     if arr.is_null() || len == 0 {

--- a/crates/ferric-ffi/tests/c/multifield_copy.c
+++ b/crates/ferric-ffi/tests/c/multifield_copy.c
@@ -1,0 +1,304 @@
+/*
+ * multifield_copy.c — C-ABI regression harness for FR-CABI-008 (issue #87).
+ *
+ * Exercises ferric_value_multifield_copy with genuinely foreign input:
+ * stack arrays, C malloc arrays, and borrowed string storage. The constructor
+ * must deep-copy the complete nested tree, retain only shallow external-address
+ * payload pointers, and return a tree that ferric_value_free can release using
+ * Ferric's allocator provenance.
+ *
+ * Intended to run under AddressSanitizer + UndefinedBehaviorSanitizer via
+ * `just ffi-c-harness`. Repeated late failures exercise partial-allocation
+ * cleanup so LeakSanitizer, where supported (including Linux CI), detects any
+ * abandoned Ferric-owned values.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ferric.h"
+
+static int failures = 0;
+
+#define CHECK(cond, msg)                                              \
+    do {                                                              \
+        if (!(cond)) {                                                \
+            fprintf(stderr, "FAIL(%s:%d): %s\n", __FILE__, __LINE__,  \
+                    (msg));                                           \
+            failures++;                                               \
+        }                                                             \
+    } while (0)
+
+static FerricValue borrowed_text(uint32_t value_type, char *text) {
+    FerricValue value = ferric_value_void();
+    value.value_type = value_type;
+    value.string_ptr = text;
+    return value;
+}
+
+static void check_void(const FerricValue *value, const char *context) {
+    CHECK(value->value_type == FERRIC_VALUE_TYPE_VOID, context);
+    CHECK(value->integer == 0, context);
+    CHECK(value->float_ == 0.0, context);
+    CHECK(value->string_ptr == NULL, context);
+    CHECK(value->multifield_ptr == NULL, context);
+    CHECK(value->multifield_len == 0, context);
+    CHECK(value->external_type_id == 0, context);
+    CHECK(value->external_pointer == NULL, context);
+}
+
+static void test_empty_and_error_contract(void) {
+    FerricValue out = ferric_value_integer(91);
+    FerricError err = ferric_value_multifield_copy(NULL, 0, &out);
+    CHECK(err == FERRIC_ERROR_OK, "NULL, 0 must construct an empty multifield");
+    CHECK(out.value_type == FERRIC_VALUE_TYPE_MULTIFIELD,
+          "empty copy must return a multifield");
+    CHECK(out.multifield_ptr == NULL && out.multifield_len == 0,
+          "empty copy must use a null, zero-length array");
+    CHECK(ferric_value_free(&out) == FERRIC_ERROR_OK,
+          "empty Ferric-owned multifield must be freeable");
+
+    CHECK(ferric_value_multifield_copy(NULL, 0, NULL) ==
+              FERRIC_ERROR_NULL_POINTER,
+          "null output must return NULL_POINTER");
+
+    out = ferric_value_integer(92);
+    err = ferric_value_multifield_copy(NULL, 1, &out);
+    CHECK(err == FERRIC_ERROR_NULL_POINTER,
+          "NULL with non-zero length must return NULL_POINTER");
+    check_void(&out, "NULL with non-zero length must leave output Void");
+
+    FerricValue bad = ferric_value_void();
+    bad.value_type = 0xDEADBEEFu;
+    bad.string_ptr = (char *)&bad;
+    bad.multifield_ptr = &bad;
+    bad.multifield_len = SIZE_MAX;
+    out = ferric_value_integer(93);
+    err = ferric_value_multifield_copy(&bad, 1, &out);
+    CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+          "unknown nested tags must return INVALID_ARGUMENT");
+    check_void(&out, "unknown nested tags must leave output Void");
+
+    FerricValue null_string = ferric_value_void();
+    null_string.value_type = FERRIC_VALUE_TYPE_STRING;
+    out = ferric_value_integer(94);
+    err = ferric_value_multifield_copy(&null_string, 1, &out);
+    CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+          "null active string pointer must return INVALID_ARGUMENT");
+    check_void(&out, "null active string pointer must leave output Void");
+
+    FerricValue null_nested = ferric_value_void();
+    null_nested.value_type = FERRIC_VALUE_TYPE_MULTIFIELD;
+    null_nested.multifield_len = 1;
+    out = ferric_value_integer(95);
+    err = ferric_value_multifield_copy(&null_nested, 1, &out);
+    CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+          "null non-empty nested array must return INVALID_ARGUMENT");
+    check_void(&out, "null non-empty nested array must leave output Void");
+
+    FerricValue cycle = ferric_value_void();
+    cycle.value_type = FERRIC_VALUE_TYPE_MULTIFIELD;
+    cycle.multifield_ptr = &cycle;
+    cycle.multifield_len = 1;
+    out = ferric_value_integer(97);
+    err = ferric_value_multifield_copy(&cycle, 1, &out);
+    CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+          "cyclic input must return INVALID_ARGUMENT");
+    check_void(&out, "cyclic input must leave output Void");
+
+    FerricValue overlap[2];
+    overlap[0] = ferric_value_void();
+    overlap[0].value_type = FERRIC_VALUE_TYPE_MULTIFIELD;
+    overlap[0].multifield_ptr = &overlap[1];
+    overlap[0].multifield_len = 1;
+    overlap[1] = ferric_value_integer(9);
+    out = ferric_value_integer(98);
+    err = ferric_value_multifield_copy(overlap, 2, &out);
+    CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+          "ancestor-overlapping input must return INVALID_ARGUMENT");
+    check_void(&out, "ancestor-overlapping input must leave output Void");
+}
+
+static void test_stack_and_malloc_tree(void) {
+    char top_symbol[] = "alpha";
+    char top_string[] = "hello";
+    char *nested_symbol = (char *)malloc(sizeof("nested"));
+    int external_payload = 77;
+
+    CHECK(nested_symbol != NULL, "nested C string allocation must succeed");
+    if (nested_symbol == NULL) {
+        return;
+    }
+    memcpy(nested_symbol, "nested", sizeof("nested"));
+
+    FerricValue *nested =
+        (FerricValue *)malloc(3 * sizeof(FerricValue));
+    CHECK(nested != NULL, "nested C allocation must succeed");
+    if (nested == NULL) {
+        free(nested_symbol);
+        return;
+    }
+    nested[0] = borrowed_text(FERRIC_VALUE_TYPE_SYMBOL, nested_symbol);
+    nested[1] = ferric_value_integer(1234);
+    nested[2] = ferric_value_float(2.5);
+
+    FerricValue source[6];
+    source[0] = ferric_value_integer(42);
+    source[1] = ferric_value_float(3.25);
+    source[2] = borrowed_text(FERRIC_VALUE_TYPE_SYMBOL, top_symbol);
+    source[3] = borrowed_text(FERRIC_VALUE_TYPE_STRING, top_string);
+    source[4] = ferric_value_void();
+    source[4].value_type = FERRIC_VALUE_TYPE_MULTIFIELD;
+    source[4].multifield_ptr = nested;
+    source[4].multifield_len = 3;
+    source[5] = ferric_value_void();
+    source[5].value_type = FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS;
+    source[5].external_type_id = 19;
+    source[5].external_pointer = &external_payload;
+
+    FerricValue out = ferric_value_void();
+    FerricError err =
+        ferric_value_multifield_copy(source, 6, &out);
+    CHECK(err == FERRIC_ERROR_OK,
+          "mixed stack/malloc tree must copy successfully");
+    if (err != FERRIC_ERROR_OK) {
+        free(nested);
+        free(nested_symbol);
+        return;
+    }
+
+    CHECK(out.value_type == FERRIC_VALUE_TYPE_MULTIFIELD &&
+              out.multifield_len == 6 && out.multifield_ptr != NULL,
+          "copy must return a six-element Ferric-owned multifield");
+    CHECK(out.multifield_ptr != source,
+          "top-level Ferric array must not alias stack input");
+    CHECK(out.multifield_ptr[4].multifield_ptr != nested,
+          "nested Ferric array must not alias malloc input");
+    CHECK(out.multifield_ptr[2].string_ptr != top_symbol &&
+              out.multifield_ptr[3].string_ptr != top_string,
+          "top-level text storage must be deep-copied");
+    CHECK(out.multifield_ptr[4].multifield_ptr[0].string_ptr != nested_symbol,
+          "nested text storage must be deep-copied");
+    CHECK(out.multifield_ptr[5].external_pointer == &external_payload &&
+              out.multifield_ptr[5].external_type_id == 19,
+          "external-address payload must remain shallow and caller-owned");
+
+    source[0].integer = -1;
+    nested[1].integer = -2;
+    top_symbol[0] = 'X';
+    top_string[0] = 'Y';
+    nested_symbol[0] = 'Z';
+    free(nested);
+    free(nested_symbol);
+
+    CHECK(out.multifield_ptr[0].integer == 42,
+          "top-level scalar copy must survive source mutation");
+    CHECK(out.multifield_ptr[4].multifield_ptr[1].integer == 1234,
+          "nested scalar copy must survive source destruction");
+    CHECK(strcmp(out.multifield_ptr[2].string_ptr, "alpha") == 0,
+          "symbol copy must survive source mutation");
+    CHECK(strcmp(out.multifield_ptr[3].string_ptr, "hello") == 0,
+          "string copy must survive source mutation");
+    CHECK(strcmp(out.multifield_ptr[4].multifield_ptr[0].string_ptr,
+                 "nested") == 0,
+          "nested symbol copy must survive source destruction");
+
+    CHECK(ferric_value_free(&out) == FERRIC_ERROR_OK,
+          "Ferric-owned mixed tree must free recursively");
+    CHECK(external_payload == 77,
+          "freeing the copy must not touch caller-owned external payloads");
+}
+
+static void test_partial_failure_cleanup(void) {
+    char first[] = "first";
+    char second[] = "second";
+    char third[] = "third";
+
+    FerricValue nested[3];
+    nested[0] = borrowed_text(FERRIC_VALUE_TYPE_SYMBOL, second);
+    nested[1] = borrowed_text(FERRIC_VALUE_TYPE_STRING, third);
+    nested[2] = ferric_value_void();
+    nested[2].value_type = 77u;
+    nested[2].string_ptr = (char *)&nested[2];
+
+    FerricValue source[2];
+    source[0] = borrowed_text(FERRIC_VALUE_TYPE_STRING, first);
+    source[1] = ferric_value_void();
+    source[1].value_type = FERRIC_VALUE_TYPE_MULTIFIELD;
+    source[1].multifield_ptr = nested;
+    source[1].multifield_len = 3;
+
+    for (size_t i = 0; i < 512; i++) {
+        FerricValue out = ferric_value_integer((int64_t)i);
+        FerricError err =
+            ferric_value_multifield_copy(source, 2, &out);
+        CHECK(err == FERRIC_ERROR_INVALID_ARGUMENT,
+              "late invalid tag must reject the complete copy");
+        check_void(&out, "partial-copy failure must leave output Void");
+    }
+}
+
+static void test_large_repeated_copy(void) {
+    enum {
+        ELEMENT_COUNT = 257,
+        ROUND_COUNT = 64
+    };
+    char text[] = "large-borrowed-text";
+
+    for (size_t round = 0; round < ROUND_COUNT; round++) {
+        FerricValue *source =
+            (FerricValue *)malloc(ELEMENT_COUNT * sizeof(FerricValue));
+        CHECK(source != NULL, "large C source allocation must succeed");
+        if (source == NULL) {
+            return;
+        }
+        for (size_t i = 0; i < ELEMENT_COUNT; i++) {
+            if (i % 3 == 0) {
+                source[i] =
+                    borrowed_text(FERRIC_VALUE_TYPE_STRING, text);
+            } else {
+                source[i] = ferric_value_integer((int64_t)(round + i));
+            }
+        }
+
+        FerricValue out = ferric_value_void();
+        FerricError err =
+            ferric_value_multifield_copy(source, ELEMENT_COUNT, &out);
+        CHECK(err == FERRIC_ERROR_OK,
+              "large borrowed array must copy successfully");
+        free(source);
+        if (err != FERRIC_ERROR_OK) {
+            continue;
+        }
+
+        text[0] = 'X';
+        CHECK(out.multifield_len == ELEMENT_COUNT,
+              "large copy must preserve element count");
+        CHECK(strcmp(out.multifield_ptr[0].string_ptr,
+                     "large-borrowed-text") == 0,
+              "large copy must own independent string bytes");
+        CHECK(out.multifield_ptr[ELEMENT_COUNT - 1].integer ==
+                  (int64_t)(round + ELEMENT_COUNT - 1),
+              "large copy must preserve trailing scalar");
+        text[0] = 'l';
+
+        CHECK(ferric_value_free(&out) == FERRIC_ERROR_OK,
+              "large Ferric-owned tree must free recursively");
+    }
+}
+
+int main(void) {
+    test_empty_and_error_contract();
+    test_stack_and_malloc_tree();
+    test_partial_failure_cleanup();
+    test_large_repeated_copy();
+
+    if (failures == 0) {
+        printf("multifield_copy: all checks passed\n");
+        return 0;
+    }
+    fprintf(stderr, "multifield_copy: %d check(s) failed\n", failures);
+    return 1;
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -855,10 +855,19 @@ ferric_engine_clear_action_diagnostics(engine);
 | Function | Purpose |
 |----------|---------|
 | `ferric_string_free` | Free a Ferric-allocated C string |
+| `ferric_value_multifield_copy` | Deep-copy a borrowed `FerricValue` array and its nested tree into one Ferric-owned multifield; external-address payload pointers remain caller-owned |
 | `ferric_value_free` | Free a `FerricValue` and its owned resources (recursive); returns `FERRIC_ERROR_INVALID_ARGUMENT` if any `value_type` tag is unknown (that value's payload is left untouched; known siblings and owned arrays are still freed) |
 | `ferric_value_array_free` | Free an array of `FerricValue`s; same unknown-tag contract as `ferric_value_free` |
 
-Borrowed pointers must **not** be freed by the caller.
+Structured values passed to assertion APIs and
+`ferric_value_multifield_copy` are borrowed for the call: Ferric never retains
+or frees their strings or arrays. The copy constructor returns an independent
+Ferric-owned tree that must be released with `ferric_value_free`; only
+Ferric-owned trees may be passed to Ferric value cleanup APIs. External-address
+payload pointers are always shallow and caller-owned. Multifield-copy inputs
+must be acyclic and no deeper than 128 nested multifield levels.
+
+Other borrowed pointers must **not** be freed by the caller.
 `ferric_engine_last_error` remains valid until the next borrowed last-error
 read on that engine or engine destruction; error writers and the copy API do
 not invalidate it. `ferric_engine_get_output` remains valid until the next

--- a/docs/phase6-baseline.md
+++ b/docs/phase6-baseline.md
@@ -133,8 +133,14 @@ C-ABI functions with opaque `FerricEngine*` handle:
 
 **Value/Memory Management:**
 - `ferric_string_free` -- free a Ferric-allocated C string
+- `ferric_value_multifield_copy` -- deep-copy a borrowed nested value tree into a Ferric-owned multifield
 - `ferric_value_free` -- free a single `FerricValue`
 - `ferric_value_array_free` -- free an array of `FerricValue`
+
+Structured assertion and multifield-copy inputs are borrowed for the duration
+of the call and are never retained or freed by Ferric. Only Ferric-owned output
+trees may be passed to the value cleanup APIs; external-address payloads remain
+caller-owned.
 
 **Thread Affinity Contract:**
 - Engine instances are thread-affine (`!Send + !Sync`).

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -95,12 +95,14 @@ profiles with `panic = abort`.
 
 - `engine.rs` — `ferric_engine_*` surface (new/free, asserts, run, serialize,
   query).
-- `types.rs` — `FerricValue`, `FerricFact`, multifield arrays, ownership.
+- `types.rs` — `FerricValue`, allocator-owned multifield copying, arrays,
+  ownership, and recursive cleanup.
 - `error.rs` — global + per-engine error channels, thread-local storage.
 - `header.rs` — C header metadata generation.
 - `tests.rs` + `src/tests/` — lifecycle, contract-lock, diagnostic-parity,
   error-model, execution, template-assertion, copy-error, build-matrix,
-  ffi-expansion, values, header tests.
+  ffi-expansion, values, multifield-copy, and header tests.
+- `tests/c/` — real-C ABI regressions run under the sanitizer harness.
 - Thread-affinity invariant: runtime state is owner-thread-only. Per-engine
   last-error copies are synchronized across threads; borrowed last-error
   pointer use must not overlap other borrowed reads or destruction. The

--- a/justfile
+++ b/justfile
@@ -70,8 +70,8 @@ test-runtime:
 test-ffi:
     cargo test -p ferric-ffi
 
-# Build the FFI staticlib and run the C ABI discriminant-abuse harness
-# as a real C subprocess under ASan/UBSan (when the compiler supports them)
+# Build the FFI staticlib and run the C ABI regression harnesses as real C
+# subprocesses under ASan/UBSan (when the compiler supports them)
 ffi-c-harness:
     ./scripts/ffi-c-harness.sh
 

--- a/scripts/ffi-c-harness.sh
+++ b/scripts/ffi-c-harness.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Build the ferric-ffi static library and run the C ABI discriminant-abuse
-# harness (crates/ferric-ffi/tests/c/) as a real C subprocess.
+# Build the ferric-ffi static library and run the C ABI regression harnesses
+# (crates/ferric-ffi/tests/c/) as real C subprocesses.
 #
 # The harness is compiled with AddressSanitizer + UndefinedBehaviorSanitizer
 # when the local C compiler supports them (falls back to plain compilation
@@ -15,7 +15,10 @@ cargo build -p ferric-ffi --profile ffi-dev
 
 CC="${CC:-cc}"
 CXX="${CXX:-c++}"
-harness_src="crates/ferric-ffi/tests/c/discriminant_abuse.c"
+harness_sources=(
+    "crates/ferric-ffi/tests/c/discriminant_abuse.c"
+    "crates/ferric-ffi/tests/c/multifield_copy.c"
+)
 outdir="target/c-harness"
 mkdir -p "$outdir"
 
@@ -30,6 +33,16 @@ if ! echo 'int main(void){return 0;}' |
     san_flags=()
 fi
 rm -f "$outdir/san-probe"
+if ((${#san_flags[@]} > 0)); then
+    if [[ -z ${ASAN_OPTIONS:-} ]]; then
+        if [[ $(uname -s) == Linux ]]; then
+            export ASAN_OPTIONS="detect_leaks=1:halt_on_error=1"
+        else
+            export ASAN_OPTIONS="halt_on_error=1"
+        fi
+    fi
+    export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=1}"
+fi
 
 case "$(uname -s)" in
 Darwin)
@@ -84,11 +97,13 @@ else
     echo "ffi-c-harness: compiler lacks C++98 -fshort-enums; skipping negative check" >&2
 fi
 
-"$CC" -std=c11 -Wall -Wextra -Werror "${san_flags[@]}" \
-    -I crates/ferric-ffi \
-    -o "$outdir/discriminant_abuse" \
-    "$harness_src" \
-    target/ffi-dev/libferric_ffi.a \
-    "${platform_libs[@]}"
-
-"$outdir/discriminant_abuse"
+for harness_src in "${harness_sources[@]}"; do
+    harness_name="$(basename "$harness_src" .c)"
+    "$CC" -std=c11 -Wall -Wextra -Werror "${san_flags[@]}" \
+        -I crates/ferric-ffi \
+        -o "$outdir/$harness_name" \
+        "$harness_src" \
+        target/ffi-dev/libferric_ffi.a \
+        "${platform_libs[@]}"
+    "$outdir/$harness_name"
+done


### PR DESCRIPTION
Closes #87

## Scope

FR-CABI-008 adds an allocator-safe C ABI for constructing Ferric-owned multifields from borrowed foreign values. `ferric_value_multifield_copy` validates and deep-copies the complete nested value tree, preserves shallow caller ownership for external-address payloads, leaves non-null output as Void on failure, releases partial copies, and rejects invalid tags, active pointers, ancestor-overlapping storage, cycles, and nesting deeper than 128 levels.

The same change makes ownership provenance explicit in the generated C headers and public compatibility documentation, keeps structured assertion inputs borrowed, and extends the sanitizer-required C harness. Go behavior remains unchanged here; migration belongs to #97, while the broader Windows/cross-platform allocator matrix belongs to #124.

## Stack

- Immediate predecessor: none
- Earlier included PRs: none
- Required merge order: this PR only
- Tests require predecessor code: no
- Branch point: `7a2662e86a65a25fc7f694667b16505d7520e0ce`

## Red-before-fix evidence

`FERRIC_REQUIRE_SANITIZERS=1 just ffi-c-harness` exited 1 on the vulnerable branch. The existing discriminant harness passed, then the new multifield harness failed to compile with four instances of `call to undeclared function 'ferric_value_multifield_copy'`, proving that the allocator-owned construction boundary was absent. The allocator mismatch itself is platform-dependent and can be masked when allocators interoperate.

## Validation

- `just preflight-pr` — passed
- `cargo test -p ferric-ffi` — passed: 286 passed, 4 ignored
- `cargo clippy -p ferric-ffi --all-targets -- -D warnings` — passed
- `FERRIC_REQUIRE_SANITIZERS=1 just ffi-c-harness` — passed both C harnesses under ASan/UBSan; the script enables LeakSanitizer on Linux
- `just build-go-ffi` plus `cmp crates/ferric-ffi/ferric.h bindings/go/internal/ffi/lib/ferric.h` — passed; committed headers are byte-identical
- Independent final-diff reviews of the unsafe/provenance implementation, public contract/documentation, and regression/sanitizer coverage — no remaining findings

## Acceptance criteria

- Documented allocator/deallocator pairing: output strings, symbols, and arrays are Ferric-owned and released through `ferric_value_free`; foreign input and external-address payloads remain caller-owned.
- Foreign input is borrowed: Rust never retains or frees input arrays or active payload pointers, and regression tests mutate and destroy stack and `malloc` sources after copying.
- Recursive output has Ferric provenance: every owned node is deep-copied, with pointer-inequality and source-independence assertions at nested levels.
- Invalid input fails closed: null/length combinations, invalid tags and pointers, ancestor overlap/cycles, and the 128/129-level boundary are locked by Rust and C tests; non-null output remains Void.
- Partial construction is safe: RAII cleanup and repeated late-failure sanitizer coverage exercise recursive deallocation without leaking or invalid-freeing source storage.
- Public contracts stay aligned: canonical and Go-distributed headers, annotations, signature locks, compatibility documentation, and structured-assertion borrowing language are synchronized.

## Residual risks

The local macOS sanitizer run provides ASan/UBSan but not LeakSanitizer; the harness enables LeakSanitizer on Linux. The Rust static library is not itself sanitizer-instrumented, so the targeted C boundary harness primarily detects allocator/deallocator misuse through sanitizer interception. Go adoption and race validation remain in #97, and the broader Windows/cross-platform allocator matrix remains in #124. The defensive 128-level nesting limit is an intentional public contract.