### PR TITLE
[FR-LANG-001] Implement non-local return from callables

### DIFF
--- a/crates/ferric-cli/src/commands/compat_observe.rs
+++ b/crates/ferric-cli/src/commands/compat_observe.rs
@@ -429,6 +429,7 @@ fn action_error_diagnostic(error: &ActionError) -> Diagnostic {
         ActionError::InvalidRetract => "invalid-retract",
         ActionError::Encoding(_) => "encoding-error",
         ActionError::EvalError(_) | ActionError::Evaluator(_) => "evaluation-error",
+        ActionError::RuleReturn => "control-flow",
     };
     Diagnostic::warning(Phase::Run, category, error.to_string())
 }

--- a/crates/ferric-runtime/src/actions.rs
+++ b/crates/ferric-runtime/src/actions.rs
@@ -419,6 +419,10 @@ pub enum ActionError {
     EvalError(String),
     #[error("expression evaluation error: {0}")]
     Evaluator(#[from] crate::evaluator::EvalError),
+    /// Internal non-error signal used to unwind the current rule RHS.
+    #[doc(hidden)]
+    #[error("internal rule return control escaped the action sequence")]
+    RuleReturn,
 }
 
 /// Execute actions for a fired rule.
@@ -518,7 +522,7 @@ pub(crate) fn execute_actions(
             .runtime_actions
             .get(index)
             .and_then(Option::as_ref);
-        if let Err(e) = execute_single_action(
+        let action_result = execute_single_action(
             &mut reset_requested,
             &mut clear_requested,
             token,
@@ -528,16 +532,30 @@ pub(crate) fn execute_actions(
             context,
             &mut eval_env,
             collected_facts,
-        ) {
-            ferric_event!(
-                warn,
-                rule = %rule_info.name,
-                action_index = index,
-                action_name = %action.call.name,
-                error = %e,
-                "rule_action_error"
-            );
-            errors.push(e);
+        );
+        match action_result {
+            Ok(()) => {}
+            Err(ActionError::RuleReturn) => {
+                ferric_event!(
+                    debug,
+                    rule = %rule_info.name,
+                    action_index = index,
+                    "rule_action_return"
+                );
+                flush_deferred_printout(context);
+                break;
+            }
+            Err(e) => {
+                ferric_event!(
+                    warn,
+                    rule = %rule_info.name,
+                    action_index = index,
+                    action_name = %action.call.name,
+                    error = %e,
+                    "rule_action_error"
+                );
+                errors.push(e);
+            }
         }
         flush_deferred_printout(context);
         // Stop executing further actions if clear/reset was requested.
@@ -1022,6 +1040,25 @@ fn execute_single_action(
             // CLIPS allows this but it's unusual. We silently ignore it.
             Ok(())
         }
+        "return" => match call.args.as_slice() {
+            [] => Err(ActionError::RuleReturn),
+            [value_expr] => {
+                let _ =
+                    eval_env.eval_expr(token, rule_info, value_expr, context, collected_facts)?;
+                Err(ActionError::RuleReturn)
+            }
+            _ => Err(ActionError::Evaluator(
+                crate::evaluator::EvalError::ArityMismatch {
+                    name: "return".to_string(),
+                    expected: "0 or 1".to_string(),
+                    actual: call.args.len(),
+                    span: Some(crate::evaluator::SourceSpan {
+                        line: call.span.start.line,
+                        column: call.span.start.column,
+                    }),
+                },
+            )),
+        },
         "bind" => {
             if let [ActionExpr::Variable(name, _), value_expr] = call.args.as_slice() {
                 let value =

--- a/crates/ferric-runtime/src/engine.rs
+++ b/crates/ferric-runtime/src/engine.rs
@@ -793,13 +793,15 @@ impl Engine {
         // Execute actions (errors are currently silently ignored).
         // The boolean return indicates whether test CEs passed, but step()
         // always returns Some(fired) to indicate an activation was processed.
-        let (_logically_fired, reset_requested, clear_requested) =
+        let (logically_fired, reset_requested, clear_requested) =
             self.execute_activation_actions(activation.rule, activation.token);
+        #[cfg(not(feature = "tracing"))]
+        let _ = logically_fired;
         ferric_event!(
             debug,
             rule = activation.rule.0,
             token = ?activation.token,
-            logically_fired = _logically_fired,
+            logically_fired,
             reset_requested,
             clear_requested,
             "engine_step_activation_processed"

--- a/crates/ferric-runtime/src/evaluator.rs
+++ b/crates/ferric-runtime/src/evaluator.rs
@@ -119,6 +119,19 @@ pub enum EvalError {
         owning_module: String,
         span: Option<SourceSpan>,
     },
+
+    #[error("`return` is not valid outside a callable at {}", format_span(.span.as_ref()))]
+    ReturnOutsideCallable { span: Option<SourceSpan> },
+
+    /// Internal non-local control signal. Callable boundaries consume this
+    /// variant, and the public evaluator converts an escaped signal into
+    /// [`EvalError::ReturnOutsideCallable`].
+    #[doc(hidden)]
+    #[error("internal return control escaped its callable at {}", format_span(.span.as_ref()))]
+    ReturnControl {
+        value: Value,
+        span: Option<SourceSpan>,
+    },
 }
 
 // ---------------------------------------------------------------------------
@@ -450,17 +463,26 @@ pub fn eval(ctx: &mut EvalContext<'_>, expr: &RuntimeExpr) -> Result<Value, Eval
     #[cfg(feature = "tracing")]
     {
         if EvalRunGuard::is_active() {
-            return eval_inner(ctx, expr);
+            return finish_root_evaluation(eval_inner(ctx, expr));
         }
 
         let _run_guard = EvalRunGuard::enter_root();
         ferric_span!(debug_span, "eval_root", call_depth = ctx.call_depth);
-        return eval_inner(ctx, expr);
+        finish_root_evaluation(eval_inner(ctx, expr))
     }
 
     #[cfg(not(feature = "tracing"))]
     {
-        eval_inner(ctx, expr)
+        finish_root_evaluation(eval_inner(ctx, expr))
+    }
+}
+
+fn finish_root_evaluation(result: Result<Value, EvalError>) -> Result<Value, EvalError> {
+    match result {
+        Err(EvalError::ReturnControl { span, .. }) => {
+            Err(EvalError::ReturnOutsideCallable { span })
+        }
+        other => other,
     }
 }
 
@@ -1132,7 +1154,11 @@ fn execute_callable_body(
 
     let mut result = Value::Void;
     for body_expr in &body_exprs {
-        result = eval_inner(&mut inner_ctx, body_expr)?;
+        match eval_inner(&mut inner_ctx, body_expr) {
+            Ok(value) => result = value,
+            Err(EvalError::ReturnControl { value, .. }) => return Ok(value),
+            Err(error) => return Err(error),
+        }
     }
     Ok(result)
 }
@@ -4826,22 +4852,28 @@ fn builtin_close(
     Ok(clips_true(ctx.symbol_table, ctx.config.string_encoding))
 }
 
-/// `return` — compatibility fallback returning its argument (or VOID).
+/// `return` — unwind the current callable with its argument (or VOID).
 fn builtin_return(
     ctx: &mut EvalContext<'_>,
     args: &[RuntimeExpr],
     span: Option<&SourceSpan>,
 ) -> Result<Value, EvalError> {
-    match args {
-        [] => Ok(Value::Void),
-        [expr] => eval_inner(ctx, expr),
-        _ => Err(EvalError::ArityMismatch {
-            name: "return".to_string(),
-            expected: "0 or 1".to_string(),
-            actual: args.len(),
-            span: span.cloned(),
-        }),
-    }
+    let value = match args {
+        [] => Value::Void,
+        [expr] => eval_inner(ctx, expr)?,
+        _ => {
+            return Err(EvalError::ArityMismatch {
+                name: "return".to_string(),
+                expected: "0 or 1".to_string(),
+                actual: args.len(),
+                span: span.cloned(),
+            });
+        }
+    };
+    Err(EvalError::ReturnControl {
+        value,
+        span: span.cloned(),
+    })
 }
 
 /// `load` — runtime load command placeholder (currently non-mutating).
@@ -8413,15 +8445,30 @@ mod tests {
     }
 
     #[test]
-    fn return_without_argument_returns_void() {
-        let result = eval_expr(&call("return", vec![])).unwrap();
-        assert!(matches!(result, Value::Void));
+    fn return_without_argument_is_invalid_outside_callable() {
+        let error = eval_expr(&call("return", vec![]))
+            .expect_err("top-level return must not escape as an ordinary value");
+        assert!(
+            error.to_string().contains("not valid outside a callable"),
+            "unexpected diagnostic: {error}"
+        );
     }
 
     #[test]
-    fn return_with_argument_returns_value() {
-        let result = eval_expr(&call("return", vec![int(123)])).unwrap();
-        assert!(result.structural_eq(&Value::Integer(123)));
+    fn return_with_argument_is_invalid_outside_callable() {
+        let error = eval_expr(&call("return", vec![int(123)]))
+            .expect_err("top-level return must not escape as an ordinary value");
+        assert!(
+            error.to_string().contains("not valid outside a callable"),
+            "unexpected diagnostic: {error}"
+        );
+    }
+
+    #[test]
+    fn return_argument_error_preserves_original_diagnostic() {
+        let division = call("/", vec![int(1), int(0)]);
+        let result = eval_expr(&call("return", vec![division]));
+        assert!(matches!(result, Err(EvalError::DivisionByZero { .. })));
     }
 
     #[test]

--- a/crates/ferric/tests/clips_compat.rs
+++ b/crates/ferric/tests/clips_compat.rs
@@ -5,7 +5,8 @@
 //! validate the harness itself before compatibility fixtures are added.
 
 use ferric::core::Fact;
-use ferric::runtime::{Engine, EngineConfig, HaltReason, LoadError, RunLimit};
+use ferric::runtime::evaluator::EvalError;
+use ferric::runtime::{ActionError, Engine, EngineConfig, HaltReason, LoadError, RunLimit};
 use std::path::Path;
 
 // ---------------------------------------------------------------------------
@@ -450,6 +451,141 @@ fn test_compat_generics_basic_dispatch() {
 #[test]
 fn test_compat_generics_specificity() {
     let _ = assert_fixture_output("generics/specificity.clp", 1, "integer\n");
+}
+
+// ===========================================================================
+// Callable return compatibility tests
+// ===========================================================================
+
+#[test]
+fn test_compat_return_unwinds_only_the_current_callable() {
+    // Pinned against the repository's CLIPS 6.30 reference image. This covers
+    // deffunction and defmethod callables, nested calls, structured control
+    // forms, every source-constructible Ferric value kind, and side effects
+    // after a taken return.
+    let source = r#"
+(deffunction return-early ()
+    (printout t "function-before|" crlf)
+    (return 1)
+    (printout t "function-after|" crlf)
+    2)
+
+(deffunction return-if ()
+    (if TRUE
+        then (return if-value)
+        else wrong)
+    after-if)
+
+(deffunction return-while ()
+    (while TRUE do
+        (return while-value)
+        (printout t "while-after|" crlf))
+    after-while)
+
+(deffunction return-count ()
+    (loop-for-count (?i 1 3) do
+        (return ?i)
+        (printout t "count-after|" crlf))
+    after-count)
+
+(deffunction return-inner ()
+    (return 7)
+    9)
+
+(deffunction return-outer ()
+    (printout t "inner=" (return-inner) crlf)
+    8)
+
+(deffunction return-void () (return) 99)
+(deffunction return-int () (return 42) 99)
+(deffunction return-float () (return 3.5) 99)
+(deffunction return-symbol () (return alpha) omega)
+(deffunction return-string () (return "hello") "after")
+(deffunction return-multifield ()
+    (return (create$ alpha 2 3.5))
+    omega)
+
+(defmethod return-method ((?x INTEGER))
+    (return (+ ?x 1))
+    999)
+
+(defrule exercise-return
+    =>
+    (printout t "early=")
+    (printout t (return-early) crlf)
+    (printout t "if=")
+    (printout t (return-if) crlf)
+    (printout t "while=")
+    (printout t (return-while) crlf)
+    (printout t "count=")
+    (printout t (return-count) crlf)
+    (printout t "outer=")
+    (printout t (return-outer) crlf)
+    (printout t "void=" (return-void) "|" crlf)
+    (printout t "int=" (return-int) crlf)
+    (printout t "float=" (return-float) crlf)
+    (printout t "symbol=" (return-symbol) crlf)
+    (printout t "string=" (return-string) crlf)
+    (printout t "multifield=" (return-multifield) crlf)
+    (printout t "method=" (return-method 4) crlf))
+"#;
+
+    let expected = concat!(
+        "early=function-before|\n",
+        "1\n",
+        "if=if-value\n",
+        "while=while-value\n",
+        "count=1\n",
+        "outer=inner=7\n",
+        "8\n",
+        "void=|\n",
+        "int=42\n",
+        "float=3.5\n",
+        "symbol=alpha\n",
+        "string=hello\n",
+        "multifield=(alpha 2 3.5)\n",
+        "method=5\n",
+    );
+    let result = assert_clips_compat_returns(source, expected);
+    assert_eq!(result.rules_fired, 1);
+}
+
+#[test]
+fn test_compat_return_stops_the_current_rule_rhs() {
+    // CLIPS permits `return` in a rule RHS and uses it to stop the remaining
+    // action sequence. Its value is discarded; it does not assert the sentinel
+    // or emit an error.
+    let source = r#"
+(defrule return-from-rhs
+    =>
+    (printout t "rhs-before|" crlf)
+    (return 42)
+    (printout t "rhs-after|" crlf)
+    (assert (rhs-after)))
+"#;
+    let result = run_clips_compat_full(source);
+    assert_eq!(result.output, "rhs-before|\n");
+    assert_eq!(result.rules_fired, 1);
+    assert!(!result.has_fact("rhs-after"));
+}
+
+#[test]
+fn test_compat_return_argument_error_preserves_diagnostic_class() {
+    let source = r#"
+(deffunction return-error ()
+    (return (/ 1 0))
+    (printout t "function-after-error|" crlf))
+
+(defrule exercise-return-error
+    =>
+    (printout t (return-error) crlf))
+"#;
+    let result = run_clips_compat_full(source);
+    assert_eq!(result.output, "");
+    assert!(matches!(
+        result.engine().action_diagnostics(),
+        [ActionError::Evaluator(EvalError::DivisionByZero { .. })]
+    ));
 }
 
 // ===========================================================================

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -391,9 +391,15 @@ Ferric supports user-defined functions via `deffunction`.
 ### Evaluation
 
 Function bodies are expression sequences. The value of the last expression is
-the return value. Bodies are evaluator expressions, not full RHS action lists:
-expression functions such as `str-cat`, `format`, and `printout` are available,
-but fact mutation and agenda/focus control belong in the calling rule's RHS.
+the return value. `(return)` and `(return <expression>)` immediately unwind the
+current deffunction or generic-method call; an inner callable's return does not
+unwind its caller. A top-level return is an evaluation error. On a rule RHS,
+`return` follows CLIPS behavior and stops only the remaining actions in that
+activation.
+
+Bodies are evaluator expressions, not full RHS action lists: expression
+functions such as `str-cat`, `format`, and `printout` are available, but fact
+mutation and agenda/focus control belong in the calling rule's RHS.
 
 ### Module Scoping
 


### PR DESCRIPTION
## Summary

Implement CLIPS-compatible non-local `return` semantics using typed evaluator/action control flow—without panic-based unwinding.

- immediately unwind the current deffunction or generic-method body while preserving the returned value
- consume the signal at exactly the active callable boundary so nested callers continue normally
- propagate argument-evaluation failures with their original diagnostic class
- reject a return that escapes public top-level expression evaluation
- match pinned CLIPS behavior for rule RHS `return`: evaluate its optional value, then stop the remaining actions for that activation
- document the resulting compatibility contract

## Root cause

`return` previously behaved like an ordinary expression: it evaluated and returned its optional argument, after which the containing callable continued through later expressions. The evaluator had no explicit control-flow result that could cross nested `if`, `while`, or `loop-for-count` evaluation and be consumed by the current callable boundary.

## Reference contract

The behavior was checked against the repository's pinned CLIPS 6.30 image. That reference established an important distinction in the ticket shorthand:

- top-level `(return ...)` is invalid (`[PRCDRPSR2]`)
- rule RHS `(return ...)` is valid and short-circuits the remaining activation actions
- a callable return unwinds only that callable; its caller continues

The compatibility coverage includes early returns, `if`, `while`, `loop-for-count`, nested calls, deffunctions, generic methods, void/integer/float/symbol/string/multifield values, RHS side-effect suppression, and argument diagnostic preservation.

## Test-first evidence

Before the implementation:

- `cargo test -p ferric-runtime return -- --nocapture` failed because top-level return produced ordinary values instead of an error
- `cargo test -p ferric --test clips_compat return -- --nocapture` failed because callable bodies and RHS action sequences continued after return

## Validation

- `cargo test -p ferric-runtime return -- --nocapture`
- `cargo test -p ferric --test clips_compat return -- --nocapture`
- `cargo test -p ferric-runtime`
- `cargo test -p ferric --test clips_compat -- --nocapture`
- `cargo test -p ferric-runtime --all-features return -- --nocapture`
- `cargo clippy -p ferric-runtime --all-targets --all-features -- -D warnings`
- `just compat-scan`
- `just compat-run` (1 oracle-backed fixture equivalent; 658 pending without oracle)
- `just preflight-pr`

## Scope notes

The evaluator and rule-action paths currently use separate typed internal signals. Refs #180 for the planned shared evaluator/action control-flow model. Refs #99 for the separate RHS-error behavior work. Refs #212 for the downstream compatibility work unblocked by this change.

Closes #98