### PR TITLE
[FR-COMPAT-004] Reject vacuous compatibility results with structured oracles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +277,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +368,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,6 +385,16 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -446,7 +484,9 @@ dependencies = [
  "ferric-runtime",
  "proptest",
  "rustyline",
+ "serde",
  "serde_json",
+ "sha2",
  "slotmap",
  "tempfile",
  "tracing",
@@ -558,6 +598,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -1367,6 +1417,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1643,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ cbindgen = "0.29"
 serde = { version = "1", features = ["derive", "rc"] }
 bincode = "1"
 serde_json = "1"
+sha2 = "0.10"
 ciborium = "0.2"
 rmp-serde = "1"
 postcard = { version = "1", features = ["alloc"] }

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -16,7 +16,7 @@ acceptable license is selected for notice generation.
 
 ## License Overview
 
-- MIT License: 211
+- MIT License: 218
 - Apache License 2.0: 4
 - Boost Software License 1.0: 2
 - ISC License: 1
@@ -536,6 +536,43 @@ AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR 
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
 NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
+
+```
+
+## MIT License (`MIT`)
+
+Used by:
+
+- sha2 0.10.9 (`MIT OR Apache-2.0`) - https://github.com/RustCrypto/hashes
+
+```text
+Copyright (c) 2006-2009 Graydon Hoare
+Copyright (c) 2009-2013 Mozilla Foundation
+Copyright (c) 2016 Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
 
 ```
 
@@ -1217,6 +1254,41 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
+- digest 0.10.7 (`MIT OR Apache-2.0`) - https://github.com/RustCrypto/traits
+
+```text
+Copyright (c) 2017 Artyom Pavlov
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+
+## MIT License (`MIT`)
+
+Used by:
+
 - fnv 1.0.7 (`Apache-2.0  OR  MIT`) - https://github.com/servo/rust-fnv
 
 ```text
@@ -1423,6 +1495,41 @@ Used by:
 
 ```text
 Copyright (c) 2018 The Servo Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+
+## MIT License (`MIT`)
+
+Used by:
+
+- block-buffer 0.10.4 (`MIT OR Apache-2.0`) - https://github.com/RustCrypto/utils
+
+```text
+Copyright (c) 2018-2019 The RustCrypto Project Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -1766,6 +1873,76 @@ Used by:
 
 ```text
 Copyright (c) 2020 Dario Nieuwenhuis
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+
+## MIT License (`MIT`)
+
+Used by:
+
+- cpufeatures 0.2.17 (`MIT OR Apache-2.0`) - https://github.com/RustCrypto/utils
+
+```text
+Copyright (c) 2020-2025 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+
+## MIT License (`MIT`)
+
+Used by:
+
+- crypto-common 0.1.7 (`MIT OR Apache-2.0`) - https://github.com/RustCrypto/traits
+
+```text
+Copyright (c) 2021 RustCrypto Developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -2439,6 +2616,37 @@ SOFTWARE.
 
 Used by:
 
+- typenum 1.20.1 (`MIT OR Apache-2.0`) - https://github.com/paholg/typenum
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2014 Paho Lurie-Gregg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+
+## MIT License (`MIT`)
+
+Used by:
+
 - endian-type 0.1.2 (`MIT`) - https://github.com/Lolirofle/endian-type.git
 
 ```text
@@ -2883,6 +3091,36 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+```
+
+## MIT License (`MIT`)
+
+Used by:
+
+- generic-array 0.14.7 (`MIT`) - https://github.com/fizyk20/generic-array.git
+
+```text
+The MIT License (MIT)
+
+Copyright (c) 2015 Bartłomiej Kamiński
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 ```
 
 ## Mozilla Public License 2.0 (`MPL-2.0`)

--- a/crates/ferric-cli/Cargo.toml
+++ b/crates/ferric-cli/Cargo.toml
@@ -17,6 +17,9 @@ ferric-core = { workspace = true }
 ferric-parser = { workspace = true }
 ferric-runtime = { workspace = true }
 rustyline = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
 slotmap = { workspace = true }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
@@ -29,7 +32,6 @@ serde = ["ferric-runtime/serde"]
 
 [dev-dependencies]
 proptest = { workspace = true }
-serde_json = "1"
 tempfile = "3.8"
 
 [lints]

--- a/crates/ferric-cli/src/commands/compat_observe.rs
+++ b/crates/ferric-cli/src/commands/compat_observe.rs
@@ -1,0 +1,720 @@
+//! Dedicated structured observation surface for compatibility tooling.
+//!
+//! This command deliberately does not share the human-oriented output contract
+//! of `ferric run`. It captures the engine's known router channels and emits one
+//! versioned JSON document on process stdout.
+//!
+//! The public runtime APIs do not currently expose the owning module for a fact,
+//! an enumeration of router channels or globals, or the names of rules fired by
+//! `Engine::run`. Version 1 reports the sole registered module when ownership is
+//! unambiguous and otherwise reports fact modules as `null`; the other limits
+//! are advertised in `capabilities`.
+
+use std::fmt::Write as _;
+use std::io::Write as _;
+use std::path::Path;
+
+use ferric_core::{Fact, Value};
+use ferric_runtime::{
+    ActionError, Engine, EngineConfig, HaltReason, LoadError, RunLimit, RunResult,
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use slotmap::Key as _;
+
+const SCHEMA_NAME: &str = "ferric.compat-observation";
+const SCHEMA_VERSION: u8 = 1;
+const MAX_FIXTURE_ID_BYTES: usize = 128;
+const MIN_NONCE_HEX_BYTES: usize = 32;
+const MAX_NONCE_HEX_BYTES: usize = 128;
+const KNOWN_CHANNELS: &[&str] = &[
+    "t", "stdin", "stdout", "stderr", "wclips", "wdialog", "wdisplay", "werror", "wtrace",
+    "wwarning",
+];
+
+/// Validate a fixture identifier at the CLI boundary.
+pub(crate) fn parse_fixture_id(value: &str) -> Result<String, String> {
+    if value.is_empty() || value.len() > MAX_FIXTURE_ID_BYTES {
+        return Err(format!(
+            "fixture id must be a protocol-safe token of 1 to {MAX_FIXTURE_ID_BYTES} ASCII bytes"
+        ));
+    }
+    let mut bytes = value.bytes();
+    let valid = bytes
+        .next()
+        .is_some_and(|byte| byte.is_ascii_alphanumeric())
+        && bytes.all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':' | b'/')
+        });
+    if !valid {
+        return Err(
+            "fixture id must start with an ASCII letter or digit and contain only ASCII letters, \
+             digits, hyphen, underscore, dot, colon, and slash"
+                .to_string(),
+        );
+    }
+    Ok(value.to_string())
+}
+
+/// Validate a nonce at the CLI boundary.
+pub(crate) fn parse_nonce(value: &str) -> Result<String, String> {
+    if !(MIN_NONCE_HEX_BYTES..=MAX_NONCE_HEX_BYTES).contains(&value.len())
+        || value.len() % 2 != 0
+        || !value
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+    {
+        return Err("nonce must encode 16 to 64 bytes as lowercase hexadecimal".to_string());
+    }
+    Ok(value.to_string())
+}
+
+/// Validate canonical lowercase SHA-256 text at the CLI boundary.
+pub(crate) fn parse_sha256(value: &str) -> Result<String, String> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'))
+    {
+        return Err("digest must be exactly 64 lowercase hexadecimal characters".to_string());
+    }
+    Ok(value.to_string())
+}
+
+/// Execute the hidden `compat-observe` subcommand.
+pub fn execute(
+    file_path: &Path,
+    fixture_id: String,
+    nonce: String,
+    source_sha256: String,
+    composed_sha256: String,
+) -> i32 {
+    let fixture = FixtureIdentity {
+        id: fixture_id,
+        nonce,
+        source_sha256,
+        composed_sha256,
+    };
+    let mut observation = Observation::started(fixture);
+    let mut engine = Engine::new(EngineConfig::default());
+
+    observation.phase_reached = Phase::Load;
+    let source_bytes = match std::fs::read(file_path) {
+        Ok(source) => source,
+        Err(error) => {
+            observation.diagnostics.push(Diagnostic::error(
+                Phase::Load,
+                "io-error",
+                format!("failed to read {}: {error}", file_path.display()),
+            ));
+            return emit_failed_observation(observation, &engine);
+        }
+    };
+
+    let actual_composed_sha256 = lowercase_sha256(&source_bytes);
+    if actual_composed_sha256 != observation.fixture.composed_sha256 {
+        observation.diagnostics.push(Diagnostic::error(
+            Phase::Load,
+            "digest-mismatch",
+            format!(
+                "composed input digest mismatch: expected {}, observed {actual_composed_sha256}",
+                observation.fixture.composed_sha256
+            ),
+        ));
+        return emit_failed_observation(observation, &engine);
+    }
+
+    let source = match std::str::from_utf8(&source_bytes) {
+        Ok(source) => source,
+        Err(error) => {
+            observation.diagnostics.push(Diagnostic::error(
+                Phase::Load,
+                "encoding-error",
+                format!("composed input is not valid UTF-8: {error}"),
+            ));
+            return emit_failed_observation(observation, &engine);
+        }
+    };
+
+    let load_result = match engine.load_str(source) {
+        Ok(result) => result,
+        Err(errors) => {
+            observation
+                .diagnostics
+                .extend(errors.iter().map(load_error_diagnostic));
+            return emit_failed_observation(observation, &engine);
+        }
+    };
+    observation.diagnostics.extend(
+        load_result
+            .warnings
+            .into_iter()
+            .map(|message| Diagnostic::warning(Phase::Load, "load-warning", message)),
+    );
+
+    observation.phase_reached = Phase::Reset;
+    if let Err(error) = engine.reset() {
+        observation.diagnostics.push(Diagnostic::error(
+            Phase::Reset,
+            "runtime-error",
+            format!("reset failed: {error}"),
+        ));
+        return emit_failed_observation(observation, &engine);
+    }
+
+    observation.phase_reached = Phase::Run;
+    let run_result = match engine.run(RunLimit::Unlimited) {
+        Ok(result) => result,
+        Err(error) => {
+            observation.diagnostics.push(Diagnostic::error(
+                Phase::Run,
+                "runtime-error",
+                format!("execution failed: {error}"),
+            ));
+            return emit_failed_observation(observation, &engine);
+        }
+    };
+
+    observation.phase_reached = Phase::PostRun;
+    match capture_state(&engine, Some(run_result)) {
+        Ok(state) => {
+            observation.apply_capture(state);
+            // COMPLETE is deliberately created only after all post-run state has
+            // been converted into owned observation data.
+            observation
+                .lifecycle
+                .push(LifecycleRecord::complete(&observation.fixture));
+            emit_observation(&observation, 0)
+        }
+        Err(error) => {
+            observation
+                .diagnostics
+                .push(Diagnostic::error(Phase::PostRun, "capture-error", error));
+            emit_observation(&observation, 1)
+        }
+    }
+}
+
+fn emit_failed_observation(mut observation: Observation, engine: &Engine) -> i32 {
+    match capture_state(engine, None) {
+        Ok(state) => observation.apply_capture(state),
+        Err(error) => observation.diagnostics.push(Diagnostic::error(
+            observation.phase_reached,
+            "capture-error",
+            error,
+        )),
+    }
+    emit_observation(&observation, 1)
+}
+
+fn emit_observation(observation: &Observation, intended_exit_code: i32) -> i32 {
+    let json = match serde_json::to_string(observation) {
+        Ok(json) => json,
+        Err(error) => {
+            eprintln!("ferric compat-observe: failed to serialize observation: {error}");
+            return 1;
+        }
+    };
+    let mut encoded = json.into_bytes();
+    encoded.push(b'\n');
+    if let Err(error) = std::io::stdout().lock().write_all(&encoded) {
+        eprintln!("ferric compat-observe: failed to write observation: {error}");
+        return 1;
+    }
+    intended_exit_code
+}
+
+fn lowercase_sha256(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut encoded = String::with_capacity(64);
+    for byte in digest {
+        write!(encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
+}
+
+fn capture_state(engine: &Engine, run_result: Option<RunResult>) -> Result<CapturedState, String> {
+    let module_names = engine.modules();
+    let fact_module = (module_names.len() == 1).then(|| module_names[0].to_string());
+    let facts = engine
+        .facts()
+        .map_err(|error| format!("failed to enumerate facts: {error}"))?
+        .enumerate()
+        .map(|(ordinal, (fact_id, fact))| {
+            observe_fact(
+                engine,
+                ordinal,
+                fact_id.data().as_ffi().to_string(),
+                fact_module.as_deref(),
+                fact,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let channels = KNOWN_CHANNELS
+        .iter()
+        .map(|name| {
+            let output = engine.get_output(name);
+            ChannelObservation {
+                name: (*name).to_string(),
+                present: output.is_some(),
+                text: output.unwrap_or_default().to_string(),
+            }
+        })
+        .collect();
+
+    let action_diagnostics = engine
+        .action_diagnostics()
+        .iter()
+        .map(action_error_diagnostic)
+        .collect();
+
+    let run = run_result.map(|result| RunObservation {
+        rules_fired: result.rules_fired,
+        fired_rule_names: None,
+        halt_reason: match result.halt_reason {
+            HaltReason::AgendaEmpty => HaltReasonObservation::AgendaEmpty,
+            HaltReason::LimitReached => HaltReasonObservation::LimitReached,
+            HaltReason::HaltRequested => HaltReasonObservation::HaltRequested,
+        },
+        agenda_size: engine.agenda_len(),
+        halted: engine.is_halted(),
+    });
+
+    Ok(CapturedState {
+        run,
+        facts,
+        fact_modules: fact_module.is_some(),
+        channels,
+        action_diagnostics,
+        modules: ModuleObservation {
+            current: engine.current_module().to_string(),
+            focus: engine.get_focus().map(str::to_string),
+            focus_stack: engine
+                .get_focus_stack()
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
+        },
+    })
+}
+
+fn observe_fact(
+    engine: &Engine,
+    ordinal: usize,
+    fact_id: String,
+    module: Option<&str>,
+    fact: &Fact,
+) -> Result<FactObservation, String> {
+    match fact {
+        Fact::Ordered(ordered) => {
+            let relation = engine.resolve_symbol(ordered.relation).ok_or_else(|| {
+                format!("ordered fact {fact_id} has an unresolved relation symbol")
+            })?;
+            let fields = ordered
+                .fields
+                .iter()
+                .map(|value| observe_value(engine, value))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(FactObservation::Ordered {
+                ordinal,
+                fact_id,
+                module: module.map(str::to_string),
+                relation: relation.to_string(),
+                fields,
+            })
+        }
+        Fact::Template(template) => {
+            let name = engine
+                .template_name_by_id(template.template_id)
+                .ok_or_else(|| format!("template fact {fact_id} has an unknown template id"))?;
+            let slot_names = engine
+                .template_slot_names_by_id(template.template_id)
+                .ok_or_else(|| format!("template fact {fact_id} has no public slot metadata"))?;
+            if slot_names.len() != template.slots.len() {
+                return Err(format!(
+                    "template fact {fact_id} has {} values but {} public slot names",
+                    template.slots.len(),
+                    slot_names.len()
+                ));
+            }
+            let slots = slot_names
+                .into_iter()
+                .zip(template.slots.iter())
+                .map(|(slot_name, value)| {
+                    Ok(SlotObservation {
+                        name: slot_name.to_string(),
+                        value: observe_value(engine, value)?,
+                    })
+                })
+                .collect::<Result<Vec<_>, String>>()?;
+            Ok(FactObservation::Template {
+                ordinal,
+                fact_id,
+                module: module.map(str::to_string),
+                name: name.to_string(),
+                slots,
+            })
+        }
+    }
+}
+
+fn observe_value(engine: &Engine, value: &Value) -> Result<ValueObservation, String> {
+    match value {
+        Value::Symbol(symbol) => {
+            let value = engine
+                .resolve_symbol(*symbol)
+                .ok_or_else(|| "fact value has an unresolved symbol".to_string())?;
+            Ok(ValueObservation::Symbol {
+                value: value.to_string(),
+            })
+        }
+        Value::String(value) => Ok(ValueObservation::String {
+            value: value.as_str().to_string(),
+        }),
+        Value::Integer(value) => Ok(ValueObservation::Integer {
+            value: value.to_string(),
+        }),
+        Value::Float(value) => Ok(ValueObservation::Float {
+            value: canonical_float(*value),
+            bits: format!("0x{:016x}", value.to_bits()),
+        }),
+        Value::Multifield(values) => Ok(ValueObservation::Multifield {
+            values: values
+                .iter()
+                .map(|value| observe_value(engine, value))
+                .collect::<Result<Vec<_>, _>>()?,
+        }),
+        Value::ExternalAddress(address) => Ok(ValueObservation::ExternalAddress {
+            external_type_id: address.type_id.0,
+            opaque: true,
+        }),
+        Value::Void => Ok(ValueObservation::Void),
+    }
+}
+
+fn canonical_float(value: f64) -> String {
+    if value.is_nan() {
+        "NaN".to_string()
+    } else if value == f64::INFINITY {
+        "Infinity".to_string()
+    } else if value == f64::NEG_INFINITY {
+        "-Infinity".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn load_error_diagnostic(error: &LoadError) -> Diagnostic {
+    let category = match error {
+        LoadError::Parse(_) => "parse-error",
+        LoadError::Interpret(_) => "interpret-error",
+        LoadError::UnsupportedForm { .. } => "unsupported-form",
+        LoadError::InvalidAssert(_) => "invalid-assert",
+        LoadError::InvalidDefrule(_) => "invalid-defrule",
+        LoadError::Compile(_) => "compile-error",
+        LoadError::Validation(_) => "validation-error",
+        LoadError::Engine(_) => "engine-error",
+        LoadError::Io(_) => "io-error",
+    };
+    Diagnostic::error(Phase::Load, category, error.to_string())
+}
+
+fn action_error_diagnostic(error: &ActionError) -> Diagnostic {
+    let category = match error {
+        ActionError::UnknownAction(_) => "unknown-action",
+        ActionError::UnboundVariable(_) => "unbound-variable",
+        ActionError::FactNotFound(_) => "fact-not-found",
+        ActionError::InvalidAssert => "invalid-assert",
+        ActionError::InvalidRetract => "invalid-retract",
+        ActionError::Encoding(_) => "encoding-error",
+        ActionError::EvalError(_) | ActionError::Evaluator(_) => "evaluation-error",
+    };
+    Diagnostic::warning(Phase::Run, category, error.to_string())
+}
+
+#[derive(Serialize)]
+struct Observation {
+    schema: &'static str,
+    version: u8,
+    engine: EngineIdentity,
+    fixture: FixtureIdentity,
+    phase_reached: Phase,
+    lifecycle: Vec<LifecycleRecord>,
+    run: Option<RunObservation>,
+    facts: Vec<FactObservation>,
+    channels: Vec<ChannelObservation>,
+    diagnostics: Vec<Diagnostic>,
+    modules: ModuleObservation,
+    capabilities: Capabilities,
+}
+
+impl Observation {
+    fn started(fixture: FixtureIdentity) -> Self {
+        let start = LifecycleRecord::start(&fixture);
+        Self {
+            schema: SCHEMA_NAME,
+            version: SCHEMA_VERSION,
+            engine: EngineIdentity {
+                name: "ferric",
+                version: env!("CARGO_PKG_VERSION"),
+            },
+            fixture,
+            phase_reached: Phase::Start,
+            lifecycle: vec![start],
+            run: None,
+            facts: Vec::new(),
+            channels: Vec::new(),
+            diagnostics: Vec::new(),
+            modules: ModuleObservation::default(),
+            capabilities: Capabilities {
+                fact_modules: false,
+                fired_rule_names: false,
+                global_values: false,
+                router_channel_enumeration: false,
+                external_address_identity: false,
+                source_digest_verification: false,
+                composed_digest_verification: true,
+            },
+        }
+    }
+
+    fn apply_capture(&mut self, capture: CapturedState) {
+        self.run = capture.run;
+        self.facts = capture.facts;
+        self.capabilities.fact_modules = capture.fact_modules;
+        self.channels = capture.channels;
+        self.diagnostics.extend(capture.action_diagnostics);
+        self.modules = capture.modules;
+    }
+}
+
+struct CapturedState {
+    run: Option<RunObservation>,
+    facts: Vec<FactObservation>,
+    fact_modules: bool,
+    channels: Vec<ChannelObservation>,
+    action_diagnostics: Vec<Diagnostic>,
+    modules: ModuleObservation,
+}
+
+#[derive(Serialize)]
+struct EngineIdentity {
+    name: &'static str,
+    version: &'static str,
+}
+
+#[derive(Serialize)]
+struct FixtureIdentity {
+    id: String,
+    nonce: String,
+    source_sha256: String,
+    composed_sha256: String,
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum Phase {
+    Start,
+    Load,
+    Reset,
+    Run,
+    PostRun,
+}
+
+#[derive(Serialize)]
+struct LifecycleRecord {
+    sequence: u8,
+    event: LifecycleEvent,
+    fixture_id: String,
+    nonce: String,
+    source_sha256: String,
+    composed_sha256: String,
+}
+
+impl LifecycleRecord {
+    fn start(fixture: &FixtureIdentity) -> Self {
+        Self::new(0, LifecycleEvent::Start, fixture)
+    }
+
+    fn complete(fixture: &FixtureIdentity) -> Self {
+        Self::new(1, LifecycleEvent::Complete, fixture)
+    }
+
+    fn new(sequence: u8, event: LifecycleEvent, fixture: &FixtureIdentity) -> Self {
+        Self {
+            sequence,
+            event,
+            fixture_id: fixture.id.clone(),
+            nonce: fixture.nonce.clone(),
+            source_sha256: fixture.source_sha256.clone(),
+            composed_sha256: fixture.composed_sha256.clone(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+enum LifecycleEvent {
+    Start,
+    Complete,
+}
+
+#[derive(Serialize)]
+struct RunObservation {
+    rules_fired: usize,
+    fired_rule_names: Option<Vec<String>>,
+    halt_reason: HaltReasonObservation,
+    agenda_size: usize,
+    halted: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum HaltReasonObservation {
+    AgendaEmpty,
+    LimitReached,
+    HaltRequested,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+enum FactObservation {
+    Ordered {
+        ordinal: usize,
+        fact_id: String,
+        module: Option<String>,
+        relation: String,
+        fields: Vec<ValueObservation>,
+    },
+    Template {
+        ordinal: usize,
+        fact_id: String,
+        module: Option<String>,
+        name: String,
+        slots: Vec<SlotObservation>,
+    },
+}
+
+#[derive(Serialize)]
+struct SlotObservation {
+    name: String,
+    value: ValueObservation,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+enum ValueObservation {
+    Symbol { value: String },
+    String { value: String },
+    Integer { value: String },
+    Float { value: String, bits: String },
+    Multifield { values: Vec<ValueObservation> },
+    ExternalAddress { external_type_id: u32, opaque: bool },
+    Void,
+}
+
+#[derive(Serialize)]
+struct ChannelObservation {
+    name: String,
+    present: bool,
+    text: String,
+}
+
+#[derive(Serialize)]
+struct Diagnostic {
+    phase: Phase,
+    severity: Severity,
+    category: &'static str,
+    message: String,
+}
+
+impl Diagnostic {
+    fn error(phase: Phase, category: &'static str, message: String) -> Self {
+        Self {
+            phase,
+            severity: Severity::Error,
+            category,
+            message,
+        }
+    }
+
+    fn warning(phase: Phase, category: &'static str, message: String) -> Self {
+        Self {
+            phase,
+            severity: Severity::Warning,
+            category,
+            message,
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "lowercase")]
+enum Severity {
+    Error,
+    Warning,
+}
+
+#[derive(Default, Serialize)]
+struct ModuleObservation {
+    current: String,
+    focus: Option<String>,
+    focus_stack: Vec<String>,
+}
+
+#[derive(Serialize)]
+#[allow(clippy::struct_excessive_bools)] // Independent wire-format capability flags are intentional.
+struct Capabilities {
+    fact_modules: bool,
+    fired_rule_names: bool,
+    global_values: bool,
+    router_channel_enumeration: bool,
+    external_address_identity: bool,
+    source_digest_verification: bool,
+    composed_digest_verification: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_parser_requires_lowercase_canonical_text() {
+        let valid = "0123456789abcdef".repeat(4);
+        assert_eq!(parse_sha256(&valid), Ok(valid));
+        assert!(parse_sha256(&"A".repeat(64)).is_err());
+        assert!(parse_sha256(&"a".repeat(63)).is_err());
+        assert!(parse_sha256(&format!("{}g", "a".repeat(63))).is_err());
+    }
+
+    #[test]
+    fn nonce_parser_applies_character_and_length_bounds() {
+        let valid = "0123456789abcdef".repeat(2);
+        assert_eq!(parse_nonce(&valid), Ok(valid));
+        assert!(parse_nonce("").is_err());
+        assert!(parse_nonce(&"A".repeat(MIN_NONCE_HEX_BYTES)).is_err());
+        assert!(parse_nonce(&"a".repeat(MIN_NONCE_HEX_BYTES - 1)).is_err());
+        assert!(parse_nonce(&"a".repeat(MAX_NONCE_HEX_BYTES + 2)).is_err());
+    }
+
+    #[test]
+    fn fixture_id_parser_rejects_ambiguous_or_unbounded_values() {
+        assert_eq!(
+            parse_fixture_id("examples/hello-world.clp"),
+            Ok("examples/hello-world.clp".to_string())
+        );
+        assert!(parse_fixture_id("").is_err());
+        assert!(parse_fixture_id("contains space").is_err());
+        assert!(parse_fixture_id("line\nbreak").is_err());
+        assert!(parse_fixture_id(&"a".repeat(MAX_FIXTURE_ID_BYTES + 1)).is_err());
+    }
+
+    #[test]
+    fn float_text_and_bits_preserve_edge_case_identity() {
+        assert_eq!(canonical_float(-0.0), "-0");
+        assert_eq!(canonical_float(f64::INFINITY), "Infinity");
+        assert_eq!(canonical_float(f64::NEG_INFINITY), "-Infinity");
+        assert_eq!(canonical_float(f64::NAN), "NaN");
+    }
+}

--- a/crates/ferric-cli/src/commands/mod.rs
+++ b/crates/ferric-cli/src/commands/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod check;
 pub(crate) mod common;
+pub mod compat_observe;
 pub mod repl;
 pub mod run;
 #[cfg(feature = "serde")]

--- a/crates/ferric-cli/src/main.rs
+++ b/crates/ferric-cli/src/main.rs
@@ -80,6 +80,29 @@ enum Command {
         file: PathBuf,
     },
 
+    /// Emit a structured compatibility observation.
+    #[command(hide = true)]
+    CompatObserve {
+        /// Stable fixture identifier bound into the lifecycle records.
+        #[arg(long, value_parser = commands::compat_observe::parse_fixture_id)]
+        fixture_id: String,
+
+        /// Per-invocation nonce bound into the lifecycle records.
+        #[arg(long, value_parser = commands::compat_observe::parse_nonce)]
+        nonce: String,
+
+        /// SHA-256 digest of the original fixture source.
+        #[arg(long, value_parser = commands::compat_observe::parse_sha256)]
+        source_sha256: String,
+
+        /// SHA-256 digest of the exact composed input file.
+        #[arg(long, value_parser = commands::compat_observe::parse_sha256)]
+        composed_sha256: String,
+
+        /// Path to the composed CLIPS source to observe.
+        file: PathBuf,
+    },
+
     /// Parse and validate a CLIPS file without executing.
     Check {
         /// Emit diagnostics as JSON objects on stderr.
@@ -150,6 +173,19 @@ fn main() {
 
     let exit_code = match cli.command {
         Command::Run { json, file } => commands::run::execute(json, &file),
+        Command::CompatObserve {
+            fixture_id,
+            nonce,
+            source_sha256,
+            composed_sha256,
+            file,
+        } => commands::compat_observe::execute(
+            &file,
+            fixture_id,
+            nonce,
+            source_sha256,
+            composed_sha256,
+        ),
         Command::Check { json, file } => commands::check::execute(json, &file),
         Command::Repl {
             load,

--- a/crates/ferric-cli/tests/compat_observe.rs
+++ b/crates/ferric-cli/tests/compat_observe.rs
@@ -1,0 +1,368 @@
+//! Black-box tests for the dedicated structured compatibility observation.
+
+use std::io::Write as _;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+const FIXTURE_ID: &str = "tests/fixtures/compat-observation.clp";
+const NONCE: &str = "0123456789abcdef0123456789abcdef";
+const SOURCE: &str = r#"
+(deftemplate person
+  (slot name)
+  (multislot tags))
+
+(deffacts seed
+  (person (name "Ada") (tags))
+  (signal "ready" 7)
+  (signal "ready" 7)
+  (go))
+
+(defrule report-person
+  ?g <- (go)
+  ?p <- (person (name "Ada"))
+  =>
+  (retract ?g)
+  (modify ?p (tags (create$ alpha 2 3.5)))
+  (printout t "hello" crlf)
+  (printout stderr "problem" crlf))
+"#;
+
+fn run_ferric(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_ferric"))
+        .args(args)
+        .output()
+        .expect("execute ferric binary")
+}
+
+fn assert_exit_code(output: &Output, expected: i32) {
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "stdout: {}\nstderr: {}",
+        stdout_str(output),
+        stderr_str(output)
+    );
+}
+
+fn stdout_str(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr_str(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn sha256(source: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(source))
+}
+
+fn source_file(source: &str) -> tempfile::NamedTempFile {
+    let mut file = tempfile::NamedTempFile::new().expect("create source file");
+    file.write_all(source.as_bytes())
+        .expect("write source file");
+    file.flush().expect("flush source file");
+    file
+}
+
+fn observe_with_digests(
+    source: &str,
+    source_sha256: &str,
+    composed_sha256: &str,
+) -> std::process::Output {
+    let file = source_file(source);
+    run_ferric(&[
+        "compat-observe",
+        "--fixture-id",
+        FIXTURE_ID,
+        "--nonce",
+        NONCE,
+        "--source-sha256",
+        source_sha256,
+        "--composed-sha256",
+        composed_sha256,
+        file.path().to_str().expect("UTF-8 temporary path"),
+    ])
+}
+
+fn observe(source: &str, composed_sha256: &str) -> std::process::Output {
+    observe_with_digests(source, &sha256(source.as_bytes()), composed_sha256)
+}
+
+fn parse_single_observation(output: &std::process::Output) -> Value {
+    let stdout = stdout_str(output);
+    assert_eq!(
+        stdout.lines().count(),
+        1,
+        "expected exactly one JSON line on stdout: {stdout:?}"
+    );
+    serde_json::from_str(&stdout).expect("stdout must be a JSON observation")
+}
+
+fn assert_identity_and_lifecycle(observation: &Value, digest: &str) {
+    assert_eq!(observation["schema"], "ferric.compat-observation");
+    assert_eq!(observation["version"], 1);
+    assert_eq!(observation["engine"]["name"], "ferric");
+    assert_eq!(observation["fixture"]["id"], FIXTURE_ID);
+    assert_eq!(observation["fixture"]["nonce"], NONCE);
+    assert_eq!(observation["fixture"]["source_sha256"], digest);
+    assert_eq!(observation["fixture"]["composed_sha256"], digest);
+    assert_eq!(observation["phase_reached"], "post-run");
+
+    let lifecycle = observation["lifecycle"]
+        .as_array()
+        .expect("lifecycle array");
+    assert_eq!(lifecycle.len(), 2);
+    assert_eq!(lifecycle[0]["sequence"], 0);
+    assert_eq!(lifecycle[0]["event"], "START");
+    assert_eq!(lifecycle[1]["sequence"], 1);
+    assert_eq!(lifecycle[1]["event"], "COMPLETE");
+    for record in lifecycle {
+        assert_eq!(record["fixture_id"], FIXTURE_ID);
+        assert_eq!(record["nonce"], NONCE);
+        assert_eq!(record["source_sha256"], digest);
+        assert_eq!(record["composed_sha256"], digest);
+    }
+}
+
+#[test]
+fn successful_observation_captures_typed_state_and_lifecycle() {
+    let digest = sha256(SOURCE.as_bytes());
+    let output = observe(SOURCE, &digest);
+    assert_exit_code(&output, 0);
+    assert!(
+        stderr_str(&output).is_empty(),
+        "successful structured observation must not leak diagnostics to stderr"
+    );
+
+    let observation = parse_single_observation(&output);
+    assert_identity_and_lifecycle(&observation, &digest);
+
+    assert_eq!(observation["run"]["rules_fired"], 1);
+    assert!(observation["run"]["fired_rule_names"].is_null());
+    assert_eq!(observation["run"]["halt_reason"], "agenda-empty");
+    assert_eq!(observation["run"]["agenda_size"], 0);
+    assert_eq!(observation["run"]["halted"], false);
+    assert_eq!(observation["diagnostics"], Value::Array(Vec::new()));
+
+    let facts = observation["facts"].as_array().expect("facts array");
+    assert_eq!(facts.len(), 3);
+    for (ordinal, fact) in facts.iter().enumerate() {
+        assert_eq!(fact["ordinal"], ordinal);
+        assert!(fact["fact_id"]
+            .as_str()
+            .expect("fact id string")
+            .bytes()
+            .all(|byte| byte.is_ascii_digit()));
+        // With only MAIN registered, ownership is unambiguous despite the
+        // absence of a per-fact module accessor.
+        assert_eq!(fact["module"], "MAIN");
+    }
+
+    let template = facts
+        .iter()
+        .find(|fact| fact["kind"] == "template")
+        .expect("template fact");
+    assert_eq!(template["name"], "person");
+    let slots = template["slots"].as_array().expect("template slots");
+    assert_eq!(slots[0]["name"], "name");
+    assert_eq!(slots[0]["value"]["type"], "string");
+    assert_eq!(slots[0]["value"]["value"], "Ada");
+    assert_eq!(slots[1]["name"], "tags");
+    assert_eq!(slots[1]["value"]["type"], "multifield");
+    assert_eq!(slots[1]["value"]["values"][0]["type"], "symbol");
+    assert_eq!(slots[1]["value"]["values"][0]["value"], "alpha");
+    assert_eq!(slots[1]["value"]["values"][1]["type"], "integer");
+    assert_eq!(slots[1]["value"]["values"][1]["value"], "2");
+    assert_eq!(slots[1]["value"]["values"][2]["type"], "float");
+    assert_eq!(slots[1]["value"]["values"][2]["value"], "3.5");
+    assert_eq!(slots[1]["value"]["values"][2]["bits"], "0x400c000000000000");
+
+    let ordered = facts
+        .iter()
+        .filter(|fact| fact["kind"] == "ordered")
+        .collect::<Vec<_>>();
+    assert_eq!(ordered.len(), 2, "duplicate facts must remain distinct");
+    assert_ne!(ordered[0]["fact_id"], ordered[1]["fact_id"]);
+    assert_eq!(ordered[0]["fields"], ordered[1]["fields"]);
+    assert_eq!(ordered[0]["relation"], "signal");
+    assert_eq!(ordered[0]["fields"][0]["type"], "string");
+    assert_eq!(ordered[0]["fields"][0]["value"], "ready");
+    assert_eq!(ordered[0]["fields"][1]["type"], "integer");
+    assert_eq!(ordered[0]["fields"][1]["value"], "7");
+
+    let channels = observation["channels"].as_array().expect("channel array");
+    let channel = |name: &str| {
+        channels
+            .iter()
+            .find(|channel| channel["name"] == name)
+            .unwrap_or_else(|| panic!("missing channel {name}"))
+    };
+    assert_eq!(channel("t")["present"], true);
+    assert_eq!(channel("t")["text"], "hello\n");
+    assert_eq!(channel("stderr")["present"], true);
+    assert_eq!(channel("stderr")["text"], "problem\n");
+    assert_eq!(channel("stdout")["present"], false);
+    assert_eq!(channel("stdout")["text"], "");
+
+    assert_eq!(observation["modules"]["current"], "MAIN");
+    assert_eq!(observation["modules"]["focus"], "MAIN");
+    assert_eq!(
+        observation["modules"]["focus_stack"],
+        serde_json::json!(["MAIN"])
+    );
+    assert_eq!(observation["capabilities"]["fact_modules"], true);
+    assert_eq!(observation["capabilities"]["fired_rule_names"], false);
+    assert_eq!(
+        observation["capabilities"]["router_channel_enumeration"],
+        false
+    );
+    assert_eq!(
+        observation["capabilities"]["composed_digest_verification"],
+        true
+    );
+}
+
+#[test]
+fn digest_mismatch_emits_parseable_start_only_partial_observation() {
+    let output = observe(SOURCE, &"0".repeat(64));
+    assert_exit_code(&output, 1);
+    assert!(stderr_str(&output).is_empty());
+
+    let observation = parse_single_observation(&output);
+    assert_eq!(observation["phase_reached"], "load");
+    assert!(observation["run"].is_null());
+    assert_eq!(observation["lifecycle"].as_array().unwrap().len(), 1);
+    assert_eq!(observation["lifecycle"][0]["event"], "START");
+    assert_eq!(observation["diagnostics"][0]["phase"], "load");
+    assert_eq!(observation["diagnostics"][0]["category"], "digest-mismatch");
+    assert_eq!(observation["modules"]["current"], "MAIN");
+}
+
+#[test]
+fn distinct_source_and_composed_digests_remain_bound_without_false_verification() {
+    let source_sha256 = "1".repeat(64);
+    let composed_sha256 = sha256(SOURCE.as_bytes());
+    let output = observe_with_digests(SOURCE, &source_sha256, &composed_sha256);
+    assert_exit_code(&output, 0);
+
+    let observation = parse_single_observation(&output);
+    assert_eq!(
+        observation["fixture"]["source_sha256"],
+        source_sha256.as_str()
+    );
+    assert_eq!(
+        observation["fixture"]["composed_sha256"],
+        composed_sha256.as_str()
+    );
+    for record in observation["lifecycle"].as_array().unwrap() {
+        assert_eq!(record["source_sha256"], source_sha256.as_str());
+        assert_eq!(record["composed_sha256"], composed_sha256.as_str());
+    }
+    assert_eq!(
+        observation["capabilities"]["source_digest_verification"],
+        false
+    );
+    assert_eq!(
+        observation["capabilities"]["composed_digest_verification"],
+        true
+    );
+}
+
+#[test]
+fn load_failure_emits_parseable_start_only_partial_observation() {
+    let invalid_source = "(defrule incomplete";
+    let digest = sha256(invalid_source.as_bytes());
+    let output = observe(invalid_source, &digest);
+    assert_exit_code(&output, 1);
+    assert!(stderr_str(&output).is_empty());
+
+    let observation = parse_single_observation(&output);
+    assert_eq!(observation["phase_reached"], "load");
+    assert!(observation["run"].is_null());
+    assert_eq!(observation["lifecycle"].as_array().unwrap().len(), 1);
+    assert_eq!(observation["lifecycle"][0]["event"], "START");
+    assert_eq!(observation["diagnostics"][0]["severity"], "error");
+    assert_eq!(observation["diagnostics"][0]["category"], "parse-error");
+}
+
+#[test]
+fn multiple_modules_leave_fact_ownership_explicitly_unavailable() {
+    let source = r"
+(defmodule MAIN (export ?ALL))
+(deffacts main-seed (main-fact))
+(defmodule AUX)
+(deffacts aux-seed (aux-fact))
+";
+    let digest = sha256(source.as_bytes());
+    let output = observe(source, &digest);
+    assert_exit_code(&output, 0);
+
+    let observation = parse_single_observation(&output);
+    assert_eq!(observation["capabilities"]["fact_modules"], false);
+    let facts = observation["facts"].as_array().expect("facts array");
+    assert_eq!(facts.len(), 2);
+    assert!(facts.iter().all(|fact| fact["module"].is_null()));
+}
+
+#[test]
+fn halt_and_nonfatal_action_diagnostic_are_captured_without_output_leakage() {
+    let source = r#"
+(deffacts seed (channel t))
+(defrule stop-first
+  (declare (salience 10))
+  (channel ?channel)
+  =>
+  (printout ?channel "must-not-leak")
+  (halt))
+(defrule left-on-agenda
+  (channel ?channel)
+  =>
+  (printout t "must-not-run"))
+"#;
+    let digest = sha256(source.as_bytes());
+    let output = observe(source, &digest);
+    assert_exit_code(&output, 0);
+    assert!(stderr_str(&output).is_empty());
+
+    let observation = parse_single_observation(&output);
+    assert_eq!(observation["run"]["rules_fired"], 1);
+    assert_eq!(observation["run"]["halt_reason"], "halt-requested");
+    assert_eq!(observation["run"]["agenda_size"], 1);
+    assert_eq!(observation["run"]["halted"], true);
+    assert_eq!(observation["diagnostics"][0]["phase"], "run");
+    assert_eq!(observation["diagnostics"][0]["severity"], "warning");
+    assert_eq!(
+        observation["diagnostics"][0]["category"],
+        "evaluation-error"
+    );
+    assert!(observation["channels"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|channel| channel["text"] == ""));
+}
+
+#[test]
+fn cli_rejects_noncanonical_digest_before_execution() {
+    let file = source_file(SOURCE);
+    let digest = sha256(SOURCE.as_bytes());
+    let uppercase_digest = digest.to_uppercase();
+    let output = run_ferric(&[
+        "compat-observe",
+        "--fixture-id",
+        FIXTURE_ID,
+        "--nonce",
+        NONCE,
+        "--source-sha256",
+        &uppercase_digest,
+        "--composed-sha256",
+        &digest,
+        file.path().to_str().expect("UTF-8 temporary path"),
+    ]);
+
+    assert_exit_code(&output, 2);
+    assert!(stdout_str(&output).is_empty());
+    assert!(stderr_str(&output).contains("64 lowercase hexadecimal"));
+}

--- a/docker/clips-reference/Dockerfile
+++ b/docker/clips-reference/Dockerfile
@@ -1,9 +1,27 @@
+FROM debian:bookworm-slim AS observer-builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libc6-dev libclips-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY ferric-clips-observer.c /src/ferric-clips-observer.c
+COPY ferric-clips-launcher.c /src/ferric-clips-launcher.c
+
+RUN gcc -std=c11 -O2 -Wall -Wextra -Werror \
+    -o /ferric-clips-observer /src/ferric-clips-observer.c \
+    -l:libclips.so.6 -lcrypto -lm \
+    && gcc -std=c11 -O2 -Wall -Wextra -Werror \
+    -o /ferric-clips-launcher /src/ferric-clips-launcher.c
+
 FROM debian:bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends clips ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
+COPY --from=observer-builder /ferric-clips-observer /usr/local/bin/ferric-clips-observer
+COPY --from=observer-builder /ferric-clips-launcher /usr/local/bin/ferric-clips-launcher
+
 WORKDIR /workspace
 
-ENTRYPOINT ["clips"]
+ENTRYPOINT ["/usr/local/bin/ferric-clips-launcher"]

--- a/docker/clips-reference/ferric-clips-launcher.c
+++ b/docker/clips-reference/ferric-clips-launcher.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define CLIPS_PATH "/usr/bin/clips"
+#define OBSERVER_PATH "/usr/local/bin/ferric-clips-observer"
+#define OBSERVER_FLAG "--ferric-observer"
+
+static void fail(const char *message) {
+  fprintf(stderr, "ferric CLIPS launcher: %s\n", message);
+  exit(127);
+}
+
+int main(int argc, char **argv) {
+  const int observer_mode = argc > 1 && strcmp(argv[1], OBSERVER_FLAG) == 0;
+  const char *program = observer_mode ? OBSERVER_PATH : CLIPS_PATH;
+  const int program_argc = observer_mode ? argc - 1 : argc;
+  char **program_argv =
+      calloc((size_t)program_argc + 1, sizeof(*program_argv));
+
+  if (program_argv == NULL) {
+    fail("could not allocate process arguments");
+  }
+  program_argv[0] = (char *)program;
+  for (int index = 1; index < program_argc; index++) {
+    program_argv[index] = argv[index + (observer_mode ? 1 : 0)];
+  }
+  program_argv[program_argc] = NULL;
+  execv(program, program_argv);
+  fail(observer_mode ? "could not execute the structured observer"
+                     : "could not execute CLIPS");
+}

--- a/docker/clips-reference/ferric-clips-observer.c
+++ b/docker/clips-reference/ferric-clips-observer.c
@@ -1,0 +1,471 @@
+#define _GNU_SOURCE
+
+#include <clips/clips.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+
+#include <errno.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define RECORD_PREFIX "__FERRIC_COMPAT_NATIVE_V1__|"
+#define MIN_NONCE_LENGTH 32
+#define MAX_NONCE_LENGTH 128
+#define MAX_TOKEN_LENGTH 128
+#define DIGEST_LENGTH 64
+#define AUTH_KEY_HEX_LENGTH 64
+#define AUTH_KEY_LENGTH 32
+#define MAX_CONFIG_LENGTH                                                     \
+  (MAX_NONCE_LENGTH + MAX_TOKEN_LENGTH + (2 * DIGEST_LENGTH) +               \
+   AUTH_KEY_HEX_LENGTH + 5)
+#define MAX_PROBE_PAYLOAD (16U * 1024U * 1024U)
+
+#define NATIVE_EMIT_FUNCTION "ferric-compat-native-emit"
+#define NATIVE_COMPLETE_FUNCTION "ferric-compat-native-complete"
+
+struct observer_config {
+  char nonce[MAX_NONCE_LENGTH + 1];
+  char fixture_id[MAX_TOKEN_LENGTH + 1];
+  char source_sha256[DIGEST_LENGTH + 1];
+  char composed_sha256[DIGEST_LENGTH + 1];
+  unsigned char auth_key[AUTH_KEY_LENGTH];
+};
+
+static struct observer_config config;
+static void *observer_environment = NULL;
+static int observed_halt_rules = 0;
+static int observed_halt_execution = 0;
+static int observed_evaluation_error = 0;
+static int observer_after_run = 0;
+static int observer_complete = 0;
+static int protocol_violation = 0;
+
+static void write_all(int descriptor, const char *data, size_t length) {
+  size_t written = 0;
+
+  while (written < length) {
+    const ssize_t result = write(descriptor, data + written, length - written);
+    if (result > 0) {
+      written += (size_t)result;
+    } else if (result < 0 && errno == EINTR) {
+      continue;
+    } else {
+      return;
+    }
+  }
+}
+
+static void fail(const char *message) {
+  static const char prefix[] = "ferric CLIPS observer: ";
+  write_all(STDERR_FILENO, prefix, sizeof(prefix) - 1);
+  write_all(STDERR_FILENO, message, strlen(message));
+  write_all(STDERR_FILENO, "\n", 1);
+  exit(127);
+}
+
+static void emit_authenticated(const char *record, size_t record_length) {
+  unsigned char digest[EVP_MAX_MD_SIZE];
+  unsigned int digest_length = 0;
+  char digest_hex[(2 * AUTH_KEY_LENGTH) + 1];
+  static const char hex[] = "0123456789abcdef";
+
+  if (HMAC(EVP_sha256(), config.auth_key, AUTH_KEY_LENGTH,
+           (const unsigned char *)record, record_length, digest,
+           &digest_length) == NULL ||
+      digest_length != AUTH_KEY_LENGTH) {
+    fail("could not authenticate a native record");
+  }
+  for (size_t index = 0; index < AUTH_KEY_LENGTH; index++) {
+    digest_hex[2 * index] = hex[digest[index] >> 4];
+    digest_hex[(2 * index) + 1] = hex[digest[index] & 0x0f];
+  }
+  digest_hex[2 * AUTH_KEY_LENGTH] = '\0';
+
+  write_all(STDERR_FILENO, "\n" RECORD_PREFIX, 1 + sizeof(RECORD_PREFIX) - 1);
+  write_all(STDERR_FILENO, config.nonce, strlen(config.nonce));
+  write_all(STDERR_FILENO, "|", 1);
+  write_all(STDERR_FILENO, record, record_length);
+  write_all(STDERR_FILENO, "|", 1);
+  write_all(STDERR_FILENO, digest_hex, 2 * AUTH_KEY_LENGTH);
+  write_all(STDERR_FILENO, "\n", 1);
+  (void)memset(digest, 0, sizeof(digest));
+  (void)memset(digest_hex, 0, sizeof(digest_hex));
+}
+
+static void emit_formatted_record(const char *format, ...) {
+  char record[1024];
+  va_list arguments;
+  int length;
+
+  va_start(arguments, format);
+  length = vsnprintf(record, sizeof(record), format, arguments);
+  va_end(arguments);
+  if (length <= 0 || (size_t)length >= sizeof(record)) {
+    fail("native record is too long");
+  }
+  emit_authenticated(record, (size_t)length);
+}
+
+static void emit_issue(const char *issue) {
+  emit_formatted_record("ISSUE|%s", issue);
+}
+
+static void mark_violation(const char *issue) {
+  protocol_violation = 1;
+  emit_issue(issue);
+}
+
+static void emit_lifecycle(int sequence, const char *event) {
+  emit_formatted_record("LIFECYCLE|%d|%s|%s|%s|%s", sequence, event,
+                        config.fixture_id, config.source_sha256,
+                        config.composed_sha256);
+}
+
+static int valid_nonce(const char *nonce) {
+  size_t length;
+
+  if (nonce == NULL) {
+    return 0;
+  }
+  length = strlen(nonce);
+  if (length < MIN_NONCE_LENGTH || length > MAX_NONCE_LENGTH ||
+      (length % 2) != 0) {
+    return 0;
+  }
+  for (size_t index = 0; index < length; index++) {
+    const char character = nonce[index];
+    if (!((character >= '0' && character <= '9') ||
+          (character >= 'a' && character <= 'f'))) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int valid_token(const char *token) {
+  const size_t length = token == NULL ? 0 : strlen(token);
+
+  if (length == 0 || length > MAX_TOKEN_LENGTH) {
+    return 0;
+  }
+  for (size_t index = 0; index < length; index++) {
+    const char character = token[index];
+    const int alphanumeric =
+        (character >= 'A' && character <= 'Z') ||
+        (character >= 'a' && character <= 'z') ||
+        (character >= '0' && character <= '9');
+    const int valid = alphanumeric || character == '.' || character == '_' ||
+                      character == ':' || character == '/' || character == '-';
+    if (!valid || (index == 0 && !alphanumeric)) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int valid_digest(const char *digest) {
+  if (digest == NULL || strlen(digest) != DIGEST_LENGTH) {
+    return 0;
+  }
+  for (size_t index = 0; index < DIGEST_LENGTH; index++) {
+    const char character = digest[index];
+    if (!((character >= '0' && character <= '9') ||
+          (character >= 'a' && character <= 'f'))) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int decode_auth_key(const char *encoded,
+                           unsigned char output[AUTH_KEY_LENGTH]) {
+  if (encoded == NULL || strlen(encoded) != AUTH_KEY_HEX_LENGTH) {
+    return 0;
+  }
+  for (size_t index = 0; index < AUTH_KEY_LENGTH; index++) {
+    unsigned int value = 0;
+    for (size_t nibble = 0; nibble < 2; nibble++) {
+      const char character = encoded[(2 * index) + nibble];
+      unsigned int digit;
+      if (character >= '0' && character <= '9') {
+        digit = (unsigned int)(character - '0');
+      } else if (character >= 'a' && character <= 'f') {
+        digit = (unsigned int)(character - 'a') + 10U;
+      } else {
+        return 0;
+      }
+      value = (value << 4) | digit;
+    }
+    output[index] = (unsigned char)value;
+  }
+  return 1;
+}
+
+static size_t read_config_line(char *buffer, size_t capacity) {
+  size_t used = 0;
+
+  while (used < capacity) {
+    char character;
+    const ssize_t result = read(STDIN_FILENO, &character, 1);
+    if (result == 1) {
+      if (character == '\n') {
+        return used;
+      }
+      buffer[used++] = character;
+    } else if (result == 0) {
+      fprintf(stderr, "ferric CLIPS observer: configuration is truncated\n");
+      exit(127);
+    } else if (errno != EINTR) {
+      fprintf(stderr, "ferric CLIPS observer: cannot read configuration\n");
+      exit(127);
+    }
+  }
+  fprintf(stderr, "ferric CLIPS observer: configuration is too long\n");
+  exit(127);
+}
+
+static void parse_config(char *raw) {
+  char *fields[5];
+  char *cursor = raw;
+
+  for (size_t index = 0; index < 5; index++) {
+    fields[index] = cursor;
+    if (index < 4) {
+      char *separator = strchr(cursor, '|');
+      if (separator == NULL) {
+        fprintf(stderr, "ferric CLIPS observer: configuration is truncated\n");
+        exit(127);
+      }
+      *separator = '\0';
+      cursor = separator + 1;
+    } else if (strchr(cursor, '|') != NULL) {
+      fprintf(stderr,
+              "ferric CLIPS observer: configuration has extra fields\n");
+      exit(127);
+    }
+  }
+  if (!valid_nonce(fields[0]) || !valid_token(fields[1]) ||
+      !valid_digest(fields[2]) || !valid_digest(fields[3]) ||
+      !decode_auth_key(fields[4], config.auth_key)) {
+    fprintf(stderr, "ferric CLIPS observer: configuration is invalid\n");
+    exit(127);
+  }
+  (void)snprintf(config.nonce, sizeof(config.nonce), "%s", fields[0]);
+  (void)snprintf(config.fixture_id, sizeof(config.fixture_id), "%s",
+                 fields[1]);
+  (void)snprintf(config.source_sha256, sizeof(config.source_sha256), "%s",
+                 fields[2]);
+  (void)snprintf(config.composed_sha256, sizeof(config.composed_sha256), "%s",
+                 fields[3]);
+}
+
+static void observe_after_firing(void *environment) {
+  if (environment != observer_environment) {
+    return;
+  }
+  observed_halt_rules |= EnvGetHaltRules(environment) != 0;
+  observed_halt_execution |= GetHaltExecution(environment) != 0;
+  observed_evaluation_error |= GetEvaluationError(environment) != 0;
+}
+
+static long long count_agenda(void *environment) {
+  void *saved_module = EnvGetCurrentModule(environment);
+  void *module = NULL;
+  long long count = 0;
+
+  while ((module = EnvGetNextDefmodule(environment, module)) != NULL) {
+    void *activation = NULL;
+    (void)EnvSetCurrentModule(environment, module);
+    while ((activation = EnvGetNextActivation(environment, activation)) !=
+           NULL) {
+      if (count == LLONG_MAX) {
+        fprintf(stderr, "ferric CLIPS observer: agenda size overflow\n");
+        exit(127);
+      }
+      count++;
+    }
+  }
+  if (saved_module != NULL) {
+    (void)EnvSetCurrentModule(environment, saved_module);
+  }
+  return count;
+}
+
+static int native_emit(void *environment) {
+  const char *payload;
+  size_t payload_length;
+  char header[64];
+  int header_length;
+  char *record;
+
+  if (environment != observer_environment || !observer_after_run ||
+      observer_complete) {
+    mark_violation("unauthorized-probe-emission");
+    return 0;
+  }
+  if (EnvRtnArgCount(environment) != 1) {
+    mark_violation("probe-argument-count");
+    return 0;
+  }
+  payload = EnvRtnLexeme(environment, 1);
+  if (payload == NULL) {
+    mark_violation("probe-payload-unavailable");
+    return 0;
+  }
+  payload_length = strlen(payload);
+  if (payload_length > MAX_PROBE_PAYLOAD) {
+    mark_violation("probe-payload-too-long");
+    return 0;
+  }
+  header_length = snprintf(header, sizeof(header), "PROBE|%zu|", payload_length);
+  if (header_length <= 0 || (size_t)header_length >= sizeof(header)) {
+    fail("probe header is too long");
+  }
+  if (payload_length > SIZE_MAX - (size_t)header_length) {
+    fail("probe record length overflow");
+  }
+  record = malloc((size_t)header_length + payload_length);
+  if (record == NULL) {
+    fail("could not allocate a probe record");
+  }
+  (void)memcpy(record, header, (size_t)header_length);
+  (void)memcpy(record + header_length, payload, payload_length);
+  emit_authenticated(record, (size_t)header_length + payload_length);
+  (void)memset(record, 0, (size_t)header_length + payload_length);
+  free(record);
+  return 0;
+}
+
+static int native_complete(void *environment) {
+  if (environment != observer_environment || !observer_after_run ||
+      observer_complete) {
+    mark_violation("unauthorized-completion");
+    return 0;
+  }
+  emit_lifecycle(3, "COMPLETE");
+  observer_complete = 1;
+  return 0;
+}
+
+static void evaluate_probe_operations(void *environment) {
+  char *line = NULL;
+  size_t capacity = 0;
+  ssize_t length;
+
+  while ((length = getline(&line, &capacity, stdin)) >= 0) {
+    DATA_OBJECT result;
+    while (length > 0 &&
+           (line[length - 1] == '\n' || line[length - 1] == '\r')) {
+      line[--length] = '\0';
+    }
+    if (length == 0) {
+      continue;
+    }
+    SetEvaluationError(environment, FALSE);
+    if (strncmp(line, "(deffunction ", 13) == 0) {
+      if (!EnvBuild(environment, line)) {
+        mark_violation("probe-evaluation-failed");
+      }
+    } else {
+      (void)EnvEval(environment, line, &result);
+    }
+    if (GetEvaluationError(environment)) {
+      mark_violation("probe-evaluation-failed");
+    }
+  }
+  free(line);
+  if (ferror(stdin)) {
+    fprintf(stderr, "ferric CLIPS observer: cannot read probe operations\n");
+    exit(127);
+  }
+}
+
+int main(int argc, char **argv) {
+  char raw_config[MAX_CONFIG_LENGTH + 1];
+  const char *source_path;
+  void *environment;
+  long long rules_fired;
+  long long agenda_size;
+  int result = 0;
+
+  if (argc != 3 || strcmp(argv[1], "--source") != 0) {
+    fprintf(stderr,
+            "usage: ferric-clips-observer --source <repository-path>\n");
+    return 127;
+  }
+  source_path = argv[2];
+  const size_t config_length =
+      read_config_line(raw_config, sizeof(raw_config) - 1);
+  raw_config[config_length] = '\0';
+  parse_config(raw_config);
+  (void)memset(raw_config, 0, sizeof(raw_config));
+
+  environment = CreateEnvironment();
+  if (environment == NULL) {
+    fprintf(stderr, "ferric CLIPS observer: cannot create environment\n");
+    return 127;
+  }
+  observer_environment = environment;
+  if (!EnvDefineFunction2(environment, NATIVE_EMIT_FUNCTION, 'v', native_emit,
+                          "ferric_compat_native_emit", "11s") ||
+      !EnvDefineFunction2(environment, NATIVE_COMPLETE_FUNCTION, 'v',
+                          native_complete, "ferric_compat_native_complete",
+                          "00")) {
+    fprintf(stderr,
+            "ferric CLIPS observer: cannot register observer functions\n");
+    (void)DestroyEnvironment(environment);
+    return 127;
+  }
+
+  if (EnvLoad(environment, source_path) != 1) {
+    mark_violation("source-load-failed");
+    (void)DestroyEnvironment(environment);
+    return 1;
+  }
+
+  emit_lifecycle(0, "START");
+  EnvReset(environment);
+  observed_halt_rules = 0;
+  observed_halt_execution = 0;
+  observed_evaluation_error = 0;
+  if (!EnvAddRunFunction(environment, "ferric-native-observer",
+                         observe_after_firing, 3000)) {
+    fprintf(stderr, "ferric CLIPS observer: cannot register run callback\n");
+    (void)DestroyEnvironment(environment);
+    return 127;
+  }
+  rules_fired = EnvRun(environment, -1);
+  observe_after_firing(environment);
+  if (!EnvRemoveRunFunction(environment, "ferric-native-observer")) {
+    fprintf(stderr, "ferric CLIPS observer: cannot remove run callback\n");
+    (void)DestroyEnvironment(environment);
+    return 127;
+  }
+  agenda_size = count_agenda(environment);
+  emit_formatted_record(
+      "RUN|-1|%lld|%d|%d|%d|%lld|%d", rules_fired,
+      observed_halt_rules != 0,
+      observed_halt_execution != 0, observed_evaluation_error != 0,
+      agenda_size, protocol_violation != 0);
+  observer_after_run = 1;
+
+  evaluate_probe_operations(environment);
+  if (!observer_complete) {
+    mark_violation("completion-missing");
+  }
+  if (protocol_violation) {
+    result = 1;
+  }
+  if (!DestroyEnvironment(environment)) {
+    fprintf(stderr, "ferric CLIPS observer: cannot destroy environment\n");
+    return 127;
+  }
+  observer_environment = NULL;
+  (void)memset(&config, 0, sizeof(config));
+  return result;
+}

--- a/docs/compatibility-assessment.md
+++ b/docs/compatibility-assessment.md
@@ -1,0 +1,120 @@
+# Compatibility assessment oracles
+
+The `just compat-*` pipeline produces differential evidence between Ferric and
+the pinned reference CLIPS container. Manifest schema v3 is intentionally
+fail-closed: matching process output, including matching empty output, is not
+compatibility evidence by itself.
+
+## Fixture declarations
+
+Executable evidence starts in
+`tests/examples/compat-oracles.json`. The registry is versioned, rejects
+duplicate JSON fields and duplicate fixture identities, and maps normalized
+paths relative to `tests/examples/` to oracle-v1 declarations.
+
+Each declaration binds:
+
+- a protocol-safe fixture ID and a human-readable feature;
+- the exact source and composed-input SHA-256 digests;
+- the `load`, `reset`, `run` setup sequence;
+- expected phase, firing count or ordered firing names, semantic effects,
+  canonical final facts, stdout and stderr, diagnostic state, run termination,
+  and any selected focus-stack or global state; and
+- the fixture-specific normalizers that are allowed.
+
+Oracle v1 supports an unlimited run, `agenda-empty` or `halt-requested`
+completion, and exactly the `stdout` and `stderr` semantic channels. Firing
+count must agree with the number of firing names when both are declared.
+Unsupported declarations are invalid configuration, not engine divergence.
+
+The only normalizers are:
+
+- `fact-ids` — ignore engine-assigned fact identity;
+- `fact-order` — compare final facts and their fact-derived effects without
+  enumeration order; and
+- `float-format` — compare finite decimal float spellings by numeric value.
+
+No normalizer is applied globally. Duplicate facts and values remain
+significant.
+
+When a fixture or generated harness changes, update both digests in its
+declaration. `just compat-scan` rejects a stale declaration before an engine is
+started.
+
+## Observation boundary
+
+Every run receives a fresh 128-bit nonce. Both engines must produce exactly one
+nonce- and digest-bound `START`/`COMPLETE` lifecycle and a complete post-run
+observation.
+
+Ferric exposes this through the hidden `ferric compat-observe` command, leaving
+the public `ferric run --json` contract unchanged. Reference CLIPS is loaded by
+a dedicated native embedding that owns the single reset/run boundary, counts
+the agenda across every module, and enables typed post-run probes only after
+`EnvRun` returns. It emits length-prefixed, nonce-bound records on the process
+stderr boundary, separate from fixture router output. Each record also carries
+a keyed authentication tag whose per-run key is never emitted. The nonce,
+identity, and authentication binding are consumed before the CLIPS environment
+is created and never enter the fixture-visible environment or command stream.
+Parsing uses byte offsets, so UTF-8 values are framed by their encoded byte
+length.
+
+The native observer is built into `ferric-rules/clips-reference:latest` from
+`docker/clips-reference/`. Rebuild that local image after changing the
+observer:
+
+```console
+docker build -t ferric-rules/clips-reference:latest docker/clips-reference
+```
+
+Do not use `just clips-build` for a local-only rebuild: that recipe publishes
+unless invoked with its explicitly local options.
+
+Generated verifier records, facts, and firings are instrumentation, not
+fixture effects. If either adapter cannot separate instrumentation from
+feature behavior, the observation is invalid rather than equivalent.
+
+## Classification and exit behavior
+
+An entry is `equivalent` only when:
+
+- its declaration is current and valid;
+- both engines independently reach and complete the observation;
+- each engine demonstrates the declared feature effect and all expectations;
+  and
+- the normalized observations agree with each other.
+
+A valid semantic mismatch is `divergent`. A missing declaration is
+`pending/oracle-missing`. Missing, stale, malformed, incomplete, spoofed, or
+unsupported evidence is `pending/oracle-invalid:*`; the exact composed input
+is retained under `.ferric-compat/failures/`, when one exists, and
+`compat-run` exits nonzero. Expected diagnostics remain invalid until
+phase-aware diagnostic classification is implemented.
+
+Manifest-v2 output-based results are deliberately reset during schema-v3
+migration. Undeclared fixtures remain pending instead of preserving legacy
+`equivalent` or `divergent` claims.
+
+## Maintainer workflow
+
+Run the assessment from the repository root:
+
+```console
+cargo build --release -p ferric-cli
+just compat-scan
+just compat-run
+just compat-report
+```
+
+`compat-report` exposes declaration, lifecycle, effect, version, and
+normalization coverage. Compare a baseline and candidate with:
+
+```console
+just compat-diff BASE_MANIFEST HEAD_MANIFEST
+```
+
+For schema-v3 heads, the diff gate rejects every unverified equivalence claim,
+including a legacy claim copied forward unchanged, as well as evidence-coverage
+loss. The initial empty-output control is
+`tests/examples/ferric-oracle/empty-output-state.clp`; it is equivalent only
+because both engines prove the declared final fact, effect, and firing count.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -194,7 +194,9 @@ helpers: `_clips_parser.py`, `_manifest.py`, `_subprocess.py`, `_formatting.py`,
 - `bat/` — `analyze`, `convert`, `extract`, `harness`, `segment`: processes
   CLIPS `.bat` batch scripts into runnable `.clp` segments and harnesses.
 - `compat/` — `scan`, `run`, `report`, `diff`: compatibility assessment
-  pipeline (ferric vs. CLIPS reference container).
+  pipeline (ferric vs. CLIPS reference container). Its structured,
+  non-vacuous oracle contract is documented in
+  [`compatibility-assessment.md`](compatibility-assessment.md).
 - `perf/` — `collect`, `report`, `diff`: Criterion → performance-manifest
   pipeline.
 
@@ -237,6 +239,8 @@ thresholds). Scaling regression: `just scaling-check` runs facade-crate
   multi-module pipelines.
 - `compatibility.md` — CLIPS compatibility matrix, by Basic Programming Guide
   section.
+- `compatibility-assessment.md` — maintainer contract for structured
+  differential oracles and evidence.
 - `migration.md` — CLIPS → ferric migration guide.
 - `benchmark-policy.md` — regression policy and thresholds.
 - `performance-analysis.md` — Phase 6 baseline numbers.

--- a/scripts/clips-reference.sh
+++ b/scripts/clips-reference.sh
@@ -5,9 +5,15 @@ IMAGE_NAME="ferric-rules/clips-reference"
 IMAGE_TAG="latest"
 PLATFORMS="linux/amd64,linux/arm64"
 LOAD_LOCAL=0
+QUIET=0
 CLIPS_FILES=()
 OPS=()
 OPS_FILE=""
+OBSERVER_NONCE=""
+OBSERVER_FIXTURE_ID=""
+OBSERVER_SOURCE_SHA256=""
+OBSERVER_COMPOSED_SHA256=""
+OBSERVER_AUTH_KEY=""
 WORKDIR_IN_CONTAINER="/workspace"
 
 usage() {
@@ -33,6 +39,17 @@ Run options:
   --file <path>         CLIPS source file to batch* load (repeatable)
   --ops-file <path>     Text file containing CLIPS expressions (one per line)
   --op <expr>           CLIPS expression to execute (repeatable)
+  --observer-nonce <n>  Enable nonce-bound native run metadata (internal)
+  --observer-fixture-id <id>
+                        Bind native observations to a fixture (internal)
+  --observer-source-sha256 <digest>
+                        Bind native observations to source bytes (internal)
+  --observer-composed-sha256 <digest>
+                        Bind native observations to composed bytes (internal)
+  --observer-auth-key <key>
+                        Authenticate native observation records (internal)
+  --quiet               Execute stdin with CLIPS batch* semantics, suppressing
+                        the interactive banner, prompts, and return values
 
 Examples:
   scripts/clips-reference.sh build
@@ -116,6 +133,7 @@ run_command() {
   repo_root="$(cd "$repo_root" && pwd -P)"
 
   local commands=()
+  local container_files=()
   local file
   for file in ${CLIPS_FILES[@]+"${CLIPS_FILES[@]}"}; do
     local abs
@@ -132,7 +150,10 @@ run_command() {
     fi
     local container_path
     container_path="$(escape_clips_string "${WORKDIR_IN_CONTAINER}/${rel}")"
-    commands+=("(batch* \"${container_path}\")")
+    container_files+=("${WORKDIR_IN_CONTAINER}/${rel}")
+    if [[ -z "$OBSERVER_NONCE" ]]; then
+      commands+=("(batch* \"${container_path}\")")
+    fi
   done
 
   if [[ -n "$OPS_FILE" ]]; then
@@ -149,7 +170,12 @@ run_command() {
     commands+=("$op")
   done
 
-  if [[ "${#commands[@]}" -eq 0 ]]; then
+  if [[ -n "$OBSERVER_NONCE" ]]; then
+    if [[ "${#container_files[@]}" -ne 1 ]]; then
+      echo "error: structured observer requires exactly one --file" >&2
+      exit 1
+    fi
+  elif [[ "${#commands[@]}" -eq 0 ]]; then
     commands+=("(reset)" "(run)")
   elif [[ "${#OPS[@]}" -eq 0 && -z "$OPS_FILE" ]]; then
     # When only --file was given (no explicit --op or --ops-file),
@@ -158,15 +184,65 @@ run_command() {
     commands+=("(reset)" "(run)")
   fi
 
+  local clips_args=()
+  local observer_args=()
+  if [[ "$QUIET" -eq 1 && -z "$OBSERVER_NONCE" ]]; then
+    clips_args+=("-f2" "/dev/stdin")
+  fi
+  if [[ -n "$OBSERVER_NONCE" ]]; then
+    if [[ ! "$OBSERVER_NONCE" =~ ^[0-9a-f]{32,128}$ ]] ||
+       (( ${#OBSERVER_NONCE} % 2 != 0 )); then
+      echo "error: --observer-nonce must encode 16-64 bytes as lowercase hexadecimal" >&2
+      exit 1
+    fi
+    if [[ ! "$OBSERVER_FIXTURE_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$ ]]; then
+      echo "error: --observer-fixture-id must be a protocol-safe token" >&2
+      exit 1
+    fi
+    if [[ ! "$OBSERVER_SOURCE_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+      echo "error: --observer-source-sha256 must be a lowercase SHA-256 digest" >&2
+      exit 1
+    fi
+    if [[ ! "$OBSERVER_COMPOSED_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+      echo "error: --observer-composed-sha256 must be a lowercase SHA-256 digest" >&2
+      exit 1
+    fi
+    if [[ ! "$OBSERVER_AUTH_KEY" =~ ^[0-9a-f]{64}$ ]]; then
+      echo "error: --observer-auth-key must encode 32 bytes as lowercase hexadecimal" >&2
+      exit 1
+    fi
+    observer_args+=(
+      "--ferric-observer"
+      "--source"
+      "${container_files[0]}"
+    )
+  elif [[ -n "$OBSERVER_FIXTURE_ID" || -n "$OBSERVER_SOURCE_SHA256" ||
+          -n "$OBSERVER_COMPOSED_SHA256" || -n "$OBSERVER_AUTH_KEY" ]]; then
+    echo "error: observer bindings require --observer-nonce" >&2
+    exit 1
+  fi
+
   {
-    for cmd in "${commands[@]}"; do
+    if [[ -n "$OBSERVER_NONCE" ]]; then
+      printf '%s|%s|%s|%s|%s\n' \
+        "$OBSERVER_NONCE" \
+        "$OBSERVER_FIXTURE_ID" \
+        "$OBSERVER_SOURCE_SHA256" \
+        "$OBSERVER_COMPOSED_SHA256" \
+        "$OBSERVER_AUTH_KEY"
+    fi
+    for cmd in ${commands[@]+"${commands[@]}"}; do
       printf '%s\n' "$cmd"
     done
-    printf '(exit)\n'
+    if [[ -z "$OBSERVER_NONCE" ]]; then
+      printf '(exit)\n'
+    fi
   } | docker run --rm -i \
       -v "${repo_root}:${WORKDIR_IN_CONTAINER}:ro" \
       -w "$WORKDIR_IN_CONTAINER" \
-      "$full_image"
+      "$full_image" \
+      ${observer_args[@]+"${observer_args[@]}"} \
+      ${clips_args[@]+"${clips_args[@]}"}
 }
 
 [[ $# -eq 0 ]] && { usage; exit 1; }
@@ -203,6 +279,30 @@ while [[ $# -gt 0 ]]; do
     --op)
       OPS+=("$2")
       shift 2
+      ;;
+    --observer-nonce)
+      OBSERVER_NONCE="$2"
+      shift 2
+      ;;
+    --observer-fixture-id)
+      OBSERVER_FIXTURE_ID="$2"
+      shift 2
+      ;;
+    --observer-source-sha256)
+      OBSERVER_SOURCE_SHA256="$2"
+      shift 2
+      ;;
+    --observer-composed-sha256)
+      OBSERVER_COMPOSED_SHA256="$2"
+      shift 2
+      ;;
+    --observer-auth-key)
+      OBSERVER_AUTH_KEY="$2"
+      shift 2
+      ;;
+    --quiet)
+      QUIET=1
+      shift
       ;;
     -h|--help)
       usage

--- a/scripts/license-notices.sh
+++ b/scripts/license-notices.sh
@@ -51,12 +51,12 @@ ensure_cargo_about
 
 case "${command}" in
 generate)
-    generate_notices >"${OUT}"
+    generate_notices | tr -d '\r' >"${OUT}"
     ;;
 check)
     tmp="$(mktemp)"
     trap 'rm -f "${tmp}"' EXIT
-    generate_notices >"${tmp}"
+    generate_notices | tr -d '\r' >"${tmp}"
     if ! diff -u "${OUT}" "${tmp}"; then
         echo "THIRD_PARTY_NOTICES.md is stale. Run: just license-notices" >&2
         exit 1

--- a/tests/examples/compat-oracles.json
+++ b/tests/examples/compat-oracles.json
@@ -1,0 +1,72 @@
+{
+  "version": 1,
+  "fixtures": {
+    "ferric-oracle/empty-output-state.clp": {
+      "version": 1,
+      "id": "ferric-oracle.empty-output-state",
+      "feature": "ordered fact state transition with intentionally empty output",
+      "source_sha256": "cae413047bc57c27241dc9567f3728114f498b27115c106eaa0d0f6d7035c09f",
+      "composed_sha256": "cae413047bc57c27241dc9567f3728114f498b27115c106eaa0d0f6d7035c09f",
+      "nonce": "00000000000000000000000000000000",
+      "setup": [
+        "load",
+        "reset",
+        "run"
+      ],
+      "expectations": {
+        "phase": "run-complete",
+        "firings": {
+          "count": 1,
+          "names": null
+        },
+        "effects": [
+          {
+            "name": "fact:MAIN::result",
+            "value": {
+              "type": "multifield",
+              "value": [
+                {
+                  "type": "integer",
+                  "value": 42
+                }
+              ]
+            }
+          }
+        ],
+        "facts": [
+          {
+            "kind": "ordered",
+            "id": 0,
+            "origin": "fixture",
+            "module": "MAIN",
+            "relation": "result",
+            "fields": [
+              {
+                "type": "integer",
+                "value": 42
+              }
+            ]
+          }
+        ],
+        "channels": {
+          "stdout": "",
+          "stderr": ""
+        },
+        "diagnostic": {
+          "phase": "none",
+          "category": "none",
+          "continued": true
+        },
+        "run": {
+          "limit": null,
+          "halt_reason": "agenda-empty"
+        },
+        "focus_stack": null,
+        "globals": null
+      },
+      "normalizers": [
+        "fact-ids"
+      ]
+    }
+  }
+}

--- a/tests/examples/ferric-oracle/empty-output-state.clp
+++ b/tests/examples/ferric-oracle/empty-output-state.clp
@@ -1,0 +1,11 @@
+; Structured-oracle control fixture: semantic work is visible in final state,
+; while the user-visible output channel is intentionally empty.
+
+(deffacts setup
+   (input 1))
+
+(defrule compute-result
+   ?input <- (input 1)
+   =>
+   (retract ?input)
+   (assert (result 42)))

--- a/tools/ferric-tools/src/ferric_tools/bat/harness.py
+++ b/tools/ferric-tools/src/ferric_tools/bat/harness.py
@@ -111,7 +111,8 @@ def main(
         stats["generated"] += 1
 
     if not dry_run:
-        manifest["version"] = 2
+        current_version = manifest.get("version")
+        manifest["version"] = max(current_version, 2) if type(current_version) is int else 2
         save_manifest(manifest_path, manifest)
         print(f"\nManifest updated: {manifest_path}")
 

--- a/tools/ferric-tools/src/ferric_tools/compat/clips_oracle.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/clips_oracle.py
@@ -1,0 +1,811 @@
+"""Structured post-run observations for the reference CLIPS process.
+
+The reference image exposes a small native observer alongside the CLIPS
+interpreter.  The native boundary brackets the exact load/reset/run sequence,
+counts the remaining agenda across every module, and gates post-run probe
+records so fixture code cannot mint accepted evidence.  Its per-invocation
+binding is consumed from the input stream before the CLIPS environment is
+created; the nonce is never placed in the fixture-visible environment or
+command stream.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+ORACLE_SCHEMA = "ferric.compat-observation"
+ORACLE_VERSION = 1
+RECORD_PREFIX = "__FERRIC_COMPAT_ORACLE_V1__|"
+NATIVE_RECORD_PREFIX = "__FERRIC_COMPAT_NATIVE_V1__|"
+NATIVE_EMIT_FUNCTION = "ferric-compat-native-emit"
+NATIVE_COMPLETE_FUNCTION = "ferric-compat-native-complete"
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+_NONCE_RE = re.compile(r"^[0-9a-f]{32,128}$")
+_AUTH_KEY_RE = re.compile(r"^[0-9a-f]{64}$")
+_DIAGNOSTIC_RE = re.compile(r"\[[A-Z][A-Z0-9]*\d+\]")
+_HARNESS_LINE_RE = re.compile(r"^FERRIC-HARNESS\|(?P<version>\d+)\|(?P<body>.*)$")
+_MAX_PROBE_PAYLOAD = 16 * 1024 * 1024
+_PROBE_KINDS = frozenset({"PHASE", "MODULE", "FOCUS", "FACT", "SLOT", "VALUE", "GLOBAL"})
+
+
+class ClipsOracleProtocolError(ValueError):
+    """Raised when nonce-bound native CLIPS output is malformed."""
+
+
+@dataclass(frozen=True)
+class _Record:
+    kind: str
+    fields: tuple[str, ...]
+    value: str | None = None
+
+
+@dataclass(frozen=True)
+class _NativeRecord:
+    kind: str
+    fields: tuple[str, ...]
+    payload: bytes | None
+    start: int
+    end: int
+
+
+def _require_token(value: str, *, label: str) -> str:
+    if not _TOKEN_RE.fullmatch(value):
+        raise ValueError(f"{label} must be a non-empty protocol-safe token")
+    return value
+
+
+def _require_digest(value: str, *, label: str) -> str:
+    if not _DIGEST_RE.fullmatch(value):
+        raise ValueError(f"{label} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _require_nonce(value: str) -> str:
+    if not _NONCE_RE.fullmatch(value) or len(value) % 2 != 0:
+        raise ValueError("nonce must be 16-64 bytes encoded as lowercase hexadecimal")
+    return value
+
+
+def _require_auth_key(value: str) -> str:
+    if not _AUTH_KEY_RE.fullmatch(value):
+        raise ValueError("observer authentication key must be 32 bytes of lowercase hexadecimal")
+    return value
+
+
+def _clips_string(value: str) -> str:
+    """Quote a protocol-controlled value as a CLIPS string."""
+    if any(ord(character) < 0x20 or ord(character) == 0x7F for character in value):
+        raise ValueError("CLIPS protocol string contains a control character")
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def build_probe_operations(
+    *,
+    fixture_id: str,
+    nonce: str,
+    source_sha256: str,
+    composed_sha256: str,
+    globals_to_capture: Iterable[str] = (),
+) -> list[str]:
+    """Build post-load operations for one native-gated observation.
+
+    The nonce and identity are validated here but deliberately do not appear in
+    these CLIPS expressions.  They reach the native observer through a
+    consumed-before-exec descriptor established by ``clips-reference.sh``.
+    """
+    _require_token(fixture_id, label="fixture id")
+    _require_nonce(nonce)
+    _require_digest(source_sha256, label="source digest")
+    _require_digest(composed_sha256, label="composed digest")
+    global_names = tuple(
+        _require_token(name, label="global name").removeprefix("?*").removesuffix("*")
+        for name in globals_to_capture
+    )
+
+    emit_name = "__ferric_compat_emit_value"
+    dump_name = "__ferric_compat_dump"
+
+    emit_definition = (
+        f"(deffunction MAIN::{emit_name} "
+        "(?fact-seq ?fact-id ?module ?relation ?slot-index ?slot ?position ?value) "
+        "(bind ?text (str-cat ?value)) "
+        f"({NATIVE_EMIT_FUNCTION} "
+        '(str-cat "VALUE|" ?fact-seq "|" ?fact-id "|" ?module "|" '
+        '?relation "|" ?slot-index "|" ?slot "|" ?position "|" (type ?value) "|" '
+        "?text)))"
+    )
+
+    dump_definition = (
+        f"(deffunction MAIN::{dump_name} () "
+        "(bind ?fact-seq 0) "
+        "(progn$ (?fact (get-fact-list *)) "
+        "(if (neq (fact-relation ?fact) initial-fact) then "
+        "(bind ?fact-seq (+ ?fact-seq 1)) "
+        "(bind ?relation (fact-relation ?fact)) "
+        "(bind ?module (deftemplate-module ?relation)) "
+        "(bind ?slots (fact-slot-names ?fact)) "
+        "(bind ?kind (if (and (= (length$ ?slots) 1) "
+        "(eq (nth$ 1 ?slots) implied)) then ordered else template)) "
+        f"({NATIVE_EMIT_FUNCTION} "
+        '(str-cat "FACT|" ?fact-seq "|" (fact-index ?fact) "|" ?module "|" '
+        '?relation "|" ?kind "|" (length$ ?slots))) '
+        "(bind ?slot-index 0) "
+        "(progn$ (?slot ?slots) "
+        "(bind ?slot-index (+ ?slot-index 1)) "
+        "(bind ?value (fact-slot-value ?fact ?slot)) "
+        "(if (multifieldp ?value) then "
+        f"({NATIVE_EMIT_FUNCTION} "
+        '(str-cat "SLOT|" ?fact-seq "|" (fact-index ?fact) "|" '
+        '?slot-index "|" ?slot "|MULTIFIELD|" (length$ ?value))) '
+        "(loop-for-count (?position 1 (length$ ?value)) "
+        f"({emit_name} ?fact-seq (fact-index ?fact) ?module ?relation "
+        "?slot-index ?slot ?position (nth$ ?position ?value))) "
+        "else "
+        f"({NATIVE_EMIT_FUNCTION} "
+        '(str-cat "SLOT|" ?fact-seq "|" (fact-index ?fact) "|" '
+        '?slot-index "|" ?slot "|ATOMIC|1")) '
+        f"({emit_name} ?fact-seq (fact-index ?fact) ?module ?relation "
+        "?slot-index ?slot 0 ?value))))) "
+        "(return TRUE))"
+    )
+
+    operations = [
+        f'({NATIVE_EMIT_FUNCTION} "PHASE|1|RESET_COMPLETE")',
+        f'({NATIVE_EMIT_FUNCTION} "PHASE|2|RUN_COMPLETE")',
+        f'({NATIVE_EMIT_FUNCTION} (str-cat "MODULE|" (get-current-module)))',
+        (f'(progn$ (?focus (get-focus-stack)) ({NATIVE_EMIT_FUNCTION} (str-cat "FOCUS|" ?focus)))'),
+        "(set-current-module MAIN)",
+        emit_definition,
+        dump_definition,
+        f"({dump_name})",
+    ]
+    for name in global_names:
+        clips_reference = f"?*{name}*"
+        operations.append(f"(bind ?__ferric_global_text (str-cat {clips_reference}))")
+        operations.append(
+            f"({NATIVE_EMIT_FUNCTION} "
+            f'(str-cat "GLOBAL|{name}|" (type {clips_reference}) "|" '
+            "?__ferric_global_text))"
+        )
+    operations.append(f"({NATIVE_COMPLETE_FUNCTION})")
+    return operations
+
+
+def _decode_utf8(value: bytes, *, label: str) -> str:
+    try:
+        return value.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ClipsOracleProtocolError(f"{label} is not valid UTF-8") from error
+
+
+def _merge_intervals(intervals: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    if not intervals:
+        return []
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(intervals):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(end, merged[-1][1]))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _remove_intervals(data: bytes, intervals: list[tuple[int, int]]) -> bytes:
+    pieces: list[bytes] = []
+    cursor = 0
+    for start, end in _merge_intervals(intervals):
+        pieces.append(data[cursor:start])
+        cursor = end
+    pieces.append(data[cursor:])
+    return b"".join(pieces)
+
+
+def _parse_native_records(
+    raw: bytes,
+    *,
+    nonce: str,
+    auth_key: str,
+) -> tuple[list[_NativeRecord], str, list[str]]:
+    exact_prefix = f"\n{NATIVE_RECORD_PREFIX}{nonce}|".encode()
+    reserved_prefix = NATIVE_RECORD_PREFIX.encode()
+    auth_key_bytes = bytes.fromhex(auth_key)
+    records: list[_NativeRecord] = []
+    intervals: list[tuple[int, int]] = []
+    issues: list[str] = []
+    cursor = 0
+
+    while True:
+        start = raw.find(exact_prefix, cursor)
+        if start < 0:
+            break
+        kind_start = start + len(exact_prefix)
+        kind_end = raw.find(b"|", kind_start)
+        newline = raw.find(b"\n", kind_start)
+        if newline >= 0 and (kind_end < 0 or newline < kind_end):
+            kind = _decode_utf8(raw[kind_start:newline], label="native record kind")
+            end = newline + 1
+            records.append(_NativeRecord(kind, (), None, start, end))
+            intervals.append((start, end))
+            cursor = end
+            continue
+        if kind_end < 0:
+            raise ClipsOracleProtocolError("native record has no kind delimiter")
+        kind = _decode_utf8(raw[kind_start:kind_end], label="native record kind")
+        payload_start = kind_end + 1
+
+        if kind == "PROBE":
+            length_end = raw.find(b"|", payload_start)
+            if length_end < 0:
+                raise ClipsOracleProtocolError("native PROBE length is truncated")
+            try:
+                payload_length = int(raw[payload_start:length_end])
+            except ValueError as error:
+                raise ClipsOracleProtocolError("native PROBE length is not an integer") from error
+            if payload_length < 0 or payload_length > _MAX_PROBE_PAYLOAD:
+                raise ClipsOracleProtocolError("native PROBE length is out of range")
+            value_start = length_end + 1
+            value_end = value_start + payload_length
+            mac_start = value_end + 1
+            mac_end = mac_start + 64
+            if (
+                value_end >= len(raw)
+                or raw[value_end] != ord("|")
+                or mac_end >= len(raw)
+                or raw[mac_end] != ord("\n")
+            ):
+                raise ClipsOracleProtocolError("native PROBE payload length does not match record")
+            end = mac_end + 1
+            logical_record = raw[kind_start:value_end]
+            supplied_mac = raw[mac_start:mac_end]
+            expected_mac = (
+                hmac.new(
+                    auth_key_bytes,
+                    logical_record,
+                    hashlib.sha256,
+                )
+                .hexdigest()
+                .encode()
+            )
+            if not hmac.compare_digest(supplied_mac, expected_mac):
+                issues.append("native-authentication-failed")
+            else:
+                records.append(_NativeRecord(kind, (), raw[value_start:value_end], start, end))
+        else:
+            end_of_line = raw.find(b"\n", payload_start)
+            if end_of_line < 0:
+                raise ClipsOracleProtocolError("native record is not newline terminated")
+            end = end_of_line + 1
+            authenticated = raw[kind_start:end_of_line]
+            logical_record, separator, supplied_mac = authenticated.rpartition(b"|")
+            if not separator or len(supplied_mac) != 64:
+                raise ClipsOracleProtocolError("native record authentication is malformed")
+            expected_mac = (
+                hmac.new(
+                    auth_key_bytes,
+                    logical_record,
+                    hashlib.sha256,
+                )
+                .hexdigest()
+                .encode()
+            )
+            if not hmac.compare_digest(supplied_mac, expected_mac):
+                issues.append("native-authentication-failed")
+            else:
+                logical_kind, kind_separator, logical_payload = logical_record.partition(b"|")
+                if not kind_separator:
+                    raise ClipsOracleProtocolError("native record has no logical payload")
+                if _decode_utf8(logical_kind, label="native logical record kind") != kind:
+                    raise ClipsOracleProtocolError("native record kind is inconsistent")
+                fields = tuple(
+                    _decode_utf8(field, label=f"native {kind} field")
+                    for field in logical_payload.split(b"|")
+                )
+                records.append(_NativeRecord(kind, fields, None, start, end))
+
+        intervals.append((start, end))
+        cursor = end
+
+    semantic_bytes = _remove_intervals(raw, intervals)
+    if reserved_prefix in semantic_bytes:
+        issues.append("unexpected-native-reserved-prefix")
+    semantic_stderr = _decode_utf8(semantic_bytes, label="semantic stderr")
+    return records, semantic_stderr, issues
+
+
+def _parse_probe_payload(payload: bytes) -> _Record:
+    kind_end = payload.find(b"|")
+    if kind_end < 0:
+        return _Record(_decode_utf8(payload, label="probe kind"), ())
+    kind = _decode_utf8(payload[:kind_end], label="probe kind")
+    remainder = payload[kind_end + 1 :]
+
+    if kind == "VALUE":
+        fields = remainder.split(b"|", 8)
+        if len(fields) != 9:
+            return _Record(
+                kind,
+                tuple(_decode_utf8(field, label="VALUE field") for field in fields),
+            )
+        return _Record(
+            kind,
+            tuple(_decode_utf8(field, label="VALUE field") for field in fields[:-1]),
+            _decode_utf8(fields[-1], label="VALUE payload"),
+        )
+    if kind == "GLOBAL":
+        fields = remainder.split(b"|", 2)
+        if len(fields) != 3:
+            return _Record(
+                kind,
+                tuple(_decode_utf8(field, label="GLOBAL field") for field in fields),
+            )
+        return _Record(
+            kind,
+            tuple(_decode_utf8(field, label="GLOBAL field") for field in fields[:-1]),
+            _decode_utf8(fields[-1], label="GLOBAL payload"),
+        )
+    return _Record(
+        kind,
+        tuple(_decode_utf8(field, label=f"{kind} field") for field in remainder.split(b"|")),
+    )
+
+
+def _typed_value(type_name: str, value: str) -> dict:
+    normalized_type = type_name.lower().replace("-", "_")
+    return {"type": normalized_type, "value": value}
+
+
+def _parse_int(text: str, *, issue: str, issues: list[str]) -> int | None:
+    try:
+        return int(text)
+    except ValueError:
+        issues.append(issue)
+        return None
+
+
+def parse_probe_output(
+    raw_stdout: str | bytes,
+    *,
+    raw_stderr: str | bytes,
+    fixture_id: str,
+    nonce: str,
+    source_sha256: str,
+    composed_sha256: str,
+    auth_key: str,
+    harnessed: bool = False,
+) -> dict:
+    """Parse one quiet CLIPS invocation into a structured observation."""
+    fixture_id = _require_token(fixture_id, label="fixture id")
+    nonce = _require_nonce(nonce)
+    source_sha256 = _require_digest(source_sha256, label="source digest")
+    composed_sha256 = _require_digest(composed_sha256, label="composed digest")
+    auth_key = _require_auth_key(auth_key)
+
+    stdout_bytes = raw_stdout.encode("utf-8") if isinstance(raw_stdout, str) else raw_stdout
+    stderr_bytes = raw_stderr.encode("utf-8") if isinstance(raw_stderr, str) else raw_stderr
+    native_records, semantic_stderr, protocol_issues = _parse_native_records(
+        stderr_bytes,
+        nonce=nonce,
+        auth_key=auth_key,
+    )
+
+    allowed_native_kinds = {"LIFECYCLE", "RUN", "PROBE", "ISSUE"}
+    unknown_native_kinds = [
+        record.kind for record in native_records if record.kind not in allowed_native_kinds
+    ]
+    if unknown_native_kinds:
+        protocol_issues.append("unknown-native-record-kind")
+
+    for record in native_records:
+        if record.kind == "ISSUE":
+            if len(record.fields) != 1 or not record.fields[0]:
+                protocol_issues.append("native-issue-field-count")
+            else:
+                protocol_issues.append(f"native-{record.fields[0]}")
+
+    lifecycle_records = [record for record in native_records if record.kind == "LIFECYCLE"]
+    lifecycle: list[dict] = []
+    expected_binding = (fixture_id, source_sha256, composed_sha256)
+    for record in lifecycle_records:
+        if len(record.fields) != 5:
+            protocol_issues.append("lifecycle-field-count")
+            continue
+        sequence_text, event, bound_fixture, bound_source, bound_composed = record.fields
+        sequence = _parse_int(
+            sequence_text,
+            issue="lifecycle-sequence",
+            issues=protocol_issues,
+        )
+        if sequence is None:
+            continue
+        if (bound_fixture, bound_source, bound_composed) != expected_binding:
+            protocol_issues.append("lifecycle-binding")
+        lifecycle.append(
+            {
+                "sequence": sequence,
+                "event": event.lower(),
+                "fixture_id": bound_fixture,
+                "nonce": nonce,
+                "source_sha256": bound_source,
+                "composed_sha256": bound_composed,
+            }
+        )
+
+    if [entry["event"] for entry in lifecycle] != ["start", "complete"]:
+        protocol_issues.append("lifecycle-cardinality-or-order")
+    if lifecycle and [entry["sequence"] for entry in lifecycle] != [0, 3]:
+        protocol_issues.append("lifecycle-sequence-order")
+
+    native_run_records = [record for record in native_records if record.kind == "RUN"]
+    native_run: dict[str, int] | None = None
+    if len(native_run_records) != 1:
+        protocol_issues.append(
+            "native-run-metadata-missing" if not native_run_records else "native-run-cardinality"
+        )
+    else:
+        record = native_run_records[0]
+        if len(record.fields) != 7:
+            protocol_issues.append("native-run-field-count")
+        else:
+            numeric_fields = [
+                _parse_int(field, issue="native-run-numeric-field", issues=protocol_issues)
+                for field in record.fields
+            ]
+            if all(value is not None for value in numeric_fields):
+                (
+                    run_limit,
+                    rules_fired,
+                    halt_rules,
+                    halt_execution,
+                    evaluation_error,
+                    agenda_size,
+                    observer_violation,
+                ) = numeric_fields
+                assert run_limit is not None
+                assert rules_fired is not None
+                assert halt_rules is not None
+                assert halt_execution is not None
+                assert evaluation_error is not None
+                assert agenda_size is not None
+                assert observer_violation is not None
+                if (
+                    run_limit != -1
+                    or rules_fired < 0
+                    or halt_rules not in {0, 1}
+                    or halt_execution not in {0, 1}
+                    or evaluation_error not in {0, 1}
+                    or agenda_size < 0
+                    or observer_violation not in {0, 1}
+                ):
+                    protocol_issues.append("native-run-value")
+                else:
+                    native_run = {
+                        "run_limit": run_limit,
+                        "rules_fired": rules_fired,
+                        "halt_rules": halt_rules,
+                        "halt_execution": halt_execution,
+                        "evaluation_error": evaluation_error,
+                        "agenda_size": agenda_size,
+                        "observer_violation": observer_violation,
+                    }
+                    if observer_violation:
+                        protocol_issues.append("native-observer-violation")
+
+    record_positions = {id(record): index for index, record in enumerate(native_records)}
+    if len(lifecycle_records) == 2 and len(native_run_records) == 1:
+        start_position = record_positions[id(lifecycle_records[0])]
+        run_position = record_positions[id(native_run_records[0])]
+        complete_position = record_positions[id(lifecycle_records[1])]
+        probe_positions = [
+            record_positions[id(record)] for record in native_records if record.kind == "PROBE"
+        ]
+        if not (
+            start_position < run_position
+            and all(run_position < position < complete_position for position in probe_positions)
+            and complete_position == len(native_records) - 1
+        ):
+            protocol_issues.append("native-record-order")
+
+    records = [
+        _parse_probe_payload(record.payload)
+        for record in native_records
+        if record.kind == "PROBE" and record.payload is not None
+    ]
+    unknown_probe_kinds = [record.kind for record in records if record.kind not in _PROBE_KINDS]
+    if unknown_probe_kinds:
+        protocol_issues.append("unknown-probe-record-kind")
+
+    phase_records = [record for record in records if record.kind == "PHASE"]
+    phase_values = [record.fields for record in phase_records]
+    if phase_values != [("1", "RESET_COMPLETE"), ("2", "RUN_COMPLETE")]:
+        protocol_issues.append("phase-cardinality-or-order")
+
+    facts_by_sequence: dict[int, dict] = {}
+    slots_by_key: dict[tuple[int, int], dict] = {}
+    for record in records:
+        if record.kind == "FACT":
+            if len(record.fields) != 6:
+                protocol_issues.append("fact-field-count")
+                continue
+            sequence_text, fact_id, module, relation, kind, slot_count_text = record.fields
+            sequence = _parse_int(
+                sequence_text,
+                issue="fact-numeric-field",
+                issues=protocol_issues,
+            )
+            slot_count = _parse_int(
+                slot_count_text,
+                issue="fact-numeric-field",
+                issues=protocol_issues,
+            )
+            if sequence is None or slot_count is None:
+                continue
+            if sequence <= 0 or slot_count < 0 or kind not in {"ordered", "template"}:
+                protocol_issues.append("fact-value")
+                continue
+            if sequence in facts_by_sequence:
+                protocol_issues.append("duplicate-fact-sequence")
+                continue
+            facts_by_sequence[sequence] = {
+                "ordinal": sequence,
+                "fact_id": fact_id,
+                "module": module,
+                "kind": kind,
+                "relation": relation,
+                "_slot_count": slot_count,
+                "_slots": {},
+            }
+        elif record.kind == "SLOT":
+            if len(record.fields) != 6:
+                protocol_issues.append("slot-field-count")
+                continue
+            sequence_text, fact_id, slot_index_text, name, slot_kind, count_text = record.fields
+            sequence = _parse_int(
+                sequence_text,
+                issue="slot-numeric-field",
+                issues=protocol_issues,
+            )
+            slot_index = _parse_int(
+                slot_index_text,
+                issue="slot-numeric-field",
+                issues=protocol_issues,
+            )
+            item_count = _parse_int(
+                count_text,
+                issue="slot-numeric-field",
+                issues=protocol_issues,
+            )
+            if sequence is None or slot_index is None or item_count is None:
+                continue
+            if (
+                sequence <= 0
+                or slot_index <= 0
+                or item_count < 0
+                or slot_kind not in {"MULTIFIELD", "ATOMIC"}
+            ):
+                protocol_issues.append("slot-value")
+                continue
+            slot = {
+                "fact_id": fact_id,
+                "index": slot_index,
+                "name": name,
+                "kind": slot_kind,
+                "item_count": item_count,
+                "items": {},
+            }
+            key = (sequence, slot_index)
+            if key in slots_by_key:
+                protocol_issues.append("duplicate-slot")
+            slots_by_key[key] = slot
+        elif record.kind == "VALUE":
+            if len(record.fields) != 8 or record.value is None:
+                protocol_issues.append("value-field-count")
+                continue
+            (
+                sequence_text,
+                fact_id,
+                module,
+                relation,
+                slot_index_text,
+                slot_name,
+                position_text,
+                type_name,
+            ) = record.fields
+            sequence = _parse_int(
+                sequence_text,
+                issue="value-numeric-field",
+                issues=protocol_issues,
+            )
+            slot_index = _parse_int(
+                slot_index_text,
+                issue="value-numeric-field",
+                issues=protocol_issues,
+            )
+            position = _parse_int(
+                position_text,
+                issue="value-numeric-field",
+                issues=protocol_issues,
+            )
+            if sequence is None or slot_index is None or position is None:
+                continue
+            slot = slots_by_key.get((sequence, slot_index))
+            if slot is None:
+                protocol_issues.append("value-before-slot")
+                continue
+            if (
+                slot["fact_id"] != fact_id
+                or slot["name"] != slot_name
+                or facts_by_sequence.get(sequence, {}).get("module") != module
+                or facts_by_sequence.get(sequence, {}).get("relation") != relation
+            ):
+                protocol_issues.append("value-binding")
+            if position in slot["items"]:
+                protocol_issues.append("duplicate-value-position")
+            slot["items"][position] = _typed_value(type_name, record.value)
+
+    fact_sequences = sorted(facts_by_sequence)
+    if fact_sequences != list(range(1, len(fact_sequences) + 1)):
+        protocol_issues.append("fact-sequence-order")
+
+    facts: list[dict] = []
+    for sequence, fact in sorted(facts_by_sequence.items()):
+        fact_slots = [
+            slot
+            for (fact_sequence, _), slot in sorted(slots_by_key.items())
+            if fact_sequence == sequence
+        ]
+        if len(fact_slots) != fact["_slot_count"]:
+            protocol_issues.append("fact-slot-count")
+        if [slot["index"] for slot in fact_slots] != list(range(1, len(fact_slots) + 1)):
+            protocol_issues.append("slot-index-order")
+
+        canonical_slots: list[dict] = []
+        for slot in fact_slots:
+            positions = sorted(slot["items"])
+            expected_positions = (
+                list(range(1, slot["item_count"] + 1)) if slot["kind"] == "MULTIFIELD" else [0]
+            )
+            if positions != expected_positions:
+                protocol_issues.append("slot-item-positions")
+            items = [slot["items"][position] for position in positions]
+            if slot["kind"] == "MULTIFIELD":
+                value = {"type": "multifield", "items": items}
+            elif slot["item_count"] == 1 and len(items) == 1:
+                value = items[0]
+            else:
+                protocol_issues.append("atomic-slot-cardinality")
+                value = {"type": "invalid", "items": items}
+            canonical_slots.append({"name": slot["name"], "value": value})
+
+        canonical_fact = {key: value for key, value in fact.items() if not key.startswith("_")}
+        if fact["kind"] == "ordered":
+            if len(canonical_slots) != 1 or canonical_slots[0]["name"] != "implied":
+                protocol_issues.append("ordered-implied-slot")
+                canonical_fact["fields"] = []
+            else:
+                implied = canonical_slots[0]["value"]
+                canonical_fact["fields"] = implied.get("items", [])
+        else:
+            canonical_fact["slots"] = canonical_slots
+        facts.append(canonical_fact)
+
+    if any(sequence not in facts_by_sequence for sequence, _slot_index in slots_by_key):
+        protocol_issues.append("orphan-slot")
+
+    modules = {"current": None, "focus": None, "focus_stack": []}
+    module_records = [record for record in records if record.kind == "MODULE"]
+    if len(module_records) == 1 and len(module_records[0].fields) == 1:
+        modules["current"] = module_records[0].fields[0]
+    else:
+        protocol_issues.append("module-cardinality")
+    focus_records = [record for record in records if record.kind == "FOCUS"]
+    if any(len(record.fields) != 1 or not record.fields[0] for record in focus_records):
+        protocol_issues.append("focus-record")
+    modules["focus_stack"] = [
+        record.fields[0] for record in focus_records if len(record.fields) == 1
+    ]
+    modules["focus"] = modules["focus_stack"][-1] if modules["focus_stack"] else None
+
+    globals_observed: dict[str, dict] = {}
+    for record in records:
+        if record.kind != "GLOBAL":
+            continue
+        if len(record.fields) != 2 or record.value is None:
+            protocol_issues.append("global-field-count")
+            continue
+        name, type_name = record.fields
+        if name in globals_observed:
+            protocol_issues.append("duplicate-global")
+        globals_observed[name] = _typed_value(type_name, record.value)
+
+    semantic_stdout = _decode_utf8(stdout_bytes, label="semantic stdout")
+    harness_records: list[dict] = []
+    feature_lines: list[str] = []
+    for line in semantic_stdout.splitlines(keepends=True):
+        match = _HARNESS_LINE_RE.match(line.rstrip("\r\n")) if harnessed else None
+        if match:
+            harness_records.append(
+                {"version": int(match.group("version")), "record": match.group("body")}
+            )
+        else:
+            feature_lines.append(line)
+    semantic_stdout = "".join(feature_lines)
+
+    if RECORD_PREFIX in semantic_stdout or NATIVE_RECORD_PREFIX in semantic_stdout:
+        protocol_issues.append("unexpected-reserved-prefix")
+
+    diagnostics: list[dict] = []
+    for channel, text in (("stdout", semantic_stdout), ("stderr", semantic_stderr)):
+        for match in _DIAGNOSTIC_RE.finditer(text):
+            diagnostics.append(
+                {
+                    "phase": "unknown",
+                    "category": match.group(0),
+                    "continuation": "unknown",
+                    "channel": channel,
+                }
+            )
+
+    if native_run is None:
+        run_state = None
+    else:
+        if native_run["evaluation_error"] or (
+            native_run["halt_execution"] and not native_run["halt_rules"]
+        ):
+            halt_reason = "error"
+        elif native_run["halt_rules"]:
+            halt_reason = "halt_requested"
+        elif native_run["agenda_size"] != 0:
+            protocol_issues.append("run-returned-with-remaining-activations")
+            halt_reason = "error"
+        else:
+            halt_reason = "agenda_empty"
+        run_state = {
+            "rules_fired": native_run["rules_fired"],
+            "halt_reason": halt_reason,
+            "agenda_size": native_run["agenda_size"],
+            "halted": halt_reason != "agenda_empty",
+        }
+
+    complete = not protocol_issues and len(lifecycle) == 2 and lifecycle[-1]["event"] == "complete"
+    reached_run = native_run is not None
+    phase_reached = "post_run" if complete else ("run" if reached_run else "load")
+
+    return {
+        "schema": ORACLE_SCHEMA,
+        "version": ORACLE_VERSION,
+        "engine": {"name": "clips", "version": "6.30-debian"},
+        "fixture": {
+            "id": fixture_id,
+            "nonce": nonce,
+            "source_sha256": source_sha256,
+            "composed_sha256": composed_sha256,
+        },
+        "phase_reached": phase_reached,
+        "lifecycle": lifecycle,
+        "run": run_state,
+        "fired_rules": None,
+        "facts": facts,
+        "channels": [
+            {"name": "t", "text": semantic_stdout},
+            {"name": "stderr", "text": semantic_stderr},
+        ],
+        "diagnostics": diagnostics,
+        "modules": modules,
+        "globals": globals_observed,
+        "instrumentation": {
+            "harness_records": harness_records,
+            "native_run_records": len(native_run_records),
+        },
+        "capabilities": {
+            "fact_modules": True,
+            "fired_rule_names": False,
+            "rules_fired": True,
+            "native_run_metadata": True,
+        },
+        "protocol_issues": protocol_issues,
+    }

--- a/tools/ferric-tools/src/ferric_tools/compat/diff.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/diff.py
@@ -9,6 +9,7 @@ import typer
 from rich.console import Console
 
 from ferric_tools._manifest import load_manifest
+from ferric_tools.compat.report import compute_oracle_coverage, oracle_evidence_view
 
 app = typer.Typer(help="Compare two compat manifests.")
 console = Console(stderr=True)
@@ -17,6 +18,25 @@ DISPLAY_ORDER = ["equivalent", "divergent", "incompatible", "pending"]
 
 # Ordered from best to worst for determining regressions vs improvements.
 RANK = {"equivalent": 0, "divergent": 1, "pending": 2, "incompatible": 3}
+ORACLE_STATUS_RANK = {"invalid": 0, "missing": 1, "valid": 2}
+ORACLE_BOOLEAN_COVERAGE = ("selected", "declaration", "reached", "completed", "effect")
+STRUCTURED_ORACLE_MANIFEST_VERSION = 3
+ABSENT_CLASSIFICATION = "absent"
+ABSENT_REASON = "not present"
+LEGACY_RUNNER_CLASSIFICATIONS = {
+    "timeout-both": frozenset({"incompatible"}),
+    "timeout-ferric": frozenset({"divergent", "incompatible"}),
+    "ferric-only-clean": frozenset({"pending"}),
+    "timeout-clips": frozenset({"divergent"}),
+    "clips-load-error": frozenset({"incompatible"}),
+    "both-error": frozenset({"incompatible"}),
+    "ferric-error": frozenset({"divergent", "incompatible"}),
+    "clips-error": frozenset({"divergent"}),
+    "empty-match": frozenset({"equivalent"}),
+    "exact-match": frozenset({"equivalent"}),
+    "float-normalized-match": frozenset({"equivalent"}),
+    "output-mismatch": frozenset({"divergent"}),
+}
 
 
 def fmt_delta(n: int) -> str:
@@ -25,6 +45,117 @@ def fmt_delta(n: int) -> str:
     if n < 0:
         return str(n)
     return "0"
+
+
+def _oracle_loss_details(
+    base_info: dict | None,
+    head_info: dict | None,
+    *,
+    require_verified_head: bool,
+) -> list[str]:
+    """Describe oracle-evidence losses from one file entry to another."""
+    if base_info is None:
+        assert head_info is not None
+        head = oracle_evidence_view(head_info)
+        if head_info.get("classification") == "equivalent" and head["status"] != "valid":
+            return ["unverified equivalent claim"]
+        return []
+
+    if head_info is None:
+        base = oracle_evidence_view(base_info)
+        if base["selected"] and base["status"] == "valid":
+            return ["valid oracle-backed fixture removed"]
+        return []
+
+    base = oracle_evidence_view(base_info)
+    head = oracle_evidence_view(head_info)
+    losses: list[str] = []
+
+    for field in ORACLE_BOOLEAN_COVERAGE:
+        if base[field] and not head[field]:
+            losses.append(f"{field} true\u2192false")
+
+    if ORACLE_STATUS_RANK[head["status"]] < ORACLE_STATUS_RANK[base["status"]]:
+        losses.append(f"status {base['status']}\u2192{head['status']}")
+
+    if base["version"] is not None and head["version"] is None:
+        losses.append(f"version {base['version']}\u2192unspecified")
+
+    added_violations = sorted(set(head["violations"]) - set(base["violations"]))
+    if added_violations:
+        losses.append(f"violations added: {', '.join(added_violations)}")
+
+    unverified_equivalent = (
+        head_info.get("classification") == "equivalent"
+        and head["status"] != "valid"
+        and (
+            require_verified_head
+            or base_info.get("classification") != "equivalent"
+            or base["status"] == "valid"
+        )
+    )
+    if unverified_equivalent:
+        losses.append("unverified equivalent claim")
+
+    return losses
+
+
+def _reason_with_oracle_loss(reason: str, losses: list[str]) -> str:
+    detail = f"oracle regression: {', '.join(losses)}"
+    return f"{reason}; {detail}" if reason else detail
+
+
+def _is_v3_oracle_reset(
+    base_version: object,
+    head_version: object,
+    base_info: dict,
+    head_info: dict,
+) -> bool:
+    """Return whether a legacy result was reset for a missing v3 oracle."""
+    if (
+        type(base_version) is not int
+        or type(head_version) is not int
+        or base_version >= STRUCTURED_ORACLE_MANIFEST_VERSION
+        or head_version < STRUCTURED_ORACLE_MANIFEST_VERSION
+    ):
+        return False
+
+    if base_info.get("oracle") is not None or base_info.get("oracle_evidence") is not None:
+        return False
+
+    if (
+        head_info.get("classification") != "pending"
+        or head_info.get("reason") != "oracle-missing"
+        or head_info.get("oracle") is not None
+        or not isinstance(head_info.get("oracle_evidence"), dict)
+    ):
+        return False
+
+    head_evidence = oracle_evidence_view(head_info)
+    return (
+        head_evidence["selected"]
+        and head_evidence["status"] == "missing"
+        and not any(
+            head_evidence[field] for field in ("declaration", "reached", "completed", "effect")
+        )
+    )
+
+
+def _is_legacy_runner_migration(
+    base_version: object,
+    head_version: object,
+    base_info: dict,
+    head_info: dict,
+) -> bool:
+    """Recognize approved resets of classifications produced by the legacy runner."""
+    if not _is_v3_oracle_reset(base_version, head_version, base_info, head_info):
+        return False
+
+    allowed_classifications = LEGACY_RUNNER_CLASSIFICATIONS.get(base_info.get("reason"))
+    return (
+        allowed_classifications is not None
+        and base_info.get("classification") in allowed_classifications
+    )
 
 
 def compute_diff(base: dict, head: dict) -> tuple[dict, dict, list, list, list]:
@@ -48,8 +179,12 @@ def compute_diff(base: dict, head: dict) -> tuple[dict, dict, list, list, list]:
         if cls in head_counts:
             head_counts[cls] += 1
 
-    improvements: list[tuple] = []
+    real_improvements: list[tuple] = []
     regressions: list[tuple] = []
+    reason_changes: list[tuple] = []
+    require_verified_head = (
+        type(head.get("version")) is int and head["version"] >= STRUCTURED_ORACLE_MANIFEST_VERSION
+    )
 
     all_keys = sorted(set(base_files) | set(head_files))
     for key in all_keys:
@@ -57,29 +192,83 @@ def compute_diff(base: dict, head: dict) -> tuple[dict, dict, list, list, list]:
         h = head_files.get(key)
 
         if b is None or h is None:
+            oracle_losses = _oracle_loss_details(
+                b,
+                h,
+                require_verified_head=require_verified_head,
+            )
+            if oracle_losses:
+                b_cls = ABSENT_CLASSIFICATION if b is None else b["classification"]
+                b_reason = ABSENT_REASON if b is None else b.get("reason", "")
+                h_cls = ABSENT_CLASSIFICATION if h is None else h["classification"]
+                h_reason = ABSENT_REASON if h is None else h.get("reason", "")
+                regressions.append(
+                    (
+                        key,
+                        b_cls,
+                        b_reason,
+                        h_cls,
+                        _reason_with_oracle_loss(h_reason, oracle_losses),
+                    )
+                )
             continue
 
         b_cls = b["classification"]
         h_cls = h["classification"]
+        b_reason = b.get("reason", "")
+        h_reason = h.get("reason", "")
 
-        if b_cls == h_cls:
-            b_reason = b.get("reason", "")
-            h_reason = h.get("reason", "")
-            if b_reason != h_reason:
-                improvements.append((key, b_cls, b_reason, h_cls, h_reason))
+        if _is_legacy_runner_migration(
+            base.get("version"),
+            head.get("version"),
+            b,
+            h,
+        ):
             continue
 
-        entry = (key, b_cls, b.get("reason", ""), h_cls, h.get("reason", ""))
+        entry = (key, b_cls, b_reason, h_cls, h_reason)
+        oracle_losses = _oracle_loss_details(
+            b,
+            h,
+            require_verified_head=require_verified_head,
+        )
+
+        if oracle_losses:
+            regressions.append(
+                (
+                    key,
+                    b_cls,
+                    b_reason,
+                    h_cls,
+                    _reason_with_oracle_loss(h_reason, oracle_losses),
+                )
+            )
+            continue
+
+        if b_cls == h_cls:
+            if b_reason != h_reason:
+                # A reason change within the same semantic classification is
+                # neutral. This is especially important during manifest and
+                # oracle schema migrations, where legacy reasons are replaced.
+                reason_changes.append((key, b_cls, b_reason, h_cls, h_reason))
+            continue
+
+        if _is_v3_oracle_reset(
+            base.get("version"),
+            head.get("version"),
+            b,
+            h,
+        ):
+            regressions.append(entry)
+            continue
+
         b_rank = RANK.get(b_cls, 99)
         h_rank = RANK.get(h_cls, 99)
 
         if h_rank < b_rank:
-            improvements.append(entry)
+            real_improvements.append(entry)
         else:
             regressions.append(entry)
-
-    real_improvements = [e for e in improvements if e[1] != e[3]]
-    reason_changes = [e for e in improvements if e[1] == e[3]]
 
     return base_counts, head_counts, regressions, real_improvements, reason_changes
 
@@ -94,6 +283,8 @@ def format_markdown(
     repo: str | None = None,
     base_sha: str | None = None,
     head_sha: str | None = None,
+    base_oracle: dict | None = None,
+    head_oracle: dict | None = None,
 ) -> list[str]:
     """Build the full Markdown report as a list of lines."""
     lines: list[str] = []
@@ -101,7 +292,8 @@ def format_markdown(
     lines.append("")
     lines.append("Compares ferric's compatibility with CLIPS across a corpus of")
     lines.append("example `.clp` files. Each file is classified as **equivalent**")
-    lines.append("(output matches CLIPS), **divergent** (runs but output differs),")
+    lines.append("(a valid structured oracle matches CLIPS), **divergent** (semantic")
+    lines.append("observations differ),")
     lines.append("**incompatible** (cannot run), or **pending** (not yet tested).")
     lines.append("")
 
@@ -125,6 +317,38 @@ def format_markdown(
     d_total = head_total - base_total
     delta_total = f"**{fmt_delta(d_total)}**" if d_total != 0 else "\u2014"
     lines.append(f"| **total** | **{base_total}** | **{head_total}** | {delta_total} |")
+
+    if base_oracle is not None and head_oracle is not None:
+        lines.append("")
+        lines.append("### Oracle evidence coverage")
+        lines.append("")
+        lines.append("| Metric | Base | Head | Delta |")
+        lines.append("|---|---:|---:|---:|")
+        for key in [
+            "selected",
+            "declaration",
+            "valid",
+            "missing",
+            "invalid",
+            "reached",
+            "completed",
+            "effect",
+            "refused_equivalent",
+        ]:
+            b = base_oracle[key]
+            h = head_oracle[key]
+            lines.append(f"| {key.replace('_', ' ')} | {b} | {h} | {fmt_delta(h - b)} |")
+        lines.append("")
+        lines.append(
+            f"Versions — base: {_format_counter(base_oracle['versions'])}; "
+            f"head: {_format_counter(head_oracle['versions'])}"
+        )
+        lines.append("")
+        lines.append(
+            "Normalizations — "
+            f"base: {_format_counter(base_oracle['normalizations'])}; "
+            f"head: {_format_counter(head_oracle['normalizations'])}"
+        )
 
     lines.append("")
     if regressions:
@@ -169,6 +393,79 @@ def format_markdown(
     return lines
 
 
+def _format_counter(counter: dict[str, int]) -> str:
+    if not counter:
+        return "(none)"
+    return ", ".join(f"{name}: {count}" for name, count in sorted(counter.items()))
+
+
+def _change_kind(
+    base_info: dict | None,
+    head_info: dict | None,
+    *,
+    base_version: object = None,
+    head_version: object = None,
+) -> tuple[str, list[str]]:
+    """Return the TSV change label and any oracle regression details."""
+    require_verified_head = (
+        type(head_version) is int and head_version >= STRUCTURED_ORACLE_MANIFEST_VERSION
+    )
+    if base_info is None:
+        oracle_losses = _oracle_loss_details(
+            None,
+            head_info,
+            require_verified_head=require_verified_head,
+        )
+        if oracle_losses:
+            return "regression", oracle_losses
+        return "added", []
+    if head_info is None:
+        oracle_losses = _oracle_loss_details(
+            base_info,
+            None,
+            require_verified_head=require_verified_head,
+        )
+        if oracle_losses:
+            return "regression", oracle_losses
+        return "removed", []
+
+    if _is_legacy_runner_migration(
+        base_version,
+        head_version,
+        base_info,
+        head_info,
+    ):
+        return "schema-migration", []
+
+    oracle_losses = _oracle_loss_details(
+        base_info,
+        head_info,
+        require_verified_head=require_verified_head,
+    )
+    if oracle_losses:
+        return "regression", oracle_losses
+
+    base_classification = base_info["classification"]
+    head_classification = head_info["classification"]
+    if base_classification == head_classification:
+        if base_info.get("reason", "") != head_info.get("reason", ""):
+            return "reason-changed", []
+        return "unchanged", []
+
+    if _is_v3_oracle_reset(
+        base_version,
+        head_version,
+        base_info,
+        head_info,
+    ):
+        return "regression", []
+
+    base_rank = RANK.get(base_classification, 99)
+    head_rank = RANK.get(head_classification, 99)
+    change = "improvement" if head_rank < base_rank else "regression"
+    return change, []
+
+
 def write_tsv(base: dict, head: dict, tsv_path: str) -> None:
     """Write per-file raw data as TSV."""
     base_files = base.get("files", {})
@@ -182,6 +479,13 @@ def write_tsv(base: dict, head: dict, tsv_path: str) -> None:
         "base_reason",
         "head_classification",
         "head_reason",
+        "base_oracle_status",
+        "head_oracle_status",
+        "base_oracle_version",
+        "head_oracle_version",
+        "base_oracle_normalizations",
+        "head_oracle_normalizations",
+        "oracle_regression",
         "change",
     ]
 
@@ -198,19 +502,14 @@ def write_tsv(base: dict, head: dict, tsv_path: str) -> None:
             h_cls = h["classification"] if h else ""
             h_reason = h.get("reason", "") if h else ""
             source_val = (h or b).get("source", "")
-
-            if not b:
-                change = "added"
-            elif not h:
-                change = "removed"
-            elif b_cls != h_cls:
-                b_rank = RANK.get(b_cls, 99)
-                h_rank = RANK.get(h_cls, 99)
-                change = "improvement" if h_rank < b_rank else "regression"
-            elif b_reason != h_reason:
-                change = "reason-changed"
-            else:
-                change = "unchanged"
+            base_oracle = oracle_evidence_view(b) if b else None
+            head_oracle = oracle_evidence_view(h) if h else None
+            change, oracle_losses = _change_kind(
+                b,
+                h,
+                base_version=base.get("version"),
+                head_version=head.get("version"),
+            )
 
             writer.writerow(
                 {
@@ -220,6 +519,25 @@ def write_tsv(base: dict, head: dict, tsv_path: str) -> None:
                     "base_reason": b_reason,
                     "head_classification": h_cls,
                     "head_reason": h_reason,
+                    "base_oracle_status": base_oracle["status"] if base_oracle else "",
+                    "head_oracle_status": head_oracle["status"] if head_oracle else "",
+                    "base_oracle_version": (
+                        ""
+                        if base_oracle is None or base_oracle["version"] is None
+                        else str(base_oracle["version"])
+                    ),
+                    "head_oracle_version": (
+                        ""
+                        if head_oracle is None or head_oracle["version"] is None
+                        else str(head_oracle["version"])
+                    ),
+                    "base_oracle_normalizations": (
+                        ";".join(base_oracle["normalizations"]) if base_oracle else ""
+                    ),
+                    "head_oracle_normalizations": (
+                        ";".join(head_oracle["normalizations"]) if head_oracle else ""
+                    ),
+                    "oracle_regression": ";".join(oracle_losses),
                     "change": change,
                 }
             )
@@ -252,6 +570,8 @@ def main(
         repo=repo,
         base_sha=base_sha,
         head_sha=head_sha,
+        base_oracle=compute_oracle_coverage(base),
+        head_oracle=compute_oracle_coverage(head),
     )
     print("\n".join(md_lines))
 

--- a/tools/ferric-tools/src/ferric_tools/compat/oracle.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/oracle.py
@@ -1,0 +1,1471 @@
+"""Strict, engine-neutral compatibility oracle contracts.
+
+This module deliberately does not know how either engine is invoked.  It
+validates versioned declaration and observation dictionaries, then compares
+the independently captured observations against the declaration and each
+other.  Callers retain responsibility for producing trustworthy observations.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+DECLARATION_VERSION = 1
+OBSERVATION_VERSION = 1
+
+NORMALIZE_FACT_IDS = "fact-ids"
+NORMALIZE_FACT_ORDER = "fact-order"
+NORMALIZE_FLOAT_FORMAT = "float-format"
+SUPPORTED_NORMALIZERS = frozenset(
+    {
+        NORMALIZE_FACT_IDS,
+        NORMALIZE_FACT_ORDER,
+        NORMALIZE_FLOAT_FORMAT,
+    }
+)
+
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_NONCE_RE = re.compile(r"[0-9a-f]{32,128}")
+_PROTOCOL_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}")
+_FLOAT_RE = re.compile(r"-?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:[eE][+-]?\d+)?")
+_VALUE_TYPES = frozenset({"symbol", "string", "integer", "float", "multifield"})
+_FACT_ORIGINS = frozenset({"fixture", "instrumentation", "engine"})
+_EVIDENCE_ORIGINS = frozenset({"fixture", "instrumentation"})
+_HALT_REASONS = frozenset(
+    {
+        "agenda-empty",
+        "limit-reached",
+        "halt-requested",
+        "error",
+        "not-run",
+    }
+)
+_V1_SETUP = ("load", "reset", "run")
+
+
+class EvidenceStatus(StrEnum):
+    """Whether an oracle contract was present and structurally trustworthy."""
+
+    VALID = "valid"
+    MISSING = "missing"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True)
+class OracleIssue:
+    """One field-addressed contract validation failure."""
+
+    field: str
+    message: str
+
+
+@dataclass(frozen=True)
+class Evidence[T]:
+    """A validated declaration or observation."""
+
+    status: EvidenceStatus
+    value: T | None = None
+    issues: tuple[OracleIssue, ...] = ()
+
+
+@dataclass(frozen=True)
+class TypedValue:
+    """A canonical, recursively typed CLIPS value."""
+
+    type: str
+    value: str | int | tuple[TypedValue, ...]
+
+
+@dataclass(frozen=True)
+class Slot:
+    """One named template slot."""
+
+    name: str
+    value: TypedValue
+
+
+@dataclass(frozen=True)
+class OrderedFact:
+    """An ordered fact, including identity and provenance."""
+
+    kind: str
+    id: int
+    origin: str
+    module: str
+    relation: str
+    fields: tuple[TypedValue, ...]
+
+
+@dataclass(frozen=True)
+class TemplateFact:
+    """A template fact, including slot names, identity, and provenance."""
+
+    kind: str
+    id: int
+    origin: str
+    module: str
+    template: str
+    slots: tuple[Slot, ...]
+
+
+type Fact = OrderedFact | TemplateFact
+
+
+@dataclass(frozen=True)
+class ExpectedEffect:
+    """A feature-specific effect declared by the fixture."""
+
+    name: str
+    value: TypedValue
+
+
+@dataclass(frozen=True)
+class ObservedEffect:
+    """A captured effect with explicit fixture/instrumentation provenance."""
+
+    name: str
+    value: TypedValue
+    origin: str
+
+
+@dataclass(frozen=True)
+class ObservedFiring:
+    """A captured firing with explicit fixture/instrumentation provenance."""
+
+    rule: str
+    origin: str
+
+
+@dataclass(frozen=True)
+class FiringExpectation:
+    """Expected fixture firings; either the count or ordered names may be omitted."""
+
+    count: int | None
+    names: tuple[str, ...] | None
+
+
+@dataclass(frozen=True)
+class DiagnosticState:
+    """Structured diagnostic phase, category, and continuation behavior."""
+
+    phase: str
+    category: str
+    continued: bool
+
+
+@dataclass(frozen=True)
+class RunState:
+    """Run limit and terminal state."""
+
+    limit: int | None
+    halt_reason: str
+
+
+@dataclass(frozen=True)
+class GlobalValue:
+    """One named global value."""
+
+    name: str
+    value: TypedValue
+
+
+@dataclass(frozen=True)
+class Expectations:
+    """All independently reviewable semantic expectations for one fixture."""
+
+    phase: str
+    firings: FiringExpectation
+    effects: tuple[ExpectedEffect, ...]
+    facts: tuple[Fact, ...]
+    channels: tuple[tuple[str, str], ...]
+    diagnostic: DiagnosticState
+    run: RunState
+    focus_stack: tuple[str, ...] | None
+    globals: tuple[GlobalValue, ...] | None
+
+
+@dataclass(frozen=True)
+class OracleDeclaration:
+    """A validated version-1 fixture declaration."""
+
+    version: int
+    id: str
+    feature: str
+    source_sha256: str
+    composed_sha256: str
+    nonce: str
+    setup: tuple[str, ...]
+    expectations: Expectations
+    normalizers: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Marker:
+    """One identity-bound protocol marker."""
+
+    kind: str
+    id: str
+    source_sha256: str
+    composed_sha256: str
+    nonce: str
+
+
+@dataclass(frozen=True)
+class OracleObservation:
+    """A validated version-1 engine observation."""
+
+    version: int
+    id: str
+    source_sha256: str
+    composed_sha256: str
+    nonce: str
+    markers: tuple[Marker, ...]
+    phase: str
+    firings: tuple[ObservedFiring, ...]
+    effects: tuple[ObservedEffect, ...]
+    facts: tuple[Fact, ...]
+    channels: tuple[tuple[str, str], ...]
+    diagnostic: DiagnosticState
+    run: RunState
+    focus_stack: tuple[str, ...] | None
+    globals: tuple[GlobalValue, ...] | None
+
+
+@dataclass(frozen=True)
+class OracleMismatch:
+    """One field-specific semantic or evidence mismatch."""
+
+    scope: str
+    field: str
+    message: str
+
+
+@dataclass(frozen=True)
+class OracleEvaluation:
+    """The complete validation and comparison result for two engines."""
+
+    status: EvidenceStatus
+    equivalent: bool
+    declaration: Evidence[OracleDeclaration]
+    ferric: Evidence[OracleObservation]
+    clips: Evidence[OracleObservation]
+    mismatches: tuple[OracleMismatch, ...]
+
+
+class _ContractViolation(ValueError):
+    def __init__(self, field: str, message: str) -> None:
+        super().__init__(f"{field}: {message}")
+        self.field = field
+        self.message = message
+
+
+def _fail(field: str, message: str) -> None:
+    raise _ContractViolation(field, message)
+
+
+def _strict_dict(
+    raw: object,
+    *,
+    field: str,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+) -> dict[str, object]:
+    if type(raw) is not dict:
+        _fail(field, "must be an object")
+    assert isinstance(raw, dict)
+    if any(type(key) is not str for key in raw):
+        _fail(field, "must contain only string field names")
+    actual = set(raw)
+    missing = sorted(required - actual)
+    unknown = sorted(actual - required - optional)
+    if missing:
+        _fail(field, f"missing fields: {', '.join(missing)}")
+    if unknown:
+        _fail(field, f"unknown fields: {', '.join(unknown)}")
+    return raw
+
+
+def _strict_list(raw: object, *, field: str) -> list[object]:
+    if type(raw) is not list:
+        _fail(field, "must be an array")
+    assert isinstance(raw, list)
+    return raw
+
+
+def _string(raw: object, *, field: str) -> str:
+    if type(raw) is not str:
+        _fail(field, "must be a string")
+    assert isinstance(raw, str)
+    if not raw:
+        _fail(field, "must not be empty")
+    if any(ord(character) < 32 or ord(character) == 127 for character in raw):
+        _fail(field, "must not contain control characters")
+    return raw
+
+
+def _digest(raw: object, *, field: str) -> str:
+    value = _string(raw, field=field)
+    if _SHA256_RE.fullmatch(value) is None:
+        _fail(field, "must be a lowercase SHA-256 digest")
+    return value
+
+
+def _nonce(raw: object, *, field: str) -> str:
+    value = _string(raw, field=field)
+    if len(value) % 2 != 0 or _NONCE_RE.fullmatch(value) is None:
+        _fail(
+            field,
+            "must encode 16 to 64 bytes as even-length lowercase hexadecimal",
+        )
+    return value
+
+
+def _protocol_token(raw: object, *, field: str) -> str:
+    value = _string(raw, field=field)
+    if _PROTOCOL_TOKEN_RE.fullmatch(value) is None:
+        _fail(field, "must be a protocol-safe token of at most 128 ASCII bytes")
+    return value
+
+
+def _version(raw: object, *, field: str, expected: int) -> int:
+    if type(raw) is not int or raw != expected:
+        _fail(field, f"unsupported version: {raw!r}")
+    assert isinstance(raw, int)
+    return raw
+
+
+def _optional_nonnegative_int(raw: object, *, field: str) -> int | None:
+    if raw is None:
+        return None
+    if type(raw) is not int or raw < 0:
+        _fail(field, "must be a non-negative integer or null")
+    assert isinstance(raw, int)
+    return raw
+
+
+def _typed_value(raw: object, *, field: str) -> TypedValue:
+    value_object = _strict_dict(
+        raw,
+        field=field,
+        required=frozenset({"type", "value"}),
+    )
+    value_type = _string(value_object["type"], field=f"{field}.type")
+    if value_type not in _VALUE_TYPES:
+        _fail(f"{field}.type", f"unsupported typed value: {value_type!r}")
+    value = value_object["value"]
+
+    if value_type in {"symbol", "string"}:
+        if type(value) is not str:
+            _fail(f"{field}.value", f"must be a string for {value_type}")
+        assert isinstance(value, str)
+        return TypedValue(value_type, value)
+    if value_type == "integer":
+        if type(value) is not int:
+            _fail(f"{field}.value", "must be an integer for integer")
+        assert isinstance(value, int)
+        return TypedValue(value_type, value)
+    if value_type == "float":
+        if type(value) is not str or _FLOAT_RE.fullmatch(value) is None:
+            _fail(
+                f"{field}.value",
+                "must be a finite decimal string for float",
+            )
+        assert isinstance(value, str)
+        return TypedValue(value_type, value)
+
+    items = _strict_list(value, field=f"{field}.value")
+    return TypedValue(
+        value_type,
+        tuple(
+            _typed_value(item, field=f"{field}.value[{index}]") for index, item in enumerate(items)
+        ),
+    )
+
+
+def _slot(raw: object, *, field: str) -> Slot:
+    slot_object = _strict_dict(
+        raw,
+        field=field,
+        required=frozenset({"name", "value"}),
+    )
+    return Slot(
+        name=_string(slot_object["name"], field=f"{field}.name"),
+        value=_typed_value(slot_object["value"], field=f"{field}.value"),
+    )
+
+
+def _fact(raw: object, *, field: str) -> Fact:
+    if type(raw) is not dict:
+        _fail(field, "must be an object")
+    assert isinstance(raw, dict)
+    kind = raw.get("kind")
+    if kind == "ordered":
+        fact_object = _strict_dict(
+            raw,
+            field=field,
+            required=frozenset(
+                {
+                    "kind",
+                    "id",
+                    "origin",
+                    "module",
+                    "relation",
+                    "fields",
+                }
+            ),
+        )
+        fact_id = _optional_nonnegative_int(fact_object["id"], field=f"{field}.id")
+        if fact_id is None:
+            _fail(f"{field}.id", "must not be null")
+        origin = _string(fact_object["origin"], field=f"{field}.origin")
+        if origin not in _FACT_ORIGINS:
+            _fail(f"{field}.origin", f"unsupported fact origin: {origin!r}")
+        fields = _strict_list(fact_object["fields"], field=f"{field}.fields")
+        return OrderedFact(
+            kind="ordered",
+            id=fact_id,
+            origin=origin,
+            module=_string(fact_object["module"], field=f"{field}.module"),
+            relation=_string(fact_object["relation"], field=f"{field}.relation"),
+            fields=tuple(
+                _typed_value(value, field=f"{field}.fields[{index}]")
+                for index, value in enumerate(fields)
+            ),
+        )
+    if kind == "template":
+        fact_object = _strict_dict(
+            raw,
+            field=field,
+            required=frozenset(
+                {
+                    "kind",
+                    "id",
+                    "origin",
+                    "module",
+                    "template",
+                    "slots",
+                }
+            ),
+        )
+        fact_id = _optional_nonnegative_int(fact_object["id"], field=f"{field}.id")
+        if fact_id is None:
+            _fail(f"{field}.id", "must not be null")
+        origin = _string(fact_object["origin"], field=f"{field}.origin")
+        if origin not in _FACT_ORIGINS:
+            _fail(f"{field}.origin", f"unsupported fact origin: {origin!r}")
+        raw_slots = _strict_list(fact_object["slots"], field=f"{field}.slots")
+        slots = tuple(
+            _slot(slot, field=f"{field}.slots[{index}]") for index, slot in enumerate(raw_slots)
+        )
+        slot_names = [slot.name for slot in slots]
+        if len(slot_names) != len(set(slot_names)):
+            _fail(f"{field}.slots", "must not contain duplicate slot names")
+        return TemplateFact(
+            kind="template",
+            id=fact_id,
+            origin=origin,
+            module=_string(fact_object["module"], field=f"{field}.module"),
+            template=_string(fact_object["template"], field=f"{field}.template"),
+            slots=slots,
+        )
+    _fail(f"{field}.kind", "must be 'ordered' or 'template'")
+
+
+def _facts(raw: object, *, field: str) -> tuple[Fact, ...]:
+    items = _strict_list(raw, field=field)
+    return tuple(_fact(item, field=f"{field}[{index}]") for index, item in enumerate(items))
+
+
+def _channels(raw: object, *, field: str) -> tuple[tuple[str, str], ...]:
+    if type(raw) is not dict:
+        _fail(field, "must be an object")
+    assert isinstance(raw, dict)
+    if any(type(key) is not str for key in raw):
+        _fail(field, "must contain only string channel names")
+    channels_object = raw
+    if "stdout" not in channels_object or "stderr" not in channels_object:
+        _fail(field, "must define stdout and stderr channels")
+    channels: list[tuple[str, str]] = []
+    for name in sorted(channels_object):
+        channel_name = _string(name, field=f"{field} field")
+        output = channels_object[name]
+        if type(output) is not str:
+            _fail(f"{field}.{channel_name}", "must be a string")
+        assert isinstance(output, str)
+        channels.append((channel_name, output))
+    return tuple(channels)
+
+
+def _diagnostic(raw: object, *, field: str) -> DiagnosticState:
+    diagnostic_object = _strict_dict(
+        raw,
+        field=field,
+        required=frozenset({"phase", "category", "continued"}),
+    )
+    phase = _string(diagnostic_object["phase"], field=f"{field}.phase")
+    category = _string(diagnostic_object["category"], field=f"{field}.category")
+    if phase == "unknown" or category == "unknown":
+        _fail(field, "unknown diagnostic evidence is not valid")
+    continued = diagnostic_object["continued"]
+    if type(continued) is not bool:
+        _fail(f"{field}.continued", "must be a boolean")
+    assert isinstance(continued, bool)
+    return DiagnosticState(phase=phase, category=category, continued=continued)
+
+
+def _run_state(raw: object, *, field: str) -> RunState:
+    run_object = _strict_dict(
+        raw,
+        field=field,
+        required=frozenset({"limit", "halt_reason"}),
+    )
+    halt_reason = _string(run_object["halt_reason"], field=f"{field}.halt_reason")
+    if halt_reason not in _HALT_REASONS:
+        _fail(f"{field}.halt_reason", f"unsupported halt reason: {halt_reason!r}")
+    return RunState(
+        limit=_optional_nonnegative_int(run_object["limit"], field=f"{field}.limit"),
+        halt_reason=halt_reason,
+    )
+
+
+def _focus_stack(raw: object, *, field: str) -> tuple[str, ...] | None:
+    if raw is None:
+        return None
+    items = _strict_list(raw, field=field)
+    return tuple(_string(item, field=f"{field}[{index}]") for index, item in enumerate(items))
+
+
+def _globals(raw: object, *, field: str) -> tuple[GlobalValue, ...] | None:
+    if raw is None:
+        return None
+    items = _strict_list(raw, field=field)
+    globals_values: list[GlobalValue] = []
+    for index, item in enumerate(items):
+        item_field = f"{field}[{index}]"
+        global_object = _strict_dict(
+            item,
+            field=item_field,
+            required=frozenset({"name", "value"}),
+        )
+        globals_values.append(
+            GlobalValue(
+                name=_protocol_token(global_object["name"], field=f"{item_field}.name"),
+                value=_typed_value(global_object["value"], field=f"{item_field}.value"),
+            )
+        )
+    names = [global_value.name for global_value in globals_values]
+    if len(names) != len(set(names)):
+        _fail(field, "must not contain duplicate global names")
+    return tuple(globals_values)
+
+
+def _firing_expectation(raw: object, *, field: str) -> FiringExpectation:
+    firing_object = _strict_dict(
+        raw,
+        field=field,
+        required=frozenset({"count", "names"}),
+    )
+    count = _optional_nonnegative_int(firing_object["count"], field=f"{field}.count")
+    raw_names = firing_object["names"]
+    names: tuple[str, ...] | None
+    if raw_names is None:
+        names = None
+    else:
+        name_items = _strict_list(raw_names, field=f"{field}.names")
+        names = tuple(
+            _string(name, field=f"{field}.names[{index}]") for index, name in enumerate(name_items)
+        )
+    if count is None and names is None:
+        _fail(field, "must declare a firing count, ordered names, or both")
+    if count is not None and names is not None and count != len(names):
+        _fail(
+            field,
+            "firing count must equal the number of ordered firing names",
+        )
+    return FiringExpectation(count=count, names=names)
+
+
+def _expected_effect(raw: object, *, field: str) -> ExpectedEffect:
+    effect_object = _strict_dict(
+        raw,
+        field=field,
+        required=frozenset({"name", "value"}),
+    )
+    return ExpectedEffect(
+        name=_string(effect_object["name"], field=f"{field}.name"),
+        value=_typed_value(effect_object["value"], field=f"{field}.value"),
+    )
+
+
+def _expectations(raw: object, *, field: str) -> Expectations:
+    expectations_object = _strict_dict(
+        raw,
+        field=field,
+        required=frozenset(
+            {
+                "phase",
+                "firings",
+                "effects",
+                "facts",
+                "channels",
+                "diagnostic",
+                "run",
+                "focus_stack",
+                "globals",
+            }
+        ),
+    )
+    raw_effects = _strict_list(expectations_object["effects"], field=f"{field}.effects")
+    effects = tuple(
+        _expected_effect(effect, field=f"{field}.effects[{index}]")
+        for index, effect in enumerate(raw_effects)
+    )
+    if not effects:
+        _fail(
+            f"{field}.effects",
+            "must declare at least one fixture-specific semantic effect",
+        )
+    channels = _channels(expectations_object["channels"], field=f"{field}.channels")
+    if {name for name, _output in channels} != {"stdout", "stderr"}:
+        _fail(
+            f"{field}.channels",
+            "oracle v1 supports exactly stdout and stderr",
+        )
+    run = _run_state(expectations_object["run"], field=f"{field}.run")
+    if run.limit is not None:
+        _fail(
+            f"{field}.run.limit",
+            "oracle v1 supports only an unlimited run",
+        )
+    if run.halt_reason not in {"agenda-empty", "halt-requested"}:
+        _fail(
+            f"{field}.run.halt_reason",
+            "oracle v1 supports only agenda-empty or halt-requested completion",
+        )
+    return Expectations(
+        phase=_string(expectations_object["phase"], field=f"{field}.phase"),
+        firings=_firing_expectation(
+            expectations_object["firings"],
+            field=f"{field}.firings",
+        ),
+        effects=effects,
+        facts=_facts(expectations_object["facts"], field=f"{field}.facts"),
+        channels=channels,
+        diagnostic=_diagnostic(
+            expectations_object["diagnostic"],
+            field=f"{field}.diagnostic",
+        ),
+        run=run,
+        focus_stack=_focus_stack(
+            expectations_object["focus_stack"],
+            field=f"{field}.focus_stack",
+        ),
+        globals=_globals(expectations_object["globals"], field=f"{field}.globals"),
+    )
+
+
+def _normalizers(raw: object, *, field: str) -> tuple[str, ...]:
+    items = _strict_list(raw, field=field)
+    normalizers = tuple(
+        _string(item, field=f"{field}[{index}]") for index, item in enumerate(items)
+    )
+    if len(normalizers) != len(set(normalizers)):
+        _fail(field, "must not contain duplicate normalizers")
+    unsupported = sorted(set(normalizers) - SUPPORTED_NORMALIZERS)
+    if unsupported:
+        _fail(field, f"unsupported normalizers: {', '.join(unsupported)}")
+    return normalizers
+
+
+def _parse_declaration(
+    raw: object,
+    *,
+    expected_source_sha256: str,
+    expected_composed_sha256: str,
+) -> OracleDeclaration:
+    expected_digest = _digest(
+        expected_source_sha256,
+        field="expected_source_sha256",
+    )
+    expected_composed_digest = _digest(
+        expected_composed_sha256,
+        field="expected_composed_sha256",
+    )
+    declaration_object = _strict_dict(
+        raw,
+        field="$",
+        required=frozenset(
+            {
+                "version",
+                "id",
+                "feature",
+                "source_sha256",
+                "composed_sha256",
+                "nonce",
+                "setup",
+                "expectations",
+                "normalizers",
+            }
+        ),
+    )
+    source_digest = _digest(
+        declaration_object["source_sha256"],
+        field="source_sha256",
+    )
+    if source_digest != expected_digest:
+        _fail("source_sha256", "source digest is stale")
+    composed_digest = _digest(
+        declaration_object["composed_sha256"],
+        field="composed_sha256",
+    )
+    if composed_digest != expected_composed_digest:
+        _fail("composed_sha256", "composed input digest is stale")
+    raw_setup = _strict_list(declaration_object["setup"], field="setup")
+    setup = tuple(
+        _string(operation, field=f"setup[{index}]") for index, operation in enumerate(raw_setup)
+    )
+    if setup != _V1_SETUP:
+        _fail("setup", "version 1 requires exactly: load, reset, run")
+    return OracleDeclaration(
+        version=_version(
+            declaration_object["version"],
+            field="version",
+            expected=DECLARATION_VERSION,
+        ),
+        id=_protocol_token(declaration_object["id"], field="id"),
+        feature=_string(declaration_object["feature"], field="feature"),
+        source_sha256=source_digest,
+        composed_sha256=composed_digest,
+        nonce=_nonce(declaration_object["nonce"], field="nonce"),
+        setup=setup,
+        expectations=_expectations(
+            declaration_object["expectations"],
+            field="expectations",
+        ),
+        normalizers=_normalizers(
+            declaration_object["normalizers"],
+            field="normalizers",
+        ),
+    )
+
+
+def validate_declaration(
+    raw: object | None,
+    *,
+    expected_source_sha256: str,
+    expected_composed_sha256: str,
+) -> Evidence[OracleDeclaration]:
+    """Validate a v1 declaration without raising for missing or invalid evidence."""
+    if raw is None:
+        return Evidence(status=EvidenceStatus.MISSING)
+    try:
+        declaration = _parse_declaration(
+            raw,
+            expected_source_sha256=expected_source_sha256,
+            expected_composed_sha256=expected_composed_sha256,
+        )
+    except _ContractViolation as error:
+        return Evidence(
+            status=EvidenceStatus.INVALID,
+            issues=(OracleIssue(error.field, error.message),),
+        )
+    return Evidence(status=EvidenceStatus.VALID, value=declaration)
+
+
+def _marker(raw: object, *, field: str) -> Marker:
+    marker_object = _strict_dict(
+        raw,
+        field=field,
+        required=frozenset(
+            {
+                "kind",
+                "id",
+                "source_sha256",
+                "composed_sha256",
+                "nonce",
+            }
+        ),
+    )
+    kind = _string(marker_object["kind"], field=f"{field}.kind")
+    if kind not in {"START", "COMPLETE"}:
+        _fail(f"{field}.kind", "must be START or COMPLETE")
+    return Marker(
+        kind=kind,
+        id=_string(marker_object["id"], field=f"{field}.id"),
+        source_sha256=_digest(
+            marker_object["source_sha256"],
+            field=f"{field}.source_sha256",
+        ),
+        composed_sha256=_digest(
+            marker_object["composed_sha256"],
+            field=f"{field}.composed_sha256",
+        ),
+        nonce=_nonce(marker_object["nonce"], field=f"{field}.nonce"),
+    )
+
+
+def _markers(
+    raw: object,
+    *,
+    field: str,
+    declaration: OracleDeclaration,
+) -> tuple[Marker, ...]:
+    items = _strict_list(raw, field=field)
+    markers = tuple(_marker(item, field=f"{field}[{index}]") for index, item in enumerate(items))
+    starts = [marker for marker in markers if marker.kind == "START"]
+    completions = [marker for marker in markers if marker.kind == "COMPLETE"]
+    if len(starts) != 1 or len(completions) != 1 or len(markers) != 2:
+        _fail(field, "must contain exactly one START and exactly one COMPLETE")
+    if tuple(marker.kind for marker in markers) != ("START", "COMPLETE"):
+        _fail(field, "START must precede COMPLETE")
+    for index, marker in enumerate(markers):
+        marker_field = f"{field}[{index}]"
+        if marker.id != declaration.id:
+            _fail(f"{marker_field}.id", "does not match declaration id")
+        if marker.source_sha256 != declaration.source_sha256:
+            _fail(
+                f"{marker_field}.source_sha256",
+                "does not match declaration source digest",
+            )
+        if marker.composed_sha256 != declaration.composed_sha256:
+            _fail(
+                f"{marker_field}.composed_sha256",
+                "does not match declaration composed input digest",
+            )
+        if marker.nonce != declaration.nonce:
+            _fail(f"{marker_field}.nonce", "does not match declaration nonce")
+    return markers
+
+
+def _observed_firing(raw: object, *, field: str) -> ObservedFiring:
+    firing_object = _strict_dict(
+        raw,
+        field=field,
+        required=frozenset({"rule", "origin"}),
+    )
+    origin = _string(firing_object["origin"], field=f"{field}.origin")
+    if origin not in _EVIDENCE_ORIGINS:
+        _fail(f"{field}.origin", f"unsupported firing origin: {origin!r}")
+    return ObservedFiring(
+        rule=_string(firing_object["rule"], field=f"{field}.rule"),
+        origin=origin,
+    )
+
+
+def _observed_effect(raw: object, *, field: str) -> ObservedEffect:
+    effect_object = _strict_dict(
+        raw,
+        field=field,
+        required=frozenset({"name", "value", "origin"}),
+    )
+    origin = _string(effect_object["origin"], field=f"{field}.origin")
+    if origin not in _EVIDENCE_ORIGINS:
+        _fail(f"{field}.origin", f"unsupported effect origin: {origin!r}")
+    return ObservedEffect(
+        name=_string(effect_object["name"], field=f"{field}.name"),
+        value=_typed_value(effect_object["value"], field=f"{field}.value"),
+        origin=origin,
+    )
+
+
+def _parse_observation(
+    raw: object,
+    *,
+    declaration: OracleDeclaration,
+) -> OracleObservation:
+    observation_object = _strict_dict(
+        raw,
+        field="$",
+        required=frozenset(
+            {
+                "version",
+                "id",
+                "source_sha256",
+                "composed_sha256",
+                "nonce",
+                "markers",
+                "phase",
+                "firings",
+                "effects",
+                "facts",
+                "channels",
+                "diagnostic",
+                "run",
+                "focus_stack",
+                "globals",
+            }
+        ),
+    )
+    fixture_id = _string(observation_object["id"], field="id")
+    if fixture_id != declaration.id:
+        _fail("id", "does not match declaration id")
+    source_digest = _digest(
+        observation_object["source_sha256"],
+        field="source_sha256",
+    )
+    if source_digest != declaration.source_sha256:
+        _fail("source_sha256", "does not match declaration source digest")
+    composed_digest = _digest(
+        observation_object["composed_sha256"],
+        field="composed_sha256",
+    )
+    if composed_digest != declaration.composed_sha256:
+        _fail("composed_sha256", "does not match declaration composed input digest")
+    nonce = _nonce(observation_object["nonce"], field="nonce")
+    if nonce != declaration.nonce:
+        _fail("nonce", "does not match declaration nonce")
+
+    raw_firings = _strict_list(observation_object["firings"], field="firings")
+    raw_effects = _strict_list(observation_object["effects"], field="effects")
+    return OracleObservation(
+        version=_version(
+            observation_object["version"],
+            field="version",
+            expected=OBSERVATION_VERSION,
+        ),
+        id=fixture_id,
+        source_sha256=source_digest,
+        composed_sha256=composed_digest,
+        nonce=nonce,
+        markers=_markers(
+            observation_object["markers"],
+            field="markers",
+            declaration=declaration,
+        ),
+        phase=_string(observation_object["phase"], field="phase"),
+        firings=tuple(
+            _observed_firing(firing, field=f"firings[{index}]")
+            for index, firing in enumerate(raw_firings)
+        ),
+        effects=tuple(
+            _observed_effect(effect, field=f"effects[{index}]")
+            for index, effect in enumerate(raw_effects)
+        ),
+        facts=_facts(observation_object["facts"], field="facts"),
+        channels=_channels(observation_object["channels"], field="channels"),
+        diagnostic=_diagnostic(observation_object["diagnostic"], field="diagnostic"),
+        run=_run_state(observation_object["run"], field="run"),
+        focus_stack=_focus_stack(
+            observation_object["focus_stack"],
+            field="focus_stack",
+        ),
+        globals=_globals(observation_object["globals"], field="globals"),
+    )
+
+
+def validate_observation(
+    raw: object | None,
+    *,
+    declaration: OracleDeclaration,
+) -> Evidence[OracleObservation]:
+    """Validate a v1 observation against one already validated declaration."""
+    if raw is None:
+        return Evidence(
+            status=EvidenceStatus.INVALID,
+            issues=(OracleIssue("$", "engine observation is missing"),),
+        )
+    try:
+        observation = _parse_observation(raw, declaration=declaration)
+    except _ContractViolation as error:
+        return Evidence(
+            status=EvidenceStatus.INVALID,
+            issues=(OracleIssue(error.field, error.message),),
+        )
+    return Evidence(status=EvidenceStatus.VALID, value=observation)
+
+
+def _compare_unsigned_decimal(left: str, right: str) -> int:
+    """Compare canonical unsigned decimal integers without converting to int."""
+    if len(left) != len(right):
+        return -1 if len(left) < len(right) else 1
+    return (left > right) - (left < right)
+
+
+def _add_unsigned_decimal(left: str, right: str) -> str:
+    """Add canonical unsigned decimal integers without interpreter digit limits."""
+    result: list[str] = []
+    carry = 0
+    width = max(len(left), len(right))
+    for offset in range(1, width + 1):
+        left_digit = ord(left[-offset]) - ord("0") if offset <= len(left) else 0
+        right_digit = ord(right[-offset]) - ord("0") if offset <= len(right) else 0
+        total = left_digit + right_digit + carry
+        result.append(chr(ord("0") + (total % 10)))
+        carry = total // 10
+    if carry:
+        result.append(chr(ord("0") + carry))
+    return "".join(reversed(result))
+
+
+def _subtract_unsigned_decimal(left: str, right: str) -> str:
+    """Subtract canonical unsigned integers where ``left`` is at least ``right``."""
+    result: list[str] = []
+    borrow = 0
+    for offset in range(1, len(left) + 1):
+        left_digit = ord(left[-offset]) - ord("0") - borrow
+        right_digit = ord(right[-offset]) - ord("0") if offset <= len(right) else 0
+        if left_digit < right_digit:
+            left_digit += 10
+            borrow = 1
+        else:
+            borrow = 0
+        result.append(chr(ord("0") + left_digit - right_digit))
+    assert borrow == 0
+    return "".join(reversed(result)).lstrip("0") or "0"
+
+
+def _add_decimal_offset(value: str, offset: int) -> str:
+    """Add a bounded integer to an arbitrary-length signed decimal integer."""
+    value_sign = -1 if value.startswith("-") else 1
+    value_magnitude = value.lstrip("+-").lstrip("0") or "0"
+    if value_magnitude == "0":
+        value_sign = 1
+
+    offset_sign = -1 if offset < 0 else 1
+    offset_magnitude = str(abs(offset))
+    if offset_magnitude == "0":
+        offset_sign = 1
+
+    if value_sign == offset_sign:
+        result_sign = value_sign
+        result_magnitude = _add_unsigned_decimal(value_magnitude, offset_magnitude)
+    else:
+        comparison = _compare_unsigned_decimal(value_magnitude, offset_magnitude)
+        if comparison == 0:
+            return "0"
+        if comparison > 0:
+            result_sign = value_sign
+            result_magnitude = _subtract_unsigned_decimal(value_magnitude, offset_magnitude)
+        else:
+            result_sign = offset_sign
+            result_magnitude = _subtract_unsigned_decimal(offset_magnitude, value_magnitude)
+
+    prefix = "-" if result_sign < 0 else ""
+    return f"{prefix}{result_magnitude}"
+
+
+def _canonical_float(value: str) -> tuple[str, str, str] | tuple[str]:
+    """Return an exact canonical decimal representation independent of context.
+
+    The coefficient and exponent remain strings. This avoids both Decimal's
+    context-sensitive 28-digit normalization and its implementation exponent
+    limits while retaining exact equality for every accepted finite literal.
+    """
+    negative = value.startswith("-")
+    unsigned = value[1:] if negative else value
+    if "e" in unsigned:
+        mantissa, exponent = unsigned.split("e", 1)
+    elif "E" in unsigned:
+        mantissa, exponent = unsigned.split("E", 1)
+    else:
+        mantissa, exponent = unsigned, "0"
+
+    if "." in mantissa:
+        integer, fraction = mantissa.split(".", 1)
+    else:
+        integer, fraction = mantissa, ""
+
+    coefficient_with_zeros = f"{integer}{fraction}".lstrip("0")
+    if not coefficient_with_zeros:
+        return ("0",)
+
+    coefficient = coefficient_with_zeros.rstrip("0")
+    trailing_zeros = len(coefficient_with_zeros) - len(coefficient)
+    canonical_exponent = _add_decimal_offset(
+        exponent,
+        trailing_zeros - len(fraction),
+    )
+    return ("-" if negative else "+", coefficient, canonical_exponent)
+
+
+def _normalized_value(value: TypedValue, normalizers: frozenset[str]) -> object:
+    if value.type == "multifield":
+        assert isinstance(value.value, tuple)
+        return (
+            value.type,
+            tuple(_normalized_value(item, normalizers) for item in value.value),
+        )
+    if value.type == "float" and NORMALIZE_FLOAT_FORMAT in normalizers:
+        assert isinstance(value.value, str)
+        return (value.type, _canonical_float(value.value))
+    return (value.type, value.value)
+
+
+def _normalized_fact(fact: Fact, normalizers: frozenset[str]) -> object:
+    fact_id: int | None = fact.id
+    if NORMALIZE_FACT_IDS in normalizers:
+        fact_id = None
+    if isinstance(fact, OrderedFact):
+        return (
+            fact.kind,
+            fact_id,
+            fact.origin,
+            fact.module,
+            fact.relation,
+            tuple(_normalized_value(value, normalizers) for value in fact.fields),
+        )
+    return (
+        fact.kind,
+        fact_id,
+        fact.origin,
+        fact.module,
+        fact.template,
+        tuple((slot.name, _normalized_value(slot.value, normalizers)) for slot in fact.slots),
+    )
+
+
+def _normalized_facts(
+    facts: tuple[Fact, ...],
+    normalizers: frozenset[str],
+) -> tuple[object, ...]:
+    normalized = tuple(_normalized_fact(fact, normalizers) for fact in facts)
+    if NORMALIZE_FACT_ORDER in normalizers:
+        return tuple(sorted(normalized, key=repr))
+    return normalized
+
+
+def _normalized_expected_effects(
+    effects: tuple[ExpectedEffect, ...],
+    normalizers: frozenset[str],
+) -> tuple[object, ...]:
+    normalized = tuple(
+        (effect.name, _normalized_value(effect.value, normalizers)) for effect in effects
+    )
+    if NORMALIZE_FACT_ORDER in normalizers:
+        return tuple(sorted(normalized, key=repr))
+    return normalized
+
+
+def _normalized_observed_effects(
+    effects: tuple[ObservedEffect, ...],
+    normalizers: frozenset[str],
+) -> tuple[object, ...]:
+    normalized = tuple(
+        (effect.name, _normalized_value(effect.value, normalizers))
+        for effect in effects
+        if effect.origin == "fixture"
+    )
+    if NORMALIZE_FACT_ORDER in normalizers:
+        return tuple(sorted(normalized, key=repr))
+    return normalized
+
+
+def _normalized_globals(
+    globals_values: tuple[GlobalValue, ...] | None,
+    normalizers: frozenset[str],
+) -> tuple[object, ...] | None:
+    if globals_values is None:
+        return None
+    return tuple(
+        (global_value.name, _normalized_value(global_value.value, normalizers))
+        for global_value in globals_values
+    )
+
+
+def _append_mismatch(
+    mismatches: list[OracleMismatch],
+    *,
+    scope: str,
+    field: str,
+    message: str = "does not match the declared expectation",
+) -> None:
+    mismatches.append(OracleMismatch(scope=scope, field=field, message=message))
+
+
+def _compare_engine(
+    scope: str,
+    declaration: OracleDeclaration,
+    observation: OracleObservation,
+) -> list[OracleMismatch]:
+    expected = declaration.expectations
+    normalizers = frozenset(declaration.normalizers)
+    mismatches: list[OracleMismatch] = []
+
+    if observation.phase != expected.phase:
+        _append_mismatch(mismatches, scope=scope, field="phase")
+
+    fixture_firings = tuple(
+        firing.rule for firing in observation.firings if firing.origin == "fixture"
+    )
+    if expected.firings.count is not None and len(fixture_firings) != expected.firings.count:
+        _append_mismatch(mismatches, scope=scope, field="firings.count")
+    if expected.firings.names is not None and fixture_firings != expected.firings.names:
+        _append_mismatch(mismatches, scope=scope, field="firings.names")
+
+    if _normalized_observed_effects(
+        observation.effects,
+        normalizers,
+    ) != _normalized_expected_effects(expected.effects, normalizers):
+        _append_mismatch(mismatches, scope=scope, field="effects")
+
+    if _normalized_facts(observation.facts, normalizers) != _normalized_facts(
+        expected.facts,
+        normalizers,
+    ):
+        _append_mismatch(mismatches, scope=scope, field="facts")
+
+    expected_channels = dict(expected.channels)
+    observed_channels = dict(observation.channels)
+    if expected_channels.keys() != observed_channels.keys():
+        _append_mismatch(mismatches, scope=scope, field="channels")
+    for channel in sorted(expected_channels.keys() & observed_channels.keys()):
+        if expected_channels[channel] != observed_channels[channel]:
+            _append_mismatch(
+                mismatches,
+                scope=scope,
+                field=f"channels.{channel}",
+            )
+
+    if observation.diagnostic.phase != expected.diagnostic.phase:
+        _append_mismatch(mismatches, scope=scope, field="diagnostic.phase")
+    if observation.diagnostic.category != expected.diagnostic.category:
+        _append_mismatch(mismatches, scope=scope, field="diagnostic.category")
+    if observation.diagnostic.continued != expected.diagnostic.continued:
+        _append_mismatch(mismatches, scope=scope, field="diagnostic.continued")
+    if observation.run.limit != expected.run.limit:
+        _append_mismatch(mismatches, scope=scope, field="run.limit")
+    if observation.run.halt_reason != expected.run.halt_reason:
+        _append_mismatch(mismatches, scope=scope, field="run.halt_reason")
+    if expected.focus_stack is not None and observation.focus_stack != expected.focus_stack:
+        _append_mismatch(mismatches, scope=scope, field="focus_stack")
+    if expected.globals is not None and _normalized_globals(
+        observation.globals,
+        normalizers,
+    ) != _normalized_globals(expected.globals, normalizers):
+        _append_mismatch(mismatches, scope=scope, field="globals")
+
+    return mismatches
+
+
+def _compare_engines(
+    declaration: OracleDeclaration,
+    ferric: OracleObservation,
+    clips: OracleObservation,
+) -> list[OracleMismatch]:
+    expected = declaration.expectations
+    normalizers = frozenset(declaration.normalizers)
+    mismatches: list[OracleMismatch] = []
+    scope = "engines"
+
+    if ferric.phase != clips.phase:
+        _append_mismatch(mismatches, scope=scope, field="phase", message="differs by engine")
+
+    ferric_firings = tuple(firing.rule for firing in ferric.firings if firing.origin == "fixture")
+    clips_firings = tuple(firing.rule for firing in clips.firings if firing.origin == "fixture")
+    if expected.firings.count is not None and len(ferric_firings) != len(clips_firings):
+        _append_mismatch(
+            mismatches,
+            scope=scope,
+            field="firings.count",
+            message="differs by engine",
+        )
+    if expected.firings.names is not None and ferric_firings != clips_firings:
+        _append_mismatch(
+            mismatches,
+            scope=scope,
+            field="firings.names",
+            message="differs by engine",
+        )
+    if _normalized_observed_effects(
+        ferric.effects,
+        normalizers,
+    ) != _normalized_observed_effects(clips.effects, normalizers):
+        _append_mismatch(
+            mismatches,
+            scope=scope,
+            field="effects",
+            message="differs by engine",
+        )
+    if _normalized_facts(ferric.facts, normalizers) != _normalized_facts(
+        clips.facts,
+        normalizers,
+    ):
+        _append_mismatch(
+            mismatches,
+            scope=scope,
+            field="facts",
+            message="differs by engine",
+        )
+
+    ferric_channels = dict(ferric.channels)
+    clips_channels = dict(clips.channels)
+    if ferric_channels.keys() != clips_channels.keys():
+        _append_mismatch(
+            mismatches,
+            scope=scope,
+            field="channels",
+            message="differs by engine",
+        )
+    for channel in sorted(ferric_channels.keys() & clips_channels.keys()):
+        if ferric_channels[channel] != clips_channels[channel]:
+            _append_mismatch(
+                mismatches,
+                scope=scope,
+                field=f"channels.{channel}",
+                message="differs by engine",
+            )
+
+    for field in ("phase", "category", "continued"):
+        if getattr(ferric.diagnostic, field) != getattr(clips.diagnostic, field):
+            _append_mismatch(
+                mismatches,
+                scope=scope,
+                field=f"diagnostic.{field}",
+                message="differs by engine",
+            )
+    for field in ("limit", "halt_reason"):
+        if getattr(ferric.run, field) != getattr(clips.run, field):
+            _append_mismatch(
+                mismatches,
+                scope=scope,
+                field=f"run.{field}",
+                message="differs by engine",
+            )
+    if expected.focus_stack is not None and ferric.focus_stack != clips.focus_stack:
+        _append_mismatch(
+            mismatches,
+            scope=scope,
+            field="focus_stack",
+            message="differs by engine",
+        )
+    if expected.globals is not None and _normalized_globals(
+        ferric.globals,
+        normalizers,
+    ) != _normalized_globals(clips.globals, normalizers):
+        _append_mismatch(
+            mismatches,
+            scope=scope,
+            field="globals",
+            message="differs by engine",
+        )
+    return mismatches
+
+
+def _unchecked_observation(raw: object | None) -> Evidence[OracleObservation]:
+    if raw is None:
+        return Evidence(status=EvidenceStatus.MISSING)
+    return Evidence(
+        status=EvidenceStatus.INVALID,
+        issues=(
+            OracleIssue(
+                "$",
+                "cannot validate an observation without a valid declaration",
+            ),
+        ),
+    )
+
+
+def _validation_mismatches(
+    scope: str,
+    evidence: Evidence[object],
+) -> list[OracleMismatch]:
+    return [
+        OracleMismatch(scope=scope, field=issue.field, message=issue.message)
+        for issue in evidence.issues
+    ]
+
+
+def evaluate_oracle(
+    raw_declaration: object | None,
+    ferric_raw: object | None,
+    clips_raw: object | None,
+    *,
+    expected_source_sha256: str,
+    expected_composed_sha256: str,
+) -> OracleEvaluation:
+    """Validate and compare two independent engine observations.
+
+    ``equivalent`` can only be true when all three evidence objects are valid,
+    each engine satisfies the declaration, and the normalized observations
+    agree with each other.  Missing or malformed evidence never raises and
+    never produces equivalence.
+    """
+    declaration_evidence = validate_declaration(
+        raw_declaration,
+        expected_source_sha256=expected_source_sha256,
+        expected_composed_sha256=expected_composed_sha256,
+    )
+    if declaration_evidence.status is not EvidenceStatus.VALID:
+        ferric_evidence = _unchecked_observation(ferric_raw)
+        clips_evidence = _unchecked_observation(clips_raw)
+        mismatches = _validation_mismatches(
+            "declaration",
+            declaration_evidence,
+        )
+        mismatches.extend(_validation_mismatches("ferric", ferric_evidence))
+        mismatches.extend(_validation_mismatches("clips", clips_evidence))
+        return OracleEvaluation(
+            status=declaration_evidence.status,
+            equivalent=False,
+            declaration=declaration_evidence,
+            ferric=ferric_evidence,
+            clips=clips_evidence,
+            mismatches=tuple(mismatches),
+        )
+
+    declaration = declaration_evidence.value
+    assert declaration is not None
+    ferric_evidence = validate_observation(ferric_raw, declaration=declaration)
+    clips_evidence = validate_observation(clips_raw, declaration=declaration)
+    statuses = {ferric_evidence.status, clips_evidence.status}
+    if EvidenceStatus.INVALID in statuses:
+        status = EvidenceStatus.INVALID
+    elif EvidenceStatus.MISSING in statuses:
+        status = EvidenceStatus.MISSING
+    else:
+        status = EvidenceStatus.VALID
+
+    mismatches = _validation_mismatches("ferric", ferric_evidence)
+    mismatches.extend(_validation_mismatches("clips", clips_evidence))
+    if status is EvidenceStatus.VALID:
+        ferric_observation = ferric_evidence.value
+        clips_observation = clips_evidence.value
+        assert ferric_observation is not None
+        assert clips_observation is not None
+        mismatches.extend(_compare_engine("ferric", declaration, ferric_observation))
+        mismatches.extend(_compare_engine("clips", declaration, clips_observation))
+        mismatches.extend(
+            _compare_engines(
+                declaration,
+                ferric_observation,
+                clips_observation,
+            )
+        )
+
+    return OracleEvaluation(
+        status=status,
+        equivalent=status is EvidenceStatus.VALID and not mismatches,
+        declaration=declaration_evidence,
+        ferric=ferric_evidence,
+        clips=clips_evidence,
+        mismatches=tuple(mismatches),
+    )
+
+
+def evidence_to_dict(evidence: Evidence[object]) -> dict[str, object]:
+    """Return deterministic JSON-ready evidence status and validation issues."""
+    return {
+        "status": evidence.status.value,
+        "issues": [{"field": issue.field, "message": issue.message} for issue in evidence.issues],
+    }
+
+
+def evaluation_to_dict(evaluation: OracleEvaluation) -> dict[str, object]:
+    """Return a compact, deterministic, JSON-ready evaluation summary."""
+    return {
+        "status": evaluation.status.value,
+        "equivalent": evaluation.equivalent,
+        "declaration": evidence_to_dict(evaluation.declaration),
+        "ferric": evidence_to_dict(evaluation.ferric),
+        "clips": evidence_to_dict(evaluation.clips),
+        "mismatches": [
+            {
+                "scope": mismatch.scope,
+                "field": mismatch.field,
+                "message": mismatch.message,
+            }
+            for mismatch in evaluation.mismatches
+        ],
+    }

--- a/tools/ferric-tools/src/ferric_tools/compat/projection.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/projection.py
@@ -1,0 +1,478 @@
+"""Project engine-specific observation envelopes into oracle v1.
+
+Raw adapters intentionally expose their actual capabilities.  This module is
+the single place that translates those envelopes into the strict,
+engine-neutral schema consumed by :mod:`ferric_tools.compat.oracle`.
+"""
+
+from __future__ import annotations
+
+import re
+
+_OBSERVATION_SCHEMA = "ferric.compat-observation"
+_OBSERVATION_VERSION = 1
+_HARNESS_LINE_RE = re.compile(r"^FERRIC-HARNESS\|\d+\|.*(?:\r?\n)?$")
+_FACT_ID_RE = re.compile(r"(?:0|[1-9][0-9]*)")
+_INTEGER_RE = re.compile(r"-?(?:0|[1-9][0-9]*)")
+_HALT_REASONS = frozenset(
+    {
+        "agenda-empty",
+        "limit-reached",
+        "halt-requested",
+        "error",
+        "not-run",
+    }
+)
+
+
+class ObservationProjectionError(ValueError):
+    """Raised when a raw adapter cannot support a trustworthy projection."""
+
+
+def _canonical_value(raw: object, *, engine: str) -> dict:
+    if type(raw) is not dict:
+        raise ObservationProjectionError(f"{engine} value is not an object")
+    assert isinstance(raw, dict)
+    value_type = raw.get("type")
+    if type(value_type) is not str:
+        raise ObservationProjectionError(f"{engine} value has no string type")
+    normalized_type = value_type.lower().replace("-", "_")
+
+    if normalized_type in {"symbol", "string"}:
+        value = raw.get("value")
+        if type(value) is not str:
+            raise ObservationProjectionError(f"{engine} {normalized_type} value is not a string")
+        return {"type": normalized_type, "value": value}
+    if normalized_type == "integer":
+        value = raw.get("value")
+        if type(value) is not str or _INTEGER_RE.fullmatch(value) is None:
+            raise ObservationProjectionError(
+                f"{engine} integer value is not canonical decimal text"
+            )
+        return {"type": "integer", "value": int(value)}
+    if normalized_type == "float":
+        value = raw.get("value")
+        if type(value) is not str:
+            raise ObservationProjectionError(f"{engine} float value is not text")
+        return {"type": "float", "value": value}
+    if normalized_type == "multifield":
+        values = raw.get("values") if engine == "ferric" else raw.get("items")
+        if type(values) is not list:
+            raise ObservationProjectionError(f"{engine} multifield is not an array")
+        return {
+            "type": "multifield",
+            "value": [_canonical_value(value, engine=engine) for value in values],
+        }
+
+    raise ObservationProjectionError(
+        f"{engine} value type {value_type!r} is not supported by oracle v1"
+    )
+
+
+def _fact_id(raw: object, *, engine: str) -> int:
+    if type(raw) is not str or _FACT_ID_RE.fullmatch(raw) is None:
+        raise ObservationProjectionError(
+            f"{engine} fact id is not canonical non-negative decimal text"
+        )
+    return int(raw)
+
+
+def _canonical_fact(raw: object, *, engine: str, harnessed: bool) -> dict:
+    if type(raw) is not dict:
+        raise ObservationProjectionError(f"{engine} fact is not an object")
+    assert isinstance(raw, dict)
+    try:
+        fact_id = _fact_id(raw["fact_id"], engine=engine)
+    except KeyError as error:
+        raise ObservationProjectionError(f"{engine} fact id is missing") from error
+    module = raw.get("module")
+    if type(module) is not str or not module:
+        raise ObservationProjectionError(
+            f"{engine} fact module is unavailable; the observation cannot prove final state"
+        )
+
+    kind = raw.get("kind")
+    fact_name = raw.get("relation", raw.get("name"))
+    origin = (
+        "instrumentation"
+        if harnessed and type(fact_name) is str and fact_name.startswith("ferric-harness-")
+        else "fixture"
+    )
+    if kind == "ordered":
+        fields = raw.get("fields")
+        relation = raw.get("relation")
+        if type(fields) is not list or type(relation) is not str or not relation:
+            raise ObservationProjectionError(f"{engine} ordered fact is malformed")
+        return {
+            "kind": "ordered",
+            "id": fact_id,
+            "origin": origin,
+            "module": module,
+            "relation": relation,
+            "fields": [_canonical_value(value, engine=engine) for value in fields],
+        }
+    if kind == "template":
+        slots = raw.get("slots")
+        template = raw.get("name") if engine == "ferric" else raw.get("relation")
+        if type(slots) is not list or type(template) is not str or not template:
+            raise ObservationProjectionError(f"{engine} template fact is malformed")
+        canonical_slots: list[dict] = []
+        for slot in slots:
+            if type(slot) is not dict or type(slot.get("name")) is not str or not slot["name"]:
+                raise ObservationProjectionError(f"{engine} template slot is malformed")
+            canonical_slots.append(
+                {
+                    "name": slot["name"],
+                    "value": _canonical_value(slot.get("value"), engine=engine),
+                }
+            )
+        slot_names = [slot["name"] for slot in canonical_slots]
+        if len(slot_names) != len(set(slot_names)):
+            raise ObservationProjectionError(f"{engine} template has duplicate slot names")
+        return {
+            "kind": "template",
+            "id": fact_id,
+            "origin": origin,
+            "module": module,
+            "template": template,
+            "slots": canonical_slots,
+        }
+    raise ObservationProjectionError(f"{engine} fact kind is unsupported")
+
+
+def _fact_effect(fact: dict) -> dict:
+    if fact["kind"] == "ordered":
+        name = f"fact:{fact['module']}::{fact['relation']}"
+        value = {"type": "multifield", "value": fact["fields"]}
+    else:
+        name = f"fact:{fact['module']}::{fact['template']}"
+        slot_values = [
+            {
+                "type": "multifield",
+                "value": [
+                    {"type": "symbol", "value": slot["name"]},
+                    slot["value"],
+                ],
+            }
+            for slot in fact["slots"]
+        ]
+        value = {"type": "multifield", "value": slot_values}
+    return {"name": name, "value": value, "origin": fact["origin"]}
+
+
+def _strip_harness_output(text: str) -> tuple[str, list[str]]:
+    semantic_lines: list[str] = []
+    instrumentation: list[str] = []
+    for line in text.splitlines(keepends=True):
+        if _HARNESS_LINE_RE.fullmatch(line):
+            instrumentation.append(line.rstrip("\r\n"))
+        else:
+            semantic_lines.append(line)
+    return "".join(semantic_lines), instrumentation
+
+
+def _canonical_diagnostic(raw: dict, *, engine: str) -> dict:
+    diagnostics = raw.get("diagnostics")
+    if type(diagnostics) is not list or not all(
+        type(diagnostic) is dict for diagnostic in diagnostics
+    ):
+        raise ObservationProjectionError(f"{engine} diagnostics are malformed")
+    protocol_issues = (
+        raw.get("protocol_issues", []) if engine == "ferric" else raw.get("protocol_issues")
+    )
+    if type(protocol_issues) is not list:
+        raise ObservationProjectionError(f"{engine} protocol issue evidence is malformed")
+    if protocol_issues:
+        raise ObservationProjectionError(
+            f"{engine} protocol violations: {', '.join(map(str, protocol_issues))}"
+        )
+    if diagnostics:
+        # Phase-aware diagnostic equivalence is deliberately unavailable until
+        # FR-COMPAT-005 (#119). Unknown evidence fails strict oracle validation.
+        return {"phase": "unknown", "category": "unknown", "continued": False}
+    return {"phase": "none", "category": "none", "continued": True}
+
+
+def _canonical_markers(raw: dict, *, engine: str) -> list[dict]:
+    fixture = raw.get("fixture")
+    lifecycle = raw.get("lifecycle")
+    if type(fixture) is not dict or type(lifecycle) is not list:
+        raise ObservationProjectionError("observation identity or lifecycle is malformed")
+    expected_sequences = (0, 1) if engine == "ferric" else (0, 3)
+    sequences = [record.get("sequence") if type(record) is dict else None for record in lifecycle]
+    if (
+        len(sequences) != 2
+        or not all(type(sequence) is int for sequence in sequences)
+        or tuple(sequences) != expected_sequences
+    ):
+        raise ObservationProjectionError(f"{engine} lifecycle sequence is malformed")
+    markers: list[dict] = []
+    for record in lifecycle:
+        if type(record) is not dict:
+            raise ObservationProjectionError("lifecycle record is malformed")
+        event = record.get("event")
+        if type(event) is not str:
+            raise ObservationProjectionError("lifecycle event is malformed")
+        kind = event.upper()
+        if kind not in {"START", "COMPLETE"}:
+            raise ObservationProjectionError("lifecycle event is malformed")
+        markers.append(
+            {
+                "kind": kind,
+                "id": record.get("fixture_id"),
+                "source_sha256": record.get("source_sha256"),
+                "composed_sha256": record.get("composed_sha256"),
+                "nonce": record.get("nonce"),
+            }
+        )
+    if [marker["kind"] for marker in markers] != ["START", "COMPLETE"]:
+        raise ObservationProjectionError(f"{engine} lifecycle event order is malformed")
+    return markers
+
+
+def _phase(raw: object) -> str:
+    if raw in {"post-run", "post_run"}:
+        return "run-complete"
+    raise ObservationProjectionError(f"unsupported observed phase: {raw!r}")
+
+
+def _halt_reason(raw: object) -> str:
+    if type(raw) is not str:
+        raise ObservationProjectionError("run halt reason is missing")
+    normalized = raw.replace("_", "-")
+    if normalized not in _HALT_REASONS:
+        raise ObservationProjectionError(f"run halt reason is unsupported: {raw!r}")
+    return normalized
+
+
+def _validate_raw_envelope(raw: dict, *, engine: str) -> None:
+    if raw.get("schema") != _OBSERVATION_SCHEMA:
+        raise ObservationProjectionError(f"{engine} observation schema is unsupported")
+    if type(raw.get("version")) is not int or raw["version"] != _OBSERVATION_VERSION:
+        raise ObservationProjectionError(f"{engine} observation version is unsupported")
+    engine_identity = raw.get("engine")
+    if type(engine_identity) is not dict or engine_identity.get("name") != engine:
+        raise ObservationProjectionError(f"{engine} observation engine identity is malformed")
+
+
+def _validate_capabilities(
+    raw: dict,
+    *,
+    engine: str,
+    require_firing_names: bool = False,
+    require_globals: bool = False,
+) -> None:
+    capabilities = raw.get("capabilities")
+    if type(capabilities) is not dict:
+        raise ObservationProjectionError(f"{engine} capabilities are malformed")
+    required = {"fact_modules"}
+    if engine == "ferric":
+        required.add("composed_digest_verification")
+        if require_firing_names:
+            required.add("fired_rule_names")
+        if require_globals:
+            required.add("global_values")
+    else:
+        required.add("rules_fired")
+        if require_firing_names:
+            required.add("fired_rule_names")
+    unavailable = sorted(name for name in required if capabilities.get(name) is not True)
+    if unavailable:
+        raise ObservationProjectionError(
+            f"{engine} required capabilities are unavailable: {', '.join(unavailable)}"
+        )
+
+
+def _channel_map(raw: dict, *, engine: str) -> dict[str, str]:
+    channels = raw.get("channels")
+    if type(channels) is not list:
+        raise ObservationProjectionError(f"{engine} channels are malformed")
+
+    observed: dict[str, str] = {}
+    seen: set[str] = set()
+    for channel in channels:
+        if type(channel) is not dict:
+            raise ObservationProjectionError(f"{engine} channel record is malformed")
+        name = channel.get("name")
+        text = channel.get("text")
+        if type(name) is not str or not name or type(text) is not str:
+            raise ObservationProjectionError(f"{engine} channel record is malformed")
+        if name in seen:
+            raise ObservationProjectionError(f"{engine} has duplicate channel {name!r}")
+        seen.add(name)
+        if engine == "ferric":
+            present = channel.get("present")
+            if type(present) is not bool:
+                raise ObservationProjectionError(f"{engine} channel presence is malformed")
+            if not present and text:
+                raise ObservationProjectionError(
+                    f"{engine} absent channel {name!r} contains output"
+                )
+        observed[name] = text
+
+    missing = {"t", "stderr"} - observed.keys()
+    if missing:
+        raise ObservationProjectionError(
+            f"{engine} required channels are unavailable: {', '.join(sorted(missing))}"
+        )
+    return observed
+
+
+def _focus_stack(raw: dict, *, engine: str) -> list[str]:
+    modules = raw.get("modules")
+    if type(modules) is not dict:
+        raise ObservationProjectionError(f"{engine} module observation is malformed")
+    focus_stack = modules.get("focus_stack")
+    if type(focus_stack) is not list or not all(
+        type(module) is str and module for module in focus_stack
+    ):
+        raise ObservationProjectionError(f"{engine} focus stack is malformed")
+    return focus_stack
+
+
+def _base_projection(
+    raw: dict,
+    *,
+    engine: str,
+    harnessed: bool,
+) -> tuple[dict, list[dict]]:
+    _validate_raw_envelope(raw, engine=engine)
+    fixture = raw.get("fixture")
+    run = raw.get("run")
+    if type(fixture) is not dict:
+        raise ObservationProjectionError(f"{engine} fixture identity is malformed")
+    if type(run) is not dict:
+        raise ObservationProjectionError(f"{engine} did not complete a run")
+    raw_facts = raw.get("facts")
+    if type(raw_facts) is not list:
+        raise ObservationProjectionError(f"{engine} facts are malformed")
+    facts = [_canonical_fact(fact, engine=engine, harnessed=harnessed) for fact in raw_facts]
+    fact_ids = [fact["id"] for fact in facts]
+    if len(fact_ids) != len(set(fact_ids)):
+        raise ObservationProjectionError(f"{engine} observation contains a duplicate fact id")
+    facts = [fact for fact in facts if fact["origin"] != "instrumentation"]
+    return (
+        {
+            "version": 1,
+            "id": fixture.get("id"),
+            "source_sha256": fixture.get("source_sha256"),
+            "composed_sha256": fixture.get("composed_sha256"),
+            "nonce": fixture.get("nonce"),
+            "markers": _canonical_markers(raw, engine=engine),
+            "phase": _phase(raw.get("phase_reached")),
+            "effects": [_fact_effect(fact) for fact in facts],
+            "facts": facts,
+            "diagnostic": _canonical_diagnostic(raw, engine=engine),
+            "run": {
+                "limit": None,
+                "halt_reason": _halt_reason(run.get("halt_reason")),
+            },
+            "globals": None,
+        },
+        facts,
+    )
+
+
+def project_ferric_observation(
+    raw: object,
+    *,
+    harnessed: bool,
+    require_firing_names: bool = False,
+    require_globals: bool = False,
+) -> dict:
+    """Project one raw ``ferric compat-observe`` envelope."""
+    if type(raw) is not dict:
+        raise ObservationProjectionError("Ferric observation is not an object")
+    assert isinstance(raw, dict)
+    _validate_capabilities(
+        raw,
+        engine="ferric",
+        require_firing_names=require_firing_names,
+        require_globals=require_globals,
+    )
+    projected, _facts = _base_projection(raw, engine="ferric", harnessed=harnessed)
+    run = raw["run"]
+    assert isinstance(run, dict)
+    rules_fired = run.get("rules_fired")
+    if type(rules_fired) is not int or rules_fired < 0:
+        raise ObservationProjectionError("Ferric firing count is unavailable")
+    if harnessed:
+        raise ObservationProjectionError(
+            "Ferric cannot separate harness firings from fixture firings"
+        )
+    projected["firings"] = [
+        {"rule": f"counted-firing-{index + 1}", "origin": "fixture"} for index in range(rules_fired)
+    ]
+
+    channel_map = _channel_map(raw, engine="ferric")
+    stdout = channel_map["t"]
+    if harnessed:
+        stdout, _instrumentation = _strip_harness_output(stdout)
+    projected["channels"] = {
+        "stdout": stdout,
+        "stderr": channel_map["stderr"],
+    }
+    projected["focus_stack"] = _focus_stack(raw, engine="ferric")
+    return projected
+
+
+def project_clips_observation(
+    raw: object,
+    *,
+    harnessed: bool,
+    require_firing_names: bool = False,
+) -> dict:
+    """Project one parsed reference-CLIPS observation envelope."""
+    if type(raw) is not dict:
+        raise ObservationProjectionError("CLIPS observation is not an object")
+    assert isinstance(raw, dict)
+    _validate_capabilities(
+        raw,
+        engine="clips",
+        require_firing_names=require_firing_names,
+    )
+    projected, _facts = _base_projection(raw, engine="clips", harnessed=harnessed)
+    run = raw["run"]
+    assert isinstance(run, dict)
+    rules_fired = run.get("rules_fired")
+    if type(rules_fired) is not int or rules_fired < 0:
+        raise ObservationProjectionError("CLIPS firing count is unavailable")
+    if harnessed:
+        raise ObservationProjectionError(
+            "CLIPS cannot separate harness firings from fixture firings"
+        )
+    fired_rules = raw.get("fired_rules")
+    if require_firing_names:
+        if type(fired_rules) is not list or not all(
+            type(rule) is str and rule for rule in fired_rules
+        ):
+            raise ObservationProjectionError("CLIPS fired-rule trace is unavailable")
+        if rules_fired != len(fired_rules):
+            raise ObservationProjectionError("CLIPS firing count and trace are inconsistent")
+        projected["firings"] = [{"rule": rule, "origin": "fixture"} for rule in fired_rules]
+    else:
+        projected["firings"] = [
+            {"rule": f"counted-firing-{index + 1}", "origin": "fixture"}
+            for index in range(rules_fired)
+        ]
+
+    channel_map = _channel_map(raw, engine="clips")
+    stdout = channel_map["t"]
+    if harnessed:
+        stdout, _instrumentation = _strip_harness_output(stdout)
+    projected["channels"] = {
+        "stdout": stdout,
+        "stderr": channel_map["stderr"],
+    }
+    projected["focus_stack"] = _focus_stack(raw, engine="clips")
+    globals_raw = raw.get("globals")
+    if type(globals_raw) is not dict:
+        raise ObservationProjectionError("CLIPS globals are malformed")
+    if globals_raw:
+        if not all(type(name) is str and name for name in globals_raw):
+            raise ObservationProjectionError("CLIPS global name is malformed")
+        projected["globals"] = [
+            {"name": name, "value": _canonical_value(value, engine="clips")}
+            for name, value in sorted(globals_raw.items())
+        ]
+    return projected

--- a/tools/ferric-tools/src/ferric_tools/compat/report.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/report.py
@@ -12,9 +12,149 @@ from rich.console import Console
 
 from ferric_tools._manifest import load_manifest
 from ferric_tools._paths import examples_dir as default_examples_dir
+from ferric_tools.compat.oracle import SUPPORTED_NORMALIZERS
 
 app = typer.Typer(help="Generate compatibility assessment reports.")
 console = Console(stderr=True)
+
+ORACLE_STATUSES = ("valid", "missing", "invalid")
+ORACLE_COVERAGE_FIELDS = ("declaration", "reached", "completed", "effect")
+ORACLE_EVIDENCE_VERSION = 1
+
+
+def oracle_evidence_view(info: dict) -> dict:
+    """Return a defensive, report-ready view of one file's oracle evidence.
+
+    Legacy entries have no ``oracle_evidence`` member and are treated as
+    missing. An equivalent claim without valid evidence is refused and counted
+    as invalid, while the rest of a legacy manifest remains reportable.
+    """
+    raw = info.get("oracle_evidence")
+    selected = raw is not None
+    malformed = selected and not isinstance(raw, dict)
+    evidence = raw if isinstance(raw, dict) else {}
+
+    status = evidence.get("status", "missing")
+    if status not in ORACLE_STATUSES:
+        status = "invalid"
+        malformed = True
+
+    version = evidence.get("version")
+    if selected and (type(version) is not int or version != ORACLE_EVIDENCE_VERSION):
+        malformed = True
+
+    coverage: dict[str, bool] = {}
+    for field in ORACLE_COVERAGE_FIELDS:
+        value = evidence.get(field, False)
+        if selected and (field not in evidence or type(value) is not bool):
+            malformed = True
+        coverage[field] = value is True
+
+    raw_normalizations = evidence.get("normalizations", [])
+    if not isinstance(raw_normalizations, list) or not all(
+        isinstance(item, str) for item in raw_normalizations
+    ):
+        normalizations: list[str] = []
+        malformed = True
+    else:
+        normalizations = sorted(set(raw_normalizations))
+        if (
+            selected
+            and version == ORACLE_EVIDENCE_VERSION
+            and any(normalization not in SUPPORTED_NORMALIZERS for normalization in normalizations)
+        ):
+            malformed = True
+
+    raw_violations = evidence.get("violations", [])
+    if not isinstance(raw_violations, list) or not all(
+        isinstance(item, str) for item in raw_violations
+    ):
+        violations = ["malformed violations"]
+        malformed = True
+    else:
+        violations = list(raw_violations)
+
+    invalid_valid_shape = status == "valid" and not all(
+        coverage[field] for field in ("declaration", "reached", "completed")
+    )
+    invalid_missing_shape = status == "missing" and any(coverage.values())
+    if malformed or invalid_valid_shape or invalid_missing_shape:
+        status = "invalid"
+
+    refused_equivalent = info.get("classification") == "equivalent" and (
+        status != "valid" or not all(coverage.values()) or bool(violations)
+    )
+    if refused_equivalent:
+        status = "invalid"
+
+    return {
+        "selected": selected,
+        "status": status,
+        "version": version,
+        **coverage,
+        "normalizations": normalizations,
+        "violations": violations,
+        "refused_equivalent": refused_equivalent,
+    }
+
+
+def compute_oracle_coverage(manifest: dict) -> dict:
+    """Aggregate oracle evidence coverage for a compatibility manifest."""
+    files = manifest.get("files", {})
+    coverage: dict = {
+        "total": len(files),
+        "selected": 0,
+        "declaration": 0,
+        "valid": 0,
+        "missing": 0,
+        "invalid": 0,
+        "reached": 0,
+        "completed": 0,
+        "effect": 0,
+        "refused_equivalent": 0,
+        "versions": {},
+        "normalizations": {},
+    }
+
+    for info in files.values():
+        evidence = oracle_evidence_view(info)
+        if evidence["selected"]:
+            coverage["selected"] += 1
+            version = evidence["version"]
+            version_label = "(unspecified)" if version is None else str(version)
+            coverage["versions"][version_label] = coverage["versions"].get(version_label, 0) + 1
+
+        coverage[evidence["status"]] += 1
+        for field in ORACLE_COVERAGE_FIELDS:
+            if evidence[field]:
+                coverage[field] += 1
+        if evidence["refused_equivalent"]:
+            coverage["refused_equivalent"] += 1
+        for normalization in evidence["normalizations"]:
+            coverage["normalizations"][normalization] = (
+                coverage["normalizations"].get(normalization, 0) + 1
+            )
+
+    return coverage
+
+
+_ORACLE_METRICS = [
+    ("selected", "selected"),
+    ("declaration", "declaration"),
+    ("valid", "valid"),
+    ("missing", "missing"),
+    ("invalid", "invalid"),
+    ("reached", "reached"),
+    ("completed", "completed"),
+    ("effect", "effect"),
+    ("refused_equivalent", "refused equivalent"),
+]
+
+
+def _format_counter(counter: dict[str, int]) -> str:
+    if not counter:
+        return "(none)"
+    return ", ".join(f"{name}: {count:,}" for name, count in sorted(counter.items()))
 
 
 def print_summary(manifest: dict) -> None:
@@ -35,6 +175,17 @@ def print_summary(manifest: dict) -> None:
         count = summary.get(cls, 0)
         pct = (count / total * 100) if total else 0
         print(f"  {cls:15s}: {count:6,} ({pct:5.1f}%)")
+
+    oracle = compute_oracle_coverage(manifest)
+    oracle_total = oracle["total"]
+    print()
+    print("Oracle evidence:")
+    for key, label in _ORACLE_METRICS:
+        count = oracle[key]
+        pct = (count / oracle_total * 100) if oracle_total else 0
+        print(f"  {label:20s}: {count:6,} ({pct:5.1f}%)")
+    print(f"  {'versions':20s}: {_format_counter(oracle['versions'])}")
+    print(f"  {'normalizations':20s}: {_format_counter(oracle['normalizations'])}")
 
     reason_counts: dict[str, int] = {}
     for info in manifest["files"].values():
@@ -86,7 +237,9 @@ def print_summary(manifest: dict) -> None:
         print()
         print(f"Equivalent files ({len(equivalent)}):")
         for k, v in sorted(equivalent):
-            print(f"  {k} ({v['reason']})")
+            oracle = oracle_evidence_view(v)
+            suffix = " [REFUSED: invalid oracle evidence]" if oracle["refused_equivalent"] else ""
+            print(f"  {k} ({v['reason']}){suffix}")
 
     divergent = [(k, v) for k, v in manifest["files"].items() if v["classification"] == "divergent"]
     if divergent:
@@ -116,6 +269,16 @@ _FIELDNAMES = [
     "clips_exit",
     "clips_duration_ms",
     "clips_timed_out",
+    "oracle_selected",
+    "oracle_declaration",
+    "oracle_status",
+    "oracle_version",
+    "oracle_reached",
+    "oracle_completed",
+    "oracle_effect",
+    "oracle_normalizations",
+    "oracle_violations",
+    "oracle_refused_equivalent",
     "notes",
 ]
 
@@ -128,13 +291,14 @@ def _write_delimited(manifest: dict, out_path: str, delimiter: str) -> None:
         for path, info in sorted(manifest["files"].items()):
             ferric = info.get("ferric") or {}
             clips = info.get("clips") or {}
+            oracle = oracle_evidence_view(info)
             writer.writerow(
                 {
                     "path": path,
-                    "source": info["source"],
-                    "classification": info["classification"],
-                    "reason": info["reason"],
-                    "runability": info["runability"],
+                    "source": info.get("source", ""),
+                    "classification": info.get("classification", ""),
+                    "reason": info.get("reason", ""),
+                    "runability": info.get("runability", ""),
                     "features": ";".join(info.get("features", [])),
                     "unsupported_features": ";".join(info.get("unsupported_features", [])),
                     "ferric_exit": ferric.get("exit_code", ""),
@@ -143,6 +307,16 @@ def _write_delimited(manifest: dict, out_path: str, delimiter: str) -> None:
                     "clips_exit": clips.get("exit_code", ""),
                     "clips_duration_ms": clips.get("duration_ms", ""),
                     "clips_timed_out": clips.get("timed_out", ""),
+                    "oracle_selected": oracle["selected"],
+                    "oracle_declaration": oracle["declaration"],
+                    "oracle_status": oracle["status"],
+                    "oracle_version": ("" if oracle["version"] is None else str(oracle["version"])),
+                    "oracle_reached": oracle["reached"],
+                    "oracle_completed": oracle["completed"],
+                    "oracle_effect": oracle["effect"],
+                    "oracle_normalizations": ";".join(oracle["normalizations"]),
+                    "oracle_violations": ";".join(oracle["violations"]),
+                    "oracle_refused_equivalent": oracle["refused_equivalent"],
                     "notes": info.get("notes", ""),
                 }
             )
@@ -162,7 +336,8 @@ def write_report(
     lines.append("")
     lines.append("Assessment of ferric's compatibility with CLIPS across a corpus of")
     lines.append("example `.clp` files. Each file is classified as **equivalent**")
-    lines.append("(output matches CLIPS), **divergent** (runs but output differs),")
+    lines.append("(a valid structured oracle matches CLIPS), **divergent** (semantic")
+    lines.append("observations differ),")
     lines.append("**incompatible** (cannot run), or **pending** (not yet tested).")
     lines.append("")
 
@@ -180,6 +355,22 @@ def write_report(
         pct = (count / total * 100) if total else 0
         lines.append(f"| {cls} | {count:,} | {pct:.1f}% |")
     lines.append(f"| **total** | **{total:,}** | |")
+
+    oracle = compute_oracle_coverage(manifest)
+    oracle_total = oracle["total"]
+    lines.append("")
+    lines.append("### Oracle evidence coverage")
+    lines.append("")
+    lines.append("| Metric | Count | % of files |")
+    lines.append("|---|---:|---:|")
+    for key, label in _ORACLE_METRICS:
+        count = oracle[key]
+        pct = (count / oracle_total * 100) if oracle_total else 0
+        lines.append(f"| {label} | {count:,} | {pct:.1f}% |")
+    lines.append("")
+    lines.append(f"Versions: {_format_counter(oracle['versions'])}")
+    lines.append("")
+    lines.append(f"Normalizations: {_format_counter(oracle['normalizations'])}")
 
     source_stats: dict[str, dict] = {}
     for info in manifest["files"].values():
@@ -217,7 +408,11 @@ def write_report(
         lines.append(f"### Equivalent files ({len(equivalent)})")
         lines.append("")
         for k, v in equivalent:
-            lines.append(f"- `{k}` ({v['reason']})")
+            oracle = oracle_evidence_view(v)
+            suffix = (
+                " — **REFUSED: invalid oracle evidence**" if oracle["refused_equivalent"] else ""
+            )
+            lines.append(f"- `{k}` ({v['reason']}){suffix}")
 
     divergent = sorted(
         (k, v) for k, v in manifest["files"].items() if v["classification"] == "divergent"

--- a/tools/ferric-tools/src/ferric_tools/compat/run.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/run.py
@@ -8,8 +8,11 @@ the manifest with classification results.
 from __future__ import annotations
 
 import contextlib
+import copy
+import json
 import os
 import re
+import secrets
 import subprocess
 import sys
 import tempfile
@@ -20,7 +23,7 @@ from typing import Annotated
 import typer
 from rich.console import Console
 
-from ferric_tools._formatting import normalize_floats, normalize_output
+from ferric_tools._formatting import normalize_output
 from ferric_tools._harness import (
     HarnessContractError,
     ResolvedHarness,
@@ -42,6 +45,19 @@ from ferric_tools._paths import (
     repo_root,
 )
 from ferric_tools._subprocess import parallel_run
+from ferric_tools.compat.clips_oracle import build_probe_operations, parse_probe_output
+from ferric_tools.compat.oracle import (
+    DECLARATION_VERSION,
+    EvidenceStatus,
+    evaluate_oracle,
+    evaluation_to_dict,
+    validate_declaration,
+)
+from ferric_tools.compat.projection import (
+    ObservationProjectionError,
+    project_clips_observation,
+    project_ferric_observation,
+)
 
 app = typer.Typer(help="Run CLIPS compatibility assessment.")
 console = Console(stderr=True)
@@ -286,38 +302,77 @@ def _retain_failure_artifact(
         ) from error
 
 
-# ---------------------------------------------------------------------------
-# Engine runners
-# ---------------------------------------------------------------------------
+def _timeout_text(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
 
 
-def run_ferric(file_path: str, ferric_bin: str, root: str, timeout_secs: int) -> dict:
-    """Run a .clp file through the ferric CLI."""
+def _output_bytes(value: str | bytes | None) -> bytes:
+    if value is None:
+        return b""
+    if isinstance(value, bytes):
+        return value
+    return value.encode("utf-8")
+
+
+def _display_output(value: bytes) -> str:
+    return value.decode("utf-8", errors="replace")
+
+
+def run_ferric_observer(
+    file_path: str,
+    ferric_bin: str,
+    root: str,
+    timeout_secs: int,
+    *,
+    fixture_id: str,
+    nonce: str,
+    source_sha256: str,
+    composed_sha256: str,
+) -> dict:
+    """Run the dedicated Ferric compatibility observer."""
     start = time.monotonic()
+    command = [
+        ferric_bin,
+        "compat-observe",
+        "--fixture-id",
+        fixture_id,
+        "--nonce",
+        nonce,
+        "--source-sha256",
+        source_sha256,
+        "--composed-sha256",
+        composed_sha256,
+        file_path,
+    ]
     try:
         proc = subprocess.run(
-            [ferric_bin, "run", file_path],
+            command,
             capture_output=True,
             text=True,
             timeout=timeout_secs,
             cwd=root,
         )
         duration_ms = int((time.monotonic() - start) * 1000)
-        return {
+        result = {
             "exit_code": proc.returncode,
             "stdout": proc.stdout,
             "stderr": proc.stderr,
             "duration_ms": duration_ms,
             "timed_out": False,
         }
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as error:
         duration_ms = int((time.monotonic() - start) * 1000)
         return {
             "exit_code": -1,
-            "stdout": "",
-            "stderr": f"timeout after {timeout_secs}s",
+            "stdout": _timeout_text(error.stdout),
+            "stderr": _timeout_text(error.stderr) or f"timeout after {timeout_secs}s",
             "duration_ms": duration_ms,
             "timed_out": True,
+            "observation_error": "observer timed out before terminal evidence",
         }
     except FileNotFoundError:
         return {
@@ -326,41 +381,103 @@ def run_ferric(file_path: str, ferric_bin: str, root: str, timeout_secs: int) ->
             "stderr": f"ferric binary not found: {ferric_bin}",
             "duration_ms": 0,
             "timed_out": False,
+            "observation_error": "observer executable not found",
         }
 
+    try:
+        if result["stdout"].count("\n") != 1 or not result["stdout"].endswith("\n"):
+            raise ValueError("stdout must contain exactly one newline-terminated JSON object")
+        observation = json.loads(result["stdout"])
+        if type(observation) is not dict:
+            raise ValueError("observation must be a JSON object")
+    except (json.JSONDecodeError, ValueError) as error:
+        result["observation_error"] = str(error)
+    else:
+        result["observation"] = observation
+    return result
 
-def run_clips_docker(file_path: str, root: str, script: str, timeout_secs: int) -> dict:
-    """Run a .clp file through the Docker CLIPS harness."""
+
+def run_clips_observer(
+    file_path: str,
+    root: str,
+    script: str,
+    timeout_secs: int,
+    *,
+    fixture_id: str,
+    nonce: str,
+    source_sha256: str,
+    composed_sha256: str,
+    globals_to_capture: tuple[str, ...],
+    harnessed: bool,
+) -> dict:
+    """Run reference CLIPS quietly and parse its nonce-bound post-run probe."""
     resolved_path = _require_contained_file(
         Path(file_path),
         root=Path(root),
         label="CLIPS input",
     )
+    operations = build_probe_operations(
+        fixture_id=fixture_id,
+        nonce=nonce,
+        source_sha256=source_sha256,
+        composed_sha256=composed_sha256,
+        globals_to_capture=globals_to_capture,
+    )
+    auth_key = secrets.token_hex(32)
+    command = [
+        script,
+        "run",
+        "--quiet",
+        "--observer-nonce",
+        nonce,
+        "--observer-fixture-id",
+        fixture_id,
+        "--observer-source-sha256",
+        source_sha256,
+        "--observer-composed-sha256",
+        composed_sha256,
+        "--observer-auth-key",
+        auth_key,
+        "--file",
+        str(resolved_path),
+    ]
+    for operation in operations:
+        command.extend(["--op", operation])
+
     start = time.monotonic()
+    raw_stdout = b""
+    raw_stderr = b""
     try:
         proc = subprocess.run(
-            [script, "run", "--file", str(resolved_path)],
+            command,
             capture_output=True,
-            text=True,
+            text=False,
             timeout=timeout_secs,
             cwd=root,
         )
+        raw_stdout = _output_bytes(proc.stdout)
+        raw_stderr = _output_bytes(proc.stderr)
         duration_ms = int((time.monotonic() - start) * 1000)
-        return {
+        result = {
             "exit_code": proc.returncode,
-            "stdout": proc.stdout,
-            "stderr": proc.stderr,
+            "stdout": _display_output(raw_stdout),
+            "stderr": _display_output(raw_stderr),
             "duration_ms": duration_ms,
             "timed_out": False,
         }
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as error:
         duration_ms = int((time.monotonic() - start) * 1000)
-        return {
+        raw_stdout = _output_bytes(error.stdout)
+        raw_stderr = _output_bytes(error.stderr)
+        partial_stdout = _display_output(raw_stdout)
+        partial_stderr = _display_output(raw_stderr)
+        result = {
             "exit_code": -1,
-            "stdout": "",
-            "stderr": f"timeout after {timeout_secs}s",
+            "stdout": partial_stdout,
+            "stderr": partial_stderr or f"timeout after {timeout_secs}s",
             "duration_ms": duration_ms,
             "timed_out": True,
+            "observation_error": "reference observer timed out before terminal evidence",
         }
     except FileNotFoundError:
         return {
@@ -369,7 +486,25 @@ def run_clips_docker(file_path: str, root: str, script: str, timeout_secs: int) 
             "stderr": f"harness script not found: {script}",
             "duration_ms": 0,
             "timed_out": False,
+            "observation_error": "reference observer executable not found",
         }
+
+    try:
+        observation = parse_probe_output(
+            raw_stdout,
+            raw_stderr=raw_stderr,
+            fixture_id=fixture_id,
+            nonce=nonce,
+            source_sha256=source_sha256,
+            composed_sha256=composed_sha256,
+            auth_key=auth_key,
+            harnessed=harnessed,
+        )
+    except (ValueError, RuntimeError) as error:
+        result["observation_error"] = str(error)
+    else:
+        result["observation"] = observation
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -377,55 +512,146 @@ def run_clips_docker(file_path: str, root: str, script: str, timeout_secs: int) 
 # ---------------------------------------------------------------------------
 
 
-def classify_results(ferric_result: dict, clips_result: dict | None) -> tuple[str, str]:
-    """Classify based on ferric and CLIPS results."""
-    f = ferric_result
-    c = clips_result
+def _oracle_outcome(evaluation) -> tuple[str, str, dict]:
+    """Translate one strict oracle evaluation into manifest fields."""
+    evaluation_dict = evaluation_to_dict(evaluation)
+    mismatches = evaluation_dict["mismatches"]
+    declaration_valid = evaluation.declaration.status is EvidenceStatus.VALID
+    observations_valid = (
+        evaluation.ferric.status is EvidenceStatus.VALID
+        and evaluation.clips.status is EvidenceStatus.VALID
+    )
+    effect_mismatch = any(mismatch["field"] == "effects" for mismatch in mismatches)
+    normalizations = (
+        list(evaluation.declaration.value.normalizers)
+        if declaration_valid and evaluation.declaration.value is not None
+        else []
+    )
+    violations = [
+        f"{mismatch['scope']}.{mismatch['field']}: {mismatch['message']}" for mismatch in mismatches
+    ]
+    evidence = {
+        "status": evaluation.status.value,
+        "version": 1,
+        "declaration": declaration_valid,
+        "reached": observations_valid,
+        "completed": observations_valid,
+        "effect": observations_valid and not effect_mismatch,
+        "normalizations": normalizations,
+        "violations": violations,
+        "evaluation": evaluation_dict,
+    }
 
-    if f["timed_out"] and (c is None or c["timed_out"]):
-        return "incompatible", "timeout-both"
+    if evaluation.status is EvidenceStatus.MISSING:
+        return "pending", "oracle-missing", evidence
+    if evaluation.status is EvidenceStatus.INVALID:
+        field = mismatches[0]["field"] if mismatches else "evidence"
+        reason_field = re.sub(r"[^a-z0-9]+", "-", field.lower()).strip("-") or "evidence"
+        return "pending", f"oracle-invalid:{reason_field}", evidence
+    if evaluation.equivalent:
+        return "equivalent", "oracle-v1-match", evidence
 
-    if c is None:
-        if f["timed_out"]:
-            return "incompatible", "timeout-ferric"
-        if f["exit_code"] != 0:
-            return "incompatible", "ferric-error"
-        return "pending", "ferric-only-clean"
+    field = mismatches[0]["field"] if mismatches else "semantic"
+    reason_field = re.sub(r"[^a-z0-9]+", "-", field.lower()).strip("-") or "semantic"
+    return "divergent", f"oracle-{reason_field}-mismatch", evidence
 
-    if f["timed_out"] and not c["timed_out"]:
-        return "divergent", "timeout-ferric"
 
-    if not f["timed_out"] and c["timed_out"]:
-        return "divergent", "timeout-clips"
+def classify_results(
+    ferric_result: dict,
+    clips_result: dict | None,
+    evaluation=None,
+) -> tuple[str, str]:
+    """Classify only from independently validated structured evidence."""
+    del ferric_result, clips_result
+    if evaluation is None:
+        return "pending", "oracle-missing"
+    classification, reason, _evidence = _oracle_outcome(evaluation)
+    return classification, reason
 
-    if c["exit_code"] == 0:
-        clips_has_error = bool(re.search(r"\[[A-Z]+\d+\]", c["stdout"]))
-        if clips_has_error and f["exit_code"] != 0:
-            return "incompatible", "both-error"
-        if clips_has_error:
-            return "incompatible", "clips-load-error"
 
-    if f["exit_code"] != 0 and c["exit_code"] == 0:
-        return "divergent", "ferric-error"
+def _missing_oracle_evidence() -> dict:
+    """Return the canonical manifest view for an undeclared fixture."""
+    return {
+        "status": "missing",
+        "version": DECLARATION_VERSION,
+        "declaration": False,
+        "reached": False,
+        "completed": False,
+        "effect": False,
+        "normalizations": [],
+        "violations": [],
+    }
 
-    if f["exit_code"] == 0 and c["exit_code"] != 0:
-        return "divergent", "clips-error"
 
-    if f["exit_code"] != 0 and c["exit_code"] != 0:
-        return "incompatible", "both-error"
+def _invalid_observation(error: str) -> dict[str, str]:
+    """Create deliberately invalid input for the strict oracle validator."""
+    return {"observation_error": error}
 
-    f_out = normalize_output(f["stdout"], "ferric")
-    c_out = normalize_output(c["stdout"], "clips")
 
-    if f_out == c_out:
-        if f_out.strip() == "":
-            return "equivalent", "empty-match"
-        return "equivalent", "exact-match"
+def _invalid_preflight_evidence(error: str) -> dict:
+    """Return fail-closed evidence for an oracle input rejected before execution."""
+    return {
+        "status": "invalid",
+        "version": DECLARATION_VERSION,
+        "declaration": False,
+        "reached": False,
+        "completed": False,
+        "effect": False,
+        "normalizations": [],
+        "violations": [error],
+    }
 
-    if normalize_floats(f_out) == normalize_floats(c_out):
-        return "equivalent", "float-normalized-match"
 
-    return "divergent", "output-mismatch"
+def _project_result(
+    result: dict,
+    *,
+    engine: str,
+    harnessed: bool,
+    require_firing_names: bool = False,
+    require_globals: bool = False,
+) -> dict:
+    """Project one successful observer result or return invalid evidence."""
+    observation = result.get("observation")
+    if result.get("timed_out"):
+        error = result.get("observation_error", f"{engine} observer timed out")
+        result["projection_error"] = error
+        return _invalid_observation(error)
+    if result.get("exit_code") != 0:
+        error = result.get(
+            "observation_error",
+            f"{engine} observer exited with status {result.get('exit_code')!r}",
+        )
+        result["projection_error"] = error
+        return _invalid_observation(error)
+    if engine == "ferric" and result.get("stderr"):
+        error = "ferric observer emitted out-of-band stderr"
+        result["projection_error"] = error
+        return _invalid_observation(error)
+    if type(observation) is not dict:
+        error = result.get("observation_error", f"{engine} observation is missing")
+        result["projection_error"] = error
+        return _invalid_observation(error)
+
+    try:
+        if engine == "ferric":
+            projected = project_ferric_observation(
+                observation,
+                harnessed=harnessed,
+                require_firing_names=require_firing_names,
+                require_globals=require_globals,
+            )
+        else:
+            projected = project_clips_observation(
+                observation,
+                harnessed=harnessed,
+                require_firing_names=require_firing_names,
+            )
+    except ObservationProjectionError as error:
+        result["projection_error"] = str(error)
+        return _invalid_observation(str(error))
+
+    result["canonical_observation"] = projected
+    return projected
 
 
 # ---------------------------------------------------------------------------
@@ -446,7 +672,11 @@ def process_file(args: tuple) -> tuple:
         harness,
         run_workspace,
         failures_dir,
+        *oracle_args,
     ) = args
+    if len(oracle_args) != 1 or oracle_args[0] is None:
+        raise TypeError("compatibility work item requires one structured oracle declaration")
+    declaration = oracle_args[0]
 
     run_path = abs_path
     composed_path: Path | None = None
@@ -468,6 +698,29 @@ def process_file(args: tuple) -> tuple:
                 root=resolved_root,
             )
             run_path = str(composed_path)
+        else:
+            if run_workspace is None:
+                raise CompatibilityWorkspaceError(
+                    f"{rel_path}: oracle execution requires an invocation workspace"
+                )
+            source_path = _require_contained_file(
+                Path(abs_path),
+                root=resolved_root,
+                label=f"{rel_path} source",
+            )
+            try:
+                composed_content = source_path.read_bytes()
+            except OSError as error:
+                raise CompatibilityWorkspaceError(
+                    f"{rel_path}: cannot read compatibility source: {error}"
+                ) from error
+            composed_digest = sha256_bytes(composed_content)
+            composed_path = _materialize_composed_source(
+                composed_content,
+                workspace=Path(run_workspace),
+                root=resolved_root,
+            )
+            run_path = str(composed_path)
 
         if composed_path is not None and composed_content is not None:
             _verify_composed_source(
@@ -476,20 +729,127 @@ def process_file(args: tuple) -> tuple:
                 root=resolved_root,
                 boundary="before Ferric execution",
             )
-        ferric_result = run_ferric(run_path, ferric, root, timeout)
+        assert composed_content is not None
+        assert composed_digest is not None
+        source_content = harness.source_bytes if harness is not None else composed_content
+        source_digest = sha256_bytes(source_content)
+        runtime_declaration = copy.deepcopy(declaration)
+        runtime_declaration["nonce"] = secrets.token_hex(16)
+        declaration_evidence = validate_declaration(
+            runtime_declaration,
+            expected_source_sha256=source_digest,
+            expected_composed_sha256=composed_digest,
+        )
+
+        if declaration_evidence.status is EvidenceStatus.VALID:
+            fixture_id = runtime_declaration["id"]
+            nonce = runtime_declaration["nonce"]
+            ferric_result = run_ferric_observer(
+                run_path,
+                ferric,
+                root,
+                timeout,
+                fixture_id=fixture_id,
+                nonce=nonce,
+                source_sha256=source_digest,
+                composed_sha256=composed_digest,
+            )
+            ferric_observation = _project_result(
+                ferric_result,
+                engine="ferric",
+                harnessed=harness is not None,
+                require_firing_names=(
+                    runtime_declaration["expectations"]["firings"]["names"] is not None
+                ),
+                require_globals=(runtime_declaration["expectations"]["globals"] is not None),
+            )
+        else:
+            ferric_result = {
+                "exit_code": -1,
+                "stdout": "",
+                "stderr": "oracle declaration is invalid for the current source",
+                "duration_ms": 0,
+                "timed_out": False,
+                "observation_error": "oracle declaration validation failed",
+            }
+            ferric_observation = None
+
+        if composed_path is not None:
+            _verify_composed_source(
+                composed_path,
+                composed_content,
+                root=resolved_root,
+                boundary="before CLIPS execution",
+            )
+
+        if declaration_evidence.status is EvidenceStatus.VALID and not skip_clips:
+            globals_expectation = runtime_declaration["expectations"]["globals"]
+            globals_to_capture = (
+                ()
+                if globals_expectation is None
+                else tuple(item["name"] for item in globals_expectation)
+            )
+            clips_result = run_clips_observer(
+                run_path,
+                root,
+                script,
+                timeout,
+                fixture_id=fixture_id,
+                nonce=nonce,
+                source_sha256=source_digest,
+                composed_sha256=composed_digest,
+                globals_to_capture=globals_to_capture,
+                harnessed=harness is not None,
+            )
+            clips_observation = _project_result(
+                clips_result,
+                engine="clips",
+                harnessed=harness is not None,
+                require_firing_names=(
+                    runtime_declaration["expectations"]["firings"]["names"] is not None
+                ),
+            )
+        else:
+            clips_result = {
+                "exit_code": -1,
+                "stdout": "",
+                "stderr": (
+                    "reference observer was skipped"
+                    if skip_clips
+                    else "oracle declaration is invalid for the current source"
+                ),
+                "duration_ms": 0,
+                "timed_out": False,
+                "observation_error": (
+                    "reference observer was skipped"
+                    if skip_clips
+                    else "oracle declaration validation failed"
+                ),
+            }
+            clips_observation = (
+                _invalid_observation("reference observer was skipped") if skip_clips else None
+            )
+
+        evaluation = evaluate_oracle(
+            runtime_declaration,
+            ferric_observation,
+            clips_observation,
+            expected_source_sha256=source_digest,
+            expected_composed_sha256=composed_digest,
+        )
+        classification, reason, evidence = _oracle_outcome(evaluation)
+        for engine_name, engine_result in (
+            ("ferric", ferric_result),
+            ("clips", clips_result),
+        ):
+            if projection_error := engine_result.get("projection_error"):
+                evidence["violations"].append(f"{engine_name}.projection: {projection_error}")
+        ferric_result["oracle_evidence"] = evidence
+        clips_result["oracle_evidence"] = evidence
+
         if harness is not None:
             ferric_result["harness"] = dict(harness.metadata)
-        clips_result = None
-        if not skip_clips:
-            if composed_path is not None and composed_content is not None:
-                _verify_composed_source(
-                    composed_path,
-                    composed_content,
-                    root=resolved_root,
-                    boundary="before CLIPS execution",
-                )
-            clips_result = run_clips_docker(run_path, root, script, timeout)
-            if harness is not None:
+            if clips_result is not None:
                 clips_result["harness"] = dict(harness.metadata)
         if composed_path is not None and composed_content is not None:
             _verify_composed_source(
@@ -498,14 +858,16 @@ def process_file(args: tuple) -> tuple:
                 root=resolved_root,
                 boundary="after engine execution",
             )
-        classification, reason = classify_results(ferric_result, clips_result)
 
+        retain_failure = classification in FAILED_CLASSIFICATIONS or reason.startswith(
+            "oracle-invalid"
+        )
         if composed_content is not None and composed_digest is not None:
             composed_metadata: dict[str, str | int] = {
                 "sha256": composed_digest,
                 "size_bytes": len(composed_content),
             }
-            if classification in FAILED_CLASSIFICATIONS:
+            if retain_failure:
                 retained_artifact = _retain_failure_artifact(
                     composed_content,
                     composed_digest,
@@ -570,6 +932,24 @@ def _resolve_harness(
     )
 
 
+def _recompute_summary(manifest_data: dict) -> dict[str, int]:
+    """Recompute compatibility totals after selection or execution updates."""
+    summary = {
+        "total": 0,
+        "equivalent": 0,
+        "divergent": 0,
+        "incompatible": 0,
+        "pending": 0,
+    }
+    for info in manifest_data["files"].values():
+        summary["total"] += 1
+        classification = info.get("classification")
+        if classification in summary:
+            summary[classification] += 1
+    manifest_data["summary"] = summary
+    return summary
+
+
 @app.command()
 def main(
     all_files: Annotated[bool, typer.Option("--all", help="Run all testable files")] = False,
@@ -601,33 +981,25 @@ def main(
         raise typer.Exit(1)
 
     mdata = load_manifest(manifest_path)
-
-    if not dry_run and not Path(ferric).exists():
-        console.print(f"[red]error:[/] ferric binary not found: {ferric}")
-        console.print("Run: cargo build --release -p ferric-cli")
+    if (
+        mdata.get("version") != 3
+        or mdata.get("oracle_protocol_version") != DECLARATION_VERSION
+        or type(mdata.get("files")) is not dict
+    ):
+        console.print(
+            "[red]error:[/] manifest is not structured-oracle schema v3; "
+            "run ferric-compat-scan first"
+        )
         raise typer.Exit(1)
-
-    # Check Docker CLIPS availability
-    if not skip_clips and not dry_run:
-        try:
-            result = subprocess.run(
-                ["docker", "image", "inspect", "ferric-rules/clips-reference:latest"],
-                capture_output=True,
-                timeout=10,
-            )
-            if result.returncode != 0:
-                console.print(
-                    "[yellow]warning:[/] Docker CLIPS image not found. Using --skip-clips mode."
-                )
-                skip_clips = True
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            console.print("[yellow]warning:[/] Docker not available. Using --skip-clips mode.")
-            skip_clips = True
 
     # Select files and validate all library harnesses before starting engines.
     files_to_run: list[tuple[str, str]] = []
     resolved_harnesses: dict[str, ResolvedHarness | None] = {}
+    declarations: dict[str, dict] = {}
     harness_targets: dict[Path, str] = {}
+    missing_selected: list[str] = []
+    invalid_selected: list[tuple[str, str]] = []
+    file_was_found = False
     for rel_path, info in mdata["files"].items():
         runability = info.get("runability")
         if runability not in VALID_RUNABILITY:
@@ -644,6 +1016,7 @@ def main(
         if file:
             if rel_path != file:
                 continue
+            file_was_found = True
         elif only_pending:
             if info["classification"] != "pending":
                 continue
@@ -662,6 +1035,27 @@ def main(
                 continue
 
         if source and info["source"] != source:
+            continue
+
+        declaration = info.get("oracle")
+        if declaration is None:
+            missing_selected.append(rel_path)
+            if not dry_run:
+                info["classification"] = "pending"
+                info["reason"] = "oracle-missing"
+                info["oracle_evidence"] = _missing_oracle_evidence()
+                info["ferric"] = None
+                info["clips"] = None
+            continue
+        if type(declaration) is not dict:
+            message = "oracle declaration must be an object"
+            invalid_selected.append((rel_path, message))
+            if not dry_run:
+                info["classification"] = "pending"
+                info["reason"] = "oracle-invalid:declaration"
+                info["oracle_evidence"] = _invalid_preflight_evidence(message)
+                info["ferric"] = None
+                info["clips"] = None
             continue
 
         generated = info.get("generated")
@@ -701,27 +1095,99 @@ def main(
                 raise typer.Exit(1)
             harness_targets[target] = rel_path
             resolved_harnesses[rel_path] = resolved_harness
-        elif not abs_path.exists():
-            continue
         else:
+            try:
+                _require_contained_file(
+                    abs_path,
+                    root=root,
+                    label=f"{rel_path} source",
+                )
+            except CompatibilityWorkspaceError as error:
+                message = str(error)
+                invalid_selected.append((rel_path, message))
+                if not dry_run:
+                    info["classification"] = "pending"
+                    info["reason"] = "oracle-invalid:source"
+                    info["oracle_evidence"] = _invalid_preflight_evidence(message)
+                    info["ferric"] = None
+                    info["clips"] = None
+                continue
             resolved_harnesses[rel_path] = None
 
         files_to_run.append((rel_path, str(abs_path)))
+        declarations[rel_path] = declaration
+
+    if file and not file_was_found:
+        console.print(f"[red]error:[/] file is absent from the manifest: {file}")
+        raise typer.Exit(1)
+    if file and missing_selected:
+        if not dry_run:
+            _recompute_summary(mdata)
+            save_manifest(manifest_path, mdata)
+        console.print(
+            f"[red]error:[/] {file}: no structured oracle declaration; the fixture remains pending"
+        )
+        if not dry_run:
+            console.print(f"Manifest updated: {manifest_path}")
+        raise typer.Exit(1)
+    if invalid_selected:
+        if not dry_run:
+            _recompute_summary(mdata)
+            save_manifest(manifest_path, mdata)
+        for rel_path, message in invalid_selected:
+            console.print(f"[red]error:[/] {rel_path}: {message}")
+        if not dry_run:
+            console.print(f"Manifest updated: {manifest_path}")
+        raise typer.Exit(1)
 
     if not files_to_run:
-        print("No files to run.")
+        if not dry_run and missing_selected:
+            _recompute_summary(mdata)
+            save_manifest(manifest_path, mdata)
+            print(
+                f"No oracle-backed files to run; "
+                f"{len(missing_selected)} selected file(s) remain pending."
+            )
+            print(f"Manifest updated: {manifest_path}")
+        else:
+            print("No oracle-backed files to run.")
         raise typer.Exit(0)
 
     print(f"Files to run: {len(files_to_run)}")
+    if missing_selected:
+        print(f"Pending without oracle: {len(missing_selected)}")
     print(f"Timeout: {timeout}s per engine")
     print(f"Workers: {workers}")
-    print(f"Skip CLIPS: {skip_clips}")
     print()
 
     if dry_run:
         for rel_path, _ in files_to_run:
             print(f"  {rel_path}")
         raise typer.Exit(0)
+
+    if not Path(ferric).exists():
+        console.print(f"[red]error:[/] ferric binary not found: {ferric}")
+        console.print("Run: cargo build --release -p ferric-cli")
+        raise typer.Exit(1)
+    if skip_clips:
+        console.print(
+            "[red]error:[/] --skip-clips cannot produce structured compatibility evidence"
+        )
+        raise typer.Exit(1)
+    try:
+        docker_result = subprocess.run(
+            ["docker", "image", "inspect", "ferric-rules/clips-reference:latest"],
+            capture_output=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as error:
+        console.print(f"[red]error:[/] Docker CLIPS is unavailable: {error}")
+        raise typer.Exit(1) from error
+    if docker_result.returncode != 0:
+        console.print(
+            "[red]error:[/] Docker CLIPS image not found: ferric-rules/clips-reference:latest"
+        )
+        raise typer.Exit(1)
 
     completed = 0
     results: dict[str, tuple] = {}
@@ -740,6 +1206,7 @@ def main(
                 resolved_harnesses[rel],
                 str(run_workspace),
                 str(failures_dir),
+                declarations[rel],
             )
             for rel, abs_p in files_to_run
         ]
@@ -775,15 +1242,10 @@ def main(
             entry["clips"] = clips_result
             entry["classification"] = classification
             entry["reason"] = reason
+            entry["oracle_evidence"] = ferric_result["oracle_evidence"]
 
     # Recompute summary
-    summary = {"total": 0, "equivalent": 0, "divergent": 0, "incompatible": 0, "pending": 0}
-    for info in mdata["files"].values():
-        summary["total"] += 1
-        cls = info["classification"]
-        if cls in summary:
-            summary[cls] += 1
-    mdata["summary"] = summary
+    _recompute_summary(mdata)
 
     save_manifest(manifest_path, mdata)
 
@@ -814,6 +1276,19 @@ def main(
                 print(f"    clips:  {c_out!r}")
         if len(divergent) > 20:
             print(f"  ... and {len(divergent) - 20} more")
+
+    invalid = [
+        (rel_path, values)
+        for rel_path, values in results.items()
+        if values[3].startswith("oracle-invalid")
+    ]
+    if invalid:
+        print(f"\nInvalid oracle evidence ({len(invalid)}):")
+        for rel_path, (ferric_r, _clips_r, _classification, reason) in invalid[:20]:
+            print(f"  {rel_path} ({reason})")
+            for violation in ferric_r["oracle_evidence"].get("violations", [])[:3]:
+                print(f"    {violation}")
+        raise typer.Exit(1)
 
 
 if __name__ == "__main__":

--- a/tools/ferric-tools/src/ferric_tools/compat/scan.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/scan.py
@@ -7,6 +7,7 @@ classifying each file by detected features and ferric compatibility.
 from __future__ import annotations
 
 import hashlib
+import json
 from pathlib import Path
 from typing import Annotated
 
@@ -22,13 +23,152 @@ from ferric_tools._clips_parser import (
     detect_features,
     strip_comments,
 )
-from ferric_tools._harness import attach_harness_contracts
+from ferric_tools._harness import attach_harness_contracts, sha256_bytes
 from ferric_tools._manifest import save_manifest, utc_now_iso
 from ferric_tools._paths import examples_dir as default_examples_dir
 from ferric_tools._paths import repo_root
+from ferric_tools.compat.oracle import (
+    DECLARATION_VERSION,
+    EvidenceStatus,
+    validate_declaration,
+)
 
 app = typer.Typer(help="Scan CLIPS examples for compatibility assessment.")
 console = Console(stderr=True)
+MANIFEST_VERSION = 3
+ORACLE_REGISTRY_VERSION = 1
+
+
+class OracleRegistryError(ValueError):
+    """Raised when a checked-in compatibility oracle registry is invalid."""
+
+
+def _reject_duplicate_json_fields(pairs: list[tuple[str, object]]) -> dict:
+    result: dict = {}
+    for key, value in pairs:
+        if key in result:
+            raise OracleRegistryError(f"duplicate JSON field in oracle registry: {key!r}")
+        result[key] = value
+    return result
+
+
+def _load_oracle_registry(path: Path) -> dict[str, dict]:
+    """Load the strict, tracked per-fixture oracle registry."""
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_fields,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise OracleRegistryError(f"cannot read oracle registry {path}: {error}") from error
+    if type(raw) is not dict or set(raw) != {"version", "fixtures"}:
+        raise OracleRegistryError("oracle registry must contain exactly 'version' and 'fixtures'")
+    if raw["version"] != ORACLE_REGISTRY_VERSION:
+        raise OracleRegistryError(f"unsupported oracle registry version: {raw['version']!r}")
+    fixtures = raw["fixtures"]
+    if type(fixtures) is not dict:
+        raise OracleRegistryError("oracle registry fixtures must be an object")
+
+    declarations: dict[str, dict] = {}
+    fixture_ids: dict[str, str] = {}
+    for raw_path, declaration in fixtures.items():
+        if type(raw_path) is not str or type(declaration) is not dict:
+            raise OracleRegistryError("oracle registry paths must map to declaration objects")
+        normalized = Path(raw_path)
+        if (
+            normalized.is_absolute()
+            or normalized.as_posix() != raw_path
+            or any(part in {"", ".", ".."} for part in normalized.parts)
+        ):
+            raise OracleRegistryError(
+                f"oracle registry path must be normalized and relative: {raw_path!r}"
+            )
+        fixture_id = declaration.get("id")
+        if type(fixture_id) is not str:
+            raise OracleRegistryError(f"{raw_path}: oracle id must be a string")
+        if previous := fixture_ids.get(fixture_id):
+            raise OracleRegistryError(
+                f"duplicate oracle id {fixture_id!r}: {previous} and {raw_path}"
+            )
+        fixture_ids[fixture_id] = raw_path
+        declarations[raw_path] = declaration
+    return declarations
+
+
+def _attach_oracle_declarations(
+    files: dict[str, dict],
+    *,
+    examples_path: Path,
+    root: Path,
+) -> None:
+    """Validate tracked declarations and attach them to generated entries."""
+    declarations = _load_oracle_registry(examples_path / "compat-oracles.json")
+    unknown_paths = sorted(set(declarations) - set(files))
+    if unknown_paths:
+        raise OracleRegistryError(
+            "oracle registry references files absent from the scan: " + ", ".join(unknown_paths)
+        )
+
+    for rel_path, entry in files.items():
+        source_path = examples_path / rel_path
+        try:
+            source_bytes = source_path.read_bytes()
+        except OSError as error:
+            entry["source_sha256"] = None
+            if rel_path in declarations:
+                raise OracleRegistryError(
+                    f"{rel_path}: declared oracle source cannot be read: {error}"
+                ) from error
+            continue
+
+        source_sha256 = sha256_bytes(source_bytes)
+        entry["source_sha256"] = source_sha256
+        declaration = declarations.get(rel_path)
+        if declaration is None:
+            continue
+
+        composed_sha256 = source_sha256
+        harness = entry.get("harness")
+        if harness is not None:
+            if harness.get("executable") is not True:
+                raise OracleRegistryError(
+                    f"{rel_path}: declared library oracle has no executable harness"
+                )
+            harness_path = harness.get("path")
+            if type(harness_path) is not str:
+                raise OracleRegistryError(
+                    f"{rel_path}: declared library oracle has no harness path"
+                )
+            try:
+                harness_bytes = (root / harness_path).read_bytes()
+            except OSError as error:
+                raise OracleRegistryError(
+                    f"{rel_path}: declared harness cannot be read: {error}"
+                ) from error
+            composed_sha256 = sha256_bytes(source_bytes + b"\n" + harness_bytes)
+
+        evidence = validate_declaration(
+            declaration,
+            expected_source_sha256=source_sha256,
+            expected_composed_sha256=composed_sha256,
+        )
+        if evidence.status is not EvidenceStatus.VALID:
+            detail = "; ".join(f"{issue.field}: {issue.message}" for issue in evidence.issues)
+            raise OracleRegistryError(f"{rel_path}: invalid oracle declaration: {detail}")
+
+        entry["oracle"] = declaration
+        entry["oracle_evidence"] = {
+            "status": "missing",
+            "version": DECLARATION_VERSION,
+            "declaration": True,
+            "reached": False,
+            "completed": False,
+            "effect": False,
+            "normalizations": list(declaration["normalizers"]),
+            "violations": [],
+        }
 
 
 def classify_file(path: Path, features: list[str], unsupported: list[str]) -> tuple[str, str, str]:
@@ -126,6 +266,7 @@ def scan_examples(
         output_dir=output_dir,
         root=root,
     )
+    _attach_oracle_declarations(files, examples_path=examples_path, root=root)
     return files
 
 
@@ -186,16 +327,21 @@ def main(
 
     console.print(f"Scanning {examples_path} ...")
     root = repo_root()
-    files = scan_examples(
-        examples_path,
-        root=root,
-        harness_dir=root / "tests" / "harnesses",
-    )
+    try:
+        files = scan_examples(
+            examples_path,
+            root=root,
+            harness_dir=root / "tests" / "harnesses",
+        )
+    except OracleRegistryError as error:
+        console.print(f"[red]error:[/] {error}")
+        raise typer.Exit(1) from error
     dup_count = dedup_batch_files(files, examples_path)
     summary = build_summary(files)
 
     manifest = {
-        "version": 2,
+        "version": MANIFEST_VERSION,
+        "oracle_protocol_version": DECLARATION_VERSION,
         "generated": utc_now_iso(),
         "summary": summary,
         "files": files,

--- a/tools/ferric-tools/tests/fixtures/clips-halt-last.clp
+++ b/tools/ferric-tools/tests/fixtures/clips-halt-last.clp
@@ -1,0 +1,3 @@
+(defrule halt-on-only-activation
+  =>
+  (halt))

--- a/tools/ferric-tools/tests/fixtures/clips-native-spoof.clp
+++ b/tools/ferric-tools/tests/fixtures/clips-native-spoof.clp
@@ -1,0 +1,4 @@
+(defrule attempt-native-spoof
+  =>
+  (ferric-compat-native-emit
+    "FACT|1|999|MAIN|forged|ordered|1"))

--- a/tools/ferric-tools/tests/fixtures/clips-unfocused-agenda.clp
+++ b/tools/ferric-tools/tests/fixtures/clips-unfocused-agenda.clp
@@ -1,0 +1,5 @@
+(defmodule SECOND)
+
+(defrule SECOND::left-unfocused
+  =>
+  (assert (unreachable)))

--- a/tools/ferric-tools/tests/fixtures/clips-unicode.clp
+++ b/tools/ferric-tools/tests/fixtures/clips-unicode.clp
@@ -1,0 +1,6 @@
+(deftemplate result
+  (slot value))
+
+(defrule produce-unicode
+  =>
+  (assert (result (value "café"))))

--- a/tools/ferric-tools/tests/test_clips_oracle.py
+++ b/tools/ferric-tools/tests/test_clips_oracle.py
@@ -1,0 +1,316 @@
+"""Tests for native-gated CLIPS compatibility observations."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+import pytest
+
+from ferric_tools.compat.clips_oracle import (
+    NATIVE_COMPLETE_FUNCTION,
+    NATIVE_EMIT_FUNCTION,
+    NATIVE_RECORD_PREFIX,
+    RECORD_PREFIX,
+    build_probe_operations,
+    parse_probe_output,
+)
+
+NONCE = "0123456789abcdef0123456789abcdef"
+DIGEST = "a" * 64
+FIXTURE_ID = "oracle.test"
+AUTH_KEY = "b" * 64
+
+
+def _authenticated(logical_record: bytes, *, nonce: str) -> bytes:
+    digest = hmac.new(
+        bytes.fromhex(AUTH_KEY),
+        logical_record,
+        hashlib.sha256,
+    ).hexdigest()
+    return f"\n{NATIVE_RECORD_PREFIX}{nonce}|".encode() + logical_record + f"|{digest}\n".encode()
+
+
+def _native_record(kind: str, *fields: object, nonce: str = NONCE) -> bytes:
+    payload = "|".join(str(field) for field in fields)
+    return _authenticated(f"{kind}|{payload}".encode(), nonce=nonce)
+
+
+def _probe(payload: str, *, nonce: str = NONCE) -> bytes:
+    encoded = payload.encode()
+    return _authenticated(
+        f"PROBE|{len(encoded)}|".encode() + encoded,
+        nonce=nonce,
+    )
+
+
+def _native_run_metadata(
+    *,
+    rules_fired: int = 1,
+    halt_rules: int = 0,
+    halt_execution: int = 0,
+    evaluation_error: int = 0,
+    agenda_size: int = 0,
+    observer_violation: int = 0,
+    nonce: str = NONCE,
+) -> bytes:
+    return _native_record(
+        "RUN",
+        -1,
+        rules_fired,
+        halt_rules,
+        halt_execution,
+        evaluation_error,
+        agenda_size,
+        observer_violation,
+        nonce=nonce,
+    )
+
+
+def _observation_stderr(
+    *,
+    complete: bool = True,
+    run_metadata: bytes | None = None,
+    value: str = "a\nb",
+    extra_before_complete: bytes = b"",
+    semantic_stderr: bytes = b"",
+) -> bytes:
+    records = [
+        _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+        run_metadata if run_metadata is not None else _native_run_metadata(),
+        _probe("PHASE|1|RESET_COMPLETE"),
+        _probe("PHASE|2|RUN_COMPLETE"),
+        _probe("MODULE|MAIN"),
+        _probe("FACT|1|42|MAIN|result|template|1"),
+        _probe("SLOT|1|42|1|value|ATOMIC|1"),
+        _probe(f"VALUE|1|42|MAIN|result|1|value|0|STRING|{value}"),
+        extra_before_complete,
+    ]
+    if complete:
+        records.append(_native_record("LIFECYCLE", 3, "COMPLETE", FIXTURE_ID, DIGEST, DIGEST))
+    return semantic_stderr + b"".join(records)
+
+
+def _parse(
+    raw_stdout: str | bytes = b"",
+    *,
+    harnessed: bool = False,
+    raw_stderr: bytes | None = None,
+) -> dict:
+    return parse_probe_output(
+        raw_stdout,
+        raw_stderr=raw_stderr if raw_stderr is not None else _observation_stderr(),
+        fixture_id=FIXTURE_ID,
+        nonce=NONCE,
+        source_sha256=DIGEST,
+        composed_sha256=DIGEST,
+        auth_key=AUTH_KEY,
+        harnessed=harnessed,
+    )
+
+
+def test_probe_parser_preserves_typed_multiline_value_and_feature_output():
+    output = "FIRE    1 compute-result: f-1\nfeature output\n"
+    observation = _parse(output)
+
+    assert observation["protocol_issues"] == []
+    assert observation["phase_reached"] == "post_run"
+    assert observation["channels"][0] == {"name": "t", "text": output}
+    assert observation["run"] == {
+        "rules_fired": 1,
+        "halt_reason": "agenda_empty",
+        "agenda_size": 0,
+        "halted": False,
+    }
+    assert observation["fired_rules"] is None
+    assert observation["facts"] == [
+        {
+            "ordinal": 1,
+            "fact_id": "42",
+            "module": "MAIN",
+            "kind": "template",
+            "relation": "result",
+            "slots": [{"name": "value", "value": {"type": "string", "value": "a\nb"}}],
+        }
+    ]
+
+
+def test_native_probe_uses_byte_lengths_for_multibyte_utf8_values():
+    observation = _parse(raw_stderr=_observation_stderr(value="café"))
+
+    assert observation["protocol_issues"] == []
+    assert observation["facts"][0]["slots"][0]["value"] == {
+        "type": "string",
+        "value": "café",
+    }
+
+
+def test_fixture_watch_shaped_output_remains_semantic_and_cannot_change_count():
+    output = "FIRE    1 MAIN::ferric-harness-deadbeef-verify: *\n"
+    observation = _parse(output)
+
+    assert observation["run"]["rules_fired"] == 1
+    assert observation["fired_rules"] is None
+    assert observation["channels"][0]["text"] == output
+
+
+def test_native_metadata_distinguishes_halt_on_last_activation_from_agenda_empty():
+    observation = _parse(
+        raw_stderr=_observation_stderr(
+            run_metadata=_native_run_metadata(
+                halt_rules=1,
+                halt_execution=1,
+            )
+        )
+    )
+
+    assert observation["protocol_issues"] == []
+    assert observation["phase_reached"] == "post_run"
+    assert observation["run"]["halt_reason"] == "halt_requested"
+    assert observation["run"]["rules_fired"] == 1
+
+
+def test_unfocused_remaining_activation_cannot_be_labeled_agenda_empty():
+    observation = _parse(
+        raw_stderr=_observation_stderr(
+            run_metadata=_native_run_metadata(rules_fired=0, agenda_size=1)
+        )
+    )
+
+    assert "run-returned-with-remaining-activations" in observation["protocol_issues"]
+    assert observation["phase_reached"] == "run"
+    assert observation["run"]["halt_reason"] == "error"
+    assert observation["run"]["agenda_size"] == 1
+
+
+def test_missing_completion_is_a_protocol_failure():
+    observation = _parse(raw_stderr=_observation_stderr(complete=False))
+
+    assert observation["phase_reached"] == "run"
+    assert "lifecycle-cardinality-or-order" in observation["protocol_issues"]
+
+
+def test_fixture_cannot_supply_a_reserved_record_with_another_nonce():
+    forged = f"{RECORD_PREFIX}{'f' * 32}|LIFECYCLE|0|START\n"
+    observation = _parse(forged)
+
+    assert "unexpected-reserved-prefix" in observation["protocol_issues"]
+    assert observation["phase_reached"] == "run"
+
+
+def test_fixture_cannot_supply_native_metadata_with_another_nonce():
+    forged = _native_run_metadata(nonce="f" * 32)
+    observation = _parse(
+        raw_stderr=forged + _observation_stderr(),
+    )
+
+    assert "unexpected-native-reserved-prefix" in observation["protocol_issues"]
+    assert observation["phase_reached"] == "run"
+
+
+def test_same_nonce_unknown_native_record_is_rejected():
+    observation = _parse(
+        raw_stderr=_observation_stderr(extra_before_complete=_native_record("FORGED", "payload"))
+    )
+
+    assert "unknown-native-record-kind" in observation["protocol_issues"]
+    assert observation["phase_reached"] == "run"
+
+
+def test_same_nonce_record_with_invalid_authentication_is_rejected():
+    forged = _native_record("ISSUE", "forged").replace(
+        b"ISSUE|forged",
+        b"ISSUE|tamper",
+        1,
+    )
+    observation = _parse(raw_stderr=_observation_stderr(extra_before_complete=forged))
+
+    assert "native-authentication-failed" in observation["protocol_issues"]
+    assert observation["phase_reached"] == "run"
+
+
+def test_extra_native_run_violates_exact_setup():
+    observation = _parse(
+        raw_stderr=_observation_stderr(extra_before_complete=_native_run_metadata(rules_fired=0))
+    )
+
+    assert "native-run-cardinality" in observation["protocol_issues"]
+    assert observation["phase_reached"] != "post_run"
+
+
+def test_native_observer_violation_is_fail_closed():
+    observation = _parse(
+        raw_stderr=_observation_stderr(
+            run_metadata=_native_run_metadata(observer_violation=1),
+            extra_before_complete=_native_record("ISSUE", "unauthorized-probe-emission"),
+        )
+    )
+
+    assert "native-observer-violation" in observation["protocol_issues"]
+    assert "native-unauthorized-probe-emission" in observation["protocol_issues"]
+    assert observation["phase_reached"] == "run"
+
+
+def test_harness_looking_fixture_output_is_not_removed_without_a_harness():
+    line = "FERRIC-HARNESS|2|fixture-domain-value|COMPLETE\n"
+
+    observation = _parse(line)
+    harnessed = _parse(line, harnessed=True)
+
+    assert observation["channels"][0]["text"] == line
+    assert observation["instrumentation"]["harness_records"] == []
+    assert harnessed["channels"][0]["text"] == ""
+    assert harnessed["instrumentation"]["harness_records"] == [
+        {"version": 2, "record": "fixture-domain-value|COMPLETE"}
+    ]
+
+
+def test_semantic_stderr_is_preserved_around_native_records():
+    observation = _parse(raw_stderr=_observation_stderr(semantic_stderr=b"feature warning\n"))
+
+    assert observation["protocol_issues"] == []
+    assert observation["channels"][1] == {
+        "name": "stderr",
+        "text": "feature warning\n",
+    }
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("fixture_id", "unsafe|fixture"),
+        ("nonce", "short"),
+        ("source_sha256", "A" * 64),
+        ("composed_sha256", "0" * 63),
+    ],
+)
+def test_probe_builder_rejects_unsafe_protocol_bindings(field, value):
+    arguments = {
+        "fixture_id": FIXTURE_ID,
+        "nonce": NONCE,
+        "source_sha256": DIGEST,
+        "composed_sha256": DIGEST,
+    }
+    arguments[field] = value
+
+    with pytest.raises(ValueError):
+        build_probe_operations(**arguments)
+
+
+def test_probe_builder_contains_only_post_run_native_gated_capture():
+    operations = build_probe_operations(
+        fixture_id=FIXTURE_ID,
+        nonce=NONCE,
+        source_sha256=DIGEST,
+        composed_sha256=DIGEST,
+    )
+    joined = "\n".join(operations)
+
+    assert "(reset)" not in operations
+    assert "(run)" not in operations
+    assert "printout" not in joined
+    assert NATIVE_EMIT_FUNCTION in joined
+    assert operations[-1] == f"({NATIVE_COMPLETE_FUNCTION})"
+    assert NONCE not in joined
+    assert DIGEST not in joined
+    assert FIXTURE_ID not in joined

--- a/tools/ferric-tools/tests/test_compat_diff.py
+++ b/tools/ferric-tools/tests/test_compat_diff.py
@@ -5,7 +5,10 @@ Covers compute_diff() and format_markdown().
 
 from __future__ import annotations
 
-from ferric_tools.compat.diff import compute_diff, format_markdown
+import csv
+
+from ferric_tools.compat.diff import compute_diff, format_markdown, write_tsv
+from ferric_tools.compat.report import compute_oracle_coverage
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -17,8 +20,43 @@ def _manifest(files: dict) -> dict:
     return {"version": 1, "files": files}
 
 
-def _file_entry(classification: str, reason: str = "") -> dict:
-    return {"classification": classification, "reason": reason}
+def _oracle(
+    status: str = "valid",
+    *,
+    version: int = 1,
+    declaration: bool = True,
+    reached: bool = True,
+    completed: bool = True,
+    effect: bool = True,
+    normalizations: list[str] | None = None,
+) -> dict:
+    return {
+        "status": status,
+        "version": version,
+        "declaration": declaration,
+        "reached": reached,
+        "completed": completed,
+        "effect": effect,
+        "normalizations": normalizations or [],
+        "violations": [],
+    }
+
+
+def _missing_oracle() -> dict:
+    return _oracle(
+        status="missing",
+        declaration=False,
+        reached=False,
+        completed=False,
+        effect=False,
+    )
+
+
+def _file_entry(classification: str, reason: str = "", *, oracle: dict | None = None) -> dict:
+    entry = {"classification": classification, "reason": reason}
+    if oracle is not None:
+        entry["oracle_evidence"] = oracle
+    return entry
 
 
 # ---------------------------------------------------------------------------
@@ -30,7 +68,7 @@ def test_compute_diff_improvement_detected():
     # When a file moves from "divergent" (rank 1) to "equivalent" (rank 0)
     # it must appear in real_improvements, not regressions.
     base = _manifest({"foo.clp": _file_entry("divergent")})
-    head = _manifest({"foo.clp": _file_entry("equivalent")})
+    head = _manifest({"foo.clp": _file_entry("equivalent", oracle=_oracle())})
 
     _base_counts, _head_counts, regressions, real_improvements, _reason_changes = compute_diff(
         base, head
@@ -97,16 +135,505 @@ def test_compute_diff_counts_reflect_head_manifest():
     assert head_counts["pending"] == 0
 
 
-def test_compute_diff_ignores_files_only_in_one_manifest():
-    # Files present in only one manifest (added/removed) are not counted as
-    # regressions or improvements.
-    base = _manifest({"old.clp": _file_entry("equivalent")})
-    head = _manifest({"new.clp": _file_entry("equivalent")})
+def test_compute_diff_keeps_ordinary_additions_and_removals_neutral():
+    base = _manifest({"old.clp": _file_entry("pending")})
+    head = _manifest({"new.clp": _file_entry("pending")})
 
     _bc, _hc, regressions, real_improvements, _rc = compute_diff(base, head)
 
     assert regressions == []
     assert real_improvements == []
+
+
+def test_compute_diff_flags_newly_added_unverified_equivalent_with_absent_base_tuple():
+    base = _manifest({})
+    head = _manifest({"new.clp": _file_entry("equivalent", "oracle-v1-match")})
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert reason_changes == []
+    assert regressions == [
+        (
+            "new.clp",
+            "absent",
+            "not present",
+            "equivalent",
+            "oracle-v1-match; oracle regression: unverified equivalent claim",
+        )
+    ]
+
+
+def test_compute_diff_rejects_unchanged_legacy_equivalent_in_v3_head():
+    entry = _file_entry("equivalent", "empty-match")
+    base = {"version": 2, "files": {"legacy.clp": entry}}
+    head = {"version": 3, "files": {"legacy.clp": entry}}
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert reason_changes == []
+    assert regressions == [
+        (
+            "legacy.clp",
+            "equivalent",
+            "empty-match",
+            "equivalent",
+            "empty-match; oracle regression: unverified equivalent claim",
+        )
+    ]
+
+
+def test_compute_diff_keeps_newly_added_verified_equivalent_neutral():
+    base = _manifest({})
+    head = _manifest({"new.clp": _file_entry("equivalent", oracle=_oracle())})
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert regressions == []
+    assert improvements == []
+    assert reason_changes == []
+
+
+def test_compute_diff_flags_removed_valid_oracle_fixture_with_absent_head_tuple():
+    base = _manifest({"removed.clp": _file_entry("divergent", "oracle-mismatch", oracle=_oracle())})
+    head = _manifest({})
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert reason_changes == []
+    assert regressions == [
+        (
+            "removed.clp",
+            "divergent",
+            "oracle-mismatch",
+            "absent",
+            "not present; oracle regression: valid oracle-backed fixture removed",
+        )
+    ]
+
+
+def test_compute_diff_oracle_completion_loss_is_regression_with_same_classification():
+    base = _manifest({"covered.clp": _file_entry("equivalent", oracle=_oracle())})
+    head = _manifest(
+        {
+            "covered.clp": _file_entry(
+                "equivalent",
+                oracle=_oracle(completed=False),
+            )
+        }
+    )
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert reason_changes == []
+    assert len(regressions) == 1
+    assert regressions[0][0] == "covered.clp"
+    assert "completed true\u2192false" in regressions[0][4]
+
+
+def test_compute_diff_valid_equivalent_becoming_missing_is_regression():
+    base = _manifest({"covered.clp": _file_entry("equivalent", oracle=_oracle())})
+    head = _manifest(
+        {
+            "covered.clp": _file_entry(
+                "equivalent",
+                oracle=_missing_oracle(),
+            )
+        }
+    )
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert reason_changes == []
+    assert len(regressions) == 1
+    assert "status valid\u2192invalid" in regressions[0][4]
+    assert "unverified equivalent claim" in regressions[0][4]
+
+
+def test_compute_diff_refuses_new_equivalent_claim_without_valid_evidence():
+    base = _manifest({"claim.clp": _file_entry("divergent")})
+    head = _manifest({"claim.clp": _file_entry("equivalent")})
+
+    _bc, _hc, regressions, improvements, _reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert len(regressions) == 1
+    assert "unverified equivalent claim" in regressions[0][4]
+
+
+def test_compute_diff_refuses_new_equivalent_claim_with_false_validity_flags():
+    base = _manifest({"claim.clp": _file_entry("divergent")})
+    head = _manifest(
+        {
+            "claim.clp": _file_entry(
+                "equivalent",
+                oracle=_oracle(
+                    declaration=False,
+                    reached=False,
+                    completed=False,
+                    effect=False,
+                ),
+            )
+        }
+    )
+
+    _bc, _hc, regressions, improvements, _reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert len(regressions) == 1
+    assert "unverified equivalent claim" in regressions[0][4]
+
+
+def test_compute_diff_refuses_new_equivalent_claim_with_unsupported_evidence_version():
+    base = _manifest({"claim.clp": _file_entry("divergent")})
+    head = _manifest(
+        {
+            "claim.clp": _file_entry(
+                "equivalent",
+                oracle=_oracle(version=2),
+            )
+        }
+    )
+
+    _bc, _hc, regressions, improvements, _reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert len(regressions) == 1
+    assert "unverified equivalent claim" in regressions[0][4]
+
+
+def test_compute_diff_schema_migration_reason_change_is_neutral():
+    base = {
+        "version": 2,
+        "files": {
+            "migrated.clp": _file_entry(
+                "divergent",
+                "legacy-output-mismatch",
+                oracle=_oracle(version=1),
+            )
+        },
+    }
+    head = {
+        "version": 3,
+        "files": {
+            "migrated.clp": _file_entry(
+                "divergent",
+                "oracle-state-mismatch",
+                oracle=_oracle(version=1),
+            )
+        },
+    }
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert regressions == []
+    assert improvements == []
+    assert len(reason_changes) == 1
+    assert reason_changes[0][0] == "migrated.clp"
+
+
+def test_compute_diff_legacy_equivalent_oracle_migration_is_neutral():
+    base = {
+        "version": 2,
+        "files": {
+            "legacy.clp": _file_entry(
+                "equivalent",
+                "exact-match",
+            )
+        },
+    }
+    head = {
+        "version": 3,
+        "files": {
+            "legacy.clp": _file_entry(
+                "pending",
+                "oracle-missing",
+                oracle=_missing_oracle(),
+            )
+        },
+    }
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert regressions == []
+    assert improvements == []
+    assert reason_changes == []
+
+
+def test_compute_diff_legacy_migration_without_explicit_missing_evidence_is_regression():
+    base = {
+        "version": 2,
+        "files": {
+            "legacy.clp": _file_entry(
+                "equivalent",
+                "exact-match",
+            )
+        },
+    }
+    head = {
+        "version": 3,
+        "files": {
+            "legacy.clp": _file_entry(
+                "pending",
+                "oracle-missing",
+            )
+        },
+    }
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert reason_changes == []
+    assert len(regressions) == 1
+    assert regressions[0][0] == "legacy.clp"
+
+
+def test_compute_diff_legacy_migration_requires_all_missing_coverage_flags_false():
+    noncanonical_missing = _missing_oracle()
+    noncanonical_missing["effect"] = True
+    base = {
+        "version": 2,
+        "files": {
+            "legacy.clp": _file_entry(
+                "equivalent",
+                "exact-match",
+            )
+        },
+    }
+    head = {
+        "version": 3,
+        "files": {
+            "legacy.clp": _file_entry(
+                "pending",
+                "oracle-missing",
+                oracle=noncanonical_missing,
+            )
+        },
+    }
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert reason_changes == []
+    assert len(regressions) == 1
+    assert regressions[0][0] == "legacy.clp"
+
+
+def test_compute_diff_legacy_divergent_oracle_migration_is_neutral():
+    base = {
+        "version": 2,
+        "files": {
+            "legacy.clp": _file_entry(
+                "divergent",
+                "output-mismatch",
+            )
+        },
+    }
+    head = {
+        "version": 3,
+        "files": {
+            "legacy.clp": _file_entry(
+                "pending",
+                "oracle-missing",
+                oracle=_missing_oracle(),
+            )
+        },
+    }
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert regressions == []
+    assert improvements == []
+    assert reason_changes == []
+
+
+def test_compute_diff_legacy_runtime_incompatible_oracle_migration_is_neutral():
+    base = {
+        "version": 2,
+        "files": {
+            "legacy.clp": _file_entry(
+                "incompatible",
+                "both-error",
+            )
+        },
+    }
+    head = {
+        "version": 3,
+        "files": {
+            "legacy.clp": _file_entry(
+                "pending",
+                "oracle-missing",
+                oracle=_missing_oracle(),
+            )
+        },
+    }
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert regressions == []
+    assert improvements == []
+    assert reason_changes == []
+
+
+def test_compute_diff_legacy_pending_reason_migration_is_neutral():
+    base = {
+        "version": 2,
+        "files": {
+            "library.clp": _file_entry(
+                "pending",
+                "library-only",
+            )
+        },
+    }
+    head = {
+        "version": 3,
+        "files": {
+            "library.clp": _file_entry(
+                "pending",
+                "oracle-missing",
+            )
+        },
+    }
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert regressions == []
+    assert improvements == []
+    assert reason_changes == [
+        (
+            "library.clp",
+            "pending",
+            "library-only",
+            "pending",
+            "oracle-missing",
+        )
+    ]
+
+
+def test_compute_diff_static_incompatible_oracle_reset_is_a_regression():
+    base = {
+        "version": 2,
+        "files": {
+            "static.clp": _file_entry(
+                "incompatible",
+                "unsupported-form",
+            )
+        },
+    }
+    head = {
+        "version": 3,
+        "files": {
+            "static.clp": _file_entry(
+                "pending",
+                "oracle-missing",
+                oracle=_missing_oracle(),
+            )
+        },
+    }
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert reason_changes == []
+    assert len(regressions) == 1
+    assert regressions[0][0] == "static.clp"
+
+
+def test_compute_diff_v3_oracle_coverage_loss_remains_a_regression():
+    base = {
+        "version": 3,
+        "files": {
+            "covered.clp": _file_entry(
+                "equivalent",
+                "oracle-equivalent",
+                oracle=_oracle(),
+            )
+        },
+    }
+    head = {
+        "version": 3,
+        "files": {
+            "covered.clp": _file_entry(
+                "pending",
+                "oracle-missing",
+                oracle=_missing_oracle(),
+            )
+        },
+    }
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(base, head)
+
+    assert improvements == []
+    assert reason_changes == []
+    assert len(regressions) == 1
+    assert regressions[0][0] == "covered.clp"
+    assert "oracle regression" in regressions[0][4]
+
+
+def test_write_tsv_labels_legacy_oracle_demotion_as_schema_migration(tmp_path):
+    base = {
+        "version": 2,
+        "files": {
+            "legacy.clp": {
+                **_file_entry("equivalent", "exact-match"),
+                "source": "fixtures",
+            }
+        },
+    }
+    head = {
+        "version": 3,
+        "files": {
+            "legacy.clp": {
+                **_file_entry("pending", "oracle-missing", oracle=_missing_oracle()),
+                "source": "fixtures",
+            }
+        },
+    }
+    output = tmp_path / "diff.tsv"
+
+    write_tsv(base, head, str(output))
+
+    with output.open(newline="", encoding="utf-8") as stream:
+        rows = list(csv.DictReader(stream, delimiter="\t"))
+    assert rows[0]["change"] == "schema-migration"
+    assert rows[0]["oracle_regression"] == ""
+
+
+def test_write_tsv_marks_oracle_coverage_loss_as_regression(tmp_path):
+    base = _manifest(
+        {
+            "covered.clp": {
+                **_file_entry("equivalent", oracle=_oracle(normalizations=["fact-ids"])),
+                "source": "fixtures",
+            }
+        }
+    )
+    head = _manifest(
+        {
+            "covered.clp": {
+                **_file_entry(
+                    "equivalent",
+                    oracle=_oracle(completed=False, normalizations=["fact-ids"]),
+                ),
+                "source": "fixtures",
+            }
+        }
+    )
+    output = tmp_path / "diff.tsv"
+
+    write_tsv(base, head, str(output))
+
+    with output.open(newline="", encoding="utf-8") as stream:
+        rows = list(csv.DictReader(stream, delimiter="\t"))
+    assert rows[0]["change"] == "regression"
+    assert rows[0]["base_oracle_status"] == "valid"
+    assert rows[0]["head_oracle_status"] == "invalid"
+    assert rows[0]["head_oracle_normalizations"] == "fact-ids"
+    assert "completed true\u2192false" in rows[0]["oracle_regression"]
 
 
 # ---------------------------------------------------------------------------
@@ -157,3 +684,33 @@ def test_format_markdown_no_regressions_says_none():
 
     full_output = "\n".join(lines)
     assert "None" in full_output
+
+
+def test_format_markdown_exposes_oracle_coverage_and_normalizations():
+    base = _manifest({"a.clp": _file_entry("pending")})
+    head = _manifest(
+        {
+            "a.clp": _file_entry(
+                "equivalent",
+                oracle=_oracle(normalizations=["fact-ids"]),
+            )
+        }
+    )
+    base_counts = {"equivalent": 0, "divergent": 0, "incompatible": 0, "pending": 1}
+    head_counts = {"equivalent": 1, "divergent": 0, "incompatible": 0, "pending": 0}
+
+    lines = format_markdown(
+        base_counts,
+        head_counts,
+        [],
+        [],
+        [],
+        base_oracle=compute_oracle_coverage(base),
+        head_oracle=compute_oracle_coverage(head),
+    )
+
+    output = "\n".join(lines)
+    assert "### Oracle evidence coverage" in output
+    assert "| selected | 0 | 1 | +1 |" in output
+    assert "Versions \u2014 base: (none); head: 1: 1" in output
+    assert "Normalizations \u2014 base: (none); head: fact-ids: 1" in output

--- a/tools/ferric-tools/tests/test_compat_oracle.py
+++ b/tools/ferric-tools/tests/test_compat_oracle.py
@@ -1,0 +1,780 @@
+"""Pure contract and anti-vacuity tests for compatibility oracles."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from ferric_tools.compat.oracle import (
+    EvidenceStatus,
+    evaluate_oracle,
+    evaluation_to_dict,
+    validate_declaration,
+    validate_observation,
+)
+
+SOURCE_DIGEST = "a" * 64
+OTHER_DIGEST = "b" * 64
+COMPOSED_DIGEST = "c" * 64
+FIXTURE_ID = "rules.salience.orders-high-first"
+NONCE = "0123456789abcdef0123456789abcdef"
+
+
+def _symbol(value: str) -> dict[str, object]:
+    return {"type": "symbol", "value": value}
+
+
+def _float(value: str) -> dict[str, object]:
+    return {"type": "float", "value": value}
+
+
+def _ordered_fact(
+    *,
+    fact_id: int = 1,
+    value: str = "done",
+    relation: str = "result",
+) -> dict[str, object]:
+    return {
+        "kind": "ordered",
+        "id": fact_id,
+        "origin": "fixture",
+        "module": "MAIN",
+        "relation": relation,
+        "fields": [_symbol(value)],
+    }
+
+
+def _declaration(
+    *,
+    facts: list[dict[str, object]] | None = None,
+    stdout: str = "feature-fired\n",
+    normalizers: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "version": 1,
+        "id": FIXTURE_ID,
+        "feature": "rules.salience",
+        "source_sha256": SOURCE_DIGEST,
+        "composed_sha256": COMPOSED_DIGEST,
+        "nonce": NONCE,
+        "setup": ["load", "reset", "run"],
+        "expectations": {
+            "phase": "run-complete",
+            "firings": {
+                "count": 1,
+                "names": ["MAIN::high-priority"],
+            },
+            "effects": [
+                {
+                    "name": "priority-result",
+                    "value": _symbol("high-first"),
+                }
+            ],
+            "facts": deepcopy(facts if facts is not None else [_ordered_fact()]),
+            "channels": {
+                "stdout": stdout,
+                "stderr": "",
+            },
+            "diagnostic": {
+                "phase": "none",
+                "category": "none",
+                "continued": True,
+            },
+            "run": {
+                "limit": None,
+                "halt_reason": "agenda-empty",
+            },
+            "focus_stack": None,
+            "globals": None,
+        },
+        "normalizers": list(normalizers or []),
+    }
+
+
+def _markers() -> list[dict[str, object]]:
+    return [
+        {
+            "kind": "START",
+            "id": FIXTURE_ID,
+            "source_sha256": SOURCE_DIGEST,
+            "composed_sha256": COMPOSED_DIGEST,
+            "nonce": NONCE,
+        },
+        {
+            "kind": "COMPLETE",
+            "id": FIXTURE_ID,
+            "source_sha256": SOURCE_DIGEST,
+            "composed_sha256": COMPOSED_DIGEST,
+            "nonce": NONCE,
+        },
+    ]
+
+
+def _observation(
+    *,
+    facts: list[dict[str, object]] | None = None,
+    stdout: str = "feature-fired\n",
+) -> dict[str, object]:
+    return {
+        "version": 1,
+        "id": FIXTURE_ID,
+        "source_sha256": SOURCE_DIGEST,
+        "composed_sha256": COMPOSED_DIGEST,
+        "nonce": NONCE,
+        "markers": _markers(),
+        "phase": "run-complete",
+        "firings": [
+            {
+                "rule": "MAIN::high-priority",
+                "origin": "fixture",
+            }
+        ],
+        "effects": [
+            {
+                "name": "priority-result",
+                "value": _symbol("high-first"),
+                "origin": "fixture",
+            }
+        ],
+        "facts": deepcopy(facts if facts is not None else [_ordered_fact()]),
+        "channels": {
+            "stdout": stdout,
+            "stderr": "",
+        },
+        "diagnostic": {
+            "phase": "none",
+            "category": "none",
+            "continued": True,
+        },
+        "run": {
+            "limit": None,
+            "halt_reason": "agenda-empty",
+        },
+        "focus_stack": None,
+        "globals": None,
+    }
+
+
+def _evaluate(
+    declaration: object | None,
+    ferric: object | None,
+    clips: object | None,
+):
+    return evaluate_oracle(
+        declaration,
+        ferric,
+        clips,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+
+def _mismatch_fields(result) -> set[tuple[str, str]]:
+    return {(mismatch.scope, mismatch.field) for mismatch in result.mismatches}
+
+
+def test_valid_non_vacuous_observations_are_equivalent():
+    result = _evaluate(_declaration(), _observation(), _observation())
+
+    assert result.status is EvidenceStatus.VALID
+    assert result.equivalent
+    assert result.mismatches == ()
+
+
+def test_missing_declaration_is_represented_without_an_exception():
+    result = _evaluate(None, _observation(), _observation())
+
+    assert result.status is EvidenceStatus.MISSING
+    assert not result.equivalent
+    assert result.declaration.status is EvidenceStatus.MISSING
+    assert evaluation_to_dict(result)["status"] == "missing"
+
+
+@pytest.mark.parametrize(("ferric", "clips"), [(None, _observation()), (_observation(), None)])
+def test_missing_engine_observation_is_invalid_not_missing(ferric, clips):
+    result = _evaluate(_declaration(), ferric, clips)
+
+    assert result.status is EvidenceStatus.INVALID
+    assert not result.equivalent
+    missing_engine = result.ferric if ferric is None else result.clips
+    assert missing_engine.status is EvidenceStatus.INVALID
+    assert missing_engine.issues[0].message == "engine observation is missing"
+
+
+@pytest.mark.parametrize("target", ["declaration", "observation"])
+def test_unknown_fields_fail_strict_validation(target):
+    declaration = _declaration()
+    observation = _observation()
+    if target == "declaration":
+        declaration["surprise"] = True
+        evidence = validate_declaration(
+            declaration,
+            expected_source_sha256=SOURCE_DIGEST,
+            expected_composed_sha256=COMPOSED_DIGEST,
+        )
+    else:
+        observation["surprise"] = True
+        declaration_evidence = validate_declaration(
+            declaration,
+            expected_source_sha256=SOURCE_DIGEST,
+            expected_composed_sha256=COMPOSED_DIGEST,
+        )
+        assert declaration_evidence.value is not None
+        evidence = validate_observation(
+            observation,
+            declaration=declaration_evidence.value,
+        )
+
+    assert evidence.status is EvidenceStatus.INVALID
+    assert evidence.issues[0].field == "$"
+    assert "unknown fields" in evidence.issues[0].message
+
+
+@pytest.mark.parametrize("target", ["declaration", "observation"])
+def test_declaration_and_observation_versions_are_independently_strict(target):
+    declaration = _declaration()
+    observation = _observation()
+    if target == "declaration":
+        declaration["version"] = 2
+        evidence = validate_declaration(
+            declaration,
+            expected_source_sha256=SOURCE_DIGEST,
+            expected_composed_sha256=COMPOSED_DIGEST,
+        )
+    else:
+        observation["version"] = 2
+        declaration_evidence = validate_declaration(
+            declaration,
+            expected_source_sha256=SOURCE_DIGEST,
+            expected_composed_sha256=COMPOSED_DIGEST,
+        )
+        assert declaration_evidence.value is not None
+        evidence = validate_observation(
+            observation,
+            declaration=declaration_evidence.value,
+        )
+
+    assert evidence.status is EvidenceStatus.INVALID
+    assert evidence.issues[0].field == "version"
+
+
+def test_unknown_normalizer_fails_closed():
+    declaration = _declaration(normalizers=["whitespace"])
+
+    evidence = validate_declaration(
+        declaration,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert evidence.status is EvidenceStatus.INVALID
+    assert evidence.issues[0].field == "normalizers"
+    assert "unsupported normalizers" in evidence.issues[0].message
+
+
+def test_v1_declaration_requires_protocol_safe_id_and_exact_setup():
+    unsafe_id = _declaration()
+    unsafe_id["id"] = "fixture with spaces"
+    unsupported_setup = _declaration()
+    unsupported_setup["setup"] = ["load", "run"]
+
+    id_evidence = validate_declaration(
+        unsafe_id,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+    setup_evidence = validate_declaration(
+        unsupported_setup,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert id_evidence.status is EvidenceStatus.INVALID
+    assert id_evidence.issues[0].field == "id"
+    assert setup_evidence.status is EvidenceStatus.INVALID
+    assert setup_evidence.issues[0].field == "setup"
+
+
+def test_v1_declaration_rejects_contradictory_firing_count_and_names():
+    declaration = _declaration()
+    declaration["expectations"]["firings"] = {
+        "count": 2,
+        "names": ["MAIN::only-one"],
+    }
+
+    evidence = validate_declaration(
+        declaration,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert evidence.status is EvidenceStatus.INVALID
+    assert evidence.issues[0].field == "expectations.firings"
+    assert "count must equal" in evidence.issues[0].message
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "issue_field"),
+    [
+        ("limit", 1, "expectations.run.limit"),
+        ("halt_reason", "limit-reached", "expectations.run.halt_reason"),
+    ],
+)
+def test_v1_declaration_rejects_unsupported_run_configuration(field, value, issue_field):
+    declaration = _declaration()
+    declaration["expectations"]["run"][field] = value
+
+    evidence = validate_declaration(
+        declaration,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert evidence.status is EvidenceStatus.INVALID
+    assert evidence.issues[0].field == issue_field
+
+
+def test_v1_declaration_accepts_native_observable_halt_requested_completion():
+    declaration = _declaration()
+    declaration["expectations"]["run"]["halt_reason"] = "halt-requested"
+
+    evidence = validate_declaration(
+        declaration,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert evidence.status is EvidenceStatus.VALID
+
+
+def test_v1_declaration_rejects_channels_the_adapters_cannot_capture():
+    declaration = _declaration()
+    declaration["expectations"]["channels"]["wtrace"] = ""
+
+    evidence = validate_declaration(
+        declaration,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert evidence.status is EvidenceStatus.INVALID
+    assert evidence.issues[0].field == "expectations.channels"
+
+
+def test_unknown_typed_value_fails_closed():
+    declaration = _declaration()
+    declaration["expectations"]["effects"][0]["value"]["type"] = "number"
+
+    evidence = validate_declaration(
+        declaration,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert evidence.status is EvidenceStatus.INVALID
+    assert evidence.issues[0].field.endswith(".type")
+
+
+@pytest.mark.parametrize(
+    "nonce",
+    [
+        "a" * 30,
+        "a" * 33,
+        "A" * 32,
+        "g" * 32,
+        "a" * 130,
+    ],
+)
+def test_nonce_requires_16_to_64_lowercase_hex_bytes(nonce):
+    declaration = _declaration()
+    declaration["nonce"] = nonce
+
+    evidence = validate_declaration(
+        declaration,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert evidence.status is EvidenceStatus.INVALID
+    assert evidence.issues[0].field == "nonce"
+
+
+# Issue #91 red case: equal output but different final facts.
+def test_equal_output_with_different_final_facts_is_not_equivalent():
+    ferric = _observation()
+    clips = _observation(facts=[_ordered_fact(value="wrong")])
+
+    result = _evaluate(_declaration(), ferric, clips)
+
+    assert result.status is EvidenceStatus.VALID
+    assert not result.equivalent
+    assert ("clips", "facts") in _mismatch_fields(result)
+    assert ("engines", "facts") in _mismatch_fields(result)
+
+
+# Issue #91 red case: a verifier firing is not the feature-specific effect.
+def test_instrumentation_only_noop_cannot_satisfy_fixture_effect_or_firing():
+    ferric = _observation()
+    clips = _observation()
+    for observation in (ferric, clips):
+        observation["firings"][0]["origin"] = "instrumentation"
+        observation["effects"][0]["origin"] = "instrumentation"
+
+    result = _evaluate(_declaration(), ferric, clips)
+
+    assert result.status is EvidenceStatus.VALID
+    assert not result.equivalent
+    assert ("ferric", "firings.count") in _mismatch_fields(result)
+    assert ("ferric", "firings.names") in _mismatch_fields(result)
+    assert ("ferric", "effects") in _mismatch_fields(result)
+    assert ("clips", "effects") in _mismatch_fields(result)
+
+
+# Issue #91 red case: completion proof must exist exactly once.
+def test_missing_completion_marker_is_invalid_evidence():
+    ferric = _observation()
+    ferric["markers"] = ferric["markers"][:1]
+
+    result = _evaluate(_declaration(), ferric, _observation())
+
+    assert result.status is EvidenceStatus.INVALID
+    assert not result.equivalent
+    assert ("ferric", "markers") in _mismatch_fields(result)
+
+
+# Issue #91 red case: matching output cannot conceal zero fixture firings.
+def test_zero_fixture_firings_do_not_satisfy_expected_firing():
+    ferric = _observation()
+    clips = _observation()
+    ferric["firings"] = []
+    clips["firings"] = []
+
+    result = _evaluate(_declaration(), ferric, clips)
+
+    assert result.status is EvidenceStatus.VALID
+    assert not result.equivalent
+    assert ("ferric", "firings.count") in _mismatch_fields(result)
+    assert ("clips", "firings.count") in _mismatch_fields(result)
+
+
+# Issue #91 red case: channels are exact unless a future contract says otherwise.
+def test_one_character_output_drift_is_not_equivalent():
+    declaration = _declaration(stdout="ok\n")
+    ferric = _observation(stdout="ok\n")
+    clips = _observation(stdout="ok!\n")
+
+    result = _evaluate(declaration, ferric, clips)
+
+    assert result.status is EvidenceStatus.VALID
+    assert not result.equivalent
+    assert ("clips", "channels.stdout") in _mismatch_fields(result)
+    assert ("engines", "channels.stdout") in _mismatch_fields(result)
+
+
+# Issue #91 red case: fact IDs differ unless this fixture explicitly allows it.
+def test_fact_id_drift_requires_fixture_declared_normalization():
+    ferric = _observation(facts=[_ordered_fact(fact_id=1)])
+    clips = _observation(facts=[_ordered_fact(fact_id=99)])
+
+    strict = _evaluate(_declaration(), ferric, clips)
+    allowed = _evaluate(
+        _declaration(normalizers=["fact-ids"]),
+        ferric,
+        clips,
+    )
+
+    assert not strict.equivalent
+    assert ("clips", "facts") in _mismatch_fields(strict)
+    assert allowed.status is EvidenceStatus.VALID
+    assert allowed.equivalent
+
+
+# Issue #91 red case: empty channels pass only alongside non-vacuous state/effect proof.
+def test_declared_empty_output_with_nonempty_state_oracle_can_be_equivalent():
+    declaration = _declaration(stdout="")
+    ferric = _observation(stdout="")
+    clips = _observation(stdout="")
+
+    result = _evaluate(declaration, ferric, clips)
+
+    assert result.status is EvidenceStatus.VALID
+    assert result.equivalent
+    assert declaration["expectations"]["facts"]
+    assert declaration["expectations"]["effects"]
+
+
+def test_empty_output_declaration_without_a_semantic_effect_is_invalid():
+    declaration = _declaration(stdout="")
+    declaration["expectations"]["effects"] = []
+
+    result = _evaluate(declaration, _observation(stdout=""), _observation(stdout=""))
+
+    assert result.status is EvidenceStatus.INVALID
+    assert not result.equivalent
+    assert result.declaration.issues[0].field == "expectations.effects"
+
+
+@pytest.mark.parametrize(
+    "bound_field",
+    ["id", "source_sha256", "composed_sha256", "nonce"],
+)
+@pytest.mark.parametrize("marker_index", [0, 1])
+def test_spoofed_marker_identity_is_invalid(bound_field, marker_index):
+    ferric = _observation()
+    spoofed_value = {
+        "id": "spoofed-fixture",
+        "source_sha256": OTHER_DIGEST,
+        "composed_sha256": OTHER_DIGEST,
+        "nonce": "f" * 32,
+    }[bound_field]
+    ferric["markers"][marker_index][bound_field] = spoofed_value
+
+    result = _evaluate(_declaration(), ferric, _observation())
+
+    assert result.status is EvidenceStatus.INVALID
+    assert not result.equivalent
+    assert ("ferric", f"markers[{marker_index}].{bound_field}") in _mismatch_fields(result)
+
+
+def test_duplicate_start_or_completion_marker_is_invalid():
+    ferric = _observation()
+    ferric["markers"].insert(1, deepcopy(ferric["markers"][0]))
+
+    result = _evaluate(_declaration(), ferric, _observation())
+
+    assert result.status is EvidenceStatus.INVALID
+    assert not result.equivalent
+    assert ("ferric", "markers") in _mismatch_fields(result)
+    assert "exactly one" in result.ferric.issues[0].message
+
+
+def test_completion_before_start_is_invalid():
+    ferric = _observation()
+    ferric["markers"].reverse()
+
+    result = _evaluate(_declaration(), ferric, _observation())
+
+    assert result.status is EvidenceStatus.INVALID
+    assert not result.equivalent
+    assert ("ferric", "markers") in _mismatch_fields(result)
+    assert "precede" in result.ferric.issues[0].message
+
+
+def test_stale_declaration_source_digest_is_invalid():
+    declaration = _declaration()
+    declaration["source_sha256"] = OTHER_DIGEST
+
+    evidence = validate_declaration(
+        declaration,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert evidence.status is EvidenceStatus.INVALID
+    assert evidence.issues[0].field == "source_sha256"
+    assert "stale" in evidence.issues[0].message
+
+
+def test_stale_declaration_composed_digest_is_invalid():
+    declaration = _declaration()
+    declaration["composed_sha256"] = OTHER_DIGEST
+
+    evidence = validate_declaration(
+        declaration,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert evidence.status is EvidenceStatus.INVALID
+    assert evidence.issues[0].field == "composed_sha256"
+    assert "stale" in evidence.issues[0].message
+
+
+def test_fact_order_drift_requires_fixture_declared_normalization():
+    facts = [
+        _ordered_fact(fact_id=1, value="one"),
+        _ordered_fact(fact_id=2, value="two"),
+    ]
+    reversed_facts = list(reversed(deepcopy(facts)))
+
+    strict = _evaluate(
+        _declaration(facts=facts),
+        _observation(facts=facts),
+        _observation(facts=reversed_facts),
+    )
+    allowed = _evaluate(
+        _declaration(facts=facts, normalizers=["fact-order"]),
+        _observation(facts=facts),
+        _observation(facts=reversed_facts),
+    )
+
+    assert not strict.equivalent
+    assert allowed.equivalent
+
+
+def test_fact_order_normalization_also_orders_fact_derived_effects():
+    facts = [
+        _ordered_fact(fact_id=1, value="one", relation="first"),
+        _ordered_fact(fact_id=2, value="two", relation="second"),
+    ]
+    effects = [
+        {
+            "name": f"fact:MAIN::{fact['relation']}",
+            "value": {
+                "type": "multifield",
+                "value": deepcopy(fact["fields"]),
+            },
+        }
+        for fact in facts
+    ]
+    declaration = _declaration(facts=facts, normalizers=["fact-order"])
+    declaration["expectations"]["effects"] = deepcopy(effects)
+    ferric = _observation(facts=facts)
+    clips = _observation(facts=list(reversed(deepcopy(facts))))
+    ferric["effects"] = [{**effect, "origin": "fixture"} for effect in deepcopy(effects)]
+    clips["effects"] = [{**effect, "origin": "fixture"} for effect in reversed(deepcopy(effects))]
+
+    result = _evaluate(declaration, ferric, clips)
+
+    assert result.status is EvidenceStatus.VALID
+    assert result.equivalent
+
+
+def test_float_format_drift_requires_fixture_declared_normalization():
+    expected_fact = _ordered_fact()
+    expected_fact["fields"] = [_float("1.0")]
+    clips_fact = deepcopy(expected_fact)
+    clips_fact["fields"] = [_float("1.00")]
+
+    strict = _evaluate(
+        _declaration(facts=[expected_fact]),
+        _observation(facts=[expected_fact]),
+        _observation(facts=[clips_fact]),
+    )
+    allowed = _evaluate(
+        _declaration(facts=[expected_fact], normalizers=["float-format"]),
+        _observation(facts=[expected_fact]),
+        _observation(facts=[clips_fact]),
+    )
+
+    assert not strict.equivalent
+    assert allowed.equivalent
+
+
+def test_float_format_normalization_preserves_digits_beyond_decimal_context_precision():
+    expected_fact = _ordered_fact()
+    expected_fact["fields"] = [_float("1.123456789012345678901234567801")]
+    drifted_fact = deepcopy(expected_fact)
+    drifted_fact["fields"] = [_float("1.123456789012345678901234567802")]
+
+    result = _evaluate(
+        _declaration(facts=[expected_fact], normalizers=["float-format"]),
+        _observation(facts=[expected_fact]),
+        _observation(facts=[drifted_fact]),
+    )
+
+    assert result.status is EvidenceStatus.VALID
+    assert not result.equivalent
+    assert ("clips", "facts") in _mismatch_fields(result)
+
+
+@pytest.mark.parametrize("exponent", ["9" * 5000, f"-{'9' * 5000}"])
+def test_float_format_normalization_accepts_extreme_finite_decimal_exponents(exponent):
+    expected_fact = _ordered_fact()
+    expected_fact["fields"] = [_float(f"1e{exponent}")]
+    alternate_fact = deepcopy(expected_fact)
+    alternate_fact["fields"] = [_float(f"1.0e{exponent}")]
+
+    result = _evaluate(
+        _declaration(facts=[expected_fact], normalizers=["float-format"]),
+        _observation(facts=[expected_fact]),
+        _observation(facts=[alternate_fact]),
+    )
+
+    assert result.status is EvidenceStatus.VALID
+    assert result.equivalent
+
+
+def test_fact_normalization_preserves_duplicate_multiplicity():
+    first = _ordered_fact(fact_id=1, value="same")
+    second = _ordered_fact(fact_id=2, value="same")
+    declaration = _declaration(
+        facts=[first, second],
+        normalizers=["fact-ids", "fact-order"],
+    )
+    ferric = _observation(facts=[first, second])
+    clips = _observation(facts=[deepcopy(first)])
+
+    result = _evaluate(declaration, ferric, clips)
+
+    assert result.status is EvidenceStatus.VALID
+    assert not result.equivalent
+    assert ("clips", "facts") in _mismatch_fields(result)
+
+
+def test_recursive_multifields_and_template_slot_names_are_compared():
+    template_fact = {
+        "kind": "template",
+        "id": 4,
+        "origin": "fixture",
+        "module": "MAIN",
+        "template": "nested-result",
+        "slots": [
+            {
+                "name": "items",
+                "value": {
+                    "type": "multifield",
+                    "value": [
+                        _symbol("head"),
+                        {
+                            "type": "multifield",
+                            "value": [
+                                {"type": "integer", "value": 2},
+                                _float("3.0"),
+                            ],
+                        },
+                    ],
+                },
+            }
+        ],
+    }
+    clips_fact = deepcopy(template_fact)
+    clips_fact["slots"][0]["name"] = "other-items"
+
+    result = _evaluate(
+        _declaration(facts=[template_fact]),
+        _observation(facts=[template_fact]),
+        _observation(facts=[clips_fact]),
+    )
+
+    assert result.status is EvidenceStatus.VALID
+    assert not result.equivalent
+    assert ("clips", "facts") in _mismatch_fields(result)
+
+
+def test_both_engines_being_identically_wrong_does_not_satisfy_expectation():
+    wrong = _observation(facts=[_ordered_fact(value="same-wrong-state")])
+
+    result = _evaluate(_declaration(), wrong, deepcopy(wrong))
+
+    assert result.status is EvidenceStatus.VALID
+    assert not result.equivalent
+    assert ("ferric", "facts") in _mismatch_fields(result)
+    assert ("clips", "facts") in _mismatch_fields(result)
+    assert ("engines", "facts") not in _mismatch_fields(result)
+
+
+def test_evaluation_serialization_is_compact_and_json_ready():
+    result = _evaluate(_declaration(), _observation(), _observation())
+
+    serialized = evaluation_to_dict(result)
+
+    assert serialized == {
+        "status": "valid",
+        "equivalent": True,
+        "declaration": {"status": "valid", "issues": []},
+        "ferric": {"status": "valid", "issues": []},
+        "clips": {"status": "valid", "issues": []},
+        "mismatches": [],
+    }

--- a/tools/ferric-tools/tests/test_compat_projection.py
+++ b/tools/ferric-tools/tests/test_compat_projection.py
@@ -1,0 +1,404 @@
+"""Focused tests for engine-specific compatibility observation projection."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from ferric_tools.compat.oracle import EvidenceStatus, evaluate_oracle
+from ferric_tools.compat.projection import (
+    ObservationProjectionError,
+    project_clips_observation,
+    project_ferric_observation,
+)
+
+FIXTURE_ID = "ferric-oracle.empty-output-state"
+SOURCE_DIGEST = "a" * 64
+COMPOSED_DIGEST = "b" * 64
+NONCE = "0123456789abcdef0123456789abcdef"
+
+
+def _identity() -> dict[str, str]:
+    return {
+        "id": FIXTURE_ID,
+        "nonce": NONCE,
+        "source_sha256": SOURCE_DIGEST,
+        "composed_sha256": COMPOSED_DIGEST,
+    }
+
+
+def _lifecycle(engine: str) -> list[dict[str, object]]:
+    complete_sequence = 1 if engine == "ferric" else 3
+    return [
+        {
+            "sequence": 0,
+            "event": "START" if engine == "ferric" else "start",
+            "fixture_id": FIXTURE_ID,
+            "nonce": NONCE,
+            "source_sha256": SOURCE_DIGEST,
+            "composed_sha256": COMPOSED_DIGEST,
+        },
+        {
+            "sequence": complete_sequence,
+            "event": "COMPLETE" if engine == "ferric" else "complete",
+            "fixture_id": FIXTURE_ID,
+            "nonce": NONCE,
+            "source_sha256": SOURCE_DIGEST,
+            "composed_sha256": COMPOSED_DIGEST,
+        },
+    ]
+
+
+def _raw_fact(
+    engine: str,
+    *,
+    fact_id: object = "2",
+    relation: str = "result",
+    value: int = 42,
+) -> dict[str, object]:
+    return {
+        "ordinal": 0,
+        "fact_id": fact_id,
+        "module": "MAIN",
+        "kind": "ordered",
+        "relation": relation,
+        "fields": [
+            {
+                "type": "integer",
+                "value": str(value),
+            }
+        ],
+    }
+
+
+def _raw_observation(engine: str) -> dict[str, object]:
+    channels: list[dict[str, object]]
+    run: dict[str, object]
+    if engine == "ferric":
+        channels = [
+            {"name": "t", "present": False, "text": ""},
+            {"name": "stderr", "present": False, "text": ""},
+            {"name": "stdout", "present": False, "text": ""},
+        ]
+        run = {
+            "rules_fired": 1,
+            "fired_rule_names": None,
+            "halt_reason": "agenda-empty",
+            "agenda_size": 0,
+            "halted": False,
+        }
+    else:
+        channels = [
+            {"name": "t", "text": ""},
+            {"name": "stderr", "text": ""},
+        ]
+        run = {
+            "rules_fired": 1,
+            "halt_reason": "agenda_empty",
+            "agenda_size": 0,
+            "halted": False,
+        }
+
+    observation: dict[str, object] = {
+        "schema": "ferric.compat-observation",
+        "version": 1,
+        "engine": {"name": engine, "version": "test"},
+        "fixture": _identity(),
+        "phase_reached": "post-run" if engine == "ferric" else "post_run",
+        "lifecycle": _lifecycle(engine),
+        "run": run,
+        "facts": [_raw_fact(engine)],
+        "channels": channels,
+        "diagnostics": [],
+        "modules": {
+            "current": "MAIN",
+            "focus": "MAIN",
+            "focus_stack": ["MAIN"],
+        },
+        "capabilities": {
+            "fact_modules": True,
+            "composed_digest_verification": engine == "ferric",
+            "fired_rule_names": False,
+            "rules_fired": engine == "clips",
+            "global_values": False,
+        },
+    }
+    if engine == "clips":
+        observation.update(
+            {
+                "fired_rules": None,
+                "globals": {},
+                "instrumentation": {
+                    "harness_records": [],
+                    "completion_sentinel": True,
+                    "rules_fired": 1,
+                },
+                "protocol_issues": [],
+            }
+        )
+    return observation
+
+
+def _declaration() -> dict[str, object]:
+    integer = {"type": "integer", "value": 42}
+    return {
+        "version": 1,
+        "id": FIXTURE_ID,
+        "feature": "ordered fact state transition with intentionally empty output",
+        "source_sha256": SOURCE_DIGEST,
+        "composed_sha256": COMPOSED_DIGEST,
+        "nonce": NONCE,
+        "setup": ["load", "reset", "run"],
+        "expectations": {
+            "phase": "run-complete",
+            "firings": {"count": 1, "names": None},
+            "effects": [
+                {
+                    "name": "fact:MAIN::result",
+                    "value": {"type": "multifield", "value": [integer]},
+                }
+            ],
+            "facts": [
+                {
+                    "kind": "ordered",
+                    "id": 0,
+                    "origin": "fixture",
+                    "module": "MAIN",
+                    "relation": "result",
+                    "fields": [integer],
+                }
+            ],
+            "channels": {"stdout": "", "stderr": ""},
+            "diagnostic": {
+                "phase": "none",
+                "category": "none",
+                "continued": True,
+            },
+            "run": {"limit": None, "halt_reason": "agenda-empty"},
+            "focus_stack": None,
+            "globals": None,
+        },
+        "normalizers": ["fact-ids"],
+    }
+
+
+def test_seed_ordered_result_projects_to_equivalent_non_vacuous_evidence():
+    ferric = project_ferric_observation(_raw_observation("ferric"), harnessed=False)
+    clips = project_clips_observation(_raw_observation("clips"), harnessed=False)
+
+    assert (
+        ferric["effects"]
+        == clips["effects"]
+        == [
+            {
+                "name": "fact:MAIN::result",
+                "value": {
+                    "type": "multifield",
+                    "value": [{"type": "integer", "value": 42}],
+                },
+                "origin": "fixture",
+            }
+        ]
+    )
+    assert ferric["facts"][0]["origin"] == clips["facts"][0]["origin"] == "fixture"
+    assert ferric["firings"] == [{"rule": "counted-firing-1", "origin": "fixture"}]
+    assert clips["firings"] == [{"rule": "counted-firing-1", "origin": "fixture"}]
+
+    evaluation = evaluate_oracle(
+        _declaration(),
+        ferric,
+        clips,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert evaluation.status is EvidenceStatus.VALID
+    assert evaluation.equivalent
+    assert evaluation.mismatches == ()
+
+
+def test_generated_clips_harness_activity_fails_when_firings_cannot_be_attributed():
+    raw = _raw_observation("clips")
+    raw["facts"] = [
+        _raw_fact(
+            "clips",
+            fact_id="1",
+            relation="ferric-harness-generated-state",
+            value=1,
+        ),
+        _raw_fact("clips", fact_id="2"),
+    ]
+    raw["run"]["rules_fired"] = 2
+    raw["channels"][0]["text"] = (
+        "FERRIC-HARNESS|2|ferric-harness-deadbeef|START\n"
+        "FERRIC-HARNESS|2|ferric-harness-deadbeef|STATE|focus=MAIN\n"
+        "FERRIC-HARNESS|2|ferric-harness-deadbeef|COMPLETE\n"
+        "feature-output\n"
+    )
+
+    with pytest.raises(
+        ObservationProjectionError,
+        match="cannot separate harness firings",
+    ):
+        project_clips_observation(raw, harnessed=True)
+
+
+def test_ferric_harness_observation_fails_when_firings_cannot_be_attributed():
+    with pytest.raises(
+        ObservationProjectionError,
+        match="cannot separate harness firings",
+    ):
+        project_ferric_observation(_raw_observation("ferric"), harnessed=True)
+
+
+def test_harness_looking_fixture_data_is_semantic_without_a_harness():
+    raw = _raw_observation("clips")
+    raw["facts"] = [
+        _raw_fact(
+            "clips",
+            relation="ferric-harness-domain-event",
+            value=7,
+        )
+    ]
+    raw["channels"][0]["text"] = "FERRIC-HARNESS|1|domain-feature|event\n"
+
+    projected = project_clips_observation(raw, harnessed=False)
+
+    assert projected["facts"][0]["origin"] == "fixture"
+    assert projected["effects"][0]["origin"] == "fixture"
+    assert projected["firings"][0]["origin"] == "fixture"
+    assert projected["channels"]["stdout"] == "FERRIC-HARNESS|1|domain-feature|event\n"
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_ambiguous_fact_ownership_fails_closed(engine):
+    raw = _raw_observation(engine)
+    raw["facts"][0]["module"] = None
+
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+    with pytest.raises(ObservationProjectionError, match="fact module is unavailable"):
+        projector(raw, harnessed=False)
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_lossy_or_duplicate_fact_identity_fails_closed(engine):
+    raw = _raw_observation(engine)
+    raw["facts"] = [
+        _raw_fact(engine, fact_id=1.5),
+        _raw_fact(engine, fact_id=1.5, relation="other"),
+    ]
+
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+    with pytest.raises(ObservationProjectionError, match="fact id"):
+        projector(raw, harnessed=False)
+
+    raw = _raw_observation(engine)
+    raw["facts"].append(deepcopy(raw["facts"][0]))
+    with pytest.raises(ObservationProjectionError, match="duplicate fact id"):
+        projector(raw, harnessed=False)
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_noncanonical_integer_transport_fails_closed(engine):
+    raw = _raw_observation(engine)
+    raw["facts"][0]["fields"][0]["value"] = "4_2"
+
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+    with pytest.raises(ObservationProjectionError, match="canonical decimal text"):
+        projector(raw, harnessed=False)
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_duplicate_semantic_channels_fail_closed(engine):
+    raw = _raw_observation(engine)
+    raw["channels"].append(deepcopy(raw["channels"][0]))
+
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+    with pytest.raises(ObservationProjectionError, match="duplicate channel"):
+        projector(raw, harnessed=False)
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_wrong_raw_envelope_or_lifecycle_sequence_fails_closed(engine):
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+    raw = _raw_observation(engine)
+    raw["schema"] = "fixture-controlled"
+    with pytest.raises(ObservationProjectionError, match="schema"):
+        projector(raw, harnessed=False)
+
+    raw = _raw_observation(engine)
+    raw["lifecycle"][1]["sequence"] = 99
+    with pytest.raises(ObservationProjectionError, match="lifecycle sequence"):
+        projector(raw, harnessed=False)
+
+
+def test_clips_protocol_issue_fails_closed():
+    raw = _raw_observation("clips")
+    raw["protocol_issues"] = ["unexpected-reserved-prefix"]
+
+    with pytest.raises(ObservationProjectionError, match="protocol violations"):
+        project_clips_observation(raw, harnessed=False)
+
+
+def test_unavailable_declared_ferric_capability_fails_closed():
+    raw = _raw_observation("ferric")
+
+    with pytest.raises(ObservationProjectionError, match="fired_rule_names"):
+        project_ferric_observation(
+            raw,
+            harnessed=False,
+            require_firing_names=True,
+        )
+    with pytest.raises(ObservationProjectionError, match="global_values"):
+        project_ferric_observation(
+            raw,
+            harnessed=False,
+            require_globals=True,
+        )
+
+    clips_raw = _raw_observation("clips")
+    with pytest.raises(ObservationProjectionError, match="fired_rule_names"):
+        project_clips_observation(
+            clips_raw,
+            harnessed=False,
+            require_firing_names=True,
+        )
+
+
+def test_expected_diagnostic_projection_remains_invalid_until_structured_support():
+    ferric_raw = _raw_observation("ferric")
+    clips_raw = _raw_observation("clips")
+    ferric_raw["diagnostics"] = [
+        {
+            "phase": "load",
+            "severity": "error",
+            "category": "parse-error",
+            "message": "fixture diagnostic",
+        }
+    ]
+    clips_raw["diagnostics"] = [
+        {
+            "phase": "unknown",
+            "category": "[EXPRNPSR3]",
+            "continuation": "unknown",
+            "channel": "stdout",
+        }
+    ]
+
+    ferric = project_ferric_observation(ferric_raw, harnessed=False)
+    clips = project_clips_observation(clips_raw, harnessed=False)
+    assert ferric["diagnostic"]["phase"] == clips["diagnostic"]["phase"] == "unknown"
+
+    evaluation = evaluate_oracle(
+        _declaration(),
+        ferric,
+        clips,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+
+    assert evaluation.status is EvidenceStatus.INVALID
+    assert not evaluation.equivalent
+    assert evaluation.ferric.issues[0].field == "diagnostic"
+    assert evaluation.clips.issues[0].field == "diagnostic"

--- a/tools/ferric-tools/tests/test_compat_report.py
+++ b/tools/ferric-tools/tests/test_compat_report.py
@@ -1,0 +1,343 @@
+"""Tests for structured-oracle compatibility reporting."""
+
+from __future__ import annotations
+
+import csv
+
+import pytest
+
+from ferric_tools.compat.report import (
+    _write_delimited,
+    compute_oracle_coverage,
+    oracle_evidence_view,
+    print_summary,
+    write_report,
+)
+
+
+def _oracle(
+    status: str,
+    *,
+    version: int,
+    declaration: bool,
+    reached: bool,
+    completed: bool,
+    effect: bool,
+    normalizations: list[str] | None = None,
+    violations: list[str] | None = None,
+) -> dict:
+    return {
+        "status": status,
+        "version": version,
+        "declaration": declaration,
+        "reached": reached,
+        "completed": completed,
+        "effect": effect,
+        "normalizations": normalizations or [],
+        "violations": violations or [],
+    }
+
+
+def _entry(classification: str, reason: str, oracle: dict | None = None) -> dict:
+    entry = {
+        "source": "fixtures",
+        "classification": classification,
+        "reason": reason,
+        "runability": "standalone",
+        "features": [],
+        "unsupported_features": [],
+    }
+    if oracle is not None:
+        entry["oracle_evidence"] = oracle
+    return entry
+
+
+def _manifest() -> dict:
+    files = {
+        "valid.clp": _entry(
+            "equivalent",
+            "oracle-match",
+            _oracle(
+                "valid",
+                version=1,
+                declaration=True,
+                reached=True,
+                completed=True,
+                effect=True,
+                normalizations=["fact-ids"],
+            ),
+        ),
+        "missing.clp": _entry(
+            "divergent",
+            "oracle-missing",
+            _oracle(
+                "missing",
+                version=1,
+                declaration=False,
+                reached=False,
+                completed=False,
+                effect=False,
+            ),
+        ),
+        "invalid.clp": _entry(
+            "pending",
+            "oracle-invalid",
+            _oracle(
+                "invalid",
+                version=2,
+                declaration=True,
+                reached=True,
+                completed=False,
+                effect=False,
+                normalizations=["float-format"],
+                violations=["completion marker missing"],
+            ),
+        ),
+        "legacy.clp": _entry("pending", "testable"),
+        "legacy-equivalent.clp": _entry("equivalent", "empty-match"),
+    }
+    return {
+        "version": 3,
+        "generated": "2026-07-26T00:00:00+00:00",
+        "summary": {
+            "total": 5,
+            "equivalent": 2,
+            "divergent": 1,
+            "incompatible": 0,
+            "pending": 2,
+        },
+        "files": files,
+    }
+
+
+def test_compute_oracle_coverage_handles_legacy_and_refuses_unverified_equivalence():
+    coverage = compute_oracle_coverage(_manifest())
+
+    assert coverage == {
+        "total": 5,
+        "selected": 3,
+        "declaration": 2,
+        "valid": 1,
+        "missing": 2,
+        "invalid": 2,
+        "reached": 2,
+        "completed": 1,
+        "effect": 1,
+        "refused_equivalent": 1,
+        "versions": {"1": 2, "2": 1},
+        "normalizations": {"fact-ids": 1, "float-format": 1},
+    }
+
+    legacy = oracle_evidence_view(_manifest()["files"]["legacy.clp"])
+    refused = oracle_evidence_view(_manifest()["files"]["legacy-equivalent.clp"])
+    assert legacy["status"] == "missing"
+    assert legacy["selected"] is False
+    assert refused["status"] == "invalid"
+    assert refused["refused_equivalent"] is True
+
+
+def test_print_summary_exposes_oracle_coverage_versions_and_normalizations(capsys):
+    print_summary(_manifest())
+
+    output = capsys.readouterr().out
+    assert "Oracle evidence:" in output
+    assert "selected            :      3 ( 60.0%)" in output
+    assert "refused equivalent  :      1 ( 20.0%)" in output
+    assert "versions            : 1: 2, 2: 1" in output
+    assert "normalizations      : fact-ids: 1, float-format: 1" in output
+    assert "legacy-equivalent.clp (empty-match) [REFUSED: invalid oracle evidence]" in output
+
+
+def test_markdown_report_exposes_oracle_coverage_and_refused_claim(tmp_path):
+    report = tmp_path / "compat.md"
+
+    write_report(_manifest(), str(report))
+
+    output = report.read_text(encoding="utf-8")
+    assert "### Oracle evidence coverage" in output
+    assert "| valid | 1 | 20.0% |" in output
+    assert "| missing | 2 | 40.0% |" in output
+    assert "| invalid | 2 | 40.0% |" in output
+    assert "Versions: 1: 2, 2: 1" in output
+    assert "Normalizations: fact-ids: 1, float-format: 1" in output
+    assert (
+        "`legacy-equivalent.clp` (empty-match) \u2014 **REFUSED: invalid oracle evidence**"
+        in output
+    )
+
+
+@pytest.mark.parametrize(("delimiter", "suffix"), [(",", "csv"), ("\t", "tsv")])
+def test_delimited_report_exposes_per_file_oracle_evidence(tmp_path, delimiter, suffix):
+    output = tmp_path / f"compat.{suffix}"
+
+    _write_delimited(_manifest(), str(output), delimiter)
+
+    with output.open(newline="", encoding="utf-8") as stream:
+        rows = {row["path"]: row for row in csv.DictReader(stream, delimiter=delimiter)}
+
+    valid = rows["valid.clp"]
+    assert valid["oracle_selected"] == "True"
+    assert valid["oracle_status"] == "valid"
+    assert valid["oracle_version"] == "1"
+    assert valid["oracle_normalizations"] == "fact-ids"
+
+    legacy = rows["legacy.clp"]
+    assert legacy["oracle_selected"] == "False"
+    assert legacy["oracle_status"] == "missing"
+
+    refused = rows["legacy-equivalent.clp"]
+    assert refused["oracle_status"] == "invalid"
+    assert refused["oracle_refused_equivalent"] == "True"
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        "not-a-mapping",
+        {"status": "unknown"},
+        {"status": "valid", "declaration": "yes"},
+        {"status": "valid", "normalizations": "fact-ids"},
+        _oracle(
+            "valid",
+            version=2,
+            declaration=True,
+            reached=True,
+            completed=True,
+            effect=True,
+        ),
+        _oracle(
+            "valid",
+            version=1,
+            declaration=False,
+            reached=True,
+            completed=True,
+            effect=True,
+        ),
+        _oracle(
+            "valid",
+            version=1,
+            declaration=True,
+            reached=False,
+            completed=True,
+            effect=True,
+        ),
+        _oracle(
+            "valid",
+            version=1,
+            declaration=True,
+            reached=True,
+            completed=False,
+            effect=True,
+        ),
+    ],
+)
+def test_malformed_oracle_evidence_is_invalid_without_crashing(evidence):
+    info = _entry("pending", "oracle-invalid")
+    info["oracle_evidence"] = evidence
+
+    view = oracle_evidence_view(info)
+
+    assert view["selected"] is True
+    assert view["status"] == "invalid"
+
+
+def test_v1_oracle_evidence_rejects_unsupported_normalizer_names():
+    info = _entry(
+        "pending",
+        "oracle-invalid",
+        _oracle(
+            "valid",
+            version=1,
+            declaration=True,
+            reached=True,
+            completed=True,
+            effect=True,
+            normalizations=["string-whitespace"],
+        ),
+    )
+
+    view = oracle_evidence_view(info)
+
+    assert view["status"] == "invalid"
+    assert view["normalizations"] == ["string-whitespace"]
+
+
+@pytest.mark.parametrize("field", ["declaration", "reached", "completed", "effect"])
+def test_missing_oracle_evidence_requires_all_coverage_flags_false(field):
+    evidence = _oracle(
+        "missing",
+        version=1,
+        declaration=False,
+        reached=False,
+        completed=False,
+        effect=False,
+    )
+    evidence[field] = True
+    info = _entry("pending", "oracle-missing", evidence)
+
+    view = oracle_evidence_view(info)
+
+    assert view["status"] == "invalid"
+
+
+def test_equivalent_claim_requires_complete_supported_oracle_evidence():
+    info = _entry(
+        "equivalent",
+        "oracle-v1-match",
+        _oracle(
+            "valid",
+            version=1,
+            declaration=False,
+            reached=False,
+            completed=False,
+            effect=False,
+        ),
+    )
+
+    view = oracle_evidence_view(info)
+
+    assert view["status"] == "invalid"
+    assert view["refused_equivalent"] is True
+
+
+def test_valid_semantic_divergence_remains_valid_evidence():
+    info = _entry(
+        "divergent",
+        "oracle-facts-mismatch",
+        _oracle(
+            "valid",
+            version=1,
+            declaration=True,
+            reached=True,
+            completed=True,
+            effect=False,
+            violations=["ferric.effects: does not match the declared expectation"],
+        ),
+    )
+
+    view = oracle_evidence_view(info)
+
+    assert view["status"] == "valid"
+    assert view["effect"] is False
+    assert view["refused_equivalent"] is False
+
+
+def test_equivalent_claim_with_semantic_mismatch_is_refused():
+    info = _entry(
+        "equivalent",
+        "oracle-v1-match",
+        _oracle(
+            "valid",
+            version=1,
+            declaration=True,
+            reached=True,
+            completed=True,
+            effect=True,
+            violations=["engines.facts: differs by engine"],
+        ),
+    )
+
+    view = oracle_evidence_view(info)
+
+    assert view["status"] == "invalid"
+    assert view["refused_equivalent"] is True

--- a/tools/ferric-tools/tests/test_compat_run.py
+++ b/tools/ferric-tools/tests/test_compat_run.py
@@ -54,7 +54,7 @@ def _engine_result(*, stdout: str = "matched\n", exit_code: int = 0) -> dict:
     }
 
 
-def test_classify_results_preserves_prompt_prefixed_harness_start_as_exact_match():
+def test_classify_results_rejects_prompt_prefixed_harness_without_feature_oracle():
     verifier_id = "ferric-harness-" + ("a" * 64)
     output = (
         f"FERRIC-HARNESS|2|{verifier_id}|START\n"
@@ -68,7 +68,16 @@ def test_classify_results_preserves_prompt_prefixed_harness_start_as_exact_match
         _engine_result(stdout=clips_output),
     )
 
-    assert result == ("equivalent", "exact-match")
+    assert result == ("pending", "oracle-missing")
+
+
+def test_classify_results_rejects_matching_empty_output_without_oracle():
+    result = run_module.classify_results(
+        _engine_result(stdout=""),
+        _engine_result(stdout=""),
+    )
+
+    assert result == ("pending", "oracle-missing")
 
 
 def _work_item(

--- a/tools/ferric-tools/tests/test_compat_run.py
+++ b/tools/ferric-tools/tests/test_compat_run.py
@@ -9,8 +9,10 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
 from ferric_tools._harness import HARNESS_GENERATION_VERSION, ResolvedHarness, sha256_bytes
+from ferric_tools._manifest import load_manifest, save_manifest
 from ferric_tools._paths import repo_root
 from ferric_tools.compat import run as run_module
 
@@ -54,6 +56,119 @@ def _engine_result(*, stdout: str = "matched\n", exit_code: int = 0) -> dict:
     }
 
 
+def _oracle_declaration(digest: str, *, composed_digest: str | None = None) -> dict:
+    integer = {"type": "integer", "value": 42}
+    return {
+        "version": 1,
+        "id": "fixture.structured",
+        "feature": "ordered state transition",
+        "source_sha256": digest,
+        "composed_sha256": composed_digest or digest,
+        "nonce": "0" * 32,
+        "setup": ["load", "reset", "run"],
+        "expectations": {
+            "phase": "run-complete",
+            "firings": {"count": 1, "names": None},
+            "effects": [
+                {
+                    "name": "fact:MAIN::result",
+                    "value": {"type": "multifield", "value": [integer]},
+                }
+            ],
+            "facts": [
+                {
+                    "kind": "ordered",
+                    "id": 0,
+                    "origin": "fixture",
+                    "module": "MAIN",
+                    "relation": "result",
+                    "fields": [integer],
+                }
+            ],
+            "channels": {"stdout": "", "stderr": ""},
+            "diagnostic": {"phase": "none", "category": "none", "continued": True},
+            "run": {"limit": None, "halt_reason": "agenda-empty"},
+            "focus_stack": None,
+            "globals": None,
+        },
+        "normalizers": ["fact-ids"],
+    }
+
+
+def _canonical_observation(
+    identity: dict,
+    *,
+    fact_id: int,
+    rule: str,
+    value: int = 42,
+) -> dict:
+    integer = {"type": "integer", "value": value}
+    return {
+        "version": 1,
+        "id": identity["fixture_id"],
+        "source_sha256": identity["source_sha256"],
+        "composed_sha256": identity["composed_sha256"],
+        "nonce": identity["nonce"],
+        "markers": [
+            {
+                "kind": kind,
+                "id": identity["fixture_id"],
+                "source_sha256": identity["source_sha256"],
+                "composed_sha256": identity["composed_sha256"],
+                "nonce": identity["nonce"],
+            }
+            for kind in ("START", "COMPLETE")
+        ],
+        "phase": "run-complete",
+        "firings": [{"rule": rule, "origin": "fixture"}],
+        "effects": [
+            {
+                "name": "fact:MAIN::result",
+                "value": {"type": "multifield", "value": [integer]},
+                "origin": "fixture",
+            }
+        ],
+        "facts": [
+            {
+                "kind": "ordered",
+                "id": fact_id,
+                "origin": "fixture",
+                "module": "MAIN",
+                "relation": "result",
+                "fields": [integer],
+            }
+        ],
+        "channels": {"stdout": "", "stderr": ""},
+        "diagnostic": {"phase": "none", "category": "none", "continued": True},
+        "run": {"limit": None, "halt_reason": "agenda-empty"},
+        "focus_stack": [],
+        "globals": None,
+    }
+
+
+def _structured_work_item(
+    *,
+    source: Path,
+    root: Path,
+    run_workspace: Path,
+    failures_dir: Path,
+    declaration: dict,
+) -> tuple:
+    return (
+        "fixture.clp",
+        str(source),
+        "ferric",
+        str(root),
+        "clips-reference",
+        5,
+        False,
+        None,
+        str(run_workspace),
+        str(failures_dir),
+        declaration,
+    )
+
+
 def test_classify_results_rejects_prompt_prefixed_harness_without_feature_oracle():
     verifier_id = "ferric-harness-" + ("a" * 64)
     output = (
@@ -80,6 +195,484 @@ def test_classify_results_rejects_matching_empty_output_without_oracle():
     assert result == ("pending", "oracle-missing")
 
 
+def test_structured_process_binds_actual_bytes_and_fresh_nonce(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    source = root / "tests" / "examples" / "fixture.clp"
+    source.parent.mkdir(parents=True)
+    source_bytes = b"(defrule compute => (assert (result 42)))\n"
+    source.write_bytes(source_bytes)
+    digest = sha256_bytes(source_bytes)
+    declaration = _oracle_declaration(digest)
+    invocations: list[tuple[str, Path, bytes, dict]] = []
+
+    def fake_ferric(path, _ferric, _root, _timeout, **identity):
+        candidate = Path(path)
+        invocations.append(("ferric", candidate, candidate.read_bytes(), identity))
+        return {**_engine_result(stdout="{}\n"), "observation": {"identity": identity}}
+
+    def fake_clips(
+        path,
+        _root,
+        _script,
+        _timeout,
+        *,
+        globals_to_capture,
+        harnessed,
+        **identity,
+    ):
+        assert globals_to_capture == ()
+        assert harnessed is False
+        candidate = Path(path)
+        invocations.append(("clips", candidate, candidate.read_bytes(), identity))
+        return {**_engine_result(stdout="protocol\n"), "observation": {"identity": identity}}
+
+    monkeypatch.setattr(run_module, "run_ferric_observer", fake_ferric)
+    monkeypatch.setattr(run_module, "run_clips_observer", fake_clips)
+    monkeypatch.setattr(
+        run_module,
+        "project_ferric_observation",
+        lambda raw, **_kwargs: _canonical_observation(
+            raw["identity"],
+            fact_id=11,
+            rule="counted-firing-1",
+        ),
+    )
+    monkeypatch.setattr(
+        run_module,
+        "project_clips_observation",
+        lambda raw, **_kwargs: _canonical_observation(
+            raw["identity"],
+            fact_id=2,
+            rule="compute",
+        ),
+    )
+
+    with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
+        item = _structured_work_item(
+            source=source,
+            root=root,
+            run_workspace=run_workspace,
+            failures_dir=failures_dir,
+            declaration=declaration,
+        )
+        first = run_module.process_file(item)
+        second = run_module.process_file(item)
+        assert list(run_workspace.iterdir()) == []
+
+    assert first[3:] == ("equivalent", "oracle-v1-match")
+    assert second[3:] == ("equivalent", "oracle-v1-match")
+    assert first[1]["oracle_evidence"]["status"] == "valid"
+    assert first[1]["oracle_evidence"]["effect"] is True
+    assert len(invocations) == 4
+    assert all(content == source_bytes for _, _, content, _ in invocations)
+    assert invocations[0][1] == invocations[1][1]
+    assert invocations[2][1] == invocations[3][1]
+    assert all(not path.exists() for _, path, _, _ in invocations)
+    first_identity = invocations[0][3]
+    second_identity = invocations[2][3]
+    assert invocations[1][3] == first_identity
+    assert invocations[3][3] == second_identity
+    assert first_identity["source_sha256"] == digest
+    assert first_identity["composed_sha256"] == digest
+    assert first_identity["nonce"] != declaration["nonce"]
+    assert first_identity["nonce"] != second_identity["nonce"]
+    assert declaration["nonce"] == "0" * 32
+
+
+def test_nonzero_structured_observer_is_invalid_and_retains_source(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    source = root / "tests" / "examples" / "fixture.clp"
+    source.parent.mkdir(parents=True)
+    source_bytes = b"(defrule compute => (assert (result 42)))\n"
+    source.write_bytes(source_bytes)
+    digest = sha256_bytes(source_bytes)
+    declaration = _oracle_declaration(digest)
+
+    def failed_ferric(_path, _ferric, _root, _timeout, **_identity):
+        return {
+            **_engine_result(stdout='{"partial":true}\n', exit_code=1),
+            "observation": {"partial": True},
+        }
+
+    def successful_clips(
+        _path,
+        _root,
+        _script,
+        _timeout,
+        *,
+        globals_to_capture,
+        harnessed,
+        **identity,
+    ):
+        assert globals_to_capture == ()
+        assert harnessed is False
+        return {**_engine_result(), "observation": {"identity": identity}}
+
+    monkeypatch.setattr(run_module, "run_ferric_observer", failed_ferric)
+    monkeypatch.setattr(run_module, "run_clips_observer", successful_clips)
+    monkeypatch.setattr(
+        run_module,
+        "project_clips_observation",
+        lambda raw, **_kwargs: _canonical_observation(
+            raw["identity"],
+            fact_id=2,
+            rule="compute",
+        ),
+    )
+
+    with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
+        result = run_module.process_file(
+            _structured_work_item(
+                source=source,
+                root=root,
+                run_workspace=run_workspace,
+                failures_dir=failures_dir,
+                declaration=declaration,
+            )
+        )
+
+    _, ferric_result, clips_result, classification, reason = result
+    assert classification == "pending"
+    assert reason == "oracle-invalid:evidence"
+    assert ferric_result["oracle_evidence"]["status"] == "invalid"
+    assert clips_result is not None
+    assert clips_result["oracle_evidence"] == ferric_result["oracle_evidence"]
+    artifact_path = root / ferric_result["composed_source"]["artifact_path"]
+    assert artifact_path.read_bytes() == source_bytes
+
+
+def test_runner_persists_missing_oracle_state_without_engine_preflight(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "fixture.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("(defrule noop =>)\n", encoding="utf-8")
+    manifest_path = examples / "compat-manifest.json"
+    entry = {
+        "source": "",
+        "classification": "pending",
+        "reason": "testable",
+        "runability": "standalone",
+        "features": ["defrule"],
+        "unsupported_features": [],
+        "ferric": {"legacy": True},
+        "clips": {"legacy": True},
+        "notes": "",
+        "source_sha256": sha256_bytes(source.read_bytes()),
+    }
+    save_manifest(
+        manifest_path,
+        {
+            "version": 3,
+            "oracle_protocol_version": 1,
+            "summary": {
+                "total": 1,
+                "equivalent": 0,
+                "divergent": 0,
+                "incompatible": 0,
+                "pending": 1,
+            },
+            "files": {"fixture.clp": entry},
+        },
+    )
+    monkeypatch.setattr(run_module, "repo_root", lambda: root)
+    monkeypatch.setattr(run_module, "default_examples_dir", lambda: examples)
+
+    result = CliRunner().invoke(
+        run_module.app,
+        ["--manifest", str(manifest_path), "--all"],
+    )
+
+    assert result.exit_code == 0, result.output
+    persisted = load_manifest(manifest_path)
+    assert persisted["summary"] == {
+        "total": 1,
+        "equivalent": 0,
+        "divergent": 0,
+        "incompatible": 0,
+        "pending": 1,
+    }
+    assert persisted["files"]["fixture.clp"]["reason"] == "oracle-missing"
+    assert persisted["files"]["fixture.clp"]["oracle_evidence"]["status"] == "missing"
+    assert persisted["files"]["fixture.clp"]["ferric"] is None
+    assert persisted["files"]["fixture.clp"]["clips"] is None
+
+
+def test_runner_persists_explicit_missing_oracle_before_nonzero_exit(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "fixture.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("(defrule noop =>)\n", encoding="utf-8")
+    manifest_path = examples / "compat-manifest.json"
+    save_manifest(
+        manifest_path,
+        {
+            "version": 3,
+            "oracle_protocol_version": 1,
+            "summary": {
+                "total": 1,
+                "equivalent": 1,
+                "divergent": 0,
+                "incompatible": 0,
+                "pending": 0,
+            },
+            "files": {
+                "fixture.clp": {
+                    "source": "",
+                    "classification": "equivalent",
+                    "reason": "exact-match",
+                    "runability": "standalone",
+                    "features": ["defrule"],
+                    "unsupported_features": [],
+                    "ferric": {"legacy": True},
+                    "clips": {"legacy": True},
+                    "notes": "",
+                    "source_sha256": sha256_bytes(source.read_bytes()),
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(run_module, "repo_root", lambda: root)
+    monkeypatch.setattr(run_module, "default_examples_dir", lambda: examples)
+
+    result = CliRunner().invoke(
+        run_module.app,
+        ["--manifest", str(manifest_path), "--file", "fixture.clp"],
+    )
+
+    assert result.exit_code == 1
+    assert "no structured oracle declaration" in result.output
+    persisted = load_manifest(manifest_path)
+    persisted_entry = persisted["files"]["fixture.clp"]
+    assert persisted["summary"]["equivalent"] == 0
+    assert persisted["summary"]["pending"] == 1
+    assert persisted_entry["classification"] == "pending"
+    assert persisted_entry["reason"] == "oracle-missing"
+    assert persisted_entry["oracle_evidence"] == run_module._missing_oracle_evidence()
+    assert persisted_entry["ferric"] is None
+    assert persisted_entry["clips"] is None
+
+
+def test_runner_persists_malformed_declaration_before_nonzero_exit(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "fixture.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("(defrule noop =>)\n", encoding="utf-8")
+    manifest_path = examples / "compat-manifest.json"
+    save_manifest(
+        manifest_path,
+        {
+            "version": 3,
+            "oracle_protocol_version": 1,
+            "summary": {
+                "total": 1,
+                "equivalent": 1,
+                "divergent": 0,
+                "incompatible": 0,
+                "pending": 0,
+            },
+            "files": {
+                "fixture.clp": {
+                    "source": "",
+                    "classification": "equivalent",
+                    "reason": "exact-match",
+                    "runability": "standalone",
+                    "features": ["defrule"],
+                    "unsupported_features": [],
+                    "ferric": {"legacy": True},
+                    "clips": {"legacy": True},
+                    "notes": "",
+                    "source_sha256": sha256_bytes(source.read_bytes()),
+                    "oracle": "not-an-object",
+                }
+            },
+        },
+    )
+    monkeypatch.setattr(run_module, "repo_root", lambda: root)
+    monkeypatch.setattr(run_module, "default_examples_dir", lambda: examples)
+
+    result = CliRunner().invoke(
+        run_module.app,
+        ["--manifest", str(manifest_path), "--file", "fixture.clp"],
+    )
+
+    assert result.exit_code == 1
+    assert "oracle declaration must be an object" in result.output
+    persisted = load_manifest(manifest_path)
+    persisted_entry = persisted["files"]["fixture.clp"]
+    assert persisted["summary"]["equivalent"] == 0
+    assert persisted["summary"]["pending"] == 1
+    assert persisted_entry["classification"] == "pending"
+    assert persisted_entry["reason"] == "oracle-invalid:declaration"
+    assert persisted_entry["oracle_evidence"]["status"] == "invalid"
+    assert persisted_entry["oracle_evidence"]["violations"] == [
+        "oracle declaration must be an object"
+    ]
+    assert persisted_entry["ferric"] is None
+    assert persisted_entry["clips"] is None
+
+
+def test_runner_persists_missing_source_as_invalid_before_engine_preflight(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    examples.mkdir(parents=True)
+    manifest_path = examples / "compat-manifest.json"
+    digest = "0" * 64
+    entry = {
+        "source": "",
+        "classification": "pending",
+        "reason": "testable",
+        "runability": "standalone",
+        "features": ["defrule"],
+        "unsupported_features": [],
+        "ferric": {"legacy": True},
+        "clips": {"legacy": True},
+        "notes": "",
+        "source_sha256": digest,
+        "oracle": _oracle_declaration(digest),
+    }
+    save_manifest(
+        manifest_path,
+        {
+            "version": 3,
+            "oracle_protocol_version": 1,
+            "summary": {
+                "total": 1,
+                "equivalent": 0,
+                "divergent": 0,
+                "incompatible": 0,
+                "pending": 1,
+            },
+            "files": {"gone.clp": entry},
+        },
+    )
+    monkeypatch.setattr(run_module, "repo_root", lambda: root)
+    monkeypatch.setattr(run_module, "default_examples_dir", lambda: examples)
+
+    result = CliRunner().invoke(
+        run_module.app,
+        ["--manifest", str(manifest_path), "--file", "gone.clp"],
+    )
+
+    assert result.exit_code == 1
+    assert "gone.clp source cannot be resolved" in result.output
+    persisted = load_manifest(manifest_path)
+    persisted_entry = persisted["files"]["gone.clp"]
+    assert persisted_entry["classification"] == "pending"
+    assert persisted_entry["reason"] == "oracle-invalid:source"
+    assert persisted_entry["oracle_evidence"]["status"] == "invalid"
+    assert persisted_entry["oracle_evidence"]["declaration"] is False
+    assert (
+        "gone.clp source cannot be resolved" in persisted_entry["oracle_evidence"]["violations"][0]
+    )
+    assert persisted_entry["ferric"] is None
+    assert persisted_entry["clips"] is None
+
+
+def test_runner_persists_invalid_evidence_before_nonzero_exit(tmp_path, monkeypatch):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "fixture.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text("(defrule noop =>)\n", encoding="utf-8")
+    ferric = root / "target" / "release" / "ferric"
+    ferric.parent.mkdir(parents=True)
+    ferric.write_text("", encoding="utf-8")
+    manifest_path = examples / "compat-manifest.json"
+    evidence = {
+        "status": "invalid",
+        "version": 1,
+        "declaration": True,
+        "reached": False,
+        "completed": False,
+        "effect": False,
+        "normalizations": [],
+        "violations": ["ferric.markers: missing COMPLETE"],
+    }
+    entry = {
+        "source": "",
+        "classification": "pending",
+        "reason": "testable",
+        "runability": "standalone",
+        "features": ["defrule"],
+        "unsupported_features": [],
+        "ferric": None,
+        "clips": None,
+        "notes": "",
+        "source_sha256": sha256_bytes(source.read_bytes()),
+        "oracle": {},
+    }
+    save_manifest(
+        manifest_path,
+        {
+            "version": 3,
+            "oracle_protocol_version": 1,
+            "summary": {
+                "total": 1,
+                "equivalent": 0,
+                "divergent": 0,
+                "incompatible": 0,
+                "pending": 1,
+            },
+            "files": {"fixture.clp": entry},
+        },
+    )
+
+    def fake_parallel(_function, items, *, workers):
+        assert workers == 1
+        assert len(list(items)) == 1
+        yield (
+            "fixture.clp",
+            {**_engine_result(exit_code=1), "oracle_evidence": evidence},
+            {**_engine_result(), "oracle_evidence": evidence},
+            "pending",
+            "oracle-invalid:markers",
+        )
+
+    monkeypatch.setattr(run_module, "repo_root", lambda: root)
+    monkeypatch.setattr(run_module, "default_examples_dir", lambda: examples)
+    monkeypatch.setattr(run_module, "parallel_run", fake_parallel)
+    monkeypatch.setattr(
+        run_module.subprocess,
+        "run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args[0], 0),
+    )
+
+    result = CliRunner().invoke(
+        run_module.app,
+        [
+            "--manifest",
+            str(manifest_path),
+            "--ferric-bin",
+            str(ferric),
+            "--workers",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Invalid oracle evidence (1)" in result.output
+    persisted = load_manifest(manifest_path)
+    persisted_entry = persisted["files"]["fixture.clp"]
+    assert persisted_entry["classification"] == "pending"
+    assert persisted_entry["reason"] == "oracle-invalid:markers"
+    assert persisted_entry["oracle_evidence"] == evidence
+
+
 def _work_item(
     *,
     source: Path,
@@ -88,6 +681,7 @@ def _work_item(
     run_workspace: Path,
     failures_dir: Path,
 ) -> tuple:
+    composed = harness.source_bytes + b"\n" + harness.harness_bytes
     return (
         "library.clp",
         str(source),
@@ -99,26 +693,74 @@ def _work_item(
         harness,
         str(run_workspace),
         str(failures_dir),
+        _oracle_declaration(
+            sha256_bytes(harness.source_bytes),
+            composed_digest=sha256_bytes(composed),
+        ),
     )
 
 
-def test_divergence_retains_content_addressed_artifact_and_cleans_temp(tmp_path, monkeypatch):
+def _install_canonical_projectors(monkeypatch) -> None:
+    monkeypatch.setattr(
+        run_module,
+        "project_ferric_observation",
+        lambda raw, **_kwargs: _canonical_observation(
+            raw["identity"],
+            fact_id=11,
+            rule="counted-firing-1",
+            value=raw.get("value", 42),
+        ),
+    )
+    monkeypatch.setattr(
+        run_module,
+        "project_clips_observation",
+        lambda raw, **_kwargs: _canonical_observation(
+            raw["identity"],
+            fact_id=2,
+            rule="counted-firing-1",
+            value=raw.get("value", 42),
+        ),
+    )
+
+
+def test_structured_divergence_retains_artifact_and_cleans_temp(
+    tmp_path,
+    monkeypatch,
+):
     root = tmp_path / "repo"
     source, harness = _resolved_harness(root)
     invocations: list[tuple[str, Path, bytes]] = []
 
-    def fake_ferric(path, _ferric, _root, _timeout):
+    def fake_ferric(path, _ferric, _root, _timeout, **identity):
         candidate = Path(path)
         invocations.append(("ferric", candidate, candidate.read_bytes()))
-        return _engine_result(stdout="ferric\n")
+        return {
+            **_engine_result(stdout="ferric\n"),
+            "observation": {"identity": identity, "value": 42},
+        }
 
-    def fake_clips(path, _root, _script, _timeout):
+    def fake_clips(
+        path,
+        _root,
+        _script,
+        _timeout,
+        *,
+        globals_to_capture,
+        harnessed,
+        **identity,
+    ):
+        assert globals_to_capture == ()
+        assert harnessed is True
         candidate = Path(path)
         invocations.append(("clips", candidate, candidate.read_bytes()))
-        return _engine_result(stdout="clips\n")
+        return {
+            **_engine_result(stdout="clips\n"),
+            "observation": {"identity": identity, "value": 43},
+        }
 
-    monkeypatch.setattr(run_module, "run_ferric", fake_ferric)
-    monkeypatch.setattr(run_module, "run_clips_docker", fake_clips)
+    monkeypatch.setattr(run_module, "run_ferric_observer", fake_ferric)
+    monkeypatch.setattr(run_module, "run_clips_observer", fake_clips)
+    _install_canonical_projectors(monkeypatch)
 
     with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
         item = _work_item(
@@ -136,7 +778,7 @@ def test_divergence_retains_content_addressed_artifact_and_cleans_temp(tmp_path,
     expected_digest = sha256_bytes(expected)
     _, ferric_result, clips_result, classification, reason = first
     assert classification == "divergent"
-    assert reason == "output-mismatch"
+    assert reason == "oracle-effects-mismatch"
     assert clips_result is not None
     assert ferric_result["composed_source"] == clips_result["composed_source"]
     assert ferric_result["composed_source"] == {
@@ -179,7 +821,7 @@ def test_concurrent_unicode_workspace_uses_unique_files_without_crosstalk(tmp_pa
         harness.source_bytes + b"\n" + harness.harness_bytes for _, harness in cases
     }
 
-    def fake_ferric(path, _ferric, _root, _timeout):
+    def fake_ferric(path, _ferric, _root, _timeout, **identity):
         candidate = Path(path)
         assert candidate.exists()
         if not run_module.IS_WINDOWS:
@@ -197,18 +839,30 @@ def test_concurrent_unicode_workspace_uses_unique_files_without_crosstalk(tmp_pa
             ferric_paths.append(candidate)
             engine_bytes.setdefault(candidate, []).append(content)
         barrier.wait(timeout=10)
-        return _engine_result()
+        return {**_engine_result(), "observation": {"identity": identity}}
 
-    def fake_clips(path, _root, _script, _timeout):
+    def fake_clips(
+        path,
+        _root,
+        _script,
+        _timeout,
+        *,
+        globals_to_capture,
+        harnessed,
+        **identity,
+    ):
+        assert globals_to_capture == ()
+        assert harnessed is True
         candidate = Path(path)
         assert candidate.exists()
         content = candidate.read_bytes()
         with lock:
             engine_bytes.setdefault(candidate, []).append(content)
-        return _engine_result()
+        return {**_engine_result(), "observation": {"identity": identity}}
 
-    monkeypatch.setattr(run_module, "run_ferric", fake_ferric)
-    monkeypatch.setattr(run_module, "run_clips_docker", fake_clips)
+    monkeypatch.setattr(run_module, "run_ferric_observer", fake_ferric)
+    monkeypatch.setattr(run_module, "run_clips_observer", fake_clips)
+    _install_canonical_projectors(monkeypatch)
 
     with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
         items = [
@@ -232,7 +886,7 @@ def test_concurrent_unicode_workspace_uses_unique_files_without_crosstalk(tmp_pa
     assert set(engine_bytes) == set(ferric_paths)
     assert all(contents[0] == contents[1] for contents in engine_bytes.values())
     assert {contents[0] for contents in engine_bytes.values()} == expected_contents
-    assert all(result[3:] == ("equivalent", "exact-match") for result in results)
+    assert all(result[3:] == ("equivalent", "oracle-v1-match") for result in results)
 
 
 def test_concurrent_workspace_creation_is_race_free_and_traversable(tmp_path):
@@ -287,12 +941,12 @@ def test_keyboard_interrupt_retains_artifact_and_cleans_run_workspace(tmp_path, 
     invocation_path: Path | None = None
     run_workspace_path: Path | None = None
 
-    def interrupting_ferric(path, _ferric, _root, _timeout):
+    def interrupting_ferric(path, _ferric, _root, _timeout, **_identity):
         nonlocal invocation_path
         invocation_path = Path(path)
         raise KeyboardInterrupt("injected interrupt")
 
-    monkeypatch.setattr(run_module, "run_ferric", interrupting_ferric)
+    monkeypatch.setattr(run_module, "run_ferric_observer", interrupting_ferric)
 
     with (
         pytest.raises(KeyboardInterrupt, match="injected interrupt") as caught,
@@ -325,18 +979,19 @@ def test_mutated_composed_source_fails_closed_before_clips(tmp_path, monkeypatch
     source, harness = _resolved_harness(root)
     invocation_path: Path | None = None
 
-    def mutating_ferric(path, _ferric, _root, _timeout):
+    def mutating_ferric(path, _ferric, _root, _timeout, **identity):
         nonlocal invocation_path
         invocation_path = Path(path)
         invocation_path.chmod(0o644)
         invocation_path.write_bytes(b"tampered\n")
-        return _engine_result()
+        return {**_engine_result(), "observation": {"identity": identity}}
 
     def unexpected_clips(*_args, **_kwargs):
         pytest.fail("CLIPS must not run after the composed source changes")
 
-    monkeypatch.setattr(run_module, "run_ferric", mutating_ferric)
-    monkeypatch.setattr(run_module, "run_clips_docker", unexpected_clips)
+    monkeypatch.setattr(run_module, "run_ferric_observer", mutating_ferric)
+    monkeypatch.setattr(run_module, "run_clips_observer", unexpected_clips)
+    _install_canonical_projectors(monkeypatch)
 
     with (
         pytest.raises(
@@ -370,21 +1025,33 @@ def test_windows_mode_keeps_composed_file_writable_for_cleanup(tmp_path, monkeyp
     source, harness = _resolved_harness(root)
     invocation_paths: list[Path] = []
 
-    def fake_ferric(path, _ferric, _root, _timeout):
+    def fake_ferric(path, _ferric, _root, _timeout, **identity):
         candidate = Path(path)
         invocation_paths.append(candidate)
         assert candidate.stat().st_mode & 0o200
-        return _engine_result()
+        return {**_engine_result(), "observation": {"identity": identity}}
 
-    def fake_clips(path, _root, _script, _timeout):
+    def fake_clips(
+        path,
+        _root,
+        _script,
+        _timeout,
+        *,
+        globals_to_capture,
+        harnessed,
+        **identity,
+    ):
+        assert globals_to_capture == ()
+        assert harnessed is True
         candidate = Path(path)
         invocation_paths.append(candidate)
         assert candidate.stat().st_mode & 0o200
-        return _engine_result()
+        return {**_engine_result(), "observation": {"identity": identity}}
 
     monkeypatch.setattr(run_module, "IS_WINDOWS", True)
-    monkeypatch.setattr(run_module, "run_ferric", fake_ferric)
-    monkeypatch.setattr(run_module, "run_clips_docker", fake_clips)
+    monkeypatch.setattr(run_module, "run_ferric_observer", fake_ferric)
+    monkeypatch.setattr(run_module, "run_clips_observer", fake_clips)
+    _install_canonical_projectors(monkeypatch)
 
     with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
         result = run_module.process_file(
@@ -398,13 +1065,16 @@ def test_windows_mode_keeps_composed_file_writable_for_cleanup(tmp_path, monkeyp
         )
         assert list(run_workspace.iterdir()) == []
 
-    assert result[3:] == ("equivalent", "exact-match")
+    assert result[3:] == ("equivalent", "oracle-v1-match")
     assert len(invocation_paths) == 2
     assert invocation_paths[0] == invocation_paths[1]
     assert not invocation_paths[0].exists()
 
 
-def test_run_clips_docker_rejects_leaf_symlink_escape_before_subprocess(tmp_path, monkeypatch):
+def test_run_clips_observer_rejects_leaf_symlink_escape_before_subprocess(
+    tmp_path,
+    monkeypatch,
+):
     root = tmp_path / "repo"
     root.mkdir()
     outside = tmp_path / "outside.clp"
@@ -421,7 +1091,18 @@ def test_run_clips_docker_rejects_leaf_symlink_escape_before_subprocess(tmp_path
         run_module.CompatibilityWorkspaceError,
         match="CLIPS input must not be a symlink",
     ):
-        run_module.run_clips_docker(str(escaped), str(root), "clips-reference", 5)
+        run_module.run_clips_observer(
+            str(escaped),
+            str(root),
+            "clips-reference",
+            5,
+            fixture_id="fixture.symlink",
+            nonce="0" * 32,
+            source_sha256="0" * 64,
+            composed_sha256="0" * 64,
+            globals_to_capture=(),
+            harnessed=False,
+        )
 
 
 def test_clips_reference_script_preserves_unicode_quotes_and_rejects_symlink(
@@ -468,6 +1149,80 @@ def test_clips_reference_script_preserves_unicode_quotes_and_rejects_symlink(
     )
     mount = f"{synthetic_repo.resolve()}:/workspace:ro"
     assert mount in captured_args.read_text(encoding="utf-8").splitlines()
+
+    quiet_result = subprocess.run(
+        [str(script), "run", "--quiet", "--file", str(fixture)],
+        cwd=synthetic_repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert quiet_result.returncode == 0, quiet_result.stderr
+    quiet_args = captured_args.read_text(encoding="utf-8").splitlines()
+    assert quiet_args[-2:] == ["-f2", "/dev/stdin"]
+    assert (
+        captured_stdin.read_text(encoding="utf-8")
+        == '(batch* "/workspace/fixtures/rules space Ω \\"quoted\\".clp")\n'
+        "(reset)\n(run)\n(exit)\n"
+    )
+
+    observer_nonce = "0123456789abcdef0123456789abcdef"
+    observer_auth_key = "c" * 64
+    observer_result = subprocess.run(
+        [
+            str(script),
+            "run",
+            "--quiet",
+            "--observer-nonce",
+            observer_nonce,
+            "--observer-fixture-id",
+            "oracle.test",
+            "--observer-source-sha256",
+            "a" * 64,
+            "--observer-composed-sha256",
+            "b" * 64,
+            "--observer-auth-key",
+            observer_auth_key,
+            "--file",
+            str(fixture),
+        ],
+        cwd=synthetic_repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert observer_result.returncode == 0, observer_result.stderr
+    observer_args = captured_args.read_text(encoding="utf-8").splitlines()
+    assert "--ferric-observer" in observer_args
+    assert "--source" in observer_args
+    assert '/workspace/fixtures/rules space Ω "quoted".clp' in observer_args
+    assert observer_nonce not in observer_args
+    assert observer_auth_key not in observer_args
+    assert not any("FERRIC_COMPAT_OBSERVER_NONCE" in argument for argument in observer_args)
+    assert not any("LD_PRELOAD" in argument for argument in observer_args)
+    assert captured_stdin.read_text(encoding="utf-8") == (
+        f"{observer_nonce}|oracle.test|{'a' * 64}|{'b' * 64}|{observer_auth_key}\n"
+    )
+
+    invalid_observer_result = subprocess.run(
+        [
+            str(script),
+            "run",
+            "--observer-nonce",
+            "not-hex",
+            "--file",
+            str(fixture),
+        ],
+        cwd=synthetic_repo,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert invalid_observer_result.returncode == 1
+    assert "--observer-nonce must encode" in invalid_observer_result.stderr
 
     outside = tmp_path / "outside.clp"
     outside.write_text("(reset)\n", encoding="utf-8")

--- a/tools/ferric-tools/tests/test_compat_scan.py
+++ b/tools/ferric-tools/tests/test_compat_scan.py
@@ -10,6 +10,7 @@ classify_file(path, features, unsupported) returns
 from __future__ import annotations
 
 import copy
+import json
 import re
 import subprocess
 from pathlib import Path
@@ -30,7 +31,12 @@ from ferric_tools._manifest import load_manifest, save_manifest
 from ferric_tools._paths import repo_root
 from ferric_tools.bat import harness as harness_module
 from ferric_tools.compat import run as run_module
-from ferric_tools.compat.scan import build_summary, classify_file, scan_examples
+from ferric_tools.compat.scan import (
+    OracleRegistryError,
+    build_summary,
+    classify_file,
+    scan_examples,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -187,7 +193,13 @@ def test_classify_file_bat_extension_is_incompatible():
     assert reason == "test-suite-batch"
 
 
-def test_harness_generation_attaches_structured_manifest_contract(tmp_path, monkeypatch):
+@pytest.mark.parametrize(("input_version", "expected_version"), [(1, 2), (3, 3)])
+def test_harness_generation_attaches_structured_manifest_contract(
+    tmp_path,
+    monkeypatch,
+    input_version,
+    expected_version,
+):
     root = tmp_path / "repo"
     examples = root / "tests" / "examples"
     source = examples / "libraries" / "facts.clp"
@@ -199,7 +211,7 @@ def test_harness_generation_attaches_structured_manifest_contract(tmp_path, monk
     save_manifest(
         manifest_path,
         {
-            "version": 1,
+            "version": input_version,
             "generated": "2026-07-26T00:00:00+00:00",
             "summary": build_summary(files),
             "files": files,
@@ -226,7 +238,7 @@ def test_harness_generation_attaches_structured_manifest_contract(tmp_path, monk
         "generation_version": HARNESS_GENERATION_VERSION,
         "executable": True,
     }
-    assert load_manifest(manifest_path)["version"] == 2
+    assert load_manifest(manifest_path)["version"] == expected_version
 
 
 def test_scan_attaches_non_executable_contract_for_empty_library(tmp_path):
@@ -260,7 +272,8 @@ def test_harness_generation_is_deterministic(tmp_path, monkeypatch):
     save_manifest(
         manifest_path,
         {
-            "version": 2,
+            "version": 3,
+            "oracle_protocol_version": 1,
             "generated": "2026-07-26T00:00:00+00:00",
             "summary": build_summary(files),
             "files": files,
@@ -764,11 +777,14 @@ def test_compat_runner_rejects_duplicate_selected_harness_mapping(tmp_path, monk
     assert first_plan.harness_bytes is not None
     atomic_write_bytes(first_plan.harness_path, first_plan.harness_bytes)
     files["b.clp"]["harness"] = copy.deepcopy(files["a.clp"]["harness"])
+    files["a.clp"]["oracle"] = {}
+    files["b.clp"]["oracle"] = {}
     manifest_path = examples / "compat-manifest.json"
     save_manifest(
         manifest_path,
         {
-            "version": 2,
+            "version": 3,
+            "oracle_protocol_version": 1,
             "generated": "2026-07-26T00:00:00+00:00",
             "summary": build_summary(files),
             "files": files,
@@ -786,7 +802,10 @@ def test_compat_runner_rejects_duplicate_selected_harness_mapping(tmp_path, monk
     assert "duplicate harness mapping" in result.output
 
 
-def test_compat_runner_skips_explicitly_non_executable_library(tmp_path, monkeypatch):
+def test_compat_runner_demotes_undeclared_library_and_rejects_explicit_run(
+    tmp_path,
+    monkeypatch,
+):
     root = tmp_path / "repo"
     examples = root / "tests" / "examples"
     source = examples / "empty.clp"
@@ -797,7 +816,8 @@ def test_compat_runner_skips_explicitly_non_executable_library(tmp_path, monkeyp
     save_manifest(
         manifest_path,
         {
-            "version": 2,
+            "version": 3,
+            "oracle_protocol_version": 1,
             "generated": "2026-07-26T00:00:00+00:00",
             "summary": build_summary(files),
             "files": files,
@@ -816,9 +836,9 @@ def test_compat_runner_skips_explicitly_non_executable_library(tmp_path, monkeyp
     )
 
     assert result.exit_code == 0
-    assert "No files to run." in result.output
+    assert "No oracle-backed files to run." in result.output
     assert explicit.exit_code == 1
-    assert "harness is not executable (empty)" in explicit.output
+    assert "no structured oracle declaration" in explicit.output
 
 
 @pytest.mark.parametrize("mutation", ["missing", "standalone"])
@@ -836,7 +856,8 @@ def test_compat_runner_rejects_runability_that_bypasses_harness_validation(
     save_manifest(
         manifest_path,
         {
-            "version": 2,
+            "version": 3,
+            "oracle_protocol_version": 1,
             "generated": "2026-07-26T00:00:00+00:00",
             "summary": build_summary({"libraries/facts.clp": malformed_entry}),
             "files": {"libraries/facts.clp": malformed_entry},
@@ -868,8 +889,13 @@ def test_process_file_records_harness_executed_by_both_engines(tmp_path, monkeyp
     )
     assert resolved is not None
     invocations: list[tuple[str, str, bytes]] = []
+    composed = resolved.source_bytes + b"\n" + resolved.harness_bytes
+    declaration = _oracle_declaration(
+        sha256_bytes(resolved.source_bytes),
+        composed_digest=sha256_bytes(composed),
+    )
 
-    def fake_ferric(path, _ferric, _root, _timeout):
+    def fake_ferric(path, _ferric, _root, _timeout, **identity):
         invocations.append(("ferric", path, Path(path).read_bytes()))
         return {
             "exit_code": 0,
@@ -877,9 +903,21 @@ def test_process_file_records_harness_executed_by_both_engines(tmp_path, monkeyp
             "stderr": "",
             "duration_ms": 1,
             "timed_out": False,
+            "observation": {"identity": identity},
         }
 
-    def fake_clips(path, _root, _script, _timeout):
+    def fake_clips(
+        path,
+        _root,
+        _script,
+        _timeout,
+        *,
+        globals_to_capture,
+        harnessed,
+        **identity,
+    ):
+        assert globals_to_capture == ()
+        assert harnessed is True
         invocations.append(("clips", path, Path(path).read_bytes()))
         return {
             "exit_code": 0,
@@ -887,10 +925,27 @@ def test_process_file_records_harness_executed_by_both_engines(tmp_path, monkeyp
             "stderr": "",
             "duration_ms": 1,
             "timed_out": False,
+            "observation": {"identity": identity},
         }
 
-    monkeypatch.setattr(run_module, "run_ferric", fake_ferric)
-    monkeypatch.setattr(run_module, "run_clips_docker", fake_clips)
+    monkeypatch.setattr(run_module, "run_ferric_observer", fake_ferric)
+    monkeypatch.setattr(run_module, "run_clips_observer", fake_clips)
+    monkeypatch.setattr(
+        run_module,
+        "project_ferric_observation",
+        lambda raw, **_kwargs: _canonical_observation(
+            raw["identity"],
+            fact_id=11,
+        ),
+    )
+    monkeypatch.setattr(
+        run_module,
+        "project_clips_observation",
+        lambda raw, **_kwargs: _canonical_observation(
+            raw["identity"],
+            fact_id=2,
+        ),
+    )
 
     with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
         result = run_module.process_file(
@@ -905,6 +960,7 @@ def test_process_file_records_harness_executed_by_both_engines(tmp_path, monkeyp
                 resolved,
                 str(run_workspace),
                 str(failures_dir),
+                declaration,
             )
         )
 
@@ -922,7 +978,7 @@ def test_process_file_records_harness_executed_by_both_engines(tmp_path, monkeyp
         "size_bytes": len(invocations[0][2]),
     }
     assert classification == "equivalent"
-    assert reason == "exact-match"
+    assert reason == "oracle-v1-match"
 
 
 def test_process_file_composes_harness_inside_clips_mounted_root(tmp_path, monkeypatch):
@@ -934,6 +990,11 @@ def test_process_file_composes_harness_inside_clips_mounted_root(tmp_path, monke
         manifest_key="libraries/facts.clp",
     )
     assert resolved is not None
+    composed = resolved.source_bytes + b"\n" + resolved.harness_bytes
+    declaration = _oracle_declaration(
+        sha256_bytes(resolved.source_bytes),
+        composed_digest=sha256_bytes(composed),
+    )
 
     system_temp = tmp_path / "system-temp"
     system_temp.mkdir()
@@ -950,12 +1011,25 @@ def test_process_file_composes_harness_inside_clips_mounted_root(tmp_path, monke
             "timed_out": False,
         }
 
-    def fake_ferric(path, _ferric, _root, _timeout):
+    def fake_ferric(path, _ferric, _root, _timeout, **identity):
         candidate = Path(path)
         invocations.append(("ferric", candidate, candidate.read_bytes()))
-        return engine_result()
+        result = engine_result()
+        result["observation"] = {"identity": identity}
+        return result
 
-    def fake_clips(path, mounted_root, _script, _timeout):
+    def fake_clips(
+        path,
+        mounted_root,
+        _script,
+        _timeout,
+        *,
+        globals_to_capture,
+        harnessed,
+        **identity,
+    ):
+        assert globals_to_capture == ()
+        assert harnessed is True
         candidate = Path(path)
         invocations.append(("clips", candidate, candidate.read_bytes()))
         if not candidate.resolve().is_relative_to(Path(mounted_root).resolve()):
@@ -963,10 +1037,28 @@ def test_process_file_composes_harness_inside_clips_mounted_root(tmp_path, monke
             result["exit_code"] = 1
             result["stderr"] = "path is outside the mounted repository"
             return result
-        return engine_result()
+        result = engine_result()
+        result["observation"] = {"identity": identity}
+        return result
 
-    monkeypatch.setattr(run_module, "run_ferric", fake_ferric)
-    monkeypatch.setattr(run_module, "run_clips_docker", fake_clips)
+    monkeypatch.setattr(run_module, "run_ferric_observer", fake_ferric)
+    monkeypatch.setattr(run_module, "run_clips_observer", fake_clips)
+    monkeypatch.setattr(
+        run_module,
+        "project_ferric_observation",
+        lambda raw, **_kwargs: _canonical_observation(
+            raw["identity"],
+            fact_id=11,
+        ),
+    )
+    monkeypatch.setattr(
+        run_module,
+        "project_clips_observation",
+        lambda raw, **_kwargs: _canonical_observation(
+            raw["identity"],
+            fact_id=2,
+        ),
+    )
 
     with run_module._compatibility_run_workspace(root) as (run_workspace, failures_dir):
         result = run_module.process_file(
@@ -981,14 +1073,168 @@ def test_process_file_composes_harness_inside_clips_mounted_root(tmp_path, monke
                 resolved,
                 str(run_workspace),
                 str(failures_dir),
+                declaration,
             )
         )
 
     _, _ferric_result, _clips_result, classification, reason = result
     assert classification == "equivalent"
-    assert reason == "exact-match"
+    assert reason == "oracle-v1-match"
     assert [engine for engine, _, _ in invocations] == ["ferric", "clips"]
     assert invocations[0][1] == invocations[1][1]
     assert invocations[0][2] == invocations[1][2]
     assert invocations[0][1].resolve().is_relative_to(root.resolve())
     assert not invocations[0][1].exists()
+
+
+def _oracle_declaration(digest: str, *, composed_digest: str | None = None) -> dict:
+    return {
+        "version": 1,
+        "id": "fixture.oracle",
+        "feature": "state effect",
+        "source_sha256": digest,
+        "composed_sha256": composed_digest or digest,
+        "nonce": "0" * 32,
+        "setup": ["load", "reset", "run"],
+        "expectations": {
+            "phase": "run-complete",
+            "firings": {"count": 1, "names": None},
+            "effects": [
+                {
+                    "name": "fact:MAIN::result",
+                    "value": {
+                        "type": "multifield",
+                        "value": [{"type": "integer", "value": 1}],
+                    },
+                }
+            ],
+            "facts": [
+                {
+                    "kind": "ordered",
+                    "id": 0,
+                    "origin": "fixture",
+                    "module": "MAIN",
+                    "relation": "result",
+                    "fields": [{"type": "integer", "value": 1}],
+                }
+            ],
+            "channels": {"stdout": "", "stderr": ""},
+            "diagnostic": {"phase": "none", "category": "none", "continued": True},
+            "run": {"limit": None, "halt_reason": "agenda-empty"},
+            "focus_stack": None,
+            "globals": None,
+        },
+        "normalizers": ["fact-ids"],
+    }
+
+
+def _canonical_observation(identity: dict, *, fact_id: int) -> dict:
+    integer = {"type": "integer", "value": 1}
+    return {
+        "version": 1,
+        "id": identity["fixture_id"],
+        "source_sha256": identity["source_sha256"],
+        "composed_sha256": identity["composed_sha256"],
+        "nonce": identity["nonce"],
+        "markers": [
+            {
+                "kind": kind,
+                "id": identity["fixture_id"],
+                "source_sha256": identity["source_sha256"],
+                "composed_sha256": identity["composed_sha256"],
+                "nonce": identity["nonce"],
+            }
+            for kind in ("START", "COMPLETE")
+        ],
+        "phase": "run-complete",
+        "firings": [{"rule": "counted-firing-1", "origin": "fixture"}],
+        "effects": [
+            {
+                "name": "fact:MAIN::result",
+                "value": {"type": "multifield", "value": [integer]},
+                "origin": "fixture",
+            }
+        ],
+        "facts": [
+            {
+                "kind": "ordered",
+                "id": fact_id,
+                "origin": "fixture",
+                "module": "MAIN",
+                "relation": "result",
+                "fields": [integer],
+            }
+        ],
+        "channels": {"stdout": "", "stderr": ""},
+        "diagnostic": {"phase": "none", "category": "none", "continued": True},
+        "run": {"limit": None, "halt_reason": "agenda-empty"},
+        "focus_stack": [],
+        "globals": None,
+    }
+
+
+def test_scan_attaches_digest_bound_oracle_declaration(tmp_path):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "fixture.clp"
+    examples.mkdir(parents=True)
+    source.write_text("(defrule effect => (assert (result 1)))\n", encoding="utf-8")
+    digest = sha256_bytes(source.read_bytes())
+    registry = {
+        "version": 1,
+        "fixtures": {"fixture.clp": _oracle_declaration(digest)},
+    }
+    (examples / "compat-oracles.json").write_text(
+        json.dumps(registry),
+        encoding="utf-8",
+    )
+
+    files = scan_examples(examples, root=root)
+
+    assert files["fixture.clp"]["source_sha256"] == digest
+    assert files["fixture.clp"]["oracle"] == registry["fixtures"]["fixture.clp"]
+    assert files["fixture.clp"]["oracle_evidence"] == {
+        "status": "missing",
+        "version": 1,
+        "declaration": True,
+        "reached": False,
+        "completed": False,
+        "effect": False,
+        "normalizations": ["fact-ids"],
+        "violations": [],
+    }
+
+
+def test_scan_rejects_stale_oracle_source_digest(tmp_path):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    examples.mkdir(parents=True)
+    (examples / "fixture.clp").write_text(
+        "(defrule effect => (assert (result 1)))\n",
+        encoding="utf-8",
+    )
+    registry = {
+        "version": 1,
+        "fixtures": {"fixture.clp": _oracle_declaration("f" * 64)},
+    }
+    (examples / "compat-oracles.json").write_text(
+        json.dumps(registry),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(OracleRegistryError, match="source digest is stale"):
+        scan_examples(examples, root=root)
+
+
+def test_scan_rejects_duplicate_registry_json_field(tmp_path):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    examples.mkdir(parents=True)
+    (examples / "fixture.clp").write_text("(defrule effect =>)\n", encoding="utf-8")
+    (examples / "compat-oracles.json").write_text(
+        '{"version":1,"version":1,"fixtures":{}}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(OracleRegistryError, match="duplicate JSON field"):
+        scan_examples(examples, root=root)


### PR DESCRIPTION
## Scope

Implements FR-COMPAT-004 for issue #91. Compatibility schema v3 no longer treats matching process output—including matching empty output—as evidence by itself.

Closes #91

## What changed

- Added strict oracle-v1 declarations and observations covering lifecycle markers, firing behavior, semantic effects, typed final facts, channels, diagnostics, run termination, focus state, globals, and fixture-scoped normalizers.
- Added the hidden Ferric `compat-observe` surface and a dedicated native CLIPS embedding that owns load/reset/run, accounts for every module’s agenda, captures typed post-run state, and authenticates nonce/digest-bound records with a per-run HMAC key.
- Made scan/run/report/diff schema-v3 consumers fail closed for missing, stale, malformed, incomplete, spoofed, or unsupported evidence, while retaining composed failure inputs.
- Added an intentionally empty-output control whose one firing and final `(result 42)` fact prove real feature behavior.
- Added defensive coverage reporting and diff gates, including rejection of unchanged legacy equivalent claims copied into a v3 head without valid evidence.
- Documented the maintainer contract and updated dependency notices.

## Stack

- Predecessor: none; the prerequisite work is already on `main`.
- Earlier PRs in stack: none.
- Required merge order: this PR only.
- Tests require a predecessor branch: no.
- Branch point: `14573451b1410cca2f8da498713497fbf39b0b7a`.

## Red evidence

Red-test commit: `959eecf`

```console
uv run pytest -q tests/test_compat_run.py -k 'rejects_prompt_prefixed_harness_without_feature_oracle or rejects_matching_empty_output_without_oracle'
```

Before implementation, the prompt-prefixed harness case was classified `equivalent/exact-match`, and matching empty output was classified `equivalent/empty-match`.

## Acceptance mapping

- Both adapters must independently reach and complete identity-, nonce-, and digest-bound lifecycle evidence.
- `equivalent` requires valid declarations, valid observations from both engines, the declared fixture effect, and normalized semantic agreement.
- Structured state differences become `divergent`; missing or invalid evidence remains `pending` and cannot support equivalence.
- Empty output is accepted only when independent non-empty semantic evidence succeeds.
- Reports expose declaration, lifecycle, effect, version, normalizer, invalid, missing, and refused-equivalence coverage.

## Validation

- `just preflight-pr`
- `uv run --project tools/ferric-tools pytest -q tools/ferric-tools/tests` — 356 passed
- `cargo test -p ferric-cli` — 23 unit, 37 CLI integration, and 7 observer tests passed
- Local reference-image build plus native controls for UTF-8 framing, halt-on-last, unfocused remaining agenda, and in-rule spoof attempts
- `just compat-scan`
- `just compat-run --workers 4 --timeout 30`
- `just compat-report`
- `just compat-diff /tmp/issue91-base-compat-manifest.json /Users/prb/conductor/workspaces/ferric-rules/tel-aviv/tests/examples/compat-manifest.json --report /tmp/issue91-compat-diff.md --tsv /tmp/issue91-compat-diff.tsv` — no regressions or improvements

## Approved migration policy

Generated verifier instrumentation does not count as a fixture feature effect. Where adapters cannot separate generated activity from feature activity, evidence fails closed. During this schema migration, the 107 legacy output-based equivalents are allowed to demote to pending; the new oracle-backed control leaves one verified equivalent.

## Follow-up boundaries

Broad corpus declarations remain in #93, CI image/gating work remains in #92, and phase-aware diagnostic equivalence remains in #119. Harness firing attribution stays fail-closed until both adapters can separate fixture and generated firings.