### PR TITLE
[FR-GO-001] Make Go Engine lifecycle close-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,24 @@ jobs:
           CC: clang
           FERRIC_TSAN_TOOLCHAIN: nightly-2025-11-04
 
+  ffi-go-asan:
+    name: Go/C Lifecycle (AddressSanitizer)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@just
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2025-11-04
+          components: rust-src
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: bindings/go/go.mod
+      - run: just ffi-go-asan-harness
+        env:
+          FERRIC_ASAN_TOOLCHAIN: nightly-2025-11-04
+
   go-lint:
     name: Go Lint
     runs-on: ubuntu-latest

--- a/bindings/go/coverage_edge_test.go
+++ b/bindings/go/coverage_edge_test.go
@@ -341,9 +341,6 @@ func TestManualNilEngineErrorBranches(t *testing.T) {
 		}
 	}
 
-	if err := e.Close(); err != nil {
-		t.Fatalf("Close on a nil handle should remain idempotent, got %v", err)
-	}
 	// Representative check that the nil-handle path surfaces the native
 	// null-pointer code as a typed *FerricError, not just "some error".
 	var fe *FerricError
@@ -444,6 +441,9 @@ func TestManualNilEngineErrorBranches(t *testing.T) {
 	}
 	if got := e.Diagnostics(); got != nil {
 		t.Fatalf("Diagnostics nil handle = %#v, want nil", got)
+	}
+	if err := e.Close(); err != nil {
+		t.Fatalf("Close on a nil handle should remain idempotent, got %v", err)
 	}
 }
 
