### PR TITLE
[FR-COMPAT-001] Attach generated library harnesses to compatibility manifest entries

### DIFF
--- a/tools/ferric-tools/src/ferric_tools/_harness.py
+++ b/tools/ferric-tools/src/ferric_tools/_harness.py
@@ -1,0 +1,430 @@
+"""Harness generation and manifest-contract helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+HARNESS_GENERATION_VERSION = 1
+EXTERNAL_DEP_KEYWORDS = ["ros-", "ament-", "blackboard-", "pb-", "navgraph-", "protobuf-"]
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+SKIP_REASONS = {"empty", "external-deps"}
+
+
+class HarnessContractError(ValueError):
+    """Raised when harness metadata or files violate the manifest contract."""
+
+
+@dataclass(frozen=True)
+class HarnessPlan:
+    """A fully validated harness generation plan for one source fixture."""
+
+    source_path: Path
+    source_bytes: bytes
+    harness_path: Path | None
+    harness_bytes: bytes | None
+    metadata: dict[str, object]
+
+
+@dataclass(frozen=True)
+class ResolvedHarness:
+    """Validated harness bytes and provenance ready for engine execution."""
+
+    path: Path
+    source_bytes: bytes
+    harness_bytes: bytes
+    metadata: dict[str, object]
+
+
+def sha256_bytes(content: bytes) -> str:
+    """Return the lowercase SHA-256 digest for *content*."""
+    return hashlib.sha256(content).hexdigest()
+
+
+def has_external_deps(content: str) -> bool:
+    """Check if file content references external dependency keywords."""
+    content_lower = content.lower()
+    return any(keyword in content_lower for keyword in EXTERNAL_DEP_KEYWORDS)
+
+
+def detect_constructs(content: str) -> dict:
+    """Parse file content with simple regexes to detect CLIPS constructs."""
+    constructs: dict[str, list] = {
+        "deffacts": [],
+        "deftemplate": [],
+        "defglobal": [],
+        "deffunction": [],
+        "defgeneric": [],
+        "defmethod": [],
+        "defmodule": [],
+    }
+
+    lines = content.split("\n")
+    stripped_lines = [line for line in lines if not line.lstrip().startswith(";")]
+    cleaned = "\n".join(stripped_lines)
+
+    for match in re.finditer(r"\(\s*deffacts\s+([\w:.-]+)", cleaned):
+        constructs["deffacts"].append(match.group(1))
+
+    for match in re.finditer(r"\(\s*deftemplate\s+([\w:.-]+)", cleaned):
+        constructs["deftemplate"].append(match.group(1))
+
+    for match in re.finditer(r"\?\*[\w-]+\*", cleaned):
+        variable = match.group(0)
+        if variable not in constructs["defglobal"]:
+            constructs["defglobal"].append(variable)
+
+    for match in re.finditer(r"\(\s*deffunction\s+([\w:.-]+)\s*\(([^)]*)\)", cleaned):
+        name = match.group(1)
+        params = match.group(2).strip()
+        parameter_count = len(re.findall(r"[\$]?\?\w+", params)) if params else 0
+        constructs["deffunction"].append((name, parameter_count))
+
+    for match in re.finditer(r"\(\s*defgeneric\s+([\w:.-]+)", cleaned):
+        constructs["defgeneric"].append(match.group(1))
+
+    for match in re.finditer(r"\(\s*defmethod\s+([\w:.-]+)", cleaned):
+        name = match.group(1)
+        if name not in constructs["defmethod"]:
+            constructs["defmethod"].append(name)
+
+    for match in re.finditer(r"\(\s*defmodule\s+([\w:.-]+)", cleaned):
+        constructs["defmodule"].append(match.group(1))
+
+    return constructs
+
+
+def has_any_constructs(constructs: dict) -> bool:
+    """Check if any constructs were detected."""
+    return any(len(items) > 0 for items in constructs.values())
+
+
+def generate_harness(source_relpath: str, constructs: dict) -> str:
+    """Generate a harness .clp file for the given source file."""
+    summary_parts: list[str] = []
+    for kind in [
+        "deffacts",
+        "deftemplate",
+        "defglobal",
+        "deffunction",
+        "defgeneric",
+        "defmethod",
+        "defmodule",
+    ]:
+        items = constructs[kind]
+        if items:
+            if kind == "deffunction":
+                names = [f"{name}/{count}" for name, count in items]
+                summary_parts.append(f"{kind}: {', '.join(names)}")
+            else:
+                summary_parts.append(f"{kind}: {', '.join(items)}")
+
+    summary = "; ".join(summary_parts) if summary_parts else "no named constructs"
+    lines = [
+        f"; Harness for {source_relpath}",
+        f"; Detected constructs: {summary}",
+        ";",
+        "; Strategy: verify file loads and reset succeeds.",
+        "; The source file is loaded via (load ...) before this harness.",
+        "",
+        "(defrule harness-verify",
+        "   (initial-fact)",
+        "   =>",
+        '   (printout t "HARNESS: loaded" crlf))',
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def compute_harness_path(output_dir: Path, manifest_key: str) -> Path:
+    """Compute the harness output path from a normalized manifest key."""
+    source_relpath = PurePosixPath(manifest_key)
+    harness_name = f"{source_relpath.stem}-harness.clp"
+    return output_dir.joinpath(*source_relpath.parent.parts, harness_name)
+
+
+def _normalized_relative_path(value: str, *, label: str) -> PurePosixPath:
+    if not value or "\\" in value:
+        raise HarnessContractError(f"{label} must be a normalized POSIX relative path")
+
+    path = PurePosixPath(value)
+    windows_path = PureWindowsPath(value)
+    if path.is_absolute() or windows_path.is_absolute() or windows_path.drive:
+        raise HarnessContractError(f"{label} must be repository-relative")
+    if ".." in path.parts or path.as_posix() != value:
+        raise HarnessContractError(f"{label} must be a normalized POSIX relative path")
+    return path
+
+
+def _resolved_contained_path(
+    path: Path,
+    root: Path,
+    *,
+    label: str,
+    must_exist: bool,
+) -> Path:
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved_path = path.resolve(strict=must_exist)
+        resolved_path.relative_to(resolved_root)
+    except (FileNotFoundError, RuntimeError, ValueError) as error:
+        if isinstance(error, FileNotFoundError):
+            raise HarnessContractError(f"{label} does not exist: {path}") from error
+        raise HarnessContractError(f"{label} escapes repository root: {path}") from error
+
+    if must_exist and not resolved_path.is_file():
+        raise HarnessContractError(f"{label} is not a regular file: {path}")
+    return resolved_path
+
+
+def _repository_relative_path(path: Path, root: Path, *, label: str) -> str:
+    resolved_root = root.resolve(strict=True)
+    resolved_path = _resolved_contained_path(path, root, label=label, must_exist=False)
+    return resolved_path.relative_to(resolved_root).as_posix()
+
+
+def build_harness_plan(
+    manifest_key: str,
+    *,
+    examples_dir: Path,
+    output_dir: Path,
+    root: Path,
+) -> HarnessPlan:
+    """Build a deterministic harness plan and metadata for one library fixture."""
+    source_relpath = _normalized_relative_path(manifest_key, label="source path")
+    source_candidate = examples_dir.joinpath(*source_relpath.parts)
+    source_path = _resolved_contained_path(
+        source_candidate,
+        examples_dir,
+        label=f"source {manifest_key}",
+        must_exist=True,
+    )
+    source_bytes = source_path.read_bytes()
+    source_digest = sha256_bytes(source_bytes)
+    content = source_bytes.decode("utf-8", errors="replace")
+
+    skip_reason: str | None = None
+    if has_external_deps(content):
+        skip_reason = "external-deps"
+    else:
+        constructs = detect_constructs(content)
+        if not has_any_constructs(constructs):
+            skip_reason = "empty"
+
+    if skip_reason is not None:
+        metadata: dict[str, object] = {
+            "path": None,
+            "source_sha256": source_digest,
+            "harness_sha256": None,
+            "generation_version": HARNESS_GENERATION_VERSION,
+            "executable": False,
+            "skip_reason": skip_reason,
+        }
+        return HarnessPlan(source_path, source_bytes, None, None, metadata)
+
+    harness_text = generate_harness(manifest_key, constructs)
+    harness_bytes = harness_text.encode("utf-8")
+    harness_path = compute_harness_path(output_dir, manifest_key)
+    if harness_path.is_symlink():
+        raise HarnessContractError(f"harness output must not be a symlink: {harness_path}")
+    harness_relpath = _repository_relative_path(
+        harness_path,
+        root,
+        label=f"harness for {manifest_key}",
+    )
+    if harness_path.exists() and not harness_path.is_file():
+        raise HarnessContractError(f"harness is not a regular file: {harness_path}")
+
+    metadata = {
+        "path": harness_relpath,
+        "source_sha256": source_digest,
+        "harness_sha256": sha256_bytes(harness_bytes),
+        "generation_version": HARNESS_GENERATION_VERSION,
+        "executable": True,
+    }
+    return HarnessPlan(source_path, source_bytes, harness_path, harness_bytes, metadata)
+
+
+def build_harness_plans(
+    files: dict[str, dict],
+    *,
+    examples_dir: Path,
+    output_dir: Path,
+    root: Path,
+) -> dict[str, HarnessPlan]:
+    """Build and validate all library harness plans before any writes occur."""
+    plans: dict[str, HarnessPlan] = {}
+    targets: dict[Path, str] = {}
+
+    for manifest_key, entry in sorted(files.items()):
+        if entry.get("runability") != "library":
+            continue
+
+        plan = build_harness_plan(
+            manifest_key,
+            examples_dir=examples_dir,
+            output_dir=output_dir,
+            root=root,
+        )
+        if plan.harness_path is not None:
+            target = plan.harness_path.resolve(strict=False)
+            if previous := targets.get(target):
+                raise HarnessContractError(
+                    f"duplicate harness mapping: {previous} and {manifest_key} -> {target}"
+                )
+            targets[target] = manifest_key
+        plans[manifest_key] = plan
+
+    return plans
+
+
+def attach_harness_contracts(
+    files: dict[str, dict],
+    *,
+    examples_dir: Path,
+    output_dir: Path,
+    root: Path,
+) -> dict[str, HarnessPlan]:
+    """Attach deterministic harness metadata to every library entry."""
+    plans = build_harness_plans(
+        files,
+        examples_dir=examples_dir,
+        output_dir=output_dir,
+        root=root,
+    )
+    for manifest_key, plan in plans.items():
+        files[manifest_key]["harness"] = dict(plan.metadata)
+        files[manifest_key].pop("harness_skip", None)
+    return plans
+
+
+def atomic_write_bytes(path: Path, content: bytes) -> None:
+    """Atomically replace *path* with *content* using a sibling temp file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path: Path | None = None
+    try:
+        file_descriptor, temp_name = tempfile.mkstemp(
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+        )
+        temp_path = Path(temp_name)
+        with os.fdopen(file_descriptor, "wb") as temp_file:
+            temp_file.write(content)
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, path)
+        temp_path = None
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+
+
+def _required_digest(value: object, *, field: str, manifest_key: str) -> str:
+    if not isinstance(value, str) or SHA256_RE.fullmatch(value) is None:
+        raise HarnessContractError(
+            f"{manifest_key}: harness.{field} must be a lowercase SHA-256 digest"
+        )
+    return value
+
+
+def resolve_harness_contract(
+    entry: dict,
+    *,
+    source_path: Path,
+    root: Path,
+    manifest_key: str,
+) -> ResolvedHarness | None:
+    """Validate and resolve one library fixture's harness contract."""
+    contract = entry.get("harness")
+    if not isinstance(contract, dict):
+        raise HarnessContractError(f"{manifest_key}: missing structured harness contract")
+
+    required_fields = {
+        "path",
+        "source_sha256",
+        "harness_sha256",
+        "generation_version",
+        "executable",
+    }
+    missing = sorted(required_fields - contract.keys())
+    extra = sorted(contract.keys() - (required_fields | {"skip_reason"}))
+    if missing:
+        raise HarnessContractError(
+            f"{manifest_key}: harness contract missing fields: {', '.join(missing)}"
+        )
+    if extra:
+        raise HarnessContractError(
+            f"{manifest_key}: harness contract has unknown fields: {', '.join(extra)}"
+        )
+
+    generation_version = contract["generation_version"]
+    if type(generation_version) is not int or generation_version != HARNESS_GENERATION_VERSION:
+        raise HarnessContractError(
+            f"{manifest_key}: unsupported harness generation version: {generation_version!r}"
+        )
+    executable = contract["executable"]
+    if type(executable) is not bool:
+        raise HarnessContractError(f"{manifest_key}: harness.executable must be a boolean")
+
+    resolved_source = _resolved_contained_path(
+        source_path,
+        root,
+        label=f"source {manifest_key}",
+        must_exist=True,
+    )
+    source_bytes = resolved_source.read_bytes()
+    source_digest = _required_digest(
+        contract["source_sha256"],
+        field="source_sha256",
+        manifest_key=manifest_key,
+    )
+    if sha256_bytes(source_bytes) != source_digest:
+        raise HarnessContractError(f"{manifest_key}: source digest is stale")
+
+    if not executable:
+        if contract["path"] is not None or contract["harness_sha256"] is not None:
+            raise HarnessContractError(
+                f"{manifest_key}: non-executable harness must have null path and digest"
+            )
+        skip_reason = contract.get("skip_reason")
+        if skip_reason not in SKIP_REASONS:
+            raise HarnessContractError(
+                f"{manifest_key}: non-executable harness has invalid skip_reason"
+            )
+        return None
+
+    if "skip_reason" in contract:
+        raise HarnessContractError(
+            f"{manifest_key}: executable harness must not define skip_reason"
+        )
+    harness_relpath = contract["path"]
+    if not isinstance(harness_relpath, str):
+        raise HarnessContractError(f"{manifest_key}: harness.path must be a string")
+    normalized_path = _normalized_relative_path(harness_relpath, label="harness path")
+    harness_path = root.joinpath(*normalized_path.parts)
+    resolved_harness_path = _resolved_contained_path(
+        harness_path,
+        root,
+        label=f"harness for {manifest_key}",
+        must_exist=True,
+    )
+    harness_bytes = resolved_harness_path.read_bytes()
+    harness_digest = _required_digest(
+        contract["harness_sha256"],
+        field="harness_sha256",
+        manifest_key=manifest_key,
+    )
+    if sha256_bytes(harness_bytes) != harness_digest:
+        raise HarnessContractError(f"{manifest_key}: harness digest is stale")
+
+    return ResolvedHarness(
+        path=resolved_harness_path,
+        source_bytes=source_bytes,
+        harness_bytes=harness_bytes,
+        metadata=dict(contract),
+    )

--- a/tools/ferric-tools/src/ferric_tools/_manifest.py
+++ b/tools/ferric-tools/src/ferric_tools/_manifest.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -14,12 +16,30 @@ def load_manifest(path: str | Path) -> dict:
 
 
 def save_manifest(path: str | Path, data: dict) -> None:
-    """Write *data* as pretty-printed JSON to *path*."""
+    """Atomically write *data* as pretty-printed JSON to *path*."""
     p = Path(path)
     p.parent.mkdir(parents=True, exist_ok=True)
-    with open(p, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
-        f.write("\n")
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=p.parent,
+            prefix=f".{p.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as f:
+            temp_path = Path(f.name)
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+
+        os.replace(temp_path, p)
+        temp_path = None
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
 
 
 def utc_now_iso() -> str:

--- a/tools/ferric-tools/src/ferric_tools/bat/harness.py
+++ b/tools/ferric-tools/src/ferric_tools/bat/harness.py
@@ -2,123 +2,36 @@
 
 from __future__ import annotations
 
-import re
+import copy
 from pathlib import Path
 from typing import Annotated
 
 import typer
 from rich.console import Console
 
+from ferric_tools._harness import (
+    HarnessContractError,
+    atomic_write_bytes,
+    build_harness_plans,
+    compute_harness_path,
+    detect_constructs,
+    generate_harness,
+    has_any_constructs,
+    has_external_deps,
+)
 from ferric_tools._manifest import load_manifest, save_manifest
 from ferric_tools._paths import repo_root
 
+__all__ = [
+    "compute_harness_path",
+    "detect_constructs",
+    "generate_harness",
+    "has_any_constructs",
+    "has_external_deps",
+]
+
 app = typer.Typer(help="Generate harness .clp files for library-only files.")
 console = Console(stderr=True)
-
-EXTERNAL_DEP_KEYWORDS = ["ros-", "ament-", "blackboard-", "pb-", "navgraph-", "protobuf-"]
-
-
-def has_external_deps(content: str) -> bool:
-    """Check if file content references external dependency keywords."""
-    content_lower = content.lower()
-    return any(keyword in content_lower for keyword in EXTERNAL_DEP_KEYWORDS)
-
-
-def detect_constructs(content: str) -> dict:
-    """Parse file content with simple regexes to detect CLIPS constructs."""
-    constructs: dict[str, list] = {
-        "deffacts": [],
-        "deftemplate": [],
-        "defglobal": [],
-        "deffunction": [],
-        "defgeneric": [],
-        "defmethod": [],
-        "defmodule": [],
-    }
-
-    lines = content.split("\n")
-    stripped_lines = [line for line in lines if not line.lstrip().startswith(";")]
-    cleaned = "\n".join(stripped_lines)
-
-    for m in re.finditer(r"\(\s*deffacts\s+([\w:.-]+)", cleaned):
-        constructs["deffacts"].append(m.group(1))
-
-    for m in re.finditer(r"\(\s*deftemplate\s+([\w:.-]+)", cleaned):
-        constructs["deftemplate"].append(m.group(1))
-
-    for m in re.finditer(r"\?\*[\w-]+\*", cleaned):
-        var = m.group(0)
-        if var not in constructs["defglobal"]:
-            constructs["defglobal"].append(var)
-
-    for m in re.finditer(r"\(\s*deffunction\s+([\w:.-]+)\s*\(([^)]*)\)", cleaned):
-        name = m.group(1)
-        params_str = m.group(2).strip()
-        param_count = len(re.findall(r"[\$]?\?\w+", params_str)) if params_str else 0
-        constructs["deffunction"].append((name, param_count))
-
-    for m in re.finditer(r"\(\s*defgeneric\s+([\w:.-]+)", cleaned):
-        constructs["defgeneric"].append(m.group(1))
-
-    for m in re.finditer(r"\(\s*defmethod\s+([\w:.-]+)", cleaned):
-        name = m.group(1)
-        if name not in constructs["defmethod"]:
-            constructs["defmethod"].append(name)
-
-    for m in re.finditer(r"\(\s*defmodule\s+([\w:.-]+)", cleaned):
-        constructs["defmodule"].append(m.group(1))
-
-    return constructs
-
-
-def has_any_constructs(constructs: dict) -> bool:
-    """Check if any constructs were detected."""
-    return any(len(v) > 0 for v in constructs.values())
-
-
-def generate_harness(source_relpath: str, constructs: dict) -> str:
-    """Generate a harness .clp file content for the given source file."""
-    summary_parts: list[str] = []
-    for kind in [
-        "deffacts",
-        "deftemplate",
-        "defglobal",
-        "deffunction",
-        "defgeneric",
-        "defmethod",
-        "defmodule",
-    ]:
-        items = constructs[kind]
-        if items:
-            if kind == "deffunction":
-                names = [f"{name}/{count}" for name, count in items]
-                summary_parts.append(f"{kind}: {', '.join(names)}")
-            else:
-                summary_parts.append(f"{kind}: {', '.join(items)}")
-
-    summary = "; ".join(summary_parts) if summary_parts else "no named constructs"
-
-    lines = [
-        f"; Harness for {source_relpath}",
-        f"; Detected constructs: {summary}",
-        ";",
-        "; Strategy: verify file loads and reset succeeds.",
-        "; The source file is loaded via (load ...) before this harness.",
-        "",
-        "(defrule harness-verify",
-        "   (initial-fact)",
-        "   =>",
-        '   (printout t "HARNESS: loaded" crlf))',
-        "",
-    ]
-    return "\n".join(lines)
-
-
-def compute_harness_path(output_dir: Path, manifest_key: str) -> Path:
-    """Compute the harness output path from the manifest key."""
-    p = Path(manifest_key)
-    harness_name = f"{p.stem}-harness.clp"
-    return output_dir / p.parent / harness_name
 
 
 @app.command()
@@ -137,7 +50,7 @@ def main(
     ] = False,
 ) -> None:
     """Generate harness .clp files for library-only files."""
-    root = repo_root()
+    root = repo_root().resolve()
     manifest_path = (
         Path(manifest_opt) if manifest_opt else root / "tests" / "examples" / "compat-manifest.json"
     )
@@ -148,72 +61,57 @@ def main(
         console.print(f"[red]error:[/] manifest not found: {manifest_path}")
         raise typer.Exit(1)
 
-    manifest = load_manifest(manifest_path)
+    manifest = copy.deepcopy(load_manifest(manifest_path))
     files = manifest.get("files", {})
+    try:
+        plans = build_harness_plans(
+            files,
+            examples_dir=examples_path,
+            output_dir=out_dir,
+            root=root,
+        )
+    except HarnessContractError as error:
+        console.print(f"[red]error:[/] {error}")
+        raise typer.Exit(1) from error
 
-    library_only = {k: v for k, v in files.items() if v.get("reason") == "library-only"}
-    print(f"Found {len(library_only)} library-only files in manifest.")
+    print(f"Found {len(plans)} library-only files in manifest.")
 
     stats = {
         "generated": 0,
         "skipped_external": 0,
         "skipped_empty": 0,
-        "skipped_missing": 0,
     }
 
-    for manifest_key in sorted(library_only.keys()):
+    for manifest_key, plan in plans.items():
         entry = files[manifest_key]
-        source_path = examples_path / manifest_key
-
-        if not source_path.exists():
+        metadata = plan.metadata
+        if not metadata["executable"]:
+            skip_reason = metadata["skip_reason"]
             if dry_run:
-                print(f"  SKIP (missing): {manifest_key}")
-            stats["skipped_missing"] += 1
+                print(f"  SKIP ({skip_reason}): {manifest_key}")
+            stats[f"skipped_{'external' if skip_reason == 'external-deps' else 'empty'}"] += 1
+            entry["harness"] = dict(metadata)
+            entry.pop("harness_skip", None)
             continue
-
-        try:
-            content = source_path.read_text(encoding="utf-8", errors="replace")
-        except Exception as e:
-            console.print(f"[red]ERROR[/] reading {manifest_key}: {e}")
-            stats["skipped_missing"] += 1
-            continue
-
-        if has_external_deps(content):
-            if dry_run:
-                print(f"  SKIP (external-deps): {manifest_key}")
-            entry["harness_skip"] = "external-deps"
-            stats["skipped_external"] += 1
-            continue
-
-        constructs = detect_constructs(content)
-
-        if not has_any_constructs(constructs):
-            if dry_run:
-                print(f"  SKIP (empty): {manifest_key}")
-            entry["harness_skip"] = "empty"
-            stats["skipped_empty"] += 1
-            continue
-
-        harness_content = generate_harness(manifest_key, constructs)
-        harness_path = compute_harness_path(out_dir, manifest_key)
-
-        try:
-            harness_relpath = str(harness_path.relative_to(root))
-        except ValueError:
-            harness_relpath = str(harness_path)
 
         if dry_run:
             print(f"  GENERATE: {manifest_key}")
-            print(f"    -> {harness_relpath}")
+            print(f"    -> {metadata['path']}")
         else:
-            harness_path.parent.mkdir(parents=True, exist_ok=True)
-            harness_path.write_text(harness_content, encoding="utf-8")
+            assert plan.harness_path is not None
+            assert plan.harness_bytes is not None
+            if (
+                not plan.harness_path.exists()
+                or plan.harness_path.read_bytes() != plan.harness_bytes
+            ):
+                atomic_write_bytes(plan.harness_path, plan.harness_bytes)
 
-        entry["harness"] = harness_relpath
+        entry["harness"] = dict(metadata)
         entry.pop("harness_skip", None)
         stats["generated"] += 1
 
     if not dry_run:
+        manifest["version"] = 2
         save_manifest(manifest_path, manifest)
         print(f"\nManifest updated: {manifest_path}")
 
@@ -221,7 +119,6 @@ def main(
     print(f"  Generated:        {stats['generated']}")
     print(f"  Skipped (ext):    {stats['skipped_external']}")
     print(f"  Skipped (empty):  {stats['skipped_empty']}")
-    print(f"  Skipped (missing):{stats['skipped_missing']}")
     print(f"  Total:            {sum(stats.values())}")
 
 

--- a/tools/ferric-tools/src/ferric_tools/compat/run.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/run.py
@@ -21,6 +21,11 @@ import typer
 from rich.console import Console
 
 from ferric_tools._formatting import normalize_floats, normalize_output
+from ferric_tools._harness import (
+    HarnessContractError,
+    ResolvedHarness,
+    resolve_harness_contract,
+)
 from ferric_tools._manifest import load_manifest, save_manifest
 from ferric_tools._paths import (
     examples_dir as default_examples_dir,
@@ -38,6 +43,7 @@ from ferric_tools._subprocess import parallel_run
 
 app = typer.Typer(help="Run CLIPS compatibility assessment.")
 console = Console(stderr=True)
+VALID_RUNABILITY = {"batch", "interactive", "library", "standalone", "unknown"}
 
 
 # ---------------------------------------------------------------------------
@@ -183,27 +189,27 @@ def classify_results(ferric_result: dict, clips_result: dict | None) -> tuple[st
 
 def process_file(args: tuple) -> tuple:
     """Process a single file through both engines."""
-    rel_path, abs_path, ferric, root, script, timeout, skip_clips, harness_path = args
+    rel_path, abs_path, ferric, root, script, timeout, skip_clips, harness = args
 
     run_path = abs_path
     tmp_path = None
     try:
-        if harness_path and os.path.exists(harness_path):
-            with open(abs_path) as f_orig:
-                original_content = f_orig.read()
-            with open(harness_path) as f_harness:
-                harness_content = f_harness.read()
-            with tempfile.NamedTemporaryFile(suffix=".clp", delete=False, mode="w") as tmp:
-                tmp.write(original_content)
-                tmp.write("\n")
-                tmp.write(harness_content)
+        if harness is not None:
+            with tempfile.NamedTemporaryFile(suffix=".clp", delete=False, mode="wb") as tmp:
+                tmp.write(harness.source_bytes)
+                tmp.write(b"\n")
+                tmp.write(harness.harness_bytes)
             tmp_path = tmp.name
             run_path = tmp_path
 
         ferric_result = run_ferric(run_path, ferric, timeout)
+        if harness is not None:
+            ferric_result["harness"] = dict(harness.metadata)
         clips_result = None
         if not skip_clips:
             clips_result = run_clips_docker(run_path, root, script, timeout)
+            if harness is not None:
+                clips_result["harness"] = dict(harness.metadata)
         classification, reason = classify_results(ferric_result, clips_result)
         return rel_path, ferric_result, clips_result, classification, reason
     finally:
@@ -212,13 +218,20 @@ def process_file(args: tuple) -> tuple:
                 os.unlink(tmp_path)
 
 
-def _resolve_harness(entry: dict, root: Path) -> str | None:
-    """Resolve harness path from manifest entry, or None."""
-    harness = entry.get("harness")
-    if not harness:
-        return None
-    path = root / harness
-    return str(path) if path.exists() else None
+def _resolve_harness(
+    entry: dict,
+    *,
+    source_path: Path,
+    root: Path,
+    manifest_key: str,
+) -> ResolvedHarness | None:
+    """Validate and resolve a library entry's structured harness contract."""
+    return resolve_harness_contract(
+        entry,
+        source_path=source_path,
+        root=root,
+        manifest_key=manifest_key,
+    )
 
 
 @app.command()
@@ -275,9 +288,23 @@ def main(
             console.print("[yellow]warning:[/] Docker not available. Using --skip-clips mode.")
             skip_clips = True
 
-    # Select files to run
+    # Select files and validate all library harnesses before starting engines.
     files_to_run: list[tuple[str, str]] = []
+    resolved_harnesses: dict[str, ResolvedHarness | None] = {}
+    harness_targets: dict[Path, str] = {}
     for rel_path, info in mdata["files"].items():
+        runability = info.get("runability")
+        if runability not in VALID_RUNABILITY:
+            console.print(
+                f"[red]error:[/] {rel_path}: invalid or missing runability: {runability!r}"
+            )
+            raise typer.Exit(1)
+        if "harness" in info and runability != "library":
+            console.print(
+                f"[red]error:[/] {rel_path}: harness contract requires library runability"
+            )
+            raise typer.Exit(1)
+
         if file:
             if rel_path != file:
                 continue
@@ -308,8 +335,40 @@ def main(
             abs_path = root / "tests" / rel_path
         else:
             abs_path = ed / rel_path
-        if not abs_path.exists():
+        if runability == "library":
+            try:
+                resolved_harness = _resolve_harness(
+                    info,
+                    source_path=abs_path,
+                    root=root,
+                    manifest_key=rel_path,
+                )
+            except HarnessContractError as error:
+                console.print(f"[red]error:[/] {error}")
+                raise typer.Exit(1) from error
+
+            if resolved_harness is None:
+                if file:
+                    skip_reason = info["harness"].get("skip_reason", "not executable")
+                    console.print(
+                        f"[red]error:[/] {rel_path}: harness is not executable ({skip_reason})"
+                    )
+                    raise typer.Exit(1)
+                continue
+
+            target = resolved_harness.path
+            if previous := harness_targets.get(target):
+                console.print(
+                    "[red]error:[/] duplicate harness mapping: "
+                    f"{previous} and {rel_path} -> {target}"
+                )
+                raise typer.Exit(1)
+            harness_targets[target] = rel_path
+            resolved_harnesses[rel_path] = resolved_harness
+        elif not abs_path.exists():
             continue
+        else:
+            resolved_harnesses[rel_path] = None
 
         files_to_run.append((rel_path, str(abs_path)))
 
@@ -337,7 +396,7 @@ def main(
             script,
             timeout,
             skip_clips,
-            _resolve_harness(mdata["files"].get(rel, {}), root),
+            resolved_harnesses[rel],
         )
         for rel, abs_p in files_to_run
     ]

--- a/tools/ferric-tools/src/ferric_tools/compat/scan.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/scan.py
@@ -22,8 +22,10 @@ from ferric_tools._clips_parser import (
     detect_features,
     strip_comments,
 )
+from ferric_tools._harness import attach_harness_contracts
 from ferric_tools._manifest import save_manifest, utc_now_iso
 from ferric_tools._paths import examples_dir as default_examples_dir
+from ferric_tools._paths import repo_root
 
 app = typer.Typer(help="Scan CLIPS examples for compatibility assessment.")
 console = Console(stderr=True)
@@ -65,14 +67,19 @@ def classify_file(path: Path, features: list[str], unsupported: list[str]) -> tu
     return "pending", "testable", "standalone"
 
 
-def scan_examples(examples_path: Path) -> dict:
+def scan_examples(
+    examples_path: Path,
+    *,
+    root: Path | None = None,
+    harness_dir: Path | None = None,
+) -> dict:
     """Scan all .clp and .bat files under examples_path."""
     files: dict[str, dict] = {}
     all_files = sorted(examples_path.rglob("*.clp")) + sorted(examples_path.rglob("*.bat"))
 
     for filepath in all_files:
         rel = filepath.relative_to(examples_path)
-        rel_str = str(rel)
+        rel_str = rel.as_posix()
         source = rel.parts[0] if len(rel.parts) > 1 else ""
 
         try:
@@ -107,6 +114,18 @@ def scan_examples(examples_path: Path) -> dict:
             "notes": "",
         }
 
+    if root is None:
+        if examples_path.name == "examples" and examples_path.parent.name == "tests":
+            root = examples_path.parent.parent
+        else:
+            root = repo_root()
+    output_dir = harness_dir or root / "tests" / "harnesses"
+    attach_harness_contracts(
+        files,
+        examples_dir=examples_path,
+        output_dir=output_dir,
+        root=root,
+    )
     return files
 
 
@@ -166,12 +185,17 @@ def main(
         raise typer.Exit(1)
 
     console.print(f"Scanning {examples_path} ...")
-    files = scan_examples(examples_path)
+    root = repo_root()
+    files = scan_examples(
+        examples_path,
+        root=root,
+        harness_dir=root / "tests" / "harnesses",
+    )
     dup_count = dedup_batch_files(files, examples_path)
     summary = build_summary(files)
 
     manifest = {
-        "version": 1,
+        "version": 2,
         "generated": utc_now_iso(),
         "summary": summary,
         "files": files,

--- a/tools/ferric-tools/tests/test_compat_scan.py
+++ b/tools/ferric-tools/tests/test_compat_scan.py
@@ -9,9 +9,24 @@ classify_file(path, features, unsupported) returns
 
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 
-from ferric_tools.compat.scan import classify_file
+import pytest
+from typer.testing import CliRunner
+
+from ferric_tools._harness import (
+    HARNESS_GENERATION_VERSION,
+    HarnessContractError,
+    atomic_write_bytes,
+    build_harness_plans,
+    resolve_harness_contract,
+    sha256_bytes,
+)
+from ferric_tools._manifest import load_manifest, save_manifest
+from ferric_tools.bat import harness as harness_module
+from ferric_tools.compat import run as run_module
+from ferric_tools.compat.scan import build_summary, classify_file, scan_examples
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -21,6 +36,26 @@ from ferric_tools.compat.scan import classify_file
 def _clp(name: str = "example.clp") -> Path:
     """Return a synthetic .clp Path."""
     return Path(name)
+
+
+def _materialized_library_harness(tmp_path):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "libraries" / "facts.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("(deffacts sample (value 1))\n", encoding="utf-8")
+    files = scan_examples(examples, root=root)
+    plans = build_harness_plans(
+        files,
+        examples_dir=examples,
+        output_dir=root / "tests" / "harnesses",
+        root=root,
+    )
+    plan = plans["libraries/facts.clp"]
+    assert plan.harness_path is not None
+    assert plan.harness_bytes is not None
+    atomic_write_bytes(plan.harness_path, plan.harness_bytes)
+    return root, source, files["libraries/facts.clp"], plan
 
 
 # ---------------------------------------------------------------------------
@@ -125,3 +160,541 @@ def test_classify_file_bat_extension_is_incompatible():
 
     assert classification == "incompatible"
     assert reason == "test-suite-batch"
+
+
+def test_harness_generation_attaches_structured_manifest_contract(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "libraries" / "facts.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("(deffacts sample (value 1))\n", encoding="utf-8")
+
+    files = scan_examples(examples)
+    manifest_path = examples / "compat-manifest.json"
+    save_manifest(
+        manifest_path,
+        {
+            "version": 1,
+            "generated": "2026-07-26T00:00:00+00:00",
+            "summary": build_summary(files),
+            "files": files,
+        },
+    )
+    monkeypatch.setattr(harness_module, "repo_root", lambda: root)
+
+    result = CliRunner().invoke(
+        harness_module.app,
+        [
+            "--manifest",
+            str(manifest_path),
+            "--output-dir",
+            str(root / "tests" / "harnesses"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    entry = load_manifest(manifest_path)["files"]["libraries/facts.clp"]
+    assert entry["harness"] == {
+        "path": "tests/harnesses/libraries/facts-harness.clp",
+        "source_sha256": ("9cbd4ed905513641a466371ad9acd658ef729cd071739ad84340b30273cfa088"),
+        "harness_sha256": ("813e26ca00f6dd8f89322aca61d1ef07441795aae6fe58dc653e69f969693e57"),
+        "generation_version": 1,
+        "executable": True,
+    }
+    assert load_manifest(manifest_path)["version"] == 2
+
+
+def test_scan_attaches_non_executable_contract_for_empty_library(tmp_path):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "empty.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("; comments only\n", encoding="utf-8")
+
+    entry = scan_examples(examples, root=root)["empty.clp"]
+
+    assert entry["runability"] == "library"
+    assert entry["harness"] == {
+        "path": None,
+        "source_sha256": sha256_bytes(b"; comments only\n"),
+        "harness_sha256": None,
+        "generation_version": HARNESS_GENERATION_VERSION,
+        "executable": False,
+        "skip_reason": "empty",
+    }
+
+
+def test_harness_generation_is_deterministic(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "library.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("(deftemplate item (slot value))\n", encoding="utf-8")
+    files = scan_examples(examples, root=root)
+    manifest_path = examples / "compat-manifest.json"
+    save_manifest(
+        manifest_path,
+        {
+            "version": 2,
+            "generated": "2026-07-26T00:00:00+00:00",
+            "summary": build_summary(files),
+            "files": files,
+        },
+    )
+    monkeypatch.setattr(harness_module, "repo_root", lambda: root)
+    args = [
+        "--manifest",
+        str(manifest_path),
+        "--output-dir",
+        str(root / "tests" / "harnesses"),
+    ]
+
+    first = CliRunner().invoke(harness_module.app, args)
+    assert first.exit_code == 0, first.output
+    first_manifest = manifest_path.read_bytes()
+    harness_path = root / "tests" / "harnesses" / "library-harness.clp"
+    first_harness = harness_path.read_bytes()
+
+    second = CliRunner().invoke(harness_module.app, args)
+
+    assert second.exit_code == 0, second.output
+    assert manifest_path.read_bytes() == first_manifest
+    assert harness_path.read_bytes() == first_harness
+
+
+def test_harness_generation_uses_stable_library_identity(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "library.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("(deffacts sample (value 1))\n", encoding="utf-8")
+    files = scan_examples(examples, root=root)
+    files["library.clp"]["reason"] = "exact-match"
+    files["library.clp"]["harness"] = {"legacy": True}
+    manifest_path = examples / "compat-manifest.json"
+    save_manifest(
+        manifest_path,
+        {
+            "version": 1,
+            "generated": "2026-07-26T00:00:00+00:00",
+            "summary": build_summary(files),
+            "files": files,
+        },
+    )
+    monkeypatch.setattr(harness_module, "repo_root", lambda: root)
+
+    result = CliRunner().invoke(
+        harness_module.app,
+        [
+            "--manifest",
+            str(manifest_path),
+            "--output-dir",
+            str(root / "tests" / "harnesses"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    entry = load_manifest(manifest_path)["files"]["library.clp"]
+    assert entry["reason"] == "exact-match"
+    assert entry["harness"]["executable"] is True
+
+
+def test_harness_generation_clears_stale_mapping_when_fixture_becomes_empty(tmp_path, monkeypatch):
+    root, source, entry, plan = _materialized_library_harness(tmp_path)
+    examples = root / "tests" / "examples"
+    manifest_path = examples / "compat-manifest.json"
+    save_manifest(
+        manifest_path,
+        {
+            "version": 2,
+            "generated": "2026-07-26T00:00:00+00:00",
+            "summary": build_summary({"libraries/facts.clp": entry}),
+            "files": {"libraries/facts.clp": entry},
+        },
+    )
+    source.write_text("; no constructs remain\n", encoding="utf-8")
+    monkeypatch.setattr(harness_module, "repo_root", lambda: root)
+
+    result = CliRunner().invoke(
+        harness_module.app,
+        [
+            "--manifest",
+            str(manifest_path),
+            "--output-dir",
+            str(root / "tests" / "harnesses"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    contract = load_manifest(manifest_path)["files"]["libraries/facts.clp"]["harness"]
+    assert contract["executable"] is False
+    assert contract["path"] is None
+    assert contract["harness_sha256"] is None
+    assert contract["skip_reason"] == "empty"
+    assert plan.harness_path is not None
+
+
+def test_generation_rejects_duplicate_output_mapping_before_writing(tmp_path):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    examples.mkdir(parents=True)
+    content = "(deffacts sample (value 1))\n"
+    (examples / "same.clp").write_text(content, encoding="utf-8")
+    (examples / "same.bat").write_text(content, encoding="utf-8")
+    files = {
+        "same.clp": {"runability": "library"},
+        "same.bat": {"runability": "library"},
+    }
+
+    with pytest.raises(HarnessContractError, match="duplicate harness mapping"):
+        build_harness_plans(
+            files,
+            examples_dir=examples,
+            output_dir=root / "tests" / "harnesses",
+            root=root,
+        )
+
+    assert not (root / "tests" / "harnesses").exists()
+
+
+def test_generation_rejects_harness_leaf_symlink(tmp_path):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "library.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("(deffacts sample (value 1))\n", encoding="utf-8")
+    output_dir = root / "tests" / "harnesses"
+    output_dir.mkdir(parents=True)
+    other_target = output_dir / "other.clp"
+    other_target.write_text("; old target\n", encoding="utf-8")
+    (output_dir / "library-harness.clp").symlink_to(other_target)
+
+    with pytest.raises(HarnessContractError, match="must not be a symlink"):
+        build_harness_plans(
+            {"library.clp": {"runability": "library"}},
+            examples_dir=examples,
+            output_dir=output_dir,
+            root=root,
+        )
+
+    assert other_target.read_text(encoding="utf-8") == "; old target\n"
+
+
+def test_generation_failure_does_not_publish_updated_manifest(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "library.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("(deffacts sample (value 1))\n", encoding="utf-8")
+    files = scan_examples(examples, root=root)
+    manifest_path = examples / "compat-manifest.json"
+    old_manifest = {
+        "version": 1,
+        "generated": "2026-07-26T00:00:00+00:00",
+        "summary": build_summary(files),
+        "files": files,
+    }
+    save_manifest(manifest_path, old_manifest)
+    old_bytes = manifest_path.read_bytes()
+    monkeypatch.setattr(harness_module, "repo_root", lambda: root)
+
+    def fail_write(_path, _content):
+        raise OSError("injected harness replacement failure")
+
+    monkeypatch.setattr(harness_module, "atomic_write_bytes", fail_write)
+
+    result = CliRunner().invoke(
+        harness_module.app,
+        [
+            "--manifest",
+            str(manifest_path),
+            "--output-dir",
+            str(root / "tests" / "harnesses"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, OSError)
+    assert manifest_path.read_bytes() == old_bytes
+    assert load_manifest(manifest_path) == old_manifest
+
+
+def test_resolver_accepts_digest_matched_harness(tmp_path):
+    root, source, entry, plan = _materialized_library_harness(tmp_path)
+
+    resolved = resolve_harness_contract(
+        entry,
+        source_path=source,
+        root=root,
+        manifest_key="libraries/facts.clp",
+    )
+
+    assert resolved is not None
+    assert resolved.path == plan.harness_path.resolve()
+    assert resolved.source_bytes == source.read_bytes()
+    assert resolved.harness_bytes == plan.harness_bytes
+    assert resolved.metadata == entry["harness"]
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ("source", "source digest is stale"),
+        ("harness", "harness digest is stale"),
+        ("missing", "does not exist"),
+    ],
+)
+def test_resolver_rejects_stale_or_missing_harness_contract(tmp_path, mutation, message):
+    root, source, entry, plan = _materialized_library_harness(tmp_path)
+    assert plan.harness_path is not None
+    if mutation == "source":
+        source.write_text("(deffacts changed (value 2))\n", encoding="utf-8")
+    elif mutation == "harness":
+        plan.harness_path.write_text("; stale harness\n", encoding="utf-8")
+    else:
+        plan.harness_path.unlink()
+
+    with pytest.raises(HarnessContractError, match=message):
+        resolve_harness_contract(
+            entry,
+            source_path=source,
+            root=root,
+            manifest_key="libraries/facts.clp",
+        )
+
+
+@pytest.mark.parametrize(
+    "escaping_path",
+    [
+        "/tmp/outside-harness.clp",
+        "../outside-harness.clp",
+        "tests/harnesses/../outside-harness.clp",
+        "C:/outside-harness.clp",
+    ],
+)
+def test_resolver_rejects_escaping_or_non_normalized_paths(tmp_path, escaping_path):
+    root, source, entry, _plan = _materialized_library_harness(tmp_path)
+    escaped_entry = copy.deepcopy(entry)
+    escaped_entry["harness"]["path"] = escaping_path
+
+    with pytest.raises(HarnessContractError, match="harness path"):
+        resolve_harness_contract(
+            escaped_entry,
+            source_path=source,
+            root=root,
+            manifest_key="libraries/facts.clp",
+        )
+
+
+def test_resolver_rejects_symlink_escape(tmp_path):
+    root, source, entry, _plan = _materialized_library_harness(tmp_path)
+    outside_harness = tmp_path / "outside-harness.clp"
+    outside_harness.write_text("; outside\n", encoding="utf-8")
+    symlink = root / "tests" / "harnesses" / "escape.clp"
+    symlink.symlink_to(outside_harness)
+    escaped_entry = copy.deepcopy(entry)
+    escaped_entry["harness"]["path"] = "tests/harnesses/escape.clp"
+    escaped_entry["harness"]["harness_sha256"] = sha256_bytes(outside_harness.read_bytes())
+
+    with pytest.raises(HarnessContractError, match="escapes repository root"):
+        resolve_harness_contract(
+            escaped_entry,
+            source_path=source,
+            root=root,
+            manifest_key="libraries/facts.clp",
+        )
+
+
+def test_resolver_rejects_missing_contract_and_unknown_generation(tmp_path):
+    root, source, entry, _plan = _materialized_library_harness(tmp_path)
+    missing_contract = copy.deepcopy(entry)
+    missing_contract.pop("harness")
+    unknown_generation = copy.deepcopy(entry)
+    unknown_generation["harness"]["generation_version"] = HARNESS_GENERATION_VERSION + 1
+
+    with pytest.raises(HarnessContractError, match="missing structured harness"):
+        resolve_harness_contract(
+            missing_contract,
+            source_path=source,
+            root=root,
+            manifest_key="libraries/facts.clp",
+        )
+    with pytest.raises(HarnessContractError, match="unsupported harness generation version"):
+        resolve_harness_contract(
+            unknown_generation,
+            source_path=source,
+            root=root,
+            manifest_key="libraries/facts.clp",
+        )
+
+
+def test_compat_runner_rejects_duplicate_selected_harness_mapping(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    examples.mkdir(parents=True)
+    content = "(deffacts sample (value 1))\n"
+    (examples / "a.clp").write_text(content, encoding="utf-8")
+    (examples / "b.clp").write_text(content, encoding="utf-8")
+    files = scan_examples(examples, root=root)
+    plans = build_harness_plans(
+        files,
+        examples_dir=examples,
+        output_dir=root / "tests" / "harnesses",
+        root=root,
+    )
+    first_plan = plans["a.clp"]
+    assert first_plan.harness_path is not None
+    assert first_plan.harness_bytes is not None
+    atomic_write_bytes(first_plan.harness_path, first_plan.harness_bytes)
+    files["b.clp"]["harness"] = copy.deepcopy(files["a.clp"]["harness"])
+    manifest_path = examples / "compat-manifest.json"
+    save_manifest(
+        manifest_path,
+        {
+            "version": 2,
+            "generated": "2026-07-26T00:00:00+00:00",
+            "summary": build_summary(files),
+            "files": files,
+        },
+    )
+    monkeypatch.setattr(run_module, "repo_root", lambda: root)
+    monkeypatch.setattr(run_module, "default_examples_dir", lambda: examples)
+
+    result = CliRunner().invoke(
+        run_module.app,
+        ["--manifest", str(manifest_path), "--dry-run"],
+    )
+
+    assert result.exit_code == 1
+    assert "duplicate harness mapping" in result.output
+
+
+def test_compat_runner_skips_explicitly_non_executable_library(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "empty.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("; comments only\n", encoding="utf-8")
+    files = scan_examples(examples, root=root)
+    manifest_path = examples / "compat-manifest.json"
+    save_manifest(
+        manifest_path,
+        {
+            "version": 2,
+            "generated": "2026-07-26T00:00:00+00:00",
+            "summary": build_summary(files),
+            "files": files,
+        },
+    )
+    monkeypatch.setattr(run_module, "repo_root", lambda: root)
+    monkeypatch.setattr(run_module, "default_examples_dir", lambda: examples)
+
+    result = CliRunner().invoke(
+        run_module.app,
+        ["--manifest", str(manifest_path), "--dry-run"],
+    )
+    explicit = CliRunner().invoke(
+        run_module.app,
+        ["--manifest", str(manifest_path), "--file", "empty.clp", "--dry-run"],
+    )
+
+    assert result.exit_code == 0
+    assert "No files to run." in result.output
+    assert explicit.exit_code == 1
+    assert "harness is not executable (empty)" in explicit.output
+
+
+@pytest.mark.parametrize("mutation", ["missing", "standalone"])
+def test_compat_runner_rejects_runability_that_bypasses_harness_validation(
+    tmp_path, monkeypatch, mutation
+):
+    root, _source, entry, plan = _materialized_library_harness(tmp_path)
+    examples = root / "tests" / "examples"
+    malformed_entry = copy.deepcopy(entry)
+    if mutation == "missing":
+        malformed_entry.pop("runability")
+    else:
+        malformed_entry["runability"] = "standalone"
+    manifest_path = examples / "compat-manifest.json"
+    save_manifest(
+        manifest_path,
+        {
+            "version": 2,
+            "generated": "2026-07-26T00:00:00+00:00",
+            "summary": build_summary({"libraries/facts.clp": malformed_entry}),
+            "files": {"libraries/facts.clp": malformed_entry},
+        },
+    )
+    monkeypatch.setattr(run_module, "repo_root", lambda: root)
+    monkeypatch.setattr(run_module, "default_examples_dir", lambda: examples)
+
+    result = CliRunner().invoke(
+        run_module.app,
+        ["--manifest", str(manifest_path), "--dry-run"],
+    )
+
+    assert result.exit_code == 1
+    if mutation == "missing":
+        assert "invalid or missing runability" in result.output
+    else:
+        assert "harness contract requires library runability" in result.output
+    assert plan.harness_path is not None
+
+
+def test_process_file_records_harness_executed_by_both_engines(tmp_path, monkeypatch):
+    root, source, entry, _plan = _materialized_library_harness(tmp_path)
+    resolved = resolve_harness_contract(
+        entry,
+        source_path=source,
+        root=root,
+        manifest_key="libraries/facts.clp",
+    )
+    assert resolved is not None
+    invocations: list[tuple[str, str, bytes]] = []
+
+    def fake_ferric(path, _ferric, _timeout):
+        invocations.append(("ferric", path, Path(path).read_bytes()))
+        return {
+            "exit_code": 0,
+            "stdout": "matched\n",
+            "stderr": "",
+            "duration_ms": 1,
+            "timed_out": False,
+        }
+
+    def fake_clips(path, _root, _script, _timeout):
+        invocations.append(("clips", path, Path(path).read_bytes()))
+        return {
+            "exit_code": 0,
+            "stdout": "matched\n",
+            "stderr": "",
+            "duration_ms": 1,
+            "timed_out": False,
+        }
+
+    monkeypatch.setattr(run_module, "run_ferric", fake_ferric)
+    monkeypatch.setattr(run_module, "run_clips_docker", fake_clips)
+
+    result = run_module.process_file(
+        (
+            "libraries/facts.clp",
+            str(source),
+            "ferric",
+            str(root),
+            "clips-reference",
+            5,
+            False,
+            resolved,
+        )
+    )
+
+    _, ferric_result, clips_result, classification, reason = result
+    assert [engine for engine, _, _ in invocations] == ["ferric", "clips"]
+    assert invocations[0][1] == invocations[1][1]
+    assert invocations[0][2] == invocations[1][2]
+    assert invocations[0][2] == resolved.source_bytes + b"\n" + resolved.harness_bytes
+    assert ferric_result["harness"] == resolved.metadata
+    assert clips_result is not None
+    assert clips_result["harness"] == resolved.metadata
+    assert classification == "equivalent"
+    assert reason == "exact-match"

--- a/tools/ferric-tools/tests/test_manifest.py
+++ b/tools/ferric-tools/tests/test_manifest.py
@@ -6,7 +6,11 @@ Verifies load/save round-trip fidelity and the ISO timestamp helper.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
+import pytest
+
+import ferric_tools._manifest as manifest_module
 from ferric_tools._manifest import load_manifest, save_manifest, utc_now_iso
 
 # ---------------------------------------------------------------------------
@@ -76,6 +80,46 @@ def test_save_preserves_unicode(tmp_path):
 
     raw = manifest_path.read_text(encoding="utf-8")
     assert "héllo wörld" in raw, "save_manifest must not escape non-ASCII characters"
+
+
+def test_save_replaces_from_same_directory(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text('{"version": 1}\n', encoding="utf-8")
+    real_replace = manifest_module.os.replace
+    replacements: list[tuple[Path, Path]] = []
+
+    def recording_replace(source, destination):
+        source_path = Path(source)
+        destination_path = Path(destination)
+        replacements.append((source_path, destination_path))
+        real_replace(source, destination)
+
+    monkeypatch.setattr(manifest_module.os, "replace", recording_replace)
+
+    save_manifest(manifest_path, {"version": 2})
+
+    assert len(replacements) == 1
+    assert replacements[0][1] == manifest_path
+    assert replacements[0][0].parent == manifest_path.parent
+    assert load_manifest(manifest_path) == {"version": 2}
+    assert list(tmp_path.iterdir()) == [manifest_path]
+
+
+def test_save_replace_failure_preserves_old_manifest_and_cleans_temp(tmp_path, monkeypatch):
+    manifest_path = tmp_path / "manifest.json"
+    old_data = {"version": 1, "files": {"old.clp": {}}}
+    save_manifest(manifest_path, old_data)
+
+    def fail_replace(_source, _destination):
+        raise OSError("injected replace failure")
+
+    monkeypatch.setattr(manifest_module.os, "replace", fail_replace)
+
+    with pytest.raises(OSError, match="injected replace failure"):
+        save_manifest(manifest_path, {"version": 2, "files": {"new.clp": {}}})
+
+    assert load_manifest(manifest_path) == old_data
+    assert list(tmp_path.iterdir()) == [manifest_path]
 
 
 def test_load_manifest_returns_dict(tmp_path):


### PR DESCRIPTION
Closes #88

## Scope

FR-COMPAT-001 introduces a versioned, structured harness contract for library-only compatibility fixtures. The scanner and generator attach a repository-relative path, source SHA-256, harness SHA-256, generation version, and executable expectation; generation writes harnesses and manifests atomically; and the runner validates the complete selected set before execution and records the validated harness provenance in each invoked engine result.

## Stack

- Immediate predecessor: https://github.com/plx/ferric-rules/pull/239 (merged)
- Earlier included PRs: none
- Required merge order: #239 (merged) → this PR
- Tests require predecessor code: no
- Branch point: `0cfa433387ff3b41d2b8e09dd40126d9282ffc32`

## Red-before-fix evidence

`uv run --project tools/ferric-tools pytest tools/ferric-tools/tests/test_compat_scan.py -q` failed because generation stored `harness` as a plain string rather than the required structured path/digest/version/executable contract (`1 failed, 6 passed`).

## Validation

- `just preflight-pr` — passed
- `uv run --project . pytest tests/test_compat_scan.py -v` from `tools/ferric-tools/` — 29 passed
- `uv run --project tools/ferric-tools pytest tools/ferric-tools/tests -q` — 192 passed
- `just compat-scan` — passed; 1,206 fixtures scanned and manifest schema v2 emitted
- `just harness-gen` — passed; 182 executable harnesses generated and 37 explicit skips recorded; repeated generation was byte-identical and produced no tracked harness diff
- `just compat-run` — passed; all 621 selected fixtures completed, with 182 library harness contracts recorded identically in both engine result records

## Acceptance criteria

- Every selected library fixture receives exactly one structured, repository-relative, digest-matched harness contract; the 37 intentionally non-executable fixtures carry explicit `executable: false` contracts and are not selected.
- Source changes, harness changes, missing files, malformed contracts, unsupported generation versions, absolute or escaping paths, symlink escapes, leaf symlink outputs, invalid runability, and duplicate mappings all fail closed before engine execution.
- Generation plans and validates the full library set before writes, atomically replaces changed harness files, and atomically publishes the manifest last; injected replacement failures preserve the previous valid manifest.
- Generation keys on stable `runability == "library"`, remains deterministic across repeated runs, and clears obsolete executable mappings when a fixture becomes empty or externally dependent.
- The runner executes the exact validated source/harness byte snapshot for each engine invocation and persists the same harness provenance in the Ferric and CLIPS result objects.

## Residual risks

Composed temporary-file visibility inside the CLIPS container remains tracked by #89. Verifier-module execution remains tracked by #90, and CI generation/diff policy remains tracked by #92.