### PR TITLE
[FR-GO-002] Use Ferric-owned multifield copies in Go

### DIFF
--- a/bindings/go/CI_POLICY.md
+++ b/bindings/go/CI_POLICY.md
@@ -40,3 +40,22 @@ Stress-test failures typically indicate:
 
 If a stress-test failure is not reproducible locally, increase the count
 (`-count=50` or higher) or try running on a Linux VM to match CI conditions.
+
+## Native ownership sanitizer
+
+The **Go/C Lifecycle (AddressSanitizer)** job builds the Rust static library
+and the cgo test binaries with AddressSanitizer on Linux. Its focused
+regressions cover post-`Close` calls plus empty, mixed, deeply nested, large,
+and failed multifield construction. LeakSanitizer is enabled so both successful
+copy/free cycles and partial conversion failures must release every
+Ferric-owned allocation.
+
+Go slices passed to `AssertFact` or `AssertTemplate` remain caller-owned.
+The binding borrows their converted elements only while calling
+`ferric_value_multifield_copy`; the returned recursive tree is entirely
+Ferric-owned and is released through `ferric_value_free`. No Go or C allocator
+storage is transferred to Rust's value cleanup.
+
+Run `just ffi-go-asan-harness` on a native Linux host to reproduce this job.
+The broader operating-system and clean-consumer binding matrix is tracked
+separately by FR-DIST-008.

--- a/bindings/go/coverage_edge_test.go
+++ b/bindings/go/coverage_edge_test.go
@@ -65,6 +65,7 @@ func resetFFIHooks() {
 	ffiEngineTemplateSlotCount = ffi.EngineTemplateSlotCount
 	ffiEngineTemplateSlotName = ffi.EngineTemplateSlotName
 	ffiEngineGetFactRelation = ffi.EngineGetFactRelation
+	ffiValueMultifieldCopy = ffi.ValueMultifieldCopy
 	ffiValueFree = ffi.ValueFree
 	factsToWire = FactsToWire
 }
