### PR TITLE
[FR-COMPAT-002] Run composed compatibility harnesses from a CLIPS-visible path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ packages/ferric/node_modules/
 
 # Compatibility assessment (generated)
 tests/examples/compat-manifest.json
+.ferric-compat/

--- a/scripts/clips-reference.sh
+++ b/scripts/clips-reference.sh
@@ -52,13 +52,30 @@ require_command() {
 
 resolve_path() {
   local input="$1"
-  if [[ -f "$input" ]]; then
-    echo "$(cd "$(dirname "$input")" && pwd)/$(basename "$input")"
-    return
+  if [[ ! -f "$input" ]]; then
+    echo "error: file not found: $input" >&2
+    exit 1
   fi
 
-  echo "error: file not found: $input" >&2
-  exit 1
+  if [[ -L "$input" ]]; then
+    echo "error: file path must not be a symlink: $input" >&2
+    exit 1
+  fi
+
+  local directory
+  local filename
+  local physical_directory
+  directory="$(dirname "$input")"
+  filename="$(basename "$input")"
+  physical_directory="$(cd "$directory" && pwd -P)"
+  printf '%s/%s\n' "$physical_directory" "$filename"
+}
+
+escape_clips_string() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s' "$value"
 }
 
 build_command() {
@@ -96,6 +113,7 @@ run_command() {
   local full_image="${IMAGE_NAME}:${IMAGE_TAG}"
   local repo_root
   repo_root="$(git rev-parse --show-toplevel)"
+  repo_root="$(cd "$repo_root" && pwd -P)"
 
   local commands=()
   local file
@@ -107,8 +125,14 @@ run_command() {
       exit 1
     fi
 
-    local rel="${abs#${repo_root}/}"
-    commands+=("(batch* \"${WORKDIR_IN_CONTAINER}/${rel}\")")
+    local rel="${abs:$(( ${#repo_root} + 1 ))}"
+    if [[ "$rel" =~ [[:cntrl:]] ]]; then
+      echo "error: --file path contains an unsupported control character: $file" >&2
+      exit 1
+    fi
+    local container_path
+    container_path="$(escape_clips_string "${WORKDIR_IN_CONTAINER}/${rel}")"
+    commands+=("(batch* \"${container_path}\")")
   done
 
   if [[ -n "$OPS_FILE" ]]; then
@@ -140,7 +164,7 @@ run_command() {
     done
     printf '(exit)\n'
   } | docker run --rm -i \
-      -v "${repo_root}:${WORKDIR_IN_CONTAINER}" \
+      -v "${repo_root}:${WORKDIR_IN_CONTAINER}:ro" \
       -w "$WORKDIR_IN_CONTAINER" \
       "$full_image"
 }

--- a/tools/ferric-tools/src/ferric_tools/compat/run.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/run.py
@@ -24,7 +24,9 @@ from ferric_tools._formatting import normalize_floats, normalize_output
 from ferric_tools._harness import (
     HarnessContractError,
     ResolvedHarness,
+    atomic_write_bytes,
     resolve_harness_contract,
+    sha256_bytes,
 )
 from ferric_tools._manifest import load_manifest, save_manifest
 from ferric_tools._paths import (
@@ -44,6 +46,244 @@ from ferric_tools._subprocess import parallel_run
 app = typer.Typer(help="Run CLIPS compatibility assessment.")
 console = Console(stderr=True)
 VALID_RUNABILITY = {"batch", "interactive", "library", "standalone", "unknown"}
+FAILED_CLASSIFICATIONS = {"divergent", "incompatible"}
+COMPAT_WORKSPACE = Path(".ferric-compat")
+IS_WINDOWS = os.name == "nt"
+
+
+class CompatibilityWorkspaceError(RuntimeError):
+    """Raised when composed compatibility inputs cannot be staged safely."""
+
+
+def _make_read_only(path: Path) -> None:
+    """Make retained or staged inputs immutable where chmod does not block unlink."""
+    if not IS_WINDOWS:
+        path.chmod(0o444)
+
+
+def _require_contained(path: Path, *, root: Path, label: str) -> Path:
+    """Resolve *path* and require it to remain physically inside *root*."""
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved_path = path.resolve(strict=True)
+    except OSError as error:
+        raise CompatibilityWorkspaceError(f"{label} cannot be resolved: {error}") from error
+
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError as error:
+        raise CompatibilityWorkspaceError(
+            f"{label} escapes repository root: {resolved_path}"
+        ) from error
+    return resolved_path
+
+
+def _require_contained_directory(path: Path, *, root: Path, label: str) -> Path:
+    """Validate an existing repository-contained directory."""
+    resolved_path = _require_contained(path, root=root, label=label)
+    if not resolved_path.is_dir():
+        raise CompatibilityWorkspaceError(f"{label} is not a directory: {resolved_path}")
+    return resolved_path
+
+
+def _require_contained_file(path: Path, *, root: Path, label: str) -> Path:
+    """Validate an existing regular file without following a leaf symlink."""
+    if path.is_symlink():
+        raise CompatibilityWorkspaceError(f"{label} must not be a symlink: {path}")
+    resolved_path = _require_contained(path, root=root, label=label)
+    if not resolved_path.is_file():
+        raise CompatibilityWorkspaceError(f"{label} is not a regular file: {resolved_path}")
+    return resolved_path
+
+
+def _ensure_workspace_directory(root: Path, relative_path: Path, *, label: str) -> Path:
+    """Create a fixed relative directory without traversing outside *root*."""
+    if relative_path.is_absolute() or any(part in {"", ".", ".."} for part in relative_path.parts):
+        raise CompatibilityWorkspaceError(f"{label} must be a normalized relative path")
+
+    try:
+        resolved_root = root.resolve(strict=True)
+    except OSError as error:
+        raise CompatibilityWorkspaceError(f"repository root cannot be resolved: {error}") from error
+    if not resolved_root.is_dir():
+        raise CompatibilityWorkspaceError(f"repository root is not a directory: {resolved_root}")
+
+    current = resolved_root
+    for part in relative_path.parts:
+        candidate = current / part
+        if candidate.is_symlink():
+            raise CompatibilityWorkspaceError(f"{label} must not contain a symlink: {candidate}")
+        try:
+            candidate.mkdir(mode=0o755, exist_ok=True)
+        except OSError as error:
+            raise CompatibilityWorkspaceError(f"cannot create {label}: {error}") from error
+        if candidate.is_symlink():
+            raise CompatibilityWorkspaceError(f"{label} must not contain a symlink: {candidate}")
+        current = _require_contained_directory(candidate, root=resolved_root, label=label)
+        try:
+            current.chmod(0o755)
+        except OSError as error:
+            raise CompatibilityWorkspaceError(
+                f"cannot set traversal permissions on {label}: {error}"
+            ) from error
+    return current
+
+
+@contextlib.contextmanager
+def _compatibility_run_workspace(root: Path):
+    """Yield one repository-visible run directory and the retained-failure directory."""
+    resolved_root = root.resolve(strict=True)
+    runs_dir = _ensure_workspace_directory(
+        resolved_root,
+        COMPAT_WORKSPACE / "runs",
+        label="compatibility run workspace",
+    )
+    failures_dir = _ensure_workspace_directory(
+        resolved_root,
+        COMPAT_WORKSPACE / "failures",
+        label="compatibility failure workspace",
+    )
+    try:
+        temporary_directory = tempfile.TemporaryDirectory(prefix="run-", dir=runs_dir)
+    except OSError as error:
+        message = f"cannot create compatibility run directory: {error}"
+        raise CompatibilityWorkspaceError(message) from error
+
+    with temporary_directory as temp_name:
+        run_dir = _require_contained_directory(
+            Path(temp_name),
+            root=resolved_root,
+            label="compatibility run directory",
+        )
+        try:
+            run_dir.chmod(0o755)
+        except OSError as error:
+            raise CompatibilityWorkspaceError(
+                f"cannot set traversal permissions on compatibility run directory: {error}"
+            ) from error
+        yield run_dir, failures_dir
+
+
+def _materialize_composed_source(content: bytes, *, workspace: Path, root: Path) -> Path:
+    """Write one closed, fsynced composed source in the invocation workspace."""
+    resolved_workspace = _require_contained_directory(
+        workspace,
+        root=root,
+        label="compatibility run directory",
+    )
+    file_descriptor = -1
+    temp_path: Path | None = None
+    materialized = False
+    try:
+        file_descriptor, temp_name = tempfile.mkstemp(
+            prefix="composed-",
+            suffix=".clp",
+            dir=resolved_workspace,
+        )
+        temp_path = Path(temp_name)
+        with os.fdopen(file_descriptor, "wb") as composed_file:
+            file_descriptor = -1
+            composed_file.write(content)
+            composed_file.flush()
+            os.fsync(composed_file.fileno())
+        _make_read_only(temp_path)
+        resolved_path = _require_contained_file(
+            temp_path,
+            root=root,
+            label="composed compatibility source",
+        )
+        if resolved_path.read_bytes() != content:
+            raise CompatibilityWorkspaceError(
+                f"composed compatibility source changed after write: {resolved_path}"
+            )
+        materialized = True
+        return resolved_path
+    except OSError as error:
+        raise CompatibilityWorkspaceError(
+            f"cannot materialize composed compatibility source: {error}"
+        ) from error
+    finally:
+        if file_descriptor >= 0:
+            os.close(file_descriptor)
+        if temp_path is not None and not materialized:
+            temp_path.unlink(missing_ok=True)
+
+
+def _verify_composed_source(
+    path: Path,
+    expected_content: bytes,
+    *,
+    root: Path,
+    boundary: str,
+) -> Path:
+    """Fail closed if a staged source changes across an engine boundary."""
+    resolved_path = _require_contained_file(
+        path,
+        root=root,
+        label="composed compatibility source",
+    )
+    try:
+        actual_content = resolved_path.read_bytes()
+    except OSError as error:
+        raise CompatibilityWorkspaceError(
+            f"cannot verify composed compatibility source {boundary}: {error}"
+        ) from error
+    if actual_content != expected_content:
+        raise CompatibilityWorkspaceError(
+            f"composed compatibility source changed {boundary}: {resolved_path}"
+        )
+    return resolved_path
+
+
+def _retain_failure_artifact(
+    content: bytes,
+    digest: str,
+    *,
+    failures_dir: Path,
+    root: Path,
+) -> Path:
+    """Atomically retain exact failed input bytes under their SHA-256 digest."""
+    resolved_failures_dir = _require_contained_directory(
+        failures_dir,
+        root=root,
+        label="compatibility failure workspace",
+    )
+    artifact_path = resolved_failures_dir / f"{digest}.clp"
+    if artifact_path.is_symlink():
+        raise CompatibilityWorkspaceError(
+            f"compatibility failure artifact must not be a symlink: {artifact_path}"
+        )
+
+    try:
+        if artifact_path.exists():
+            resolved_artifact = _require_contained_file(
+                artifact_path,
+                root=root,
+                label="compatibility failure artifact",
+            )
+            if resolved_artifact.read_bytes() != content:
+                raise CompatibilityWorkspaceError(
+                    f"compatibility failure artifact digest collision: {artifact_path}"
+                )
+            _make_read_only(resolved_artifact)
+            return resolved_artifact
+
+        atomic_write_bytes(artifact_path, content)
+        _make_read_only(artifact_path)
+        resolved_artifact = _require_contained_file(
+            artifact_path,
+            root=root,
+            label="compatibility failure artifact",
+        )
+        if sha256_bytes(resolved_artifact.read_bytes()) != digest:
+            raise CompatibilityWorkspaceError(
+                f"compatibility failure artifact changed after retention: {resolved_artifact}"
+            )
+        return resolved_artifact
+    except OSError as error:
+        raise CompatibilityWorkspaceError(
+            f"cannot retain compatibility failure artifact: {error}"
+        ) from error
 
 
 # ---------------------------------------------------------------------------
@@ -51,7 +291,7 @@ VALID_RUNABILITY = {"batch", "interactive", "library", "standalone", "unknown"}
 # ---------------------------------------------------------------------------
 
 
-def run_ferric(file_path: str, ferric_bin: str, timeout_secs: int) -> dict:
+def run_ferric(file_path: str, ferric_bin: str, root: str, timeout_secs: int) -> dict:
     """Run a .clp file through the ferric CLI."""
     start = time.monotonic()
     try:
@@ -60,6 +300,7 @@ def run_ferric(file_path: str, ferric_bin: str, timeout_secs: int) -> dict:
             capture_output=True,
             text=True,
             timeout=timeout_secs,
+            cwd=root,
         )
         duration_ms = int((time.monotonic() - start) * 1000)
         return {
@@ -90,10 +331,15 @@ def run_ferric(file_path: str, ferric_bin: str, timeout_secs: int) -> dict:
 
 def run_clips_docker(file_path: str, root: str, script: str, timeout_secs: int) -> dict:
     """Run a .clp file through the Docker CLIPS harness."""
+    resolved_path = _require_contained_file(
+        Path(file_path),
+        root=Path(root),
+        label="CLIPS input",
+    )
     start = time.monotonic()
     try:
         proc = subprocess.run(
-            [script, "run", "--file", file_path],
+            [script, "run", "--file", str(resolved_path)],
             capture_output=True,
             text=True,
             timeout=timeout_secs,
@@ -189,33 +435,123 @@ def classify_results(ferric_result: dict, clips_result: dict | None) -> tuple[st
 
 def process_file(args: tuple) -> tuple:
     """Process a single file through both engines."""
-    rel_path, abs_path, ferric, root, script, timeout, skip_clips, harness = args
+    (
+        rel_path,
+        abs_path,
+        ferric,
+        root,
+        script,
+        timeout,
+        skip_clips,
+        harness,
+        run_workspace,
+        failures_dir,
+    ) = args
 
     run_path = abs_path
-    tmp_path = None
+    composed_path: Path | None = None
+    composed_content: bytes | None = None
+    composed_digest: str | None = None
+    retained_artifact: Path | None = None
+    resolved_root = Path(root).resolve(strict=True)
     try:
         if harness is not None:
-            with tempfile.NamedTemporaryFile(suffix=".clp", delete=False, mode="wb") as tmp:
-                tmp.write(harness.source_bytes)
-                tmp.write(b"\n")
-                tmp.write(harness.harness_bytes)
-            tmp_path = tmp.name
-            run_path = tmp_path
+            if run_workspace is None or failures_dir is None:
+                raise CompatibilityWorkspaceError(
+                    f"{rel_path}: harness execution requires an invocation workspace"
+                )
+            composed_content = harness.source_bytes + b"\n" + harness.harness_bytes
+            composed_digest = sha256_bytes(composed_content)
+            composed_path = _materialize_composed_source(
+                composed_content,
+                workspace=Path(run_workspace),
+                root=resolved_root,
+            )
+            run_path = str(composed_path)
 
-        ferric_result = run_ferric(run_path, ferric, timeout)
+        if composed_path is not None and composed_content is not None:
+            _verify_composed_source(
+                composed_path,
+                composed_content,
+                root=resolved_root,
+                boundary="before Ferric execution",
+            )
+        ferric_result = run_ferric(run_path, ferric, root, timeout)
         if harness is not None:
             ferric_result["harness"] = dict(harness.metadata)
         clips_result = None
         if not skip_clips:
+            if composed_path is not None and composed_content is not None:
+                _verify_composed_source(
+                    composed_path,
+                    composed_content,
+                    root=resolved_root,
+                    boundary="before CLIPS execution",
+                )
             clips_result = run_clips_docker(run_path, root, script, timeout)
             if harness is not None:
                 clips_result["harness"] = dict(harness.metadata)
+        if composed_path is not None and composed_content is not None:
+            _verify_composed_source(
+                composed_path,
+                composed_content,
+                root=resolved_root,
+                boundary="after engine execution",
+            )
         classification, reason = classify_results(ferric_result, clips_result)
+
+        if composed_content is not None and composed_digest is not None:
+            composed_metadata: dict[str, str | int] = {
+                "sha256": composed_digest,
+                "size_bytes": len(composed_content),
+            }
+            if classification in FAILED_CLASSIFICATIONS:
+                retained_artifact = _retain_failure_artifact(
+                    composed_content,
+                    composed_digest,
+                    failures_dir=Path(failures_dir),
+                    root=resolved_root,
+                )
+                composed_metadata["artifact_path"] = retained_artifact.relative_to(
+                    resolved_root
+                ).as_posix()
+            ferric_result["composed_source"] = dict(composed_metadata)
+            if clips_result is not None:
+                clips_result["composed_source"] = dict(composed_metadata)
+
         return rel_path, ferric_result, clips_result, classification, reason
+    except BaseException as error:
+        if (
+            composed_content is not None
+            and composed_digest is not None
+            and failures_dir is not None
+            and retained_artifact is None
+        ):
+            try:
+                retained_artifact = _retain_failure_artifact(
+                    composed_content,
+                    composed_digest,
+                    failures_dir=Path(failures_dir),
+                    root=resolved_root,
+                )
+            except Exception as retention_error:
+                error.add_note(f"could not retain composed failure artifact: {retention_error}")
+            else:
+                artifact_relpath = retained_artifact.relative_to(resolved_root).as_posix()
+                error.add_note(f"composed failure artifact retained at {artifact_relpath}")
+        raise
     finally:
-        if tmp_path:
-            with contextlib.suppress(OSError):
-                os.unlink(tmp_path)
+        if composed_path is not None:
+            try:
+                composed_path.unlink(missing_ok=True)
+            except OSError as cleanup_error:
+                active_error = sys.exception()
+                message = (
+                    f"could not remove composed temporary source {composed_path}: {cleanup_error}"
+                )
+                if active_error is None:
+                    raise CompatibilityWorkspaceError(message) from cleanup_error
+                active_error.add_note(message)
 
 
 def _resolve_harness(
@@ -387,43 +723,46 @@ def main(
             print(f"  {rel_path}")
         raise typer.Exit(0)
 
-    work_items = [
-        (
-            rel,
-            abs_p,
-            ferric,
-            str(root),
-            script,
-            timeout,
-            skip_clips,
-            resolved_harnesses[rel],
-        )
-        for rel, abs_p in files_to_run
-    ]
-
     completed = 0
     results: dict[str, tuple] = {}
     start_time = time.monotonic()
 
-    for result_tuple in parallel_run(process_file, work_items, workers=workers):
-        try:
-            rel, ferric_result, clips_result, classification, reason = result_tuple
-            results[rel] = (ferric_result, clips_result, classification, reason)
-            completed += 1
-            status_char = {
-                "equivalent": ".",
-                "divergent": "D",
-                "incompatible": "X",
-                "pending": "?",
-            }.get(classification, "?")
-            sys.stdout.write(status_char)
-            if completed % 80 == 0:
-                sys.stdout.write(f" [{completed}/{len(files_to_run)}]\n")
-            sys.stdout.flush()
-        except Exception:
-            completed += 1
-            sys.stdout.write("E")
-            sys.stdout.flush()
+    with _compatibility_run_workspace(root) as (run_workspace, failures_dir):
+        work_items = [
+            (
+                rel,
+                abs_p,
+                ferric,
+                str(root),
+                script,
+                timeout,
+                skip_clips,
+                resolved_harnesses[rel],
+                str(run_workspace),
+                str(failures_dir),
+            )
+            for rel, abs_p in files_to_run
+        ]
+
+        for result_tuple in parallel_run(process_file, work_items, workers=workers):
+            try:
+                rel, ferric_result, clips_result, classification, reason = result_tuple
+                results[rel] = (ferric_result, clips_result, classification, reason)
+                completed += 1
+                status_char = {
+                    "equivalent": ".",
+                    "divergent": "D",
+                    "incompatible": "X",
+                    "pending": "?",
+                }.get(classification, "?")
+                sys.stdout.write(status_char)
+                if completed % 80 == 0:
+                    sys.stdout.write(f" [{completed}/{len(files_to_run)}]\n")
+                sys.stdout.flush()
+            except Exception:
+                completed += 1
+                sys.stdout.write("E")
+                sys.stdout.flush()
 
     elapsed = time.monotonic() - start_time
     print(f"\n\nCompleted {completed} files in {elapsed:.1f}s")
@@ -465,6 +804,9 @@ def main(
         print(f"\nDivergent files ({len(divergent)}):")
         for rel_path, (ferric_r, clips_r, _cls, reason) in divergent[:20]:
             print(f"  {rel_path} ({reason})")
+            artifact_path = (ferric_r.get("composed_source") or {}).get("artifact_path")
+            if artifact_path:
+                print(f"    composed artifact: {artifact_path}")
             if reason == "output-mismatch" and clips_r:
                 f_out = normalize_output(ferric_r["stdout"], "ferric")[:100]
                 c_out = normalize_output(clips_r["stdout"], "clips")[:100]

--- a/tools/ferric-tools/tests/test_compat_run.py
+++ b/tools/ferric-tools/tests/test_compat_run.py
@@ -1,0 +1,464 @@
+"""Tests for repository-visible composed compatibility execution."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from ferric_tools._harness import ResolvedHarness, sha256_bytes
+from ferric_tools._paths import repo_root
+from ferric_tools.compat import run as run_module
+
+
+def _resolved_harness(
+    root: Path,
+    *,
+    marker: bytes = b"one",
+    name: str = "library",
+) -> tuple[Path, ResolvedHarness]:
+    source = root / "tests" / "examples" / f"{name}.clp"
+    harness_path = root / "tests" / "harnesses" / f"{name}-harness.clp"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    harness_path.parent.mkdir(parents=True, exist_ok=True)
+    source_bytes = b"(deffacts sample (value " + marker + b"))\n"
+    harness_bytes = b'(defrule verify => (printout t "matched" crlf))\n'
+    source.write_bytes(source_bytes)
+    harness_path.write_bytes(harness_bytes)
+    harness = ResolvedHarness(
+        path=harness_path,
+        source_bytes=source_bytes,
+        harness_bytes=harness_bytes,
+        metadata={
+            "path": f"tests/harnesses/{name}-harness.clp",
+            "source_sha256": sha256_bytes(source_bytes),
+            "harness_sha256": sha256_bytes(harness_bytes),
+            "generation_version": 1,
+            "executable": True,
+        },
+    )
+    return source, harness
+
+
+def _engine_result(*, stdout: str = "matched\n", exit_code: int = 0) -> dict:
+    return {
+        "exit_code": exit_code,
+        "stdout": stdout,
+        "stderr": "",
+        "duration_ms": 1,
+        "timed_out": False,
+    }
+
+
+def _work_item(
+    *,
+    source: Path,
+    harness: ResolvedHarness,
+    root: Path,
+    run_workspace: Path,
+    failures_dir: Path,
+) -> tuple:
+    return (
+        "library.clp",
+        str(source),
+        "ferric",
+        str(root),
+        "clips-reference",
+        5,
+        False,
+        harness,
+        str(run_workspace),
+        str(failures_dir),
+    )
+
+
+def test_divergence_retains_content_addressed_artifact_and_cleans_temp(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    source, harness = _resolved_harness(root)
+    invocations: list[tuple[str, Path, bytes]] = []
+
+    def fake_ferric(path, _ferric, _root, _timeout):
+        candidate = Path(path)
+        invocations.append(("ferric", candidate, candidate.read_bytes()))
+        return _engine_result(stdout="ferric\n")
+
+    def fake_clips(path, _root, _script, _timeout):
+        candidate = Path(path)
+        invocations.append(("clips", candidate, candidate.read_bytes()))
+        return _engine_result(stdout="clips\n")
+
+    monkeypatch.setattr(run_module, "run_ferric", fake_ferric)
+    monkeypatch.setattr(run_module, "run_clips_docker", fake_clips)
+
+    with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
+        item = _work_item(
+            source=source,
+            harness=harness,
+            root=root,
+            run_workspace=run_workspace,
+            failures_dir=failures_dir,
+        )
+        first = run_module.process_file(item)
+        second = run_module.process_file(item)
+        assert list(run_workspace.iterdir()) == []
+
+    expected = harness.source_bytes + b"\n" + harness.harness_bytes
+    expected_digest = sha256_bytes(expected)
+    _, ferric_result, clips_result, classification, reason = first
+    assert classification == "divergent"
+    assert reason == "output-mismatch"
+    assert clips_result is not None
+    assert ferric_result["composed_source"] == clips_result["composed_source"]
+    assert ferric_result["composed_source"] == {
+        "sha256": expected_digest,
+        "size_bytes": len(expected),
+        "artifact_path": f".ferric-compat/failures/{expected_digest}.clp",
+    }
+    artifact = root / ferric_result["composed_source"]["artifact_path"]
+    assert artifact.read_bytes() == expected
+    assert sha256_bytes(artifact.read_bytes()) == expected_digest
+    if not run_module.IS_WINDOWS:
+        assert artifact.stat().st_mode & 0o222 == 0
+    assert second[1]["composed_source"] == ferric_result["composed_source"]
+    assert len(list(artifact.parent.glob("*.clp"))) == 1
+    assert [engine for engine, _, _ in invocations] == [
+        "ferric",
+        "clips",
+        "ferric",
+        "clips",
+    ]
+    assert all(content == expected for _, _, content in invocations)
+    assert all(not path.exists() for _, path, _ in invocations)
+
+
+def test_concurrent_unicode_workspace_uses_unique_files_without_crosstalk(tmp_path, monkeypatch):
+    root = tmp_path / "repo space Ω"
+    barrier = threading.Barrier(8)
+    lock = threading.Lock()
+    ferric_paths: list[Path] = []
+    engine_bytes: dict[Path, list[bytes]] = {}
+    cases = [
+        _resolved_harness(
+            root,
+            marker=str(index).encode(),
+            name=f"library-{index}",
+        )
+        for index in range(8)
+    ]
+    expected_contents = {
+        harness.source_bytes + b"\n" + harness.harness_bytes for _, harness in cases
+    }
+
+    def fake_ferric(path, _ferric, _root, _timeout):
+        candidate = Path(path)
+        assert candidate.exists()
+        if not run_module.IS_WINDOWS:
+            assert candidate.stat().st_mode & 0o222 == 0
+        assert all(
+            directory.stat().st_mode & 0o111 == 0o111
+            for directory in (
+                candidate.parent,
+                candidate.parent.parent,
+                candidate.parent.parent.parent,
+            )
+        )
+        content = candidate.read_bytes()
+        with lock:
+            ferric_paths.append(candidate)
+            engine_bytes.setdefault(candidate, []).append(content)
+        barrier.wait(timeout=10)
+        return _engine_result()
+
+    def fake_clips(path, _root, _script, _timeout):
+        candidate = Path(path)
+        assert candidate.exists()
+        content = candidate.read_bytes()
+        with lock:
+            engine_bytes.setdefault(candidate, []).append(content)
+        return _engine_result()
+
+    monkeypatch.setattr(run_module, "run_ferric", fake_ferric)
+    monkeypatch.setattr(run_module, "run_clips_docker", fake_clips)
+
+    with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
+        items = [
+            _work_item(
+                source=source,
+                harness=harness,
+                root=root,
+                run_workspace=run_workspace,
+                failures_dir=failures_dir,
+            )
+            for source, harness in cases
+        ]
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(executor.map(run_module.process_file, items))
+        assert list(run_workspace.iterdir()) == []
+        assert list(failures_dir.glob("*.clp")) == []
+
+    assert len(set(ferric_paths)) == 8
+    assert all(path.resolve().is_relative_to(root.resolve()) for path in ferric_paths)
+    assert all(not path.exists() for path in ferric_paths)
+    assert set(engine_bytes) == set(ferric_paths)
+    assert all(contents[0] == contents[1] for contents in engine_bytes.values())
+    assert {contents[0] for contents in engine_bytes.values()} == expected_contents
+    assert all(result[3:] == ("equivalent", "exact-match") for result in results)
+
+
+def test_concurrent_workspace_creation_is_race_free_and_traversable(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    barrier = threading.Barrier(16)
+
+    def open_workspace(_index):
+        with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
+            assert run_workspace.stat().st_mode & 0o111 == 0o111
+            assert failures_dir.stat().st_mode & 0o111 == 0o111
+            barrier.wait(timeout=10)
+            return run_workspace
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        run_workspaces = list(executor.map(open_workspace, range(16)))
+
+    assert len(set(run_workspaces)) == 16
+    assert all(not workspace.exists() for workspace in run_workspaces)
+    assert all(
+        directory.stat().st_mode & 0o111 == 0o111
+        for directory in (
+            root / ".ferric-compat",
+            root / ".ferric-compat" / "runs",
+            root / ".ferric-compat" / "failures",
+        )
+    )
+
+
+def test_workspace_rejects_symlink_escape_before_creating_external_files(tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (root / ".ferric-compat").symlink_to(outside, target_is_directory=True)
+
+    with (
+        pytest.raises(
+            run_module.CompatibilityWorkspaceError,
+            match="compatibility run workspace must not contain a symlink",
+        ),
+        run_module._compatibility_run_workspace(root),
+    ):
+        pytest.fail("escaped workspace should not be yielded")
+
+    assert list(outside.iterdir()) == []
+
+
+def test_keyboard_interrupt_retains_artifact_and_cleans_run_workspace(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    source, harness = _resolved_harness(root)
+    invocation_path: Path | None = None
+    run_workspace_path: Path | None = None
+
+    def interrupting_ferric(path, _ferric, _root, _timeout):
+        nonlocal invocation_path
+        invocation_path = Path(path)
+        raise KeyboardInterrupt("injected interrupt")
+
+    monkeypatch.setattr(run_module, "run_ferric", interrupting_ferric)
+
+    with (
+        pytest.raises(KeyboardInterrupt, match="injected interrupt") as caught,
+        run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir),
+    ):
+        run_workspace_path = run_workspace
+        run_module.process_file(
+            _work_item(
+                source=source,
+                harness=harness,
+                root=root,
+                run_workspace=run_workspace,
+                failures_dir=failures_dir,
+            )
+        )
+
+    expected = harness.source_bytes + b"\n" + harness.harness_bytes
+    digest = sha256_bytes(expected)
+    artifact = root / ".ferric-compat" / "failures" / f"{digest}.clp"
+    assert artifact.read_bytes() == expected
+    assert any("composed failure artifact retained" in note for note in caught.value.__notes__)
+    assert invocation_path is not None
+    assert not invocation_path.exists()
+    assert run_workspace_path is not None
+    assert not run_workspace_path.exists()
+
+
+def test_mutated_composed_source_fails_closed_before_clips(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    source, harness = _resolved_harness(root)
+    invocation_path: Path | None = None
+
+    def mutating_ferric(path, _ferric, _root, _timeout):
+        nonlocal invocation_path
+        invocation_path = Path(path)
+        invocation_path.chmod(0o644)
+        invocation_path.write_bytes(b"tampered\n")
+        return _engine_result()
+
+    def unexpected_clips(*_args, **_kwargs):
+        pytest.fail("CLIPS must not run after the composed source changes")
+
+    monkeypatch.setattr(run_module, "run_ferric", mutating_ferric)
+    monkeypatch.setattr(run_module, "run_clips_docker", unexpected_clips)
+
+    with (
+        pytest.raises(
+            run_module.CompatibilityWorkspaceError,
+            match="changed before CLIPS execution",
+        ),
+        run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir),
+    ):
+        run_module.process_file(
+            _work_item(
+                source=source,
+                harness=harness,
+                root=root,
+                run_workspace=run_workspace,
+                failures_dir=failures_dir,
+            )
+        )
+
+    expected = harness.source_bytes + b"\n" + harness.harness_bytes
+    digest = sha256_bytes(expected)
+    artifact = root / ".ferric-compat" / "failures" / f"{digest}.clp"
+    assert artifact.read_bytes() == expected
+    if not run_module.IS_WINDOWS:
+        assert artifact.stat().st_mode & 0o222 == 0
+    assert invocation_path is not None
+    assert not invocation_path.exists()
+
+
+def test_windows_mode_keeps_composed_file_writable_for_cleanup(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    source, harness = _resolved_harness(root)
+    invocation_paths: list[Path] = []
+
+    def fake_ferric(path, _ferric, _root, _timeout):
+        candidate = Path(path)
+        invocation_paths.append(candidate)
+        assert candidate.stat().st_mode & 0o200
+        return _engine_result()
+
+    def fake_clips(path, _root, _script, _timeout):
+        candidate = Path(path)
+        invocation_paths.append(candidate)
+        assert candidate.stat().st_mode & 0o200
+        return _engine_result()
+
+    monkeypatch.setattr(run_module, "IS_WINDOWS", True)
+    monkeypatch.setattr(run_module, "run_ferric", fake_ferric)
+    monkeypatch.setattr(run_module, "run_clips_docker", fake_clips)
+
+    with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
+        result = run_module.process_file(
+            _work_item(
+                source=source,
+                harness=harness,
+                root=root,
+                run_workspace=run_workspace,
+                failures_dir=failures_dir,
+            )
+        )
+        assert list(run_workspace.iterdir()) == []
+
+    assert result[3:] == ("equivalent", "exact-match")
+    assert len(invocation_paths) == 2
+    assert invocation_paths[0] == invocation_paths[1]
+    assert not invocation_paths[0].exists()
+
+
+def test_run_clips_docker_rejects_leaf_symlink_escape_before_subprocess(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    root.mkdir()
+    outside = tmp_path / "outside.clp"
+    outside.write_text("(reset)\n", encoding="utf-8")
+    escaped = root / "escaped.clp"
+    escaped.symlink_to(outside)
+
+    def unexpected_run(*_args, **_kwargs):
+        pytest.fail("Docker subprocess must not run for an escaped symlink")
+
+    monkeypatch.setattr(run_module.subprocess, "run", unexpected_run)
+
+    with pytest.raises(
+        run_module.CompatibilityWorkspaceError,
+        match="CLIPS input must not be a symlink",
+    ):
+        run_module.run_clips_docker(str(escaped), str(root), "clips-reference", 5)
+
+
+def test_clips_reference_script_preserves_unicode_quotes_and_rejects_symlink(
+    tmp_path,
+):
+    synthetic_repo = tmp_path / "repo space Ω"
+    synthetic_repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=synthetic_repo, check=True)
+    fixture = synthetic_repo / "fixtures" / 'rules space Ω "quoted".clp'
+    fixture.parent.mkdir()
+    fixture.write_text("(reset)\n", encoding="utf-8")
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_docker = fake_bin / "docker"
+    fake_docker.write_text(
+        '#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "$CAPTURE_ARGS"\ncat > "$CAPTURE_STDIN"\n',
+        encoding="utf-8",
+    )
+    fake_docker.chmod(0o755)
+    captured_args = tmp_path / "docker-args"
+    captured_stdin = tmp_path / "docker-stdin"
+    env = {
+        **os.environ,
+        "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+        "CAPTURE_ARGS": str(captured_args),
+        "CAPTURE_STDIN": str(captured_stdin),
+    }
+    script = repo_root() / "scripts" / "clips-reference.sh"
+
+    result = subprocess.run(
+        [str(script), "run", "--file", str(fixture)],
+        cwd=synthetic_repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        captured_stdin.read_text(encoding="utf-8")
+        == '(batch* "/workspace/fixtures/rules space Ω \\"quoted\\".clp")\n'
+        "(reset)\n(run)\n(exit)\n"
+    )
+    mount = f"{synthetic_repo.resolve()}:/workspace:ro"
+    assert mount in captured_args.read_text(encoding="utf-8").splitlines()
+
+    outside = tmp_path / "outside.clp"
+    outside.write_text("(reset)\n", encoding="utf-8")
+    escaped = synthetic_repo / "fixtures" / "escaped.clp"
+    escaped.symlink_to(outside)
+    captured_args.unlink()
+    captured_stdin.unlink()
+
+    escaped_result = subprocess.run(
+        [str(script), "run", "--file", str(escaped)],
+        cwd=synthetic_repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert escaped_result.returncode == 1
+    assert "file path must not be a symlink" in escaped_result.stderr
+    assert not captured_args.exists()
+    assert not captured_stdin.exists()

--- a/tools/ferric-tools/tests/test_compat_scan.py
+++ b/tools/ferric-tools/tests/test_compat_scan.py
@@ -652,7 +652,7 @@ def test_process_file_records_harness_executed_by_both_engines(tmp_path, monkeyp
     assert resolved is not None
     invocations: list[tuple[str, str, bytes]] = []
 
-    def fake_ferric(path, _ferric, _timeout):
+    def fake_ferric(path, _ferric, _root, _timeout):
         invocations.append(("ferric", path, Path(path).read_bytes()))
         return {
             "exit_code": 0,
@@ -675,18 +675,21 @@ def test_process_file_records_harness_executed_by_both_engines(tmp_path, monkeyp
     monkeypatch.setattr(run_module, "run_ferric", fake_ferric)
     monkeypatch.setattr(run_module, "run_clips_docker", fake_clips)
 
-    result = run_module.process_file(
-        (
-            "libraries/facts.clp",
-            str(source),
-            "ferric",
-            str(root),
-            "clips-reference",
-            5,
-            False,
-            resolved,
+    with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
+        result = run_module.process_file(
+            (
+                "libraries/facts.clp",
+                str(source),
+                "ferric",
+                str(root),
+                "clips-reference",
+                5,
+                False,
+                resolved,
+                str(run_workspace),
+                str(failures_dir),
+            )
         )
-    )
 
     _, ferric_result, clips_result, classification, reason = result
     assert [engine for engine, _, _ in invocations] == ["ferric", "clips"]
@@ -696,5 +699,79 @@ def test_process_file_records_harness_executed_by_both_engines(tmp_path, monkeyp
     assert ferric_result["harness"] == resolved.metadata
     assert clips_result is not None
     assert clips_result["harness"] == resolved.metadata
+    assert ferric_result["composed_source"] == clips_result["composed_source"]
+    assert ferric_result["composed_source"] == {
+        "sha256": sha256_bytes(invocations[0][2]),
+        "size_bytes": len(invocations[0][2]),
+    }
     assert classification == "equivalent"
     assert reason == "exact-match"
+
+
+def test_process_file_composes_harness_inside_clips_mounted_root(tmp_path, monkeypatch):
+    root, source, entry, _plan = _materialized_library_harness(tmp_path)
+    resolved = resolve_harness_contract(
+        entry,
+        source_path=source,
+        root=root,
+        manifest_key="libraries/facts.clp",
+    )
+    assert resolved is not None
+
+    system_temp = tmp_path / "system-temp"
+    system_temp.mkdir()
+    monkeypatch.setattr(run_module.tempfile, "tempdir", str(system_temp))
+
+    invocations: list[tuple[str, Path, bytes]] = []
+
+    def engine_result() -> dict:
+        return {
+            "exit_code": 0,
+            "stdout": "matched\n",
+            "stderr": "",
+            "duration_ms": 1,
+            "timed_out": False,
+        }
+
+    def fake_ferric(path, _ferric, _root, _timeout):
+        candidate = Path(path)
+        invocations.append(("ferric", candidate, candidate.read_bytes()))
+        return engine_result()
+
+    def fake_clips(path, mounted_root, _script, _timeout):
+        candidate = Path(path)
+        invocations.append(("clips", candidate, candidate.read_bytes()))
+        if not candidate.resolve().is_relative_to(Path(mounted_root).resolve()):
+            result = engine_result()
+            result["exit_code"] = 1
+            result["stderr"] = "path is outside the mounted repository"
+            return result
+        return engine_result()
+
+    monkeypatch.setattr(run_module, "run_ferric", fake_ferric)
+    monkeypatch.setattr(run_module, "run_clips_docker", fake_clips)
+
+    with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
+        result = run_module.process_file(
+            (
+                "libraries/facts.clp",
+                str(source),
+                "ferric",
+                str(root),
+                "clips-reference",
+                5,
+                False,
+                resolved,
+                str(run_workspace),
+                str(failures_dir),
+            )
+        )
+
+    _, _ferric_result, _clips_result, classification, reason = result
+    assert classification == "equivalent"
+    assert reason == "exact-match"
+    assert [engine for engine, _, _ in invocations] == ["ferric", "clips"]
+    assert invocations[0][1] == invocations[1][1]
+    assert invocations[0][2] == invocations[1][2]
+    assert invocations[0][1].resolve().is_relative_to(root.resolve())
+    assert not invocations[0][1].exists()


### PR DESCRIPTION
Closes #89

## Scope

FR-COMPAT-002 composes each resolved source and generated harness exactly once inside a unique repo-contained `.ferric-compat/runs` workspace, so Ferric and Docker CLIPS execute the same validated source instead of handing CLIPS an inaccessible system-temp path.

- Give both engines the same staged bytes and SHA-256 provenance, with validation before, between, and after engine execution.
- Physically validate repository containment, reject symlink escapes, and preserve spaces, Unicode, and quotes through the shell/container boundary.
- Retain failed compositions by content digest under `.ferric-compat/failures` while cleaning all transient run files, including interrupted runs.
- Add concurrency, clean-start race, mutation, symlink, cleanup, interruption, shell-boundary, and simulated-Windows regressions.

## Stack

- Immediate predecessor: none
- Earlier included PRs: none
- Required merge order: https://github.com/plx/ferric-rules/pull/241 only
- Tests require predecessor code: no
- Branch point: `f91a4f2bf76bfd54f727c4b05fd262f6bdabea21`

## Red-before-fix evidence

From `tools/ferric-tools`:

```text
uv run pytest tests/test_compat_scan.py::test_process_file_composes_harness_inside_clips_mounted_root -q
```

Pre-fix result: `1 failed`. The composed file was created in the system temporary directory outside the repository mounted into CLIPS, so the fake CLIPS boundary returned an inaccessible path and the classification was `divergent` instead of the expected `equivalent`.

## Validation

- `just preflight-pr` — passed on the committed diff.
- `cd tools/ferric-tools && uv run pytest -v` — 202 passed.
- Focused compatibility tests — 39 passed.
- `bash -n scripts/clips-reference.sh` and `git diff --check` — passed.
- `just clips-build --load` — passed (safe local equivalent; the ticket's `just clips-ref-build` recipe does not exist, while bare `just clips-build` publishes via buildx).
- `just compat-scan` — 1,206 total: 658 pending, 548 incompatible.
- `just harness-gen` — 219 libraries: 182 generated, 21 extension skips, 16 empty skips.
- `just compat-run` — passed across 621 files: 78 equivalent, 115 divergent, 428 incompatible.
- Post-run audit — all 182 executable library fixtures had identical expected SHA/size metadata for Ferric and CLIPS; 178 retained failure artifacts matched their digest; no legacy outside-repository path rejections; transient run workspace empty.
- Known real fixture smoke (`ff-config.clp`) — both engines exited 0 over the same 1,188-byte composition and digest. Its output mismatch remains in the verifier/module scope below.
- Literal root command `uv run --project tools/ferric-tools pytest -v` mis-scopes pytest to the repository and fails collection because the Python extension is not installed there; the package-scoped equivalent above passes all 202 tooling tests.
- Hosted checks — 21/21 passed. The release-profile assessment reported zero compatibility regressions across 1,206 files and zero benchmark regressions above its 5% threshold across 135 Criterion benchmarks.

## Acceptance criteria

- Byte-identical source/digest: both results carry the same `composed_source` SHA-256 and size, and mandatory byte checks guard every engine boundary.
- Container-visible and contained paths: staging is repo-local; Python and the shell driver use physical-path containment and reject directory and leaf symlinks.
- Collision-free concurrency: per-command directories and per-worker files are unique; concurrent clean-start and distinct-payload regressions cover races and cross-talk.
- Reproducible failures without temp leaks: failed/incompatible/interrupted compositions are retained content-addressably, successful and failed transient run paths are removed, and mutation is detected before CLIPS can consume changed bytes.

## Residual risks

Verifier/module normalization remains tracked by #90, oracle/vacuity safeguards by #91, CI wiring by #92, diagnostic classification by #119, and scanner parsing by #120. This PR makes no performance improvement claim.