@@ -824,7 +824,7 @@ func TestManualFinalizerAndBuildFactsHelpers(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mustClose(t, e)
-	if _, err := e.buildFacts([]uint64{999}); err == nil {
+	if _, err := e.buildFacts(e.handle, []uint64{999}); err == nil {
 		t.Fatal("buildFacts should fail when an ID cannot be resolved")
 	}
 }
@@ -1177,7 +1177,7 @@ func TestManualHookedBuildFactErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			withFFIHooks(t)
 			tc.setup()
-			_, err := (&Engine{}).buildFact(1)
+			_, err := (&Engine{}).buildFact(nil, 1)
 			// Every lookup failure must preserve the underlying native code
 			// (ErrRuntime) through any fmt.Errorf wrapping buildFact adds.
 			if !errors.Is(err, ErrRuntime) {
@@ -1222,6 +1222,7 @@ func TestManualHookedEvaluateAndPinnedEdges(t *testing.T) {
 	})
 
 	t.Run("wire conversion failure", func(t *testing.T) {
+		lockThread(t)
 		withFFIHooks(t)
 		factsToWire = func([]Fact) ([]WireFact, error) { return nil, errUnsupportedWireConversionType }
 		e, err := NewEngine()

--- a/bindings/go/engine.go
+++ b/bindings/go/engine.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 
 	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
 )
@@ -19,9 +20,11 @@ var errIntOverflow = fmt.Errorf("ferric: integer overflow")
 // use, use Coordinator and Manager instead.
 //
 // Engine implements io.Closer. Always defer Close() after creation.
+// An Engine must not be copied after first use.
 type Engine struct {
-	handle ffi.EngineHandle
-	closed bool
+	lifecycle sync.RWMutex
+	handle    ffi.EngineHandle
+	closed    bool
 }
 
 // NewEngine creates a new engine on the current OS thread.
@@ -88,9 +91,7 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 }
 
 func finalizeEngine(e *Engine) {
-	if !e.closed {
-		ffiEngineFreeUnchecked(e.handle)
-	}
+	_, _ = e.closeWith(ffiEngineFreeUnchecked)
 }
 
 // NewEngineFromFile creates a new engine by deserializing a snapshot from the
@@ -183,27 +184,60 @@ func clampUintptrToInt(n uintptr) int {
 
 // Close frees the engine. Implements io.Closer.
 func (e *Engine) Close() error {
-	if e.closed {
-		return nil
+	closed, err := e.closeWith(ffiEngineFree)
+	if err != nil {
+		return err
 	}
-	rc := ffiEngineFree(e.handle)
-	if rc != ffi.ErrOK {
-		// Leave closed=false and finalizer intact so the caller
-		// can retry or the finalizer can still clean up.
-		return errorFromFFI(rc, e.handle)
+	if closed {
+		runtime.SetFinalizer(e, nil)
 	}
-	e.closed = true
-	runtime.SetFinalizer(e, nil)
 	return nil
+}
+
+// closeWith serializes explicit and finalizer cleanup. The handle becomes nil
+// only after the native free succeeds, so a failed thread-affine Close remains
+// retryable while successful cleanup is published exactly once.
+func (e *Engine) closeWith(free func(ffi.EngineHandle) ffi.ErrorCode) (bool, error) {
+	e.lifecycle.Lock()
+	defer e.lifecycle.Unlock()
+
+	if e.closed {
+		return false, nil
+	}
+	rc := free(e.handle)
+	if rc != ffi.ErrOK {
+		return false, errorFromFFI(rc, e.handle)
+	}
+	e.handle = nil
+	e.closed = true
+	return true, nil
+}
+
+// leaseHandle prevents Close from freeing the native engine until release is
+// called. Every native operation must hold this lease for its complete FFI
+// interaction, including error-message retrieval.
+func (e *Engine) leaseHandle() (ffi.EngineHandle, func(), error) {
+	e.lifecycle.RLock()
+	if e.closed {
+		e.lifecycle.RUnlock()
+		return nil, nil, ErrEngineClosed
+	}
+	return e.handle, e.lifecycle.RUnlock, nil
 }
 
 // --- Loading ---
 
 // Load loads CLIPS source into the engine.
 func (e *Engine) Load(source string) error {
-	rc := ffiEngineLoadString(e.handle, source)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	rc := ffiEngineLoadString(handle, source)
 	if rc != ffi.ErrOK {
-		return errorFromFFI(rc, e.handle)
+		return errorFromFFI(rc, handle)
 	}
 	return nil
 }
@@ -213,15 +247,27 @@ func (e *Engine) Load(source string) error {
 // AssertString asserts a fact from a CLIPS source string
 // (e.g., "(assert (color red))").
 func (e *Engine) AssertString(source string) (uint64, error) {
-	id, rc := ffiEngineAssertString(e.handle, source)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+
+	id, rc := ffiEngineAssertString(handle, source)
 	if rc != ffi.ErrOK {
-		return 0, errorFromFFI(rc, e.handle)
+		return 0, errorFromFFI(rc, handle)
 	}
 	return id, nil
 }
 
 // AssertFact asserts an ordered fact with the given relation and fields.
 func (e *Engine) AssertFact(relation string, fields ...any) (uint64, error) {
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+
 	vals := make([]ffi.Value, len(fields))
 	defer func() {
 		for i := range vals {
@@ -229,22 +275,28 @@ func (e *Engine) AssertFact(relation string, fields ...any) (uint64, error) {
 		}
 	}()
 	for i, f := range fields {
-		v, err := goToFFIValue(f)
-		if err != nil {
-			return 0, err
+		v, conversionErr := goToFFIValue(f)
+		if conversionErr != nil {
+			return 0, conversionErr
 		}
 		vals[i] = v
 	}
 
-	id, rc := ffiEngineAssertOrdered(e.handle, relation, vals)
+	id, rc := ffiEngineAssertOrdered(handle, relation, vals)
 	if rc != ffi.ErrOK {
-		return 0, errorFromFFI(rc, e.handle)
+		return 0, errorFromFFI(rc, handle)
 	}
 	return id, nil
 }
 
 // AssertTemplate asserts a template fact with named slot values.
 func (e *Engine) AssertTemplate(templateName string, slots map[string]any) (uint64, error) {
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+
 	names := make([]string, 0, len(slots))
 	vals := make([]ffi.Value, 0, len(slots))
 	defer func() {
@@ -253,48 +305,66 @@ func (e *Engine) AssertTemplate(templateName string, slots map[string]any) (uint
 		}
 	}()
 	for k, v := range slots {
-		fv, err := goToFFIValue(v)
-		if err != nil {
-			return 0, err
+		fv, conversionErr := goToFFIValue(v)
+		if conversionErr != nil {
+			return 0, conversionErr
 		}
 		names = append(names, k)
 		vals = append(vals, fv)
 	}
 
-	id, rc := ffiEngineAssertTemplate(e.handle, templateName, names, vals)
+	id, rc := ffiEngineAssertTemplate(handle, templateName, names, vals)
 	if rc != ffi.ErrOK {
-		return 0, errorFromFFI(rc, e.handle)
+		return 0, errorFromFFI(rc, handle)
 	}
 	return id, nil
 }
 
 // Retract removes a fact by its ID.
 func (e *Engine) Retract(factID uint64) error {
-	rc := ffiEngineRetract(e.handle, factID)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	rc := ffiEngineRetract(handle, factID)
 	if rc != ffi.ErrOK {
-		return errorFromFFI(rc, e.handle)
+		return errorFromFFI(rc, handle)
 	}
 	return nil
 }
 
 // GetFact returns a snapshot of a single fact.
 func (e *Engine) GetFact(factID uint64) (*Fact, error) {
-	return e.buildFact(factID)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	return e.buildFact(handle, factID)
 }
 
 // Facts returns snapshots of all user-visible facts.
 func (e *Engine) Facts() ([]Fact, error) {
-	ids, rc := ffiEngineFactIDs(e.handle)
-	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil, err
 	}
-	return e.buildFacts(ids)
+	defer release()
+
+	ids, rc := ffiEngineFactIDs(handle)
+	if rc != ffi.ErrOK {
+		return nil, errorFromFFI(rc, handle)
+	}
+	return e.buildFacts(handle, ids)
 }
 
-func (e *Engine) buildFacts(ids []uint64) ([]Fact, error) {
+func (e *Engine) buildFacts(handle ffi.EngineHandle, ids []uint64) ([]Fact, error) {
 	facts := make([]Fact, 0, len(ids))
 	for _, id := range ids {
-		f, err := e.buildFact(id)
+		f, err := e.buildFact(handle, id)
 		if err != nil {
 			return nil, err
 		}
@@ -305,18 +375,30 @@ func (e *Engine) buildFacts(ids []uint64) ([]Fact, error) {
 
 // FindFacts returns snapshots of facts matching the given relation name.
 func (e *Engine) FindFacts(relation string) ([]Fact, error) {
-	ids, rc := ffiEngineFindFactIDs(e.handle, relation)
-	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil, err
 	}
-	return e.buildFacts(ids)
+	defer release()
+
+	ids, rc := ffiEngineFindFactIDs(handle, relation)
+	if rc != ffi.ErrOK {
+		return nil, errorFromFFI(rc, handle)
+	}
+	return e.buildFacts(handle, ids)
 }
 
 // FactCount returns the number of user-visible facts.
 func (e *Engine) FactCount() (int, error) {
-	count, rc := ffiEngineFactCount(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+
+	count, rc := ffiEngineFactCount(handle)
 	if rc != ffi.ErrOK {
-		return 0, errorFromFFI(rc, e.handle)
+		return 0, errorFromFFI(rc, handle)
 	}
 	return uintptrToInt(count)
 }
@@ -332,6 +414,12 @@ func (e *Engine) Run(ctx context.Context) (*RunResult, error) {
 // A limit of 0 means unlimited. Checks context for cancellation between
 // batches of rule firings.
 func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error) {
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	if ctx == nil {
 		return nil, errNilContext
 	}
@@ -342,7 +430,7 @@ func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error
 		if limit > 0 {
 			ffiLimit = int64(limit)
 		}
-		return e.runDirect(ffiLimit)
+		return e.runDirect(handle, ffiLimit)
 	}
 
 	// For cancelable contexts, run in small batches and check context.
@@ -365,9 +453,9 @@ func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error
 			}
 		}
 
-		fired, reason, rc := ffiEngineRunEx(e.handle, batch)
+		fired, reason, rc := ffiEngineRunEx(handle, batch)
 		if rc != ffi.ErrOK {
-			return &RunResult{RulesFired: totalFired}, errorFromFFI(rc, e.handle)
+			return &RunResult{RulesFired: totalFired}, errorFromFFI(rc, handle)
 		}
 		firedCount, err := uint64ToInt(fired)
 		if err != nil {
@@ -390,10 +478,10 @@ func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error
 	}
 }
 
-func (e *Engine) runDirect(limit int64) (*RunResult, error) {
-	fired, reason, rc := ffiEngineRunEx(e.handle, limit)
+func (e *Engine) runDirect(handle ffi.EngineHandle, limit int64) (*RunResult, error) {
+	fired, reason, rc := ffiEngineRunEx(handle, limit)
 	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+		return nil, errorFromFFI(rc, handle)
 	}
 	var hr HaltReason
 	switch reason {
@@ -414,9 +502,15 @@ func (e *Engine) runDirect(limit int64) (*RunResult, error) {
 // Step executes a single rule firing.
 // Returns nil if the agenda is empty.
 func (e *Engine) Step() (*FiredRule, error) {
-	status, rc := ffiEngineStep(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	status, rc := ffiEngineStep(handle)
 	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+		return nil, errorFromFFI(rc, handle)
 	}
 	if status != 1 {
 		return nil, nil //nolint:nilnil // nil indicates agenda empty and is part of Step's public contract.
@@ -425,36 +519,61 @@ func (e *Engine) Step() (*FiredRule, error) {
 	return &FiredRule{}, nil
 }
 
-// Halt requests the engine to halt.
+// Halt requests the engine to halt. It is a no-op after Close.
 func (e *Engine) Halt() {
-	ffiEngineHalt(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return
+	}
+	defer release()
+
+	ffiEngineHalt(handle)
 }
 
 // Reset resets the engine to its initial state (facts cleared, rules kept).
 func (e *Engine) Reset() error {
-	rc := ffiEngineReset(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	rc := ffiEngineReset(handle)
 	if rc != ffi.ErrOK {
-		return errorFromFFI(rc, e.handle)
+		return errorFromFFI(rc, handle)
 	}
 	return nil
 }
 
-// Clear removes all rules, facts, templates, etc. from the engine.
+// Clear removes all rules, facts, templates, etc. from the engine. It is a
+// no-op after Close.
 func (e *Engine) Clear() {
-	ffiEngineClear(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return
+	}
+	defer release()
+
+	ffiEngineClear(handle)
 }
 
 // Serialize produces a snapshot of the engine's current state using the
 // specified format. The snapshot can be used with WithSnapshot to create
 // new engines that skip the parse/compile pipeline.
 func (e *Engine) Serialize(format Format) ([]byte, error) {
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	ffiFormat, err := formatToFFI(format)
 	if err != nil {
 		return nil, err
 	}
-	data, rc := ffiEngineSerializeAs(e.handle, ffiFormat)
+	data, rc := ffiEngineSerializeAs(handle, ffiFormat)
 	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+		return nil, errorFromFFI(rc, handle)
 	}
 	return data, nil
 }
@@ -474,15 +593,22 @@ func (e *Engine) SerializeToFile(path string, format Format) error {
 
 // --- Introspection ---
 
-// Rules returns information about all registered rules.
+// Rules returns information about all registered rules. It returns nil after
+// Close; use RulesE to distinguish a closed engine from an empty rule set.
 func (e *Engine) Rules() []RuleInfo {
-	count, rc := ffiEngineRuleCount(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil
+	}
+	defer release()
+
+	count, rc := ffiEngineRuleCount(handle)
 	if rc != ffi.ErrOK {
 		return nil
 	}
 	rules := make([]RuleInfo, 0, count)
 	for i := range count {
-		name, salience, rc := ffiEngineRuleInfo(e.handle, i)
+		name, salience, rc := ffiEngineRuleInfo(handle, i)
 		if rc != ffi.ErrOK {
 			break
 		}
@@ -491,15 +617,22 @@ func (e *Engine) Rules() []RuleInfo {
 	return rules
 }
 
-// Templates returns the names of all registered templates.
+// Templates returns the names of all registered templates. It returns nil
+// after Close; use TemplatesE to distinguish a closed engine from no templates.
 func (e *Engine) Templates() []string {
-	count, rc := ffiEngineTemplateCount(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil
+	}
+	defer release()
+
+	count, rc := ffiEngineTemplateCount(handle)
 	if rc != ffi.ErrOK {
 		return nil
 	}
 	names := make([]string, 0, count)
 	for i := range count {
-		name, rc := ffiEngineTemplateName(e.handle, i)
+		name, rc := ffiEngineTemplateName(handle, i)
 		if rc != ffi.ErrOK {
 			break
 		}
@@ -511,42 +644,51 @@ func (e *Engine) Templates() []string {
 // GetGlobal retrieves a global variable's value by name.
 // The name should not include the ?* prefix/suffix.
 func (e *Engine) GetGlobal(name string) (any, error) {
-	val, rc := ffiEngineGetGlobal(e.handle, name)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	val, rc := ffiEngineGetGlobal(handle, name)
 	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+		return nil, errorFromFFI(rc, handle)
 	}
 	result := ffiValueToGoAndFree(&val)
 	return result, nil
 }
 
-// CurrentModule returns the name of the current module.
+// CurrentModule returns the name of the current module, or an empty string
+// after Close. Use CurrentModuleE to distinguish that state from an empty name.
 func (e *Engine) CurrentModule() string {
-	name, rc := ffiEngineCurrentModule(e.handle)
-	if rc != ffi.ErrOK {
-		return ""
-	}
+	name, _ := e.CurrentModuleE()
 	return name
 }
 
 // Focus returns the module at the top of the focus stack.
-// Returns empty string and false if the focus stack is empty.
+// Returns empty string and false if the focus stack is empty or the engine is
+// closed. Use FocusE to distinguish an error.
 func (e *Engine) Focus() (string, bool) {
-	name, rc := ffiEngineGetFocus(e.handle)
-	if rc != ffi.ErrOK {
-		return "", false
-	}
-	return name, true
+	name, ok, _ := e.FocusE()
+	return name, ok
 }
 
-// FocusStack returns the focus stack entries from bottom to top.
+// FocusStack returns the focus stack entries from bottom to top, or nil after
+// Close. Use FocusStackE to distinguish an error.
 func (e *Engine) FocusStack() []string {
-	depth, rc := ffiEngineFocusStackDepth(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil
+	}
+	defer release()
+
+	depth, rc := ffiEngineFocusStackDepth(handle)
 	if rc != ffi.ErrOK {
 		return nil
 	}
 	stack := make([]string, 0, depth)
 	for i := range depth {
-		name, rc := ffiEngineFocusStackEntry(e.handle, i)
+		name, rc := ffiEngineFocusStackEntry(handle, i)
 		if rc != ffi.ErrOK {
 			break
 		}
@@ -555,21 +697,17 @@ func (e *Engine) FocusStack() []string {
 	return stack
 }
 
-// AgendaSize returns the number of activations on the agenda.
+// AgendaSize returns the number of activations on the agenda, or zero after
+// Close. Use AgendaSizeE to distinguish an error.
 func (e *Engine) AgendaSize() int {
-	count, rc := ffiEngineAgendaCount(e.handle)
-	if rc != ffi.ErrOK {
-		return 0
-	}
-	return clampUintptrToInt(count)
+	count, _ := e.AgendaSizeE()
+	return count
 }
 
-// IsHalted returns true if the engine is halted.
+// IsHalted returns true if the engine is halted and false after Close. Use
+// IsHaltedE to distinguish an error.
 func (e *Engine) IsHalted() bool {
-	halted, rc := ffiEngineIsHalted(e.handle)
-	if rc != ffi.ErrOK {
-		return false
-	}
+	halted, _ := e.IsHaltedE()
 	return halted
 }
 
@@ -578,30 +716,55 @@ func (e *Engine) IsHalted() bool {
 // GetOutput retrieves captured output for a named channel.
 // Returns the output string and true, or empty string and false if no output.
 func (e *Engine) GetOutput(channel string) (string, bool) {
-	return ffiEngineGetOutput(e.handle, channel)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return "", false
+	}
+	defer release()
+
+	return ffiEngineGetOutput(handle, channel)
 }
 
-// ClearOutput clears a specific output channel.
+// ClearOutput clears a specific output channel. It is a no-op after Close.
 func (e *Engine) ClearOutput(channel string) {
-	ffiEngineClearOutput(e.handle, channel)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return
+	}
+	defer release()
+
+	ffiEngineClearOutput(handle, channel)
 }
 
-// PushInput pushes an input line for read/readline.
+// PushInput pushes an input line for read/readline. It is a no-op after Close.
 func (e *Engine) PushInput(line string) {
-	ffiEnginePushInput(e.handle, line)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return
+	}
+	defer release()
+
+	ffiEnginePushInput(handle, line)
 }
 
 // --- Diagnostics ---
 
-// Diagnostics returns all action diagnostic messages from recent execution.
+// Diagnostics returns all action diagnostic messages from recent execution. It
+// returns nil after Close; use DiagnosticsE to distinguish an error.
 func (e *Engine) Diagnostics() []string {
-	count, rc := ffiEngineActionDiagnosticCount(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil
+	}
+	defer release()
+
+	count, rc := ffiEngineActionDiagnosticCount(handle)
 	if rc != ffi.ErrOK {
 		return nil
 	}
 	diags := make([]string, 0, count)
 	for i := range count {
-		msg, rc := ffiEngineActionDiagnosticCopy(e.handle, i)
+		msg, rc := ffiEngineActionDiagnosticCopy(handle, i)
 		if rc != ffi.ErrOK {
 			break
 		}
@@ -610,9 +773,16 @@ func (e *Engine) Diagnostics() []string {
 	return diags
 }
 
-// ClearDiagnostics clears all stored action diagnostics.
+// ClearDiagnostics clears all stored action diagnostics. It is a no-op after
+// Close.
 func (e *Engine) ClearDiagnostics() {
-	ffiEngineClearActionDiagnostics(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return
+	}
+	defer release()
+
+	ffiEngineClearActionDiagnostics(handle)
 }
 
 // ---------------------------------------------------------------------------
@@ -621,15 +791,21 @@ func (e *Engine) ClearDiagnostics() {
 
 // RulesE returns information about all registered rules, or an error.
 func (e *Engine) RulesE() ([]RuleInfo, error) {
-	count, rc := ffiEngineRuleCount(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	count, rc := ffiEngineRuleCount(handle)
 	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+		return nil, errorFromFFI(rc, handle)
 	}
 	rules := make([]RuleInfo, 0, count)
 	for i := range count {
-		name, salience, rc := ffiEngineRuleInfo(e.handle, i)
+		name, salience, rc := ffiEngineRuleInfo(handle, i)
 		if rc != ffi.ErrOK {
-			return nil, errorFromFFI(rc, e.handle)
+			return nil, errorFromFFI(rc, handle)
 		}
 		rules = append(rules, RuleInfo{Name: name, Salience: int(salience)})
 	}
@@ -638,15 +814,21 @@ func (e *Engine) RulesE() ([]RuleInfo, error) {
 
 // TemplatesE returns the names of all registered templates, or an error.
 func (e *Engine) TemplatesE() ([]string, error) {
-	count, rc := ffiEngineTemplateCount(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	count, rc := ffiEngineTemplateCount(handle)
 	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+		return nil, errorFromFFI(rc, handle)
 	}
 	names := make([]string, 0, count)
 	for i := range count {
-		name, rc := ffiEngineTemplateName(e.handle, i)
+		name, rc := ffiEngineTemplateName(handle, i)
 		if rc != ffi.ErrOK {
-			return nil, errorFromFFI(rc, e.handle)
+			return nil, errorFromFFI(rc, handle)
 		}
 		names = append(names, name)
 	}
@@ -655,15 +837,21 @@ func (e *Engine) TemplatesE() ([]string, error) {
 
 // DiagnosticsE returns all action diagnostic messages, or an error.
 func (e *Engine) DiagnosticsE() ([]string, error) {
-	count, rc := ffiEngineActionDiagnosticCount(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	count, rc := ffiEngineActionDiagnosticCount(handle)
 	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+		return nil, errorFromFFI(rc, handle)
 	}
 	diags := make([]string, 0, count)
 	for i := range count {
-		msg, rc := ffiEngineActionDiagnosticCopy(e.handle, i)
+		msg, rc := ffiEngineActionDiagnosticCopy(handle, i)
 		if rc != ffi.ErrOK {
-			return nil, errorFromFFI(rc, e.handle)
+			return nil, errorFromFFI(rc, handle)
 		}
 		diags = append(diags, msg)
 	}
@@ -672,9 +860,15 @@ func (e *Engine) DiagnosticsE() ([]string, error) {
 
 // CurrentModuleE returns the name of the current module, or an error.
 func (e *Engine) CurrentModuleE() (string, error) {
-	name, rc := ffiEngineCurrentModule(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return "", err
+	}
+	defer release()
+
+	name, rc := ffiEngineCurrentModule(handle)
 	if rc != ffi.ErrOK {
-		return "", errorFromFFI(rc, e.handle)
+		return "", errorFromFFI(rc, handle)
 	}
 	return name, nil
 }
@@ -683,24 +877,36 @@ func (e *Engine) CurrentModuleE() (string, error) {
 // Returns ("", false, nil) when the result cannot be distinguished from
 // an empty stack without an error; callers should check the bool first.
 func (e *Engine) FocusE() (string, bool, error) {
-	name, rc := ffiEngineGetFocus(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return "", false, err
+	}
+	defer release()
+
+	name, rc := ffiEngineGetFocus(handle)
 	if rc != ffi.ErrOK {
-		return "", false, errorFromFFI(rc, e.handle)
+		return "", false, errorFromFFI(rc, handle)
 	}
 	return name, true, nil
 }
 
 // FocusStackE returns the focus stack entries from bottom to top, or an error.
 func (e *Engine) FocusStackE() ([]string, error) {
-	depth, rc := ffiEngineFocusStackDepth(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
+	depth, rc := ffiEngineFocusStackDepth(handle)
 	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+		return nil, errorFromFFI(rc, handle)
 	}
 	stack := make([]string, 0, depth)
 	for i := range depth {
-		name, rc := ffiEngineFocusStackEntry(e.handle, i)
+		name, rc := ffiEngineFocusStackEntry(handle, i)
 		if rc != ffi.ErrOK {
-			return nil, errorFromFFI(rc, e.handle)
+			return nil, errorFromFFI(rc, handle)
 		}
 		stack = append(stack, name)
 	}
@@ -709,40 +915,52 @@ func (e *Engine) FocusStackE() ([]string, error) {
 
 // AgendaSizeE returns the number of activations on the agenda, or an error.
 func (e *Engine) AgendaSizeE() (int, error) {
-	count, rc := ffiEngineAgendaCount(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return 0, err
+	}
+	defer release()
+
+	count, rc := ffiEngineAgendaCount(handle)
 	if rc != ffi.ErrOK {
-		return 0, errorFromFFI(rc, e.handle)
+		return 0, errorFromFFI(rc, handle)
 	}
 	return clampUintptrToInt(count), nil
 }
 
 // IsHaltedE returns whether the engine is halted, or an error.
 func (e *Engine) IsHaltedE() (bool, error) {
-	halted, rc := ffiEngineIsHalted(e.handle)
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return false, err
+	}
+	defer release()
+
+	halted, rc := ffiEngineIsHalted(handle)
 	if rc != ffi.ErrOK {
-		return false, errorFromFFI(rc, e.handle)
+		return false, errorFromFFI(rc, handle)
 	}
 	return halted, nil
 }
 
 // --- Internal: fact building ---
 
-func (e *Engine) buildFact(factID uint64) (*Fact, error) {
-	ft, rc := ffiEngineGetFactType(e.handle, factID)
+func (e *Engine) buildFact(handle ffi.EngineHandle, factID uint64) (*Fact, error) {
+	ft, rc := ffiEngineGetFactType(handle, factID)
 	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+		return nil, errorFromFFI(rc, handle)
 	}
 
-	fieldCount, rc := ffiEngineGetFactFieldCount(e.handle, factID)
+	fieldCount, rc := ffiEngineGetFactFieldCount(handle, factID)
 	if rc != ffi.ErrOK {
-		return nil, errorFromFFI(rc, e.handle)
+		return nil, errorFromFFI(rc, handle)
 	}
 
 	fields := make([]any, fieldCount)
 	for i := range fieldCount {
-		val, rc := ffiEngineGetFactField(e.handle, factID, i)
+		val, rc := ffiEngineGetFactField(handle, factID, i)
 		if rc != ffi.ErrOK {
-			return nil, errorFromFFI(rc, e.handle)
+			return nil, errorFromFFI(rc, handle)
 		}
 		fields[i] = ffiValueToGoAndFree(&val)
 	}
@@ -754,23 +972,23 @@ func (e *Engine) buildFact(factID uint64) (*Fact, error) {
 
 	if ft == ffi.FactTypeTemplate {
 		fact.Type = FactTemplate
-		name, rc := ffiEngineGetFactTemplateName(e.handle, factID)
+		name, rc := ffiEngineGetFactTemplateName(handle, factID)
 		if rc != ffi.ErrOK {
-			return nil, errorFromFFI(rc, e.handle)
+			return nil, errorFromFFI(rc, handle)
 		}
 		fact.TemplateName = name
 
 		// Build slot map by querying template slot names.
-		slotCount, rc := ffiEngineTemplateSlotCount(e.handle, name)
+		slotCount, rc := ffiEngineTemplateSlotCount(handle, name)
 		if rc != ffi.ErrOK {
-			return nil, fmt.Errorf("ferric: failed to get slot count for template %q: %w", name, errorFromFFI(rc, e.handle))
+			return nil, fmt.Errorf("ferric: failed to get slot count for template %q: %w", name, errorFromFFI(rc, handle))
 		}
 		if slotCount > 0 {
 			fact.Slots = make(map[string]any, slotCount)
 			for i := range slotCount {
-				slotName, rc := ffiEngineTemplateSlotName(e.handle, name, i)
+				slotName, rc := ffiEngineTemplateSlotName(handle, name, i)
 				if rc != ffi.ErrOK {
-					return nil, fmt.Errorf("ferric: failed to get slot name %d for template %q: %w", i, name, errorFromFFI(rc, e.handle))
+					return nil, fmt.Errorf("ferric: failed to get slot name %d for template %q: %w", i, name, errorFromFFI(rc, handle))
 				}
 				if i < fieldCount {
 					fact.Slots[slotName] = fields[i]
@@ -779,9 +997,9 @@ func (e *Engine) buildFact(factID uint64) (*Fact, error) {
 		}
 	} else {
 		fact.Type = FactOrdered
-		rel, rc := ffiEngineGetFactRelation(e.handle, factID)
+		rel, rc := ffiEngineGetFactRelation(handle, factID)
 		if rc != ffi.ErrOK {
-			return nil, fmt.Errorf("ferric: failed to get relation for fact %d: %w", factID, errorFromFFI(rc, e.handle))
+			return nil, fmt.Errorf("ferric: failed to get relation for fact %d: %w", factID, errorFromFFI(rc, handle))
 		}
 		fact.Relation = rel
 	}

--- a/bindings/go/engine_close_test.go
+++ b/bindings/go/engine_close_test.go
@@ -1,0 +1,648 @@
+package ferric
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
+)
+
+func TestEngineRealFFIPostClose(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	e, err := NewEngine()
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	if err := e.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if _, err := e.AssertString("(probe)"); !errors.Is(err, ErrEngineClosed) {
+		t.Fatalf("AssertString after Close = %v, want ErrEngineClosed", err)
+	}
+	if _, err := e.Run(context.Background()); !errors.Is(err, ErrEngineClosed) {
+		t.Fatalf("Run after Close = %v, want ErrEngineClosed", err)
+	}
+	if _, err := e.GetFact(1); !errors.Is(err, ErrEngineClosed) {
+		t.Fatalf("GetFact after Close = %v, want ErrEngineClosed", err)
+	}
+}
+
+//nolint:gocyclo,err113,funlen,maintidx // The exhaustive table keeps each method's zero-value contract beside its call.
+func TestEngineMethodsAfterClose(t *testing.T) {
+	withFFIHooks(t)
+
+	freeCalls := 0
+	ffiEngineFree = func(ffi.EngineHandle) ffi.ErrorCode {
+		freeCalls++
+		return ffi.ErrOK
+	}
+
+	e := &Engine{}
+	if err := e.Close(); err != nil {
+		t.Fatalf("initial Close: %v", err)
+	}
+	if freeCalls != 1 {
+		t.Fatalf("initial Close called free %d times, want 1", freeCalls)
+	}
+
+	forbidEngineOperationFFI(t)
+	ffiEngineFree = func(ffi.EngineHandle) ffi.ErrorCode {
+		t.Error("repeated Close reached native free")
+		return ffi.ErrOK
+	}
+
+	wantClosed := func(err error) error {
+		if !errors.Is(err, ErrEngineClosed) {
+			return fmt.Errorf("want ErrEngineClosed: %w", err)
+		}
+		return nil
+	}
+	wantNil := func(name string, value any, err error) error {
+		if value != nil && !reflect.ValueOf(value).IsNil() {
+			return fmt.Errorf("%s value = %#v, want nil", name, value)
+		}
+		return wantClosed(err)
+	}
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{"Close", e.Close},
+		{"Load", func() error { return wantClosed(e.Load("(deffacts x)")) }},
+		{"AssertString", func() error {
+			id, err := e.AssertString("(x)")
+			if id != 0 {
+				return fmt.Errorf("id = %d, want 0", id)
+			}
+			return wantClosed(err)
+		}},
+		{"AssertFact", func() error {
+			id, err := e.AssertFact("x", int64(1))
+			if id != 0 {
+				return fmt.Errorf("id = %d, want 0", id)
+			}
+			return wantClosed(err)
+		}},
+		{"AssertTemplate", func() error {
+			id, err := e.AssertTemplate("x", map[string]any{"slot": int64(1)})
+			if id != 0 {
+				return fmt.Errorf("id = %d, want 0", id)
+			}
+			return wantClosed(err)
+		}},
+		{"Retract", func() error { return wantClosed(e.Retract(1)) }},
+		{"GetFact", func() error {
+			value, err := e.GetFact(1)
+			return wantNil("fact", value, err)
+		}},
+		{"Facts", func() error {
+			value, err := e.Facts()
+			return wantNil("facts", value, err)
+		}},
+		{"FindFacts", func() error {
+			value, err := e.FindFacts("x")
+			return wantNil("facts", value, err)
+		}},
+		{"FactCount", func() error {
+			value, err := e.FactCount()
+			if value != 0 {
+				return fmt.Errorf("count = %d, want 0", value)
+			}
+			return wantClosed(err)
+		}},
+		{"Run", func() error {
+			value, err := e.Run(context.Background())
+			return wantNil("result", value, err)
+		}},
+		{"RunWithLimit", func() error {
+			value, err := e.RunWithLimit(nil, 1) //nolint:staticcheck // Closed state intentionally takes precedence over nil-context validation.
+			return wantNil("result", value, err)
+		}},
+		{"Step", func() error {
+			value, err := e.Step()
+			return wantNil("fired rule", value, err)
+		}},
+		{"Halt", func() error {
+			e.Halt()
+			return nil
+		}},
+		{"Reset", func() error { return wantClosed(e.Reset()) }},
+		{"Clear", func() error {
+			e.Clear()
+			return nil
+		}},
+		{"Serialize", func() error {
+			value, err := e.Serialize(FormatBincode)
+			return wantNil("snapshot", value, err)
+		}},
+		{"SerializeToFile", func() error {
+			return wantClosed(e.SerializeToFile(t.TempDir()+"/snapshot.bin", FormatBincode))
+		}},
+		{"Rules", func() error {
+			if value := e.Rules(); value != nil {
+				return fmt.Errorf("rules = %#v, want nil", value)
+			}
+			return nil
+		}},
+		{"Templates", func() error {
+			if value := e.Templates(); value != nil {
+				return fmt.Errorf("templates = %#v, want nil", value)
+			}
+			return nil
+		}},
+		{"GetGlobal", func() error {
+			value, err := e.GetGlobal("x")
+			return wantNil("global", value, err)
+		}},
+		{"CurrentModule", func() error {
+			if value := e.CurrentModule(); value != "" {
+				return fmt.Errorf("module = %q, want empty", value)
+			}
+			return nil
+		}},
+		{"Focus", func() error {
+			name, ok := e.Focus()
+			if name != "" || ok {
+				return fmt.Errorf("focus = (%q, %v), want empty false", name, ok)
+			}
+			return nil
+		}},
+		{"FocusStack", func() error {
+			if value := e.FocusStack(); value != nil {
+				return fmt.Errorf("focus stack = %#v, want nil", value)
+			}
+			return nil
+		}},
+		{"AgendaSize", func() error {
+			if value := e.AgendaSize(); value != 0 {
+				return fmt.Errorf("agenda size = %d, want 0", value)
+			}
+			return nil
+		}},
+		{"IsHalted", func() error {
+			if e.IsHalted() {
+				return errors.New("IsHalted = true, want false")
+			}
+			return nil
+		}},
+		{"GetOutput", func() error {
+			output, ok := e.GetOutput("stdout")
+			if output != "" || ok {
+				return fmt.Errorf("output = (%q, %v), want empty false", output, ok)
+			}
+			return nil
+		}},
+		{"ClearOutput", func() error {
+			e.ClearOutput("stdout")
+			return nil
+		}},
+		{"PushInput", func() error {
+			e.PushInput("line")
+			return nil
+		}},
+		{"Diagnostics", func() error {
+			if value := e.Diagnostics(); value != nil {
+				return fmt.Errorf("diagnostics = %#v, want nil", value)
+			}
+			return nil
+		}},
+		{"ClearDiagnostics", func() error {
+			e.ClearDiagnostics()
+			return nil
+		}},
+		{"RulesE", func() error {
+			value, err := e.RulesE()
+			return wantNil("rules", value, err)
+		}},
+		{"TemplatesE", func() error {
+			value, err := e.TemplatesE()
+			return wantNil("templates", value, err)
+		}},
+		{"DiagnosticsE", func() error {
+			value, err := e.DiagnosticsE()
+			return wantNil("diagnostics", value, err)
+		}},
+		{"CurrentModuleE", func() error {
+			value, err := e.CurrentModuleE()
+			if value != "" {
+				return fmt.Errorf("module = %q, want empty", value)
+			}
+			return wantClosed(err)
+		}},
+		{"FocusE", func() error {
+			name, ok, err := e.FocusE()
+			if name != "" || ok {
+				return fmt.Errorf("focus = (%q, %v), want empty false", name, ok)
+			}
+			return wantClosed(err)
+		}},
+		{"FocusStackE", func() error {
+			value, err := e.FocusStackE()
+			return wantNil("focus stack", value, err)
+		}},
+		{"AgendaSizeE", func() error {
+			value, err := e.AgendaSizeE()
+			if value != 0 {
+				return fmt.Errorf("agenda size = %d, want 0", value)
+			}
+			return wantClosed(err)
+		}},
+		{"IsHaltedE", func() error {
+			value, err := e.IsHaltedE()
+			if value {
+				return errors.New("IsHaltedE = true, want false")
+			}
+			return wantClosed(err)
+		}},
+		{"FactIter", func() error {
+			for value := range e.FactIter() {
+				return fmt.Errorf("unexpected fact: %#v", value)
+			}
+			return nil
+		}},
+		{"RuleIter", func() error {
+			for value := range e.RuleIter() {
+				return fmt.Errorf("unexpected rule: %#v", value)
+			}
+			return nil
+		}},
+		{"TemplateIter", func() error {
+			for value := range e.TemplateIter() {
+				return fmt.Errorf("unexpected template: %q", value)
+			}
+			return nil
+		}},
+		{"DiagnosticIter", func() error {
+			for value := range e.DiagnosticIter() {
+				return fmt.Errorf("unexpected diagnostic: %q", value)
+			}
+			return nil
+		}},
+		{"FactIterE", func() error {
+			count := 0
+			for value, err := range e.FactIterE() {
+				count++
+				if !reflect.DeepEqual(value, Fact{}) {
+					return fmt.Errorf("fact = %#v, want zero", value)
+				}
+				if err := wantClosed(err); err != nil {
+					return err
+				}
+			}
+			if count != 1 {
+				return fmt.Errorf("yield count = %d, want 1", count)
+			}
+			return nil
+		}},
+		{"RuleIterE", func() error {
+			count := 0
+			for value, err := range e.RuleIterE() {
+				count++
+				if value != (RuleInfo{}) {
+					return fmt.Errorf("rule = %#v, want zero", value)
+				}
+				if err := wantClosed(err); err != nil {
+					return err
+				}
+			}
+			if count != 1 {
+				return fmt.Errorf("yield count = %d, want 1", count)
+			}
+			return nil
+		}},
+		{"TemplateIterE", func() error {
+			count := 0
+			for value, err := range e.TemplateIterE() {
+				count++
+				if value != "" {
+					return fmt.Errorf("template = %q, want empty", value)
+				}
+				if err := wantClosed(err); err != nil {
+					return err
+				}
+			}
+			if count != 1 {
+				return fmt.Errorf("yield count = %d, want 1", count)
+			}
+			return nil
+		}},
+		{"DiagnosticIterE", func() error {
+			count := 0
+			for value, err := range e.DiagnosticIterE() {
+				count++
+				if value != "" {
+					return fmt.Errorf("diagnostic = %q, want empty", value)
+				}
+				if err := wantClosed(err); err != nil {
+					return err
+				}
+			}
+			if count != 1 {
+				return fmt.Errorf("yield count = %d, want 1", count)
+			}
+			return nil
+		}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := test.call(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestEngineCloseWaitsForInFlightFFI(t *testing.T) {
+	withFFIHooks(t)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var inFlight atomic.Bool
+	var freedDuringCall atomic.Bool
+
+	ffiEngineFactCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) {
+		inFlight.Store(true)
+		close(entered)
+		<-release
+		inFlight.Store(false)
+		return 0, ffi.ErrOK
+	}
+	ffiEngineFree = func(ffi.EngineHandle) ffi.ErrorCode {
+		if inFlight.Load() {
+			freedDuringCall.Store(true)
+		}
+		return ffi.ErrOK
+	}
+
+	e := &Engine{}
+	callDone := make(chan error, 1)
+	go func() {
+		_, err := e.FactCount()
+		callDone <- err
+	}()
+	<-entered
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- e.Close()
+	}()
+	close(release)
+
+	if err := <-callDone; err != nil {
+		t.Fatalf("FactCount: %v", err)
+	}
+	if err := <-closeDone; err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if freedDuringCall.Load() {
+		t.Fatal("Close freed the native engine while FactCount was in flight")
+	}
+}
+
+func TestEngineConcurrentCleanupFreesExactlyOnce(t *testing.T) {
+	withFFIHooks(t)
+
+	var freeCalls atomic.Int64
+	free := func(ffi.EngineHandle) ffi.ErrorCode {
+		freeCalls.Add(1)
+		return ffi.ErrOK
+	}
+	ffiEngineFree = free
+	ffiEngineFreeUnchecked = free
+
+	e := &Engine{}
+	const closers = 32
+	errs := make(chan error, closers+1)
+	var wg sync.WaitGroup
+	wg.Add(closers + 1)
+	for range closers {
+		go func() {
+			defer wg.Done()
+			errs <- e.Close()
+		}()
+	}
+	go func() {
+		defer wg.Done()
+		finalizeEngine(e)
+		errs <- nil
+	}()
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+	}
+	if got := freeCalls.Load(); got != 1 {
+		t.Fatalf("native free calls = %d, want 1", got)
+	}
+}
+
+func TestEngineFailedCloseRemainsRetryable(t *testing.T) {
+	withFFIHooks(t)
+
+	freeCalls := 0
+	ffiEngineFree = func(ffi.EngineHandle) ffi.ErrorCode {
+		freeCalls++
+		if freeCalls == 1 {
+			return ffi.ErrThreadViolation
+		}
+		return ffi.ErrOK
+	}
+	factCalls := 0
+	ffiEngineFactCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) {
+		factCalls++
+		return 7, ffi.ErrOK
+	}
+
+	e := &Engine{}
+	if err := e.Close(); !errors.Is(err, ErrThreadViolation) {
+		t.Fatalf("first Close error = %v, want ErrThreadViolation", err)
+	}
+	if count, err := e.FactCount(); err != nil || count != 7 {
+		t.Fatalf("FactCount after failed Close = (%d, %v), want (7, nil)", count, err)
+	}
+	if err := e.Close(); err != nil {
+		t.Fatalf("retry Close: %v", err)
+	}
+	if freeCalls != 2 {
+		t.Fatalf("native free calls = %d, want 2", freeCalls)
+	}
+	if factCalls != 1 {
+		t.Fatalf("native fact-count calls = %d, want 1", factCalls)
+	}
+}
+
+//nolint:funlen // Every engine FFI hook must fail independently if a closed method reaches it.
+func forbidEngineOperationFFI(t *testing.T) {
+	t.Helper()
+	called := func(name string) {
+		t.Helper()
+		t.Errorf("post-close %s reached FFI", name)
+	}
+
+	ffiEngineLoadString = func(ffi.EngineHandle, string) ffi.ErrorCode {
+		called("Load")
+		return ffi.ErrOK
+	}
+	ffiEngineAssertString = func(ffi.EngineHandle, string) (uint64, ffi.ErrorCode) {
+		called("AssertString")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineAssertOrdered = func(ffi.EngineHandle, string, []ffi.Value) (uint64, ffi.ErrorCode) {
+		called("AssertFact")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineAssertTemplate = func(ffi.EngineHandle, string, []string, []ffi.Value) (uint64, ffi.ErrorCode) {
+		called("AssertTemplate")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineRetract = func(ffi.EngineHandle, uint64) ffi.ErrorCode {
+		called("Retract")
+		return ffi.ErrOK
+	}
+	ffiEngineFactIDs = func(ffi.EngineHandle) ([]uint64, ffi.ErrorCode) {
+		called("FactIDs")
+		return nil, ffi.ErrOK
+	}
+	ffiEngineFindFactIDs = func(ffi.EngineHandle, string) ([]uint64, ffi.ErrorCode) {
+		called("FindFactIDs")
+		return nil, ffi.ErrOK
+	}
+	ffiEngineFactCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) {
+		called("FactCount")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		called("Run")
+		return 0, ffi.HaltReasonAgendaEmpty, ffi.ErrOK
+	}
+	ffiEngineStep = func(ffi.EngineHandle) (int32, ffi.ErrorCode) {
+		called("Step")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineHalt = func(ffi.EngineHandle) ffi.ErrorCode {
+		called("Halt")
+		return ffi.ErrOK
+	}
+	ffiEngineReset = func(ffi.EngineHandle) ffi.ErrorCode {
+		called("Reset")
+		return ffi.ErrOK
+	}
+	ffiEngineClear = func(ffi.EngineHandle) ffi.ErrorCode {
+		called("Clear")
+		return ffi.ErrOK
+	}
+	ffiEngineSerializeAs = func(ffi.EngineHandle, ffi.SerializationFormat) ([]byte, ffi.ErrorCode) {
+		called("Serialize")
+		return nil, ffi.ErrOK
+	}
+	ffiEngineRuleCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) {
+		called("RuleCount")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineRuleInfo = func(ffi.EngineHandle, uintptr) (string, int32, ffi.ErrorCode) {
+		called("RuleInfo")
+		return "", 0, ffi.ErrOK
+	}
+	ffiEngineTemplateCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) {
+		called("TemplateCount")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineTemplateName = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
+		called("TemplateName")
+		return "", ffi.ErrOK
+	}
+	ffiEngineGetGlobal = func(ffi.EngineHandle, string) (ffi.Value, ffi.ErrorCode) {
+		called("GetGlobal")
+		return ffi.Value{}, ffi.ErrOK
+	}
+	ffiEngineCurrentModule = func(ffi.EngineHandle) (string, ffi.ErrorCode) {
+		called("CurrentModule")
+		return "", ffi.ErrOK
+	}
+	ffiEngineGetFocus = func(ffi.EngineHandle) (string, ffi.ErrorCode) {
+		called("GetFocus")
+		return "", ffi.ErrOK
+	}
+	ffiEngineFocusStackDepth = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) {
+		called("FocusStackDepth")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineFocusStackEntry = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
+		called("FocusStackEntry")
+		return "", ffi.ErrOK
+	}
+	ffiEngineAgendaCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) {
+		called("AgendaCount")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineIsHalted = func(ffi.EngineHandle) (bool, ffi.ErrorCode) {
+		called("IsHalted")
+		return false, ffi.ErrOK
+	}
+	ffiEngineGetOutput = func(ffi.EngineHandle, string) (string, bool) {
+		called("GetOutput")
+		return "", false
+	}
+	ffiEngineClearOutput = func(ffi.EngineHandle, string) ffi.ErrorCode {
+		called("ClearOutput")
+		return ffi.ErrOK
+	}
+	ffiEnginePushInput = func(ffi.EngineHandle, string) ffi.ErrorCode {
+		called("PushInput")
+		return ffi.ErrOK
+	}
+	ffiEngineActionDiagnosticCount = func(ffi.EngineHandle) (uintptr, ffi.ErrorCode) {
+		called("DiagnosticCount")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineActionDiagnosticCopy = func(ffi.EngineHandle, uintptr) (string, ffi.ErrorCode) {
+		called("DiagnosticCopy")
+		return "", ffi.ErrOK
+	}
+	ffiEngineClearActionDiagnostics = func(ffi.EngineHandle) ffi.ErrorCode {
+		called("ClearDiagnostics")
+		return ffi.ErrOK
+	}
+	ffiEngineGetFactType = func(ffi.EngineHandle, uint64) (ffi.FactType, ffi.ErrorCode) {
+		called("GetFactType")
+		return ffi.FactTypeOrdered, ffi.ErrOK
+	}
+	ffiEngineGetFactFieldCount = func(ffi.EngineHandle, uint64) (uintptr, ffi.ErrorCode) {
+		called("GetFactFieldCount")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineGetFactField = func(ffi.EngineHandle, uint64, uintptr) (ffi.Value, ffi.ErrorCode) {
+		called("GetFactField")
+		return ffi.Value{}, ffi.ErrOK
+	}
+	ffiEngineGetFactTemplateName = func(ffi.EngineHandle, uint64) (string, ffi.ErrorCode) {
+		called("GetFactTemplateName")
+		return "", ffi.ErrOK
+	}
+	ffiEngineTemplateSlotCount = func(ffi.EngineHandle, string) (uintptr, ffi.ErrorCode) {
+		called("TemplateSlotCount")
+		return 0, ffi.ErrOK
+	}
+	ffiEngineTemplateSlotName = func(ffi.EngineHandle, string, uintptr) (string, ffi.ErrorCode) {
+		called("TemplateSlotName")
+		return "", ffi.ErrOK
+	}
+	ffiEngineGetFactRelation = func(ffi.EngineHandle, uint64) (string, ffi.ErrorCode) {
+		called("GetFactRelation")
+		return "", ffi.ErrOK
+	}
+}

--- a/bindings/go/errors.go
+++ b/bindings/go/errors.go
@@ -39,6 +39,7 @@ var (
 	ErrThreadViolation = errors.New("ferric: thread violation")
 	ErrInvalidArgument = errors.New("ferric: invalid argument")
 	ErrSerialization   = errors.New("ferric: serialization error")
+	ErrEngineClosed    = errors.New("ferric: engine closed")
 )
 
 // ---------------------------------------------------------------------------

--- a/bindings/go/iterators.go
+++ b/bindings/go/iterators.go
@@ -2,24 +2,18 @@ package ferric
 
 import (
 	"iter"
-
-	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
 )
 
 // FactIter returns an iterator over all user-visible facts.
 // Each iteration yields a Fact snapshot. Stops early on error.
 func (e *Engine) FactIter() iter.Seq[Fact] {
 	return func(yield func(Fact) bool) {
-		ids, rc := ffiEngineFactIDs(e.handle)
-		if rc != ffi.ErrOK {
+		facts, err := e.Facts()
+		if err != nil {
 			return
 		}
-		for _, id := range ids {
-			f, err := e.buildFact(id)
-			if err != nil {
-				return
-			}
-			if !yield(*f) {
+		for _, fact := range facts {
+			if !yield(fact) {
 				return
 			}
 		}
@@ -29,16 +23,9 @@ func (e *Engine) FactIter() iter.Seq[Fact] {
 // RuleIter returns an iterator over all registered rules.
 func (e *Engine) RuleIter() iter.Seq[RuleInfo] {
 	return func(yield func(RuleInfo) bool) {
-		count, rc := ffiEngineRuleCount(e.handle)
-		if rc != ffi.ErrOK {
-			return
-		}
-		for i := range count {
-			name, salience, rc := ffiEngineRuleInfo(e.handle, i)
-			if rc != ffi.ErrOK {
-				return
-			}
-			if !yield(RuleInfo{Name: name, Salience: int(salience)}) {
+		rules := e.Rules()
+		for _, rule := range rules {
+			if !yield(rule) {
 				return
 			}
 		}
@@ -48,15 +35,8 @@ func (e *Engine) RuleIter() iter.Seq[RuleInfo] {
 // TemplateIter returns an iterator over all registered template names.
 func (e *Engine) TemplateIter() iter.Seq[string] {
 	return func(yield func(string) bool) {
-		count, rc := ffiEngineTemplateCount(e.handle)
-		if rc != ffi.ErrOK {
-			return
-		}
-		for i := range count {
-			name, rc := ffiEngineTemplateName(e.handle, i)
-			if rc != ffi.ErrOK {
-				return
-			}
+		names := e.Templates()
+		for _, name := range names {
 			if !yield(name) {
 				return
 			}
@@ -67,15 +47,8 @@ func (e *Engine) TemplateIter() iter.Seq[string] {
 // DiagnosticIter returns an iterator over action diagnostic messages.
 func (e *Engine) DiagnosticIter() iter.Seq[string] {
 	return func(yield func(string) bool) {
-		count, rc := ffiEngineActionDiagnosticCount(e.handle)
-		if rc != ffi.ErrOK {
-			return
-		}
-		for i := range count {
-			msg, rc := ffiEngineActionDiagnosticCopy(e.handle, i)
-			if rc != ffi.ErrOK {
-				return
-			}
+		diagnostics := e.Diagnostics()
+		for _, msg := range diagnostics {
 			if !yield(msg) {
 				return
 			}
@@ -92,18 +65,13 @@ func (e *Engine) DiagnosticIter() iter.Seq[string] {
 // a final (Fact{}, err) is yielded and iteration stops.
 func (e *Engine) FactIterE() iter.Seq2[Fact, error] {
 	return func(yield func(Fact, error) bool) {
-		ids, rc := ffiEngineFactIDs(e.handle)
-		if rc != ffi.ErrOK {
-			yield(Fact{}, errorFromFFI(rc, e.handle))
+		facts, err := e.Facts()
+		if err != nil {
+			yield(Fact{}, err)
 			return
 		}
-		for _, id := range ids {
-			f, err := e.buildFact(id)
-			if err != nil {
-				yield(Fact{}, err)
-				return
-			}
-			if !yield(*f, nil) {
+		for _, fact := range facts {
+			if !yield(fact, nil) {
 				return
 			}
 		}
@@ -115,18 +83,13 @@ func (e *Engine) FactIterE() iter.Seq2[Fact, error] {
 // a final (RuleInfo{}, err) is yielded and iteration stops.
 func (e *Engine) RuleIterE() iter.Seq2[RuleInfo, error] {
 	return func(yield func(RuleInfo, error) bool) {
-		count, rc := ffiEngineRuleCount(e.handle)
-		if rc != ffi.ErrOK {
-			yield(RuleInfo{}, errorFromFFI(rc, e.handle))
+		rules, err := e.RulesE()
+		if err != nil {
+			yield(RuleInfo{}, err)
 			return
 		}
-		for i := range count {
-			name, salience, rc := ffiEngineRuleInfo(e.handle, i)
-			if rc != ffi.ErrOK {
-				yield(RuleInfo{}, errorFromFFI(rc, e.handle))
-				return
-			}
-			if !yield(RuleInfo{Name: name, Salience: int(salience)}, nil) {
+		for _, rule := range rules {
+			if !yield(rule, nil) {
 				return
 			}
 		}
@@ -138,17 +101,12 @@ func (e *Engine) RuleIterE() iter.Seq2[RuleInfo, error] {
 // error occurs, a final ("", err) is yielded and iteration stops.
 func (e *Engine) TemplateIterE() iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
-		count, rc := ffiEngineTemplateCount(e.handle)
-		if rc != ffi.ErrOK {
-			yield("", errorFromFFI(rc, e.handle))
+		names, err := e.TemplatesE()
+		if err != nil {
+			yield("", err)
 			return
 		}
-		for i := range count {
-			name, rc := ffiEngineTemplateName(e.handle, i)
-			if rc != ffi.ErrOK {
-				yield("", errorFromFFI(rc, e.handle))
-				return
-			}
+		for _, name := range names {
 			if !yield(name, nil) {
 				return
 			}
@@ -161,17 +119,12 @@ func (e *Engine) TemplateIterE() iter.Seq2[string, error] {
 // occurs, a final ("", err) is yielded and iteration stops.
 func (e *Engine) DiagnosticIterE() iter.Seq2[string, error] {
 	return func(yield func(string, error) bool) {
-		count, rc := ffiEngineActionDiagnosticCount(e.handle)
-		if rc != ffi.ErrOK {
-			yield("", errorFromFFI(rc, e.handle))
+		diagnostics, err := e.DiagnosticsE()
+		if err != nil {
+			yield("", err)
 			return
 		}
-		for i := range count {
-			msg, rc := ffiEngineActionDiagnosticCopy(e.handle, i)
-			if rc != ffi.ErrOK {
-				yield("", errorFromFFI(rc, e.handle))
-				return
-			}
+		for _, msg := range diagnostics {
 			if !yield(msg, nil) {
 				return
 			}

--- a/justfile
+++ b/justfile
@@ -80,6 +80,11 @@ ffi-c-harness:
 ffi-tsan-harness:
     ./scripts/ffi-tsan-harness.sh
 
+# Build the Rust static library and Go cgo binding with AddressSanitizer, then
+# run the real-handle post-Close lifecycle regression (Linux amd64/arm64)
+ffi-go-asan-harness:
+    ./scripts/ffi-go-asan-harness.sh
+
 # Run tests for the facade crate
 test-ferric:
     cargo test -p ferric

--- a/scripts/ffi-go-asan-harness.sh
+++ b/scripts/ffi-go-asan-harness.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Build the Rust static library with AddressSanitizer instrumentation, link it
+# into Go's cgo binding under Go's ASan mode, and run the real-handle
+# post-Close regression test.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+if [[ $(uname -s) != Linux ]]; then
+    echo "ffi-go-asan-harness: requires Linux" >&2
+    exit 1
+fi
+
+asan_toolchain="${FERRIC_ASAN_TOOLCHAIN:-nightly-2025-11-04}"
+case "$(uname -m)" in
+x86_64)
+    asan_target="x86_64-unknown-linux-gnu"
+    ;;
+aarch64 | arm64)
+    asan_target="aarch64-unknown-linux-gnu"
+    ;;
+*)
+    echo "ffi-go-asan-harness: unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+outdir="$root/target/ffi-go-asan"
+staticlib="$outdir/$asan_target/ffi-dev/libferric_ffi.a"
+go_staticlib="$root/bindings/go/internal/ffi/lib/libferric_ffi.a"
+backup_dir="$(mktemp -d)"
+had_staticlib=0
+
+restore_staticlib() {
+    if ((had_staticlib)); then
+        cp "$backup_dir/libferric_ffi.a" "$go_staticlib"
+    else
+        rm -f "$go_staticlib"
+    fi
+    rm -rf "$backup_dir"
+}
+trap restore_staticlib EXIT
+
+for command in go nm; do
+    if ! command -v "$command" >/dev/null 2>&1; then
+        echo "ffi-go-asan-harness: required command not found: $command" >&2
+        exit 1
+    fi
+done
+
+if [[ -f "$go_staticlib" ]]; then
+    cp "$go_staticlib" "$backup_dir/libferric_ffi.a"
+    had_staticlib=1
+fi
+
+CARGO_TARGET_DIR="$outdir" \
+CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}" \
+RUSTFLAGS="-Zsanitizer=address -Zexternal-clangrt -Cforce-frame-pointers=yes" \
+    cargo +"$asan_toolchain" rustc \
+        --locked \
+        -Zbuild-std=std,panic_abort \
+        --target "$asan_target" \
+        -p ferric-ffi \
+        --profile ffi-dev \
+        --features serde \
+        --crate-type staticlib
+
+if ! nm -u "$staticlib" | grep "__asan_" >/dev/null; then
+    echo "ffi-go-asan-harness: Rust static library has no ASan instrumentation" >&2
+    exit 1
+fi
+
+cp "$staticlib" "$go_staticlib"
+
+cd bindings/go
+ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=1:halt_on_error=1}" \
+    go test -asan -count=1 -run '^TestEngineRealFFIPostClose$' .


### PR DESCRIPTION
Closes #96

## Summary

- serialize `Engine` cleanup with a shared read/write lifecycle guard and atomically clear the native handle exactly once
- add `ErrEngineClosed` and require every direct method and iterator to lease the handle or return its documented post-close zero/no-op form
- share cleanup between explicit `Close` and the finalizer while preserving retry after a thread-affine free failure
- add exhaustive no-FFI-after-close, concurrent close/call, and exact-once free regression coverage
- add a native Linux Rust/Go AddressSanitizer harness and CI job

## Validation

- `just build-go-ffi`
- `just test-go-race`
- `just test-go-stress 50`
- `just preflight-pr`
- Linux Rust/Go AddressSanitizer CI harness