@@ -308,12 +309,42 @@ func TestManualFFIValueConversionEdges(t *testing.T) {
 	t.Run("multifield error frees converted elements", func(t *testing.T) {
 		withFFIHooks(t)
 		freed := 0
-		ffiValueFree = func(*ffi.Value) { freed++ }
-		if _, err := goToFFIValue([]any{"a", "b", struct{}{}}); !errors.Is(err, errUnsupportedGoTypeForFFI) {
+		ffiValueFree = func(value *ffi.Value) {
+			freed++
+			ffi.ValueFree(value)
+		}
+		if _, err := goToFFIValue([]any{"a", []any{"b"}, struct{}{}}); !errors.Is(err, errUnsupportedGoTypeForFFI) {
 			t.Fatalf("expected unsupported error, got %v", err)
 		}
-		if freed != 2 {
-			t.Fatalf("freed %d converted elements, want 2", freed)
+		if freed != 3 {
+			t.Fatalf("freed %d converted values, want 3", freed)
+		}
+	})
+
+	t.Run("multifield copy failure frees every borrowed element", func(t *testing.T) {
+		withFFIHooks(t)
+		copied := 0
+		freed := 0
+		ffiValueMultifieldCopy = func(elements []ffi.Value) (ffi.Value, ffi.ErrorCode) {
+			copied++
+			if len(elements) != 3 {
+				t.Fatalf("copy received %d elements, want 3", len(elements))
+			}
+			return ffi.ValueVoid(), ffi.ErrInvalidArgument
+		}
+		ffiValueFree = func(value *ffi.Value) {
+			freed++
+			ffi.ValueFree(value)
+		}
+
+		if _, err := goToFFIValue([]any{"a", Symbol("b"), int64(3)}); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("copy failure = %v, want ErrInvalidArgument", err)
+		}
+		if copied != 1 {
+			t.Fatalf("copy called %d times, want 1", copied)
+		}
+		if freed != 3 {
+			t.Fatalf("freed %d borrowed elements, want 3", freed)
 		}
 	})
 

--- a/bindings/go/engine.go
+++ b/bindings/go/engine.go
@@ -261,6 +261,9 @@ func (e *Engine) AssertString(source string) (uint64, error) {
 }
 
 // AssertFact asserts an ordered fact with the given relation and fields.
+// Slice values are recursively copied into temporary Ferric-owned multifields;
+// the Go inputs remain caller-owned and are not retained by Ferric. Nested
+// slices deeper than 128 levels return ErrInvalidArgument.
 func (e *Engine) AssertFact(relation string, fields ...any) (uint64, error) {
 	handle, release, err := e.leaseHandle()
 	if err != nil {
@@ -290,6 +293,9 @@ func (e *Engine) AssertFact(relation string, fields ...any) (uint64, error) {
 }
 
 // AssertTemplate asserts a template fact with named slot values.
+// Slice values are recursively copied into temporary Ferric-owned multifields;
+// the Go inputs remain caller-owned and are not retained by Ferric. Nested
+// slices deeper than 128 levels return ErrInvalidArgument.
 func (e *Engine) AssertTemplate(templateName string, slots map[string]any) (uint64, error) {
 	handle, release, err := e.leaseHandle()
 	if err != nil {

--- a/bindings/go/ffi_hooks.go
+++ b/bindings/go/ffi_hooks.go
@@ -50,6 +50,7 @@ var (
 	ffiEngineTemplateSlotCount      = ffi.EngineTemplateSlotCount
 	ffiEngineTemplateSlotName       = ffi.EngineTemplateSlotName
 	ffiEngineGetFactRelation        = ffi.EngineGetFactRelation
+	ffiValueMultifieldCopy          = ffi.ValueMultifieldCopy
 	ffiValueFree                    = ffi.ValueFree
 )
 

--- a/bindings/go/internal/ffi/coverage_edge_test.go
+++ b/bindings/go/internal/ffi/coverage_edge_test.go
@@ -53,10 +53,17 @@ func TestManualValueAccessorsAndConstructors(t *testing.T) {
 	}
 	ValueFree(&str)
 
-	multifield := ValueMultifield([]Value{
+	multifieldElements := []Value{
 		ValueInteger(1),
 		ValueString("nested"),
-	})
+	}
+	multifield, rc := ValueMultifieldCopy(multifieldElements)
+	for i := range multifieldElements {
+		ValueFree(&multifieldElements[i])
+	}
+	if rc != ErrOK {
+		t.Fatalf("ValueMultifieldCopy returned %d", rc)
+	}
 	if ValueGetType(&multifield) != ValueTypeMultifield {
 		t.Fatalf("multifield type mismatch")
 	}
@@ -68,7 +75,10 @@ func TestManualValueAccessorsAndConstructors(t *testing.T) {
 	}
 	ValueFree(&multifield)
 
-	emptyMultifield := ValueMultifield(nil)
+	emptyMultifield, rc := ValueMultifieldCopy(nil)
+	if rc != ErrOK {
+		t.Fatalf("empty ValueMultifieldCopy returned %d", rc)
+	}
 	if ValueGetType(&emptyMultifield) != ValueTypeMultifield || ValueGetMultifieldLen(&emptyMultifield) != 0 {
 		t.Fatalf("empty multifield accessor mismatch")
 	}
@@ -847,7 +857,10 @@ func TestPropertyNativeFFISurfaceSweep(t *testing.T) {
 			rt.Fatalf("void string ptr = %q, want empty", got)
 		}
 		_ = ValueGetExternalPointer(&void)
-		emptyMulti := ValueMultifield(nil)
+		emptyMulti, rc := ValueMultifieldCopy(nil)
+		if rc != ErrOK {
+			rt.Fatalf("empty ValueMultifieldCopy returned %d", rc)
+		}
 		if ValueGetMultifieldLen(&emptyMulti) != 0 {
 			rt.Fatal("empty multifield length mismatch")
 		}
@@ -856,7 +869,14 @@ func TestPropertyNativeFFISurfaceSweep(t *testing.T) {
 			rt.Fatal("symbol accessor mismatch")
 		}
 		ValueFree(&symbol)
-		multi := ValueMultifield([]Value{ValueString("nested")})
+		multiElements := []Value{ValueString("nested")}
+		multi, rc := ValueMultifieldCopy(multiElements)
+		for i := range multiElements {
+			ValueFree(&multiElements[i])
+		}
+		if rc != ErrOK {
+			rt.Fatalf("ValueMultifieldCopy returned %d", rc)
+		}
 		if ValueGetMultifieldLen(&multi) != 1 {
 			rt.Fatal("multifield length mismatch")
 		}

--- a/bindings/go/internal/ffi/ffi.go
+++ b/bindings/go/internal/ffi/ffi.go
@@ -583,24 +583,23 @@ func ValueVoid() Value {
 	return Value(C.ferric_value_void())
 }
 
-// ValueMultifield creates a multifield FerricValue from a slice of elements.
-// The returned Value owns the heap-allocated element array; callers must
-// free it with ValueFree (which handles recursive cleanup).
-func ValueMultifield(elements []Value) Value {
-	var v C.struct_FerricValue
-	v.value_type = C.FERRIC_VALUE_TYPE_MULTIFIELD
-	if len(elements) == 0 {
-		return Value(v)
+// ValueMultifieldCopy deep-copies borrowed elements into a Ferric-owned
+// multifield. The input slice and every value reachable from it remain owned
+// by the caller and must be released separately. On success, callers must
+// release the returned Value with ValueFree.
+func ValueMultifieldCopy(elements []Value) (Value, ErrorCode) {
+	var elementsPtr *C.struct_FerricValue
+	if len(elements) > 0 {
+		elementsPtr = &elements[0]
 	}
-	size := C.size_t(len(elements)) * C.size_t(unsafe.Sizeof(C.struct_FerricValue{}))
-	ptr := (*C.struct_FerricValue)(C.malloc(size))
-	arr := unsafe.Slice(ptr, len(elements))
-	for i, elem := range elements {
-		arr[i] = C.struct_FerricValue(elem)
-	}
-	v.multifield_ptr = ptr
-	v.multifield_len = C.uintptr_t(len(elements))
-	return Value(v)
+
+	var result C.struct_FerricValue
+	rc := ErrorCode(C.ferric_value_multifield_copy(
+		elementsPtr,
+		C.uintptr_t(len(elements)),
+		&result, //nolint:gocritic // dupSubExpr false positive in cgo-generated code
+	))
+	return Value(result), rc
 }
 
 // ---------------------------------------------------------------------------

--- a/bindings/go/internal/ffi/multifield_ownership_test.go
+++ b/bindings/go/internal/ffi/multifield_ownership_test.go
@@ -1,0 +1,82 @@
+package ffi
+
+import "testing"
+
+func TestValueMultifieldCopyEmpty(t *testing.T) {
+	result, rc := ValueMultifieldCopy(nil)
+	if rc != ErrOK {
+		t.Fatalf("ValueMultifieldCopy(nil) returned %d", rc)
+	}
+	defer ValueFree(&result)
+	if got := ValueGetType(&result); got != ValueTypeMultifield {
+		t.Fatalf("empty result type = %d, want multifield", got)
+	}
+	if got := ValueGetMultifieldLen(&result); got != 0 {
+		t.Fatalf("empty result length = %d, want 0", got)
+	}
+}
+
+func TestValueMultifieldCopyOwnsIndependentNestedTree(t *testing.T) {
+	sourceString := ValueString("borrowed")
+	nestedSource, rc := ValueMultifieldCopy([]Value{
+		ValueInteger(7),
+		sourceString,
+	})
+	if rc != ErrOK {
+		ValueFree(&sourceString)
+		t.Fatalf("nested ValueMultifieldCopy returned %d", rc)
+	}
+
+	sourceSymbol := ValueSymbol("outer")
+	result, rc := ValueMultifieldCopy([]Value{
+		sourceSymbol,
+		nestedSource,
+	})
+	if rc != ErrOK {
+		ValueFree(&sourceString)
+		ValueFree(&nestedSource)
+		ValueFree(&sourceSymbol)
+		t.Fatalf("outer ValueMultifieldCopy returned %d", rc)
+	}
+	defer ValueFree(&result)
+
+	// The copy API borrows its inputs. Releasing every source value must leave
+	// the recursively Ferric-owned result intact.
+	ValueFree(&sourceString)
+	ValueFree(&nestedSource)
+	ValueFree(&sourceSymbol)
+
+	if got := ValueGetMultifieldLen(&result); got != 2 {
+		t.Fatalf("outer multifield length = %d, want 2", got)
+	}
+	outerSymbol := ValueGetMultifieldElement(&result, 0)
+	if got := ValueGetStringPtr(&outerSymbol); got != "outer" {
+		t.Fatalf("outer symbol = %q, want outer", got)
+	}
+	nested := ValueGetMultifieldElement(&result, 1)
+	if got := ValueGetMultifieldLen(&nested); got != 2 {
+		t.Fatalf("nested multifield length = %d, want 2", got)
+	}
+	nestedInteger := ValueGetMultifieldElement(&nested, 0)
+	if got := ValueGetInteger(&nestedInteger); got != 7 {
+		t.Fatalf("nested integer = %d, want 7", got)
+	}
+	nestedString := ValueGetMultifieldElement(&nested, 1)
+	if got := ValueGetStringPtr(&nestedString); got != "borrowed" {
+		t.Fatalf("nested string = %q, want borrowed", got)
+	}
+}
+
+func TestValueMultifieldCopyRejectsInvalidNestedTag(t *testing.T) {
+	invalid := ValueVoid()
+	invalid.value_type = ValueType(9999)
+
+	result, rc := ValueMultifieldCopy([]Value{invalid})
+	if rc != ErrInvalidArgument {
+		t.Fatalf("invalid nested tag returned %d, want %d", rc, ErrInvalidArgument)
+	}
+	if got := ValueGetType(&result); got != ValueTypeVoid {
+		t.Fatalf("failed copy result type = %d, want void", got)
+	}
+	ValueFree(&result)
+}

--- a/bindings/go/multifield_ownership_test.go
+++ b/bindings/go/multifield_ownership_test.go
@@ -1,0 +1,111 @@
+package ferric
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+//nolint:funlen // The table keeps the required empty, nested, mixed, and large ownership cases together.
+func TestMultifieldAllocatorProvenanceRoundTrip(t *testing.T) {
+	lockThread(t)
+
+	engine, err := NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, engine)
+	mustNoError(t, engine.Reset())
+
+	large := make([]any, 4096)
+	for i := range large {
+		large[i] = int64(i)
+	}
+
+	cases := []struct {
+		name  string
+		input []any
+		want  []any
+	}{
+		{
+			name:  "empty",
+			input: []any{},
+			want:  []any{},
+		},
+		{
+			name: "nested",
+			input: []any{
+				Symbol("outer"),
+				[]any{
+					int64(7),
+					[]any{"deep", Symbol("leaf")},
+				},
+			},
+			want: []any{
+				Symbol("outer"),
+				[]any{
+					int64(7),
+					[]any{"deep", Symbol("leaf")},
+				},
+			},
+		},
+		{
+			name:  "mixed",
+			input: []any{nil, int32(3), float32(1.25), Symbol("sym"), "text", true, false},
+			want:  []any{nil, int64(3), float64(float32(1.25)), Symbol("sym"), "text", Symbol("TRUE"), Symbol("FALSE")},
+		},
+		{
+			name:  "large",
+			input: large,
+			want:  large,
+		},
+	}
+
+	for _, tc := range cases {
+		roundTrips := 1
+		if tc.name == "nested" {
+			roundTrips = 100
+		}
+		for range roundTrips {
+			factID, assertErr := engine.AssertFact("multifield-ownership", tc.input)
+			if assertErr != nil {
+				t.Fatalf("%s: AssertFact failed: %v", tc.name, assertErr)
+			}
+			fact, getErr := engine.GetFact(factID)
+			if getErr != nil {
+				t.Fatalf("%s: GetFact failed: %v", tc.name, getErr)
+			}
+			if len(fact.Fields) != 1 {
+				t.Fatalf("%s: field count = %d, want 1", tc.name, len(fact.Fields))
+			}
+			if !reflect.DeepEqual(fact.Fields[0], tc.want) {
+				t.Fatalf("%s: round trip = %#v, want %#v", tc.name, fact.Fields[0], tc.want)
+			}
+			if retractErr := engine.Retract(factID); retractErr != nil {
+				t.Fatalf("%s: Retract failed: %v", tc.name, retractErr)
+			}
+		}
+	}
+}
+
+func TestMultifieldCopyDepthBoundaryCleansUp(t *testing.T) {
+	var nested any = int64(1)
+	for range maxMultifieldNestingDepth {
+		nested = []any{nested}
+	}
+
+	value, err := goToFFIValue(nested)
+	if err != nil {
+		t.Fatalf("%d-level multifield failed: %v", maxMultifieldNestingDepth, err)
+	}
+	ffiValueFree(&value)
+
+	nested = []any{nested}
+	value, err = goToFFIValue(nested)
+	if !errors.Is(err, ErrInvalidArgument) {
+		if err == nil {
+			ffiValueFree(&value)
+		}
+		t.Fatalf("%d-level multifield error = %v, want ErrInvalidArgument", maxMultifieldNestingDepth+1, err)
+	}
+}

--- a/bindings/go/values.go
+++ b/bindings/go/values.go
@@ -11,13 +11,21 @@ var (
 	errUnsupportedGoTypeForFFI = errors.New("ferric: unsupported Go type for FFI conversion")
 )
 
+const maxMultifieldNestingDepth = 128
+
 // Symbol is a distinct type representing a CLIPS symbol value.
 // Symbols are unquoted identifiers (e.g. TRUE, FALSE, foo) as
 // opposed to quoted string literals.
 type Symbol string
 
-// goToFFIValue converts a Go value to a C FerricValue for passing to the FFI layer.
+// goToFFIValue converts a Go value to a Ferric-owned C FerricValue for passing
+// to the FFI layer. Recursive multifields are constructed through Ferric's
+// copy API; no Go- or C-allocated value array is transferred to Rust cleanup.
 func goToFFIValue(v any) (ffi.Value, error) {
+	return goToFFIValueAtDepth(v, 0)
+}
+
+func goToFFIValueAtDepth(v any, depth int) (ffi.Value, error) {
 	switch val := v.(type) {
 	case int:
 		return ffi.ValueInteger(int64(val)), nil
@@ -41,9 +49,16 @@ func goToFFIValue(v any) (ffi.Value, error) {
 	case nil:
 		return ffi.ValueVoid(), nil
 	case []any:
+		if depth >= maxMultifieldNestingDepth {
+			return ffi.Value{}, fmt.Errorf(
+				"%w: multifield nesting exceeds %d levels",
+				ErrInvalidArgument,
+				maxMultifieldNestingDepth,
+			)
+		}
 		elements := make([]ffi.Value, len(val))
 		for i, elem := range val {
-			ev, err := goToFFIValue(elem)
+			ev, err := goToFFIValueAtDepth(elem, depth+1)
 			if err != nil {
 				// Free the elements converted before this failure. Goes through
 				// the ffiValueFree seam (as AssertFact/AssertTemplate do) so the
@@ -55,7 +70,14 @@ func goToFFIValue(v any) (ffi.Value, error) {
 			}
 			elements[i] = ev
 		}
-		return ffi.ValueMultifield(elements), nil
+		result, rc := ffiValueMultifieldCopy(elements)
+		for i := range elements {
+			ffiValueFree(&elements[i])
+		}
+		if rc != ffi.ErrOK {
+			return ffi.Value{}, errorFromFFI(rc, nil)
+		}
+		return result, nil
 	default:
 		return ffi.Value{}, fmt.Errorf("%w: %T", errUnsupportedGoTypeForFFI, v)
 	}

--- a/scripts/ffi-go-asan-harness.sh
+++ b/scripts/ffi-go-asan-harness.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Build the Rust static library with AddressSanitizer instrumentation, link it
 # into Go's cgo binding under Go's ASan mode, and run the real-handle
-# post-Close regression test.
+# lifecycle and recursive multifield-ownership regressions.
 set -euo pipefail
 
 root="$(cd "$(dirname "$0")/.." && pwd)"
@@ -74,4 +74,6 @@ cp "$staticlib" "$go_staticlib"
 
 cd bindings/go
 ASAN_OPTIONS="${ASAN_OPTIONS:-detect_leaks=1:halt_on_error=1}" \
-    go test -asan -count=1 -run '^TestEngineRealFFIPostClose$' .
+    go test -asan -count=1 \
+        -run '^(TestEngineRealFFIPostClose|TestManualFFIValueConversionEdges|TestMultifieldAllocatorProvenanceRoundTrip|TestMultifieldCopyDepthBoundaryCleansUp|TestValueMultifieldCopy.*)$' \
+        . ./internal/ffi


### PR DESCRIPTION
Closes #97

## Scope

FR-GO-002 removes the Go/C/Rust allocator mismatch in recursive multifield construction. The cgo layer now borrows Go slices only for `ferric_value_multifield_copy`, returns wholly Ferric-owned trees, and releases every Ferric-owned source value separately. The former `C.malloc` array path is gone, copy errors propagate through the Go error model, and Go enforces the C contract's 128-level nesting limit.

The focused Linux ASan harness now covers lifecycle plus empty, mixed, nested, large, depth-boundary, and partial-failure multifield cleanup. Go API comments and the binding CI policy document the ownership boundary; the landed C header contract from FR-CABI-008 remains byte-identical. Refs #87 and #124.

## Stack

- Immediate predecessor: none
- Earlier included PRs: none
- Required merge order: this PR only
- Tests require predecessor code: no open predecessor; the required FR-CABI-008 API is already on `main`
- Branch point: `08a9a5b504b377ef7bb7e3e5b250a7d9ffc9cb6c`

## Red-before-fix evidence

`cd bindings/go && go test ./internal/ffi -run '^TestValueMultifieldCopyOwnsIndependentNestedTree$' -count=1` exited 1 on unmodified production code. Compilation failed twice with `undefined: ValueMultifieldCopy`, proving the Go binding had no wrapper for the required Ferric-owned copy boundary. This contract-level reproducer intentionally avoids triggering the old allocator-mismatched free.

## Validation

- `just preflight-pr` — passed
- `just build-go-ffi` — passed; canonical and Go-distributed C headers remain byte-identical
- `just test-go-race` — passed
- `just test-go-stress 10` — passed
- `cd bindings/go && go test -race -run '^TestMultifield' -count=25 .` — passed
- `cd bindings/go && go test -race -run '^TestValueMultifieldCopy' -count=100 ./internal/ffi` — passed
- `just run-golang-ci` — passed with 0 issues
- `cd bindings/go && GOEXPERIMENT=cgocheck2 go test -count=1 -run '^(TestManualFFIValueConversionEdges|TestMultifieldAllocatorProvenanceRoundTrip|TestMultifieldCopyDepthBoundaryCleansUp|TestValueMultifieldCopy.*)$' . ./internal/ffi` — passed
- `rg -n 'C\.malloc|ValueMultifield\(' bindings/go -g '*.go'` — no matches
- `Go/C Lifecycle (AddressSanitizer)` — passed on native Linux in 2m53s with ASan and LeakSanitizer enabled
- PR assessment — passed: no compatibility or performance regressions across 1,207 corpus cases and 135 release benchmarks

## Acceptance criteria

- Allocator/deallocator provenance matches at every level: the Go layer calls `ferric_value_multifield_copy`, frees borrowed Ferric-owned elements individually, and only passes Ferric-owned recursive outputs to `ferric_value_free`; no foreign array allocation remains.
- Success and partial failure are covered: deterministic tests round-trip empty, mixed, 100 repeated nested, and 4,096-element multifields; accept 128 levels and reject 129; reject invalid nested tags with a Void output; and count exact cleanup on nested conversion and copy failures.
- Ownership is documented in Go and C: public Go assertion comments, the internal copy wrapper, and `bindings/go/CI_POLICY.md` align with the already-landed canonical C header contract.
- Sanitizer coverage is blocking: the existing Linux Go/Rust ASan+LeakSanitizer job now runs the new ownership, depth, and cleanup regressions in addition to the lifecycle test.

## Residual risks

The local macOS host cannot execute the Linux-only Go/Rust ASan harness, so its result comes from GitHub CI. The broader Windows and cross-platform clean-consumer allocator matrix remains explicitly owned by FR-DIST-008 (#124).
