### PR TITLE
[FR-RELEASE-002] Enforce the declared Rust 1.75 MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,31 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - run: ./scripts/preflight.sh check
 
+  msrv:
+    name: MSRV (Rust 1.75)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: "1.75.0"
+      - name: Check workspace with locked dependencies
+        run: cargo check --workspace --locked
+      - name: Check all workspace features
+        run: cargo check --workspace --all-features --locked
+      - name: Check serialization feature set
+        run: cargo check -p ferric-runtime --features serde --locked
+      - name: Check CLI feature set
+        run: cargo check -p ferric-cli --locked
+      - name: Test workspace and MSRV metadata
+        run: cargo test --workspace --locked
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,15 +34,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "atomic-polyfill"
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bincode"
@@ -114,9 +114,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -147,19 +147,19 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbindgen"
-version = "0.29.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
+checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
 dependencies = [
  "clap",
- "heck",
+ "heck 0.4.1",
  "indexmap",
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.119",
  "tempfile",
  "toml",
 ]
@@ -172,9 +172,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "ciborium"
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "52fa72306bb30daf11bc97773431628e5b4916e97aaa74b7d3f625d4d495da02"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "2071365c5c56eae7d77414029dde2f4f4ba151cf68d5a3261c9a40de428ace93"
 dependencies = [
  "anstream",
  "anstyle",
@@ -227,21 +227,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.5.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "dec5be1eea072311774b7b84ded287adbd9f293f9d23456817605c6042f4f5e0"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "0e78417baa3b3114dc0e95e7357389a249c4da97c3c2b540700079db6171bfd7"
 
 [[package]]
 name = "clipboard-win"
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "convert_case"
@@ -338,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -348,18 +348,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -384,7 +384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embedded-io"
@@ -445,9 +445,9 @@ checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fd-lock"
@@ -456,7 +456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -468,6 +468,8 @@ dependencies = [
  "ferric-core",
  "ferric-parser",
  "ferric-runtime",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -594,12 +596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,38 +607,23 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
- "wasip3",
+ "wasi",
 ]
 
 [[package]]
 name = "half"
-version = "2.7.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy",
 ]
 
 [[package]]
@@ -652,15 +633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -685,6 +657,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -696,30 +674,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -759,15 +720,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.88"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e709f3e3d22866f9c25b3aff01af289b18422cc8b4262fb19103ee80fe513d"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -780,16 +741,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -803,9 +758,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
@@ -818,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "matchers"
@@ -833,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -861,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "2.3.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
+checksum = "e1c0f5d67ee408a4685b61f5ab7e58605c8ae3f2b4189f0127d804ff13d5560a"
 
 [[package]]
 name = "napi-derive"
@@ -876,7 +837,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -891,7 +852,7 @@ dependencies = [
  "quote",
  "regex",
  "semver",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -914,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.30.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -959,9 +920,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -974,6 +935,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -1011,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "postcard"
@@ -1038,33 +1005,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
+ "lazy_static",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1122,7 +1080,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1131,11 +1089,11 @@ version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1146,18 +1104,12 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radix_trie"
@@ -1171,19 +1123,20 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
+ "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.9.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1191,27 +1144,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -1219,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.13.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -1229,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1241,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1252,25 +1205,28 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rmp"
-version = "0.8.15"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
 dependencies = [
+ "byteorder",
  "num-traits",
+ "paste",
 ]
 
 [[package]]
 name = "rmp-serde"
-version = "1.3.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+checksum = "52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db"
 dependencies = [
+ "byteorder",
  "rmp",
  "serde",
 ]
@@ -1292,22 +1248,35 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -1323,15 +1292,14 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "17.0.2"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
 dependencies = [
  "bitflags",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
- "home",
  "libc",
  "log",
  "memchr",
@@ -1340,7 +1308,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1360,15 +1328,15 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1376,29 +1344,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1409,11 +1377,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -1448,18 +1416,18 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -1478,9 +1446,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1495,42 +1474,43 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
+ "cfg-if",
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom",
  "once_cell",
- "rustix",
- "windows-sys 0.61.2",
+ "rustix 0.38.44",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -1547,42 +1527,44 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
- "indexmap",
- "serde_core",
+ "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_parser",
- "toml_writer",
- "winnow",
+ "toml_edit",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+name = "toml_edit"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
  "winnow",
 ]
 
 [[package]]
-name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+name = "toml_write"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -1628,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1658,9 +1640,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1670,15 +1652,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unindent"
@@ -1842,28 +1818,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1adf1535672f5b7824f817792b1afd731d7e843d2d04ec8f27e8cb51edd8ac"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1874,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e638317c08b21663aed4d2b9a2091450548954695ff4efa75bff5fa546b3b1"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1884,65 +1848,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c64760850114d03d5f65457e96fc988f11f01d38fbaa51b254e4ab5809102af"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.111"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60eecd4fe26177cfa3339eb00b4a36445889ba3ad37080c2429879718e20ca41"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.88"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6bb20ed2d9572df8584f6dc81d68a41a625cadc6f15999d649a70ce7e3597a"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1965,20 +1895,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1996,31 +1926,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2030,22 +1943,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2054,22 +1955,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2078,22 +1967,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2102,139 +1979,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
+ "memchr",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,13 @@ anyhow = "1"
 # CLI argument parsing
 clap = { version = "4", features = ["derive"] }
 
-# Line editing for interactive REPL
-rustyline = "17"
+# Line editing for interactive REPL. Ferric resolves its own history path, so
+# rustyline's directory-discovery feature (and its fast-moving `home`
+# dependency) is intentionally excluded from the MSRV surface.
+rustyline = { version = "=14.0.0", default-features = false, features = ["custom-bindings", "with-file-history"] }
 
 # C header generation (build-time only)
-cbindgen = "0.29"
+cbindgen = "=0.28.0"
 
 # Serialization
 serde = { version = "1", features = ["derive", "rc"] }
@@ -42,7 +44,7 @@ bincode = "1"
 serde_json = "1"
 sha2 = "0.10"
 ciborium = "0.2"
-rmp-serde = "1"
+rmp-serde = "=1.3.0"
 postcard = { version = "1", features = ["alloc"] }
 
 # Slot-based storage (serde feature always on — negligible cost, needed when serde is enabled)
@@ -64,13 +66,17 @@ pyo3-build-config = "0.23"
 # napi-rs Node.js bindings
 napi = { version = "2", default-features = false, features = ["napi8"] }
 napi-derive = "2"
-napi-build = "2"
+napi-build = "=2.1.3"
 
 # Property-based testing
-proptest = "1"
+proptest = "=1.6.0"
 
 # Benchmarking
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "=0.5.1", features = ["html_reports"] }
+
+# Temporary files used by tests and cbindgen. 3.15 is the newest line before
+# tempfile moved to getrandom 0.3's newer target dependency graph.
+tempfile = "=3.15.0"
 
 # Tracing / profiling (optional, feature-gated)
 tracing = { version = "0.1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -196,6 +196,25 @@ These scenarios are verified as tests in
 [`crates/ferric/tests/clips_compat.rs`](crates/ferric/tests/clips_compat.rs)
 (look for `test_engagement_*`), so they won't silently go stale.
 
+## Rust version support
+
+Ferric's minimum supported Rust version (MSRV) is **1.75**. Every publishable
+workspace crate declares the same MSRV. CI uses the committed lockfile to check
+the default workspace, the CLI, and the serialization feature set, and runs the
+complete workspace test suite on Rust 1.75.
+
+Dependency updates must retain that contract. Generate an MSRV-aware lockfile
+with a current Cargo, then validate it with the oldest supported toolchain:
+
+```sh
+cargo update --config 'resolver.incompatible-rust-versions="fallback"'
+cargo +1.75 check --workspace --locked
+cargo +1.75 check --workspace --all-features --locked
+cargo +1.75 test --workspace --locked
+cargo +1.75 check -p ferric-runtime --features serde --locked
+cargo +1.75 check -p ferric-cli --locked
+```
+
 ## License
 
 Licensed under either of:

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -16,7 +16,7 @@ acceptable license is selected for notice generation.
 
 ## License Overview
 
-- MIT License: 218
+- MIT License: 209
 - Apache License 2.0: 4
 - Boost Software License 1.0: 2
 - ISC License: 1
@@ -581,8 +581,8 @@ DEALINGS IN THE SOFTWARE.
 Used by:
 
 - lazy_static 1.5.0 (`MIT OR Apache-2.0`) - https://github.com/rust-lang-nursery/lazy-static.rs
-- rayon-core 1.13.0 (`MIT OR Apache-2.0`) - https://github.com/rayon-rs/rayon
-- rayon 1.11.0 (`MIT OR Apache-2.0`) - https://github.com/rayon-rs/rayon
+- rayon-core 1.12.1 (`MIT OR Apache-2.0`) - https://github.com/rayon-rs/rayon
+- rayon 1.10.0 (`MIT OR Apache-2.0`) - https://github.com/rayon-rs/rayon
 
 ```text
 Copyright (c) 2010 The Rust Project Developers
@@ -618,13 +618,13 @@ DEALINGS IN THE SOFTWARE.
 Used by:
 
 - cfg-if 1.0.4 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/cfg-if
-- js-sys 0.3.88 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys
+- js-sys 0.3.94 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys
 - wait-timeout 0.2.1 (`MIT OR Apache-2.0`) - https://github.com/alexcrichton/wait-timeout
-- wasm-bindgen-macro-support 0.2.111 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support
-- wasm-bindgen-macro 0.2.111 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro
-- wasm-bindgen-shared 0.2.111 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared
-- wasm-bindgen 0.2.111 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen
-- web-sys 0.3.88 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys
+- wasm-bindgen-macro-support 0.2.117 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support
+- wasm-bindgen-macro 0.2.117 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro
+- wasm-bindgen-shared 0.2.117 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared
+- wasm-bindgen 0.2.117 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen
+- web-sys 0.3.94 (`MIT OR Apache-2.0`) - https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys
 
 ```text
 Copyright (c) 2014 Alex Crichton
@@ -730,12 +730,12 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- bitflags 2.10.0 (`MIT OR Apache-2.0`) - https://github.com/bitflags/bitflags
-- log 0.4.29 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/log
+- bitflags 2.13.1 (`MIT OR Apache-2.0`) - https://github.com/bitflags/bitflags
+- log 0.4.33 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/log
 - num-traits 0.2.19 (`MIT OR Apache-2.0`) - https://github.com/rust-num/num-traits
-- regex-automata 0.4.14 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/regex
-- regex-syntax 0.8.9 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/regex
-- regex 1.12.3 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/regex
+- regex-automata 0.4.16 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/regex
+- regex-syntax 0.8.11 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/regex
+- regex 1.13.1 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/regex
 
 ```text
 Copyright (c) 2014 The Rust Project Developers
@@ -805,42 +805,7 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- libc 0.2.181 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/libc
-
-```text
-Copyright (c) 2014-2020 The Rust Project Developers
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-```
-
-## MIT License (`MIT`)
-
-Used by:
-
-- either 1.15.0 (`MIT OR Apache-2.0`) - https://github.com/rayon-rs/either
+- either 1.17.0 (`MIT OR Apache-2.0`) - https://github.com/rayon-rs/either
 - itertools 0.10.5 (`MIT OR Apache-2.0`) - https://github.com/rust-itertools/itertools
 
 ```text
@@ -876,7 +841,7 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- tempfile 3.25.0 (`MIT OR Apache-2.0`) - https://github.com/Stebalien/tempfile
+- tempfile 3.15.0 (`MIT OR Apache-2.0`) - https://github.com/Stebalien/tempfile
 
 ```text
 Copyright (c) 2015 Steven Allen
@@ -911,9 +876,10 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
+- heck 0.4.1 (`MIT OR Apache-2.0`) - https://github.com/withoutboats/heck
 - heck 0.5.0 (`MIT OR Apache-2.0`) - https://github.com/withoutboats/heck
 - unicode-segmentation 1.12.0 (`MIT OR Apache-2.0`) - https://github.com/unicode-rs/unicode-segmentation
-- unicode-width 0.2.2 (`MIT OR Apache-2.0`) - https://github.com/unicode-rs/unicode-width
+- unicode-width 0.1.14 (`MIT OR Apache-2.0`) - https://github.com/unicode-rs/unicode-width
 
 ```text
 Copyright (c) 2015 The Rust Project Developers
@@ -1041,7 +1007,7 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- proptest 1.10.0 (`MIT OR Apache-2.0`) - https://github.com/proptest-rs/proptest
+- proptest 1.6.0 (`MIT OR Apache-2.0`) - https://github.com/proptest-rs/proptest
 - rusty-fork 0.3.1 (`MIT OR Apache-2.0`) - https://github.com/altsysrq/rusty-fork
 
 ```text
@@ -1114,7 +1080,7 @@ Used by:
 
 - lock_api 0.4.14 (`MIT OR Apache-2.0`) - https://github.com/Amanieu/parking_lot
 - rustc_version 0.4.1 (`MIT OR Apache-2.0`) - https://github.com/djc/rustc-version-rs
-- thread_local 1.1.9 (`MIT OR Apache-2.0`) - https://github.com/Amanieu/thread_local-rs
+- thread_local 1.1.10 (`MIT OR Apache-2.0`) - https://github.com/Amanieu/thread_local-rs
 
 ```text
 Copyright (c) 2016 The Rust Project Developers
@@ -1149,7 +1115,7 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- indexmap 2.13.0 (`Apache-2.0 OR MIT`) - https://github.com/indexmap-rs/indexmap
+- indexmap 2.11.4 (`Apache-2.0 OR MIT`) - https://github.com/indexmap-rs/indexmap
 
 ```text
 Copyright (c) 2016--2017
@@ -1456,7 +1422,7 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- autocfg 1.5.0 (`Apache-2.0 OR MIT`) - https://github.com/cuviper/autocfg
+- autocfg 1.5.1 (`Apache-2.0 OR MIT`) - https://github.com/cuviper/autocfg
 
 ```text
 Copyright (c) 2018 Josh Stone
@@ -1491,7 +1457,7 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- smallvec 1.15.1 (`MIT OR Apache-2.0`) - https://github.com/servo/rust-smallvec
+- smallvec 1.15.2 (`MIT OR Apache-2.0`) - https://github.com/servo/rust-smallvec
 
 ```text
 Copyright (c) 2018 The Servo Project Developers
@@ -1561,46 +1527,10 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- getrandom 0.3.4 (`MIT OR Apache-2.0`) - https://github.com/rust-random/getrandom
+- getrandom 0.2.17 (`MIT OR Apache-2.0`) - https://github.com/rust-random/getrandom
 
 ```text
-Copyright (c) 2018-2025 The rust-random Project Developers
-Copyright (c) 2014 The Rust Project Developers
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-```
-
-## MIT License (`MIT`)
-
-Used by:
-
-- getrandom 0.4.1 (`MIT OR Apache-2.0`) - https://github.com/rust-random/getrandom
-
-```text
-Copyright (c) 2018-2026 The rust-random Project Developers
+Copyright (c) 2018-2024 The rust-random Project Developers
 Copyright (c) 2014 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any
@@ -1761,7 +1691,7 @@ SOFTWARE.
 
 Used by:
 
-- bumpalo 3.20.2 (`MIT OR Apache-2.0`) - https://github.com/fitzgen/bumpalo
+- bumpalo 3.20.3 (`MIT OR Apache-2.0`) - https://github.com/fitzgen/bumpalo
 
 ```text
 Copyright (c) 2019 Nick Fitzgerald
@@ -1833,7 +1763,7 @@ Used by:
 
 - tracing-core 0.1.36 (`MIT`) - https://github.com/tokio-rs/tracing
 - tracing-log 0.2.0 (`MIT`) - https://github.com/tokio-rs/tracing
-- tracing-subscriber 0.3.22 (`MIT`) - https://github.com/tokio-rs/tracing
+- tracing-subscriber 0.3.23 (`MIT`) - https://github.com/tokio-rs/tracing
 - tracing 0.1.44 (`MIT`) - https://github.com/tokio-rs/tracing
 
 ```text
@@ -2084,22 +2014,23 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- anstream 0.6.21 (`MIT OR Apache-2.0`) - https://github.com/rust-cli/anstyle.git
-- anstyle-parse 0.2.7 (`MIT OR Apache-2.0`) - https://github.com/rust-cli/anstyle.git
+- anstream 1.0.0 (`MIT OR Apache-2.0`) - https://github.com/rust-cli/anstyle.git
+- anstyle-parse 1.0.0 (`MIT OR Apache-2.0`) - https://github.com/rust-cli/anstyle.git
 - anstyle-query 1.1.5 (`MIT OR Apache-2.0`) - https://github.com/rust-cli/anstyle.git
 - anstyle-wincon 3.0.11 (`MIT OR Apache-2.0`) - https://github.com/rust-cli/anstyle.git
-- anstyle 1.0.13 (`MIT OR Apache-2.0`) - https://github.com/rust-cli/anstyle.git
-- clap 4.5.60 (`MIT OR Apache-2.0`) - https://github.com/clap-rs/clap
-- clap_builder 4.5.60 (`MIT OR Apache-2.0`) - https://github.com/clap-rs/clap
-- clap_derive 4.5.55 (`MIT OR Apache-2.0`) - https://github.com/clap-rs/clap
-- clap_lex 1.0.0 (`MIT OR Apache-2.0`) - https://github.com/clap-rs/clap
-- colorchoice 1.0.4 (`MIT OR Apache-2.0`) - https://github.com/rust-cli/anstyle.git
+- anstyle 1.0.14 (`MIT OR Apache-2.0`) - https://github.com/rust-cli/anstyle.git
+- clap 4.5.61 (`MIT OR Apache-2.0`) - https://github.com/clap-rs/clap
+- clap_builder 4.5.61 (`MIT OR Apache-2.0`) - https://github.com/clap-rs/clap
+- clap_derive 4.5.61 (`MIT OR Apache-2.0`) - https://github.com/clap-rs/clap
+- clap_lex 1.0.1 (`MIT OR Apache-2.0`) - https://github.com/clap-rs/clap
+- colorchoice 1.0.5 (`MIT OR Apache-2.0`) - https://github.com/rust-cli/anstyle.git
 - is_terminal_polyfill 1.70.2 (`MIT OR Apache-2.0`) - https://github.com/polyfill-rs/is_terminal_polyfill
 - once_cell_polyfill 1.70.2 (`MIT OR Apache-2.0`) - https://github.com/polyfill-rs/once_cell_polyfill
-- serde_spanned 1.0.4 (`MIT OR Apache-2.0`) - https://github.com/toml-rs/toml
-- toml 0.9.12+spec-1.1.0 (`MIT OR Apache-2.0`) - https://github.com/toml-rs/toml
-- toml_datetime 0.7.5+spec-1.1.0 (`MIT OR Apache-2.0`) - https://github.com/toml-rs/toml
-- toml_parser 1.0.9+spec-1.1.0 (`MIT OR Apache-2.0`) - https://github.com/toml-rs/toml
+- serde_spanned 0.6.9 (`MIT OR Apache-2.0`) - https://github.com/toml-rs/toml
+- toml 0.8.23 (`MIT OR Apache-2.0`) - https://github.com/toml-rs/toml
+- toml_datetime 0.6.11 (`MIT OR Apache-2.0`) - https://github.com/toml-rs/toml
+- toml_edit 0.22.27 (`MIT OR Apache-2.0`) - https://github.com/toml-rs/toml
+- toml_write 0.1.2 (`MIT OR Apache-2.0`) - https://github.com/toml-rs/toml
 
 ```text
 Copyright (c) Individual contributors
@@ -2128,10 +2059,45 @@ SOFTWARE.
 
 Used by:
 
-- rand 0.9.2 (`MIT OR Apache-2.0`) - https://github.com/rust-random/rand
-- rand_chacha 0.9.0 (`MIT OR Apache-2.0`) - https://github.com/rust-random/rand
-- rand_core 0.9.5 (`MIT OR Apache-2.0`) - https://github.com/rust-random/rand
-- rand_xorshift 0.4.0 (`MIT OR Apache-2.0`) - https://github.com/rust-random/rngs
+- libc 0.2.189 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/libc
+
+```text
+Copyright (c) The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+
+## MIT License (`MIT`)
+
+Used by:
+
+- rand 0.8.7 (`MIT OR Apache-2.0`) - https://github.com/rust-random/rand
+- rand_chacha 0.3.1 (`MIT OR Apache-2.0`) - https://github.com/rust-random/rand
+- rand_core 0.6.4 (`MIT OR Apache-2.0`) - https://github.com/rust-random/rand
+- rand_xorshift 0.3.0 (`MIT OR Apache-2.0`) - https://github.com/rust-random/rngs
 
 ```text
 Copyright 2018 Developers of the Rand project
@@ -2167,8 +2133,7 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- zerocopy-derive 0.8.39 (`BSD-2-Clause OR Apache-2.0 OR MIT`) - https://github.com/google/zerocopy
-- zerocopy 0.8.39 (`BSD-2-Clause OR Apache-2.0 OR MIT`) - https://github.com/google/zerocopy
+- zerocopy 0.8.55 (`BSD-2-Clause OR Apache-2.0 OR MIT`) - https://github.com/google/zerocopy
 
 ```text
 Copyright 2023 The Fuchsia Authors
@@ -2204,8 +2169,8 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- rmp-serde 1.3.1 (`MIT`) - https://github.com/3Hren/msgpack-rust
-- rmp 0.8.15 (`MIT`) - https://github.com/3Hren/msgpack-rust
+- rmp-serde 1.3.0 (`MIT`) - https://github.com/3Hren/msgpack-rust
+- rmp 0.8.14 (`MIT`) - https://github.com/3Hren/msgpack-rust
 
 ```text
 MIT License
@@ -2267,7 +2232,7 @@ SOFTWARE.
 
 Used by:
 
-- cfg_aliases 0.2.1 (`MIT`) - https://github.com/katharostech/cfg_aliases
+- cfg_aliases 0.1.1 (`MIT`) - https://github.com/katharostech/cfg_aliases
 
 ```text
 MIT License
@@ -2331,7 +2296,7 @@ Used by:
 - users-guide-14-pipeline 0.1.0 (`MIT OR Apache-2.0`)
 - users-guide-sync 0.1.0 (`MIT OR Apache-2.0`)
 - anes 0.1.6 (`MIT OR Apache-2.0`) - https://github.com/zrzka/anes-rs
-- napi-build 2.3.1 (`MIT`) - https://github.com/napi-rs/napi-rs
+- napi-build 2.1.3 (`MIT`) - https://github.com/napi-rs/napi-rs
 - napi-derive-backend 1.0.75 (`MIT`) - https://github.com/napi-rs/napi-rs
 - napi-derive 2.16.13 (`MIT`) - https://github.com/napi-rs/napi-rs
 - napi-sys 2.4.0 (`MIT`) - https://github.com/napi-rs/napi-rs
@@ -2341,31 +2306,19 @@ Used by:
 - plotters-backend 0.3.7 (`MIT`) - https://github.com/plotters-rs/plotters
 - plotters-svg 0.3.7 (`MIT`) - https://github.com/plotters-rs/plotters.git
 - plotters 0.3.7 (`MIT`) - https://github.com/plotters-rs/plotters
-- r-efi 5.3.0 (`MIT OR Apache-2.0 OR LGPL-2.1-or-later`) - https://github.com/r-efi/r-efi
-- wasip2 1.0.2+wasi-0.2.9 (`Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`) - https://github.com/bytecodealliance/wasi-rs
-- wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06 (`Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`) - https://github.com/bytecodealliance/wasi-rs
 - windows-link 0.2.1 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
+- windows-sys 0.52.0 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 - windows-sys 0.59.0 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
-- windows-sys 0.60.2 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 - windows-sys 0.61.2 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 - windows-targets 0.52.6 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
-- windows-targets 0.53.5 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 - windows_aarch64_gnullvm 0.52.6 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
-- windows_aarch64_gnullvm 0.53.1 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 - windows_aarch64_msvc 0.52.6 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
-- windows_aarch64_msvc 0.53.1 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 - windows_i686_gnu 0.52.6 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
-- windows_i686_gnu 0.53.1 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 - windows_i686_gnullvm 0.52.6 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
-- windows_i686_gnullvm 0.53.1 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 - windows_i686_msvc 0.52.6 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
-- windows_i686_msvc 0.53.1 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 - windows_x86_64_gnu 0.52.6 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
-- windows_x86_64_gnu 0.53.1 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 - windows_x86_64_gnullvm 0.52.6 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
-- windows_x86_64_gnullvm 0.53.1 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 - windows_x86_64_msvc 0.52.6 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
-- windows_x86_64_msvc 0.53.1 (`MIT OR Apache-2.0`) - https://github.com/microsoft/windows-rs
 
 ```text
 MIT License
@@ -2393,30 +2346,18 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- unarray 0.1.4 (`MIT OR Apache-2.0`) - https://github.com/cameron1024/unarray
+- half 2.4.1 (`MIT OR Apache-2.0`) - https://github.com/starkat99/half-rs
 
 ```text
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) <year> <copyright holders>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 
@@ -2424,10 +2365,12 @@ SOFTWARE.
 
 Used by:
 
-- half 2.7.1 (`MIT OR Apache-2.0`) - https://github.com/VoidStarKat/half-rs
+- unarray 0.1.4 (`MIT OR Apache-2.0`) - https://github.com/cameron1024/unarray
 
 ```text
 MIT License
+
+Copyright (c) [year] [fullname]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -2485,33 +2428,36 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- anyhow 1.0.101 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/anyhow
-- fastrand 2.3.0 (`Apache-2.0 OR MIT`) - https://github.com/smol-rs/fastrand
+- anyhow 1.0.104 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/anyhow
+- fastrand 2.5.0 (`Apache-2.0 OR MIT`) - https://github.com/smol-rs/fastrand
 - hermit-abi 0.5.2 (`MIT OR Apache-2.0`) - https://github.com/hermit-os/hermit-rs
-- home 0.5.12 (`MIT OR Apache-2.0`) - https://github.com/rust-lang/cargo
 - indoc 2.0.7 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/indoc
 - is-terminal 0.4.17 (`MIT`) - https://github.com/sunfishcode/is-terminal
-- itoa 1.0.17 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/itoa
-- linux-raw-sys 0.11.0 (`Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`) - https://github.com/sunfishcode/linux-raw-sys
-- once_cell 1.21.3 (`MIT OR Apache-2.0`) - https://github.com/matklad/once_cell
+- itoa 1.0.18 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/itoa
+- linux-raw-sys 0.12.1 (`Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`) - https://github.com/sunfishcode/linux-raw-sys
+- linux-raw-sys 0.4.15 (`Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`) - https://github.com/sunfishcode/linux-raw-sys
+- once_cell 1.21.4 (`MIT OR Apache-2.0`) - https://github.com/matklad/once_cell
+- paste 1.0.15 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/paste
 - pin-project-lite 0.2.17 (`Apache-2.0 OR MIT`) - https://github.com/taiki-e/pin-project-lite
-- portable-atomic 1.13.1 (`Apache-2.0 OR MIT`) - https://github.com/taiki-e/portable-atomic
-- proc-macro2 1.0.106 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/proc-macro2
-- quote 1.0.44 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/quote
-- rustix 1.1.3 (`Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`) - https://github.com/bytecodealliance/rustix
-- rustversion 1.0.22 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/rustversion
-- semver 1.0.27 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/semver
-- serde 1.0.228 (`MIT OR Apache-2.0`) - https://github.com/serde-rs/serde
-- serde_core 1.0.228 (`MIT OR Apache-2.0`) - https://github.com/serde-rs/serde
-- serde_derive 1.0.228 (`MIT OR Apache-2.0`) - https://github.com/serde-rs/serde
-- serde_json 1.0.149 (`MIT OR Apache-2.0`) - https://github.com/serde-rs/json
-- syn 2.0.114 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/syn
-- thiserror-impl 2.0.18 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/thiserror
-- thiserror 2.0.18 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/thiserror
-- unicode-ident 1.0.23 (`(MIT OR Apache-2.0) AND Unicode-3.0`) - https://github.com/dtolnay/unicode-ident
+- portable-atomic 1.14.0 (`Apache-2.0 OR MIT`) - https://github.com/taiki-e/portable-atomic
+- proc-macro2 1.0.107 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/proc-macro2
+- quote 1.0.47 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/quote
+- rustix 0.38.44 (`Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`) - https://github.com/bytecodealliance/rustix
+- rustix 1.1.4 (`Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`) - https://github.com/bytecodealliance/rustix
+- rustversion 1.0.23 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/rustversion
+- semver 1.0.28 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/semver
+- serde 1.0.229 (`MIT OR Apache-2.0`) - https://github.com/serde-rs/serde
+- serde_core 1.0.229 (`MIT OR Apache-2.0`) - https://github.com/serde-rs/serde
+- serde_derive 1.0.229 (`MIT OR Apache-2.0`) - https://github.com/serde-rs/serde
+- serde_json 1.0.151 (`MIT OR Apache-2.0`) - https://github.com/serde-rs/json
+- syn 2.0.119 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/syn
+- syn 3.0.3 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/syn
+- thiserror-impl 2.0.19 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/thiserror
+- thiserror 2.0.19 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/thiserror
+- unicode-ident 1.0.24 (`(MIT OR Apache-2.0) AND Unicode-3.0`) - https://github.com/dtolnay/unicode-ident
 - unindent 0.2.4 (`MIT OR Apache-2.0`) - https://github.com/dtolnay/indoc
-- wit-bindgen 0.51.0 (`Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`) - https://github.com/bytecodealliance/wit-bindgen
-- zmij 1.0.20 (`MIT`) - https://github.com/dtolnay/zmij
+- wasi 0.11.1+wasi-snapshot-preview1 (`Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT`) - https://github.com/bytecodealliance/wasi
+- zmij 1.0.23 (`MIT`) - https://github.com/dtolnay/zmij
 
 ```text
 Permission is hereby granted, free of charge, to any
@@ -2544,7 +2490,7 @@ DEALINGS IN THE SOFTWARE.
 
 Used by:
 
-- winnow 0.7.14 (`MIT`) - https://github.com/winnow-rs/winnow
+- winnow 0.7.15 (`MIT`) - https://github.com/winnow-rs/winnow
 
 ```text
 Permission is hereby granted, free of charge, to any person obtaining
@@ -2586,7 +2532,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 Used by:
 
-- spin 0.9.8 (`MIT`) - https://github.com/mvdnes/spin-rs.git
+- spin 0.9.9 (`MIT`) - https://github.com/mvdnes/spin-rs.git
 
 ```text
 The MIT License (MIT)
@@ -2681,7 +2627,7 @@ Used by:
 
 - aho-corasick 1.1.4 (`Unlicense OR MIT`) - https://github.com/BurntSushi/aho-corasick
 - byteorder 1.5.0 (`Unlicense OR MIT`) - https://github.com/BurntSushi/byteorder
-- memchr 2.8.0 (`Unlicense OR MIT`) - https://github.com/BurntSushi/memchr
+- memchr 2.8.3 (`Unlicense OR MIT`) - https://github.com/BurntSushi/memchr
 - walkdir 2.5.0 (`Unlicense OR MIT`) - https://github.com/BurntSushi/walkdir
 
 ```text
@@ -2713,7 +2659,7 @@ THE SOFTWARE.
 
 Used by:
 
-- nix 0.30.1 (`MIT`) - https://github.com/nix-rust/nix
+- nix 0.28.0 (`MIT`) - https://github.com/nix-rust/nix
 
 ```text
 The MIT License (MIT)
@@ -2777,7 +2723,7 @@ SOFTWARE.
 
 Used by:
 
-- rustyline 17.0.2 (`MIT`) - https://github.com/kkawakam/rustyline
+- rustyline 14.0.0 (`MIT`) - https://github.com/kkawakam/rustyline
 
 ```text
 The MIT License (MIT)
@@ -2904,9 +2850,9 @@ SOFTWARE.
 Used by:
 
 - crossbeam-channel 0.5.16 (`MIT OR Apache-2.0`) - https://github.com/crossbeam-rs/crossbeam
-- crossbeam-deque 0.8.6 (`MIT OR Apache-2.0`) - https://github.com/crossbeam-rs/crossbeam
-- crossbeam-epoch 0.9.18 (`MIT OR Apache-2.0`) - https://github.com/crossbeam-rs/crossbeam
-- crossbeam-utils 0.8.21 (`MIT OR Apache-2.0`) - https://github.com/crossbeam-rs/crossbeam
+- crossbeam-deque 0.8.7 (`MIT OR Apache-2.0`) - https://github.com/crossbeam-rs/crossbeam
+- crossbeam-epoch 0.9.20 (`MIT OR Apache-2.0`) - https://github.com/crossbeam-rs/crossbeam
+- crossbeam-utils 0.8.22 (`MIT OR Apache-2.0`) - https://github.com/crossbeam-rs/crossbeam
 
 ```text
 The MIT License (MIT)
@@ -3127,7 +3073,7 @@ SOFTWARE.
 
 Used by:
 
-- cbindgen 0.29.2 (`MPL-2.0`) - https://github.com/mozilla/cbindgen
+- cbindgen 0.28.0 (`MPL-2.0`) - https://github.com/mozilla/cbindgen
 
 ```text
 Mozilla Public License Version 2.0
@@ -3510,7 +3456,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 Used by:
 
-- unicode-ident 1.0.23 (`(MIT OR Apache-2.0) AND Unicode-3.0`) - https://github.com/dtolnay/unicode-ident
+- unicode-ident 1.0.24 (`(MIT OR Apache-2.0) AND Unicode-3.0`) - https://github.com/dtolnay/unicode-ident
 
 ```text
 UNICODE LICENSE V3

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -163,6 +163,14 @@
 #endif
 
 
+// C-facing conflict-resolution strategy for `FerricConfig`.
+typedef enum FerricConflictStrategy {
+    FERRIC_CONFLICT_STRATEGY_DEPTH = 0,
+    FERRIC_CONFLICT_STRATEGY_BREADTH = 1,
+    FERRIC_CONFLICT_STRATEGY_LEX = 2,
+    FERRIC_CONFLICT_STRATEGY_MEA = 3
+} FerricConflictStrategy;
+
 // C-facing error codes returned by all fallible FFI entry points.
 //
 // Stable numeric values — new codes may be added but existing values
@@ -226,20 +234,39 @@ typedef enum FerricHaltReason {
     FERRIC_HALT_REASON_ACTION_ERROR = 3
 } FerricHaltReason;
 
+// Autorelease-pool installation policy used by the pinned worker.
+typedef enum FerricPinnedAutoreleasePolicy {
+    // Never install an Apple autorelease pool.
+    FERRIC_PINNED_AUTORELEASE_POLICY_NONE = 0,
+    // Install one pool per drained request.
+    FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM = 1,
+    // Install one pool per drained batch.
+    FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH = 2
+} FerricPinnedAutoreleasePolicy;
+
+#if defined(FERRIC_SERDE)
+// Serialization format selector for `ferric_engine_serialize_as` and
+// `ferric_engine_deserialize_as`.
+typedef enum FerricSerializationFormat {
+    // Compact binary (bincode). Fast and small.
+    FERRIC_SERIALIZATION_FORMAT_BINCODE = 0,
+    // JSON (human-readable, larger output).
+    FERRIC_SERIALIZATION_FORMAT_JSON = 1,
+    // CBOR (Concise Binary Object Representation).
+    FERRIC_SERIALIZATION_FORMAT_CBOR = 2,
+    // `MessagePack` (compact binary, JSON-like schema).
+    FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK = 3,
+    // Postcard (compact, `no_std`-friendly binary).
+    FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4
+} FerricSerializationFormat;
+#endif
+
 // C-facing string-encoding configuration for `FerricConfig`.
 typedef enum FerricStringEncoding {
     FERRIC_STRING_ENCODING_ASCII = 0,
     FERRIC_STRING_ENCODING_UTF8 = 1,
     FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS = 2
 } FerricStringEncoding;
-
-// C-facing conflict-resolution strategy for `FerricConfig`.
-typedef enum FerricConflictStrategy {
-    FERRIC_CONFLICT_STRATEGY_DEPTH = 0,
-    FERRIC_CONFLICT_STRATEGY_BREADTH = 1,
-    FERRIC_CONFLICT_STRATEGY_LEX = 2,
-    FERRIC_CONFLICT_STRATEGY_MEA = 3
-} FerricConflictStrategy;
 
 // C-facing value type discriminant.
 //
@@ -259,33 +286,6 @@ typedef enum FerricValueType {
     FERRIC_VALUE_TYPE_MULTIFIELD = 5,
     FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS = 6
 } FerricValueType;
-
-#if defined(FERRIC_SERDE)
-// Serialization format selector for `ferric_engine_serialize_as` and
-// `ferric_engine_deserialize_as`.
-typedef enum FerricSerializationFormat {
-    // Compact binary (bincode). Fast and small.
-    FERRIC_SERIALIZATION_FORMAT_BINCODE = 0,
-    // JSON (human-readable, larger output).
-    FERRIC_SERIALIZATION_FORMAT_JSON = 1,
-    // CBOR (Concise Binary Object Representation).
-    FERRIC_SERIALIZATION_FORMAT_CBOR = 2,
-    // `MessagePack` (compact binary, JSON-like schema).
-    FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK = 3,
-    // Postcard (compact, `no_std`-friendly binary).
-    FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4
-} FerricSerializationFormat;
-#endif
-
-// Autorelease-pool installation policy used by the pinned worker.
-typedef enum FerricPinnedAutoreleasePolicy {
-    // Never install an Apple autorelease pool.
-    FERRIC_PINNED_AUTORELEASE_POLICY_NONE = 0,
-    // Install one pool per drained request.
-    FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM = 1,
-    // Install one pool per drained batch.
-    FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH = 2
-} FerricPinnedAutoreleasePolicy;
 
 // Opaque engine handle exposed to C.
 //

--- a/crates/ferric-cli/Cargo.toml
+++ b/crates/ferric-cli/Cargo.toml
@@ -32,7 +32,7 @@ serde = ["ferric-runtime/serde"]
 
 [dev-dependencies]
 proptest = { workspace = true }
-tempfile = "3.8"
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/ferric-core/src/rete.rs
+++ b/crates/ferric-core/src/rete.rs
@@ -2913,8 +2913,6 @@ mod tests {
     fn build_negative_with_variable_binding(
         symbol_table: &mut SymbolTable,
     ) -> (ReteNetwork, AlphaMemoryId, AlphaMemoryId, RuleId) {
-        use crate::binding::VarId;
-
         let mut rete = ReteNetwork::new();
 
         let item_sym = make_symbol(symbol_table, "item");
@@ -4143,8 +4141,6 @@ mod tests {
         symbol_table: &mut SymbolTable,
         test_type: JoinTestType,
     ) -> (ReteNetwork, FactBase, Symbol, Symbol) {
-        use crate::binding::VarId;
-
         let mut rete = ReteNetwork::new();
         let fact_base = FactBase::new();
 

--- a/crates/ferric-ffi/ferric.h
+++ b/crates/ferric-ffi/ferric.h
@@ -163,6 +163,14 @@
 #endif
 
 
+// C-facing conflict-resolution strategy for `FerricConfig`.
+typedef enum FerricConflictStrategy {
+    FERRIC_CONFLICT_STRATEGY_DEPTH = 0,
+    FERRIC_CONFLICT_STRATEGY_BREADTH = 1,
+    FERRIC_CONFLICT_STRATEGY_LEX = 2,
+    FERRIC_CONFLICT_STRATEGY_MEA = 3
+} FerricConflictStrategy;
+
 // C-facing error codes returned by all fallible FFI entry points.
 //
 // Stable numeric values — new codes may be added but existing values
@@ -226,20 +234,39 @@ typedef enum FerricHaltReason {
     FERRIC_HALT_REASON_ACTION_ERROR = 3
 } FerricHaltReason;
 
+// Autorelease-pool installation policy used by the pinned worker.
+typedef enum FerricPinnedAutoreleasePolicy {
+    // Never install an Apple autorelease pool.
+    FERRIC_PINNED_AUTORELEASE_POLICY_NONE = 0,
+    // Install one pool per drained request.
+    FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM = 1,
+    // Install one pool per drained batch.
+    FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH = 2
+} FerricPinnedAutoreleasePolicy;
+
+#if defined(FERRIC_SERDE)
+// Serialization format selector for `ferric_engine_serialize_as` and
+// `ferric_engine_deserialize_as`.
+typedef enum FerricSerializationFormat {
+    // Compact binary (bincode). Fast and small.
+    FERRIC_SERIALIZATION_FORMAT_BINCODE = 0,
+    // JSON (human-readable, larger output).
+    FERRIC_SERIALIZATION_FORMAT_JSON = 1,
+    // CBOR (Concise Binary Object Representation).
+    FERRIC_SERIALIZATION_FORMAT_CBOR = 2,
+    // `MessagePack` (compact binary, JSON-like schema).
+    FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK = 3,
+    // Postcard (compact, `no_std`-friendly binary).
+    FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4
+} FerricSerializationFormat;
+#endif
+
 // C-facing string-encoding configuration for `FerricConfig`.
 typedef enum FerricStringEncoding {
     FERRIC_STRING_ENCODING_ASCII = 0,
     FERRIC_STRING_ENCODING_UTF8 = 1,
     FERRIC_STRING_ENCODING_ASCII_SYMBOLS_UTF8_STRINGS = 2
 } FerricStringEncoding;
-
-// C-facing conflict-resolution strategy for `FerricConfig`.
-typedef enum FerricConflictStrategy {
-    FERRIC_CONFLICT_STRATEGY_DEPTH = 0,
-    FERRIC_CONFLICT_STRATEGY_BREADTH = 1,
-    FERRIC_CONFLICT_STRATEGY_LEX = 2,
-    FERRIC_CONFLICT_STRATEGY_MEA = 3
-} FerricConflictStrategy;
 
 // C-facing value type discriminant.
 //
@@ -259,33 +286,6 @@ typedef enum FerricValueType {
     FERRIC_VALUE_TYPE_MULTIFIELD = 5,
     FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS = 6
 } FerricValueType;
-
-#if defined(FERRIC_SERDE)
-// Serialization format selector for `ferric_engine_serialize_as` and
-// `ferric_engine_deserialize_as`.
-typedef enum FerricSerializationFormat {
-    // Compact binary (bincode). Fast and small.
-    FERRIC_SERIALIZATION_FORMAT_BINCODE = 0,
-    // JSON (human-readable, larger output).
-    FERRIC_SERIALIZATION_FORMAT_JSON = 1,
-    // CBOR (Concise Binary Object Representation).
-    FERRIC_SERIALIZATION_FORMAT_CBOR = 2,
-    // `MessagePack` (compact binary, JSON-like schema).
-    FERRIC_SERIALIZATION_FORMAT_MESSAGE_PACK = 3,
-    // Postcard (compact, `no_std`-friendly binary).
-    FERRIC_SERIALIZATION_FORMAT_POSTCARD = 4
-} FerricSerializationFormat;
-#endif
-
-// Autorelease-pool installation policy used by the pinned worker.
-typedef enum FerricPinnedAutoreleasePolicy {
-    // Never install an Apple autorelease pool.
-    FERRIC_PINNED_AUTORELEASE_POLICY_NONE = 0,
-    // Install one pool per drained request.
-    FERRIC_PINNED_AUTORELEASE_POLICY_PER_ITEM = 1,
-    // Install one pool per drained batch.
-    FERRIC_PINNED_AUTORELEASE_POLICY_PER_BATCH = 2
-} FerricPinnedAutoreleasePolicy;
 
 // Opaque engine handle exposed to C.
 //

--- a/crates/ferric-ffi/src/tests/template_assertion.rs
+++ b/crates/ferric-ffi/src/tests/template_assertion.rs
@@ -45,7 +45,8 @@ fn assert_template_basic() {
         let slot_age_name = CString::new("age").unwrap();
 
         let slot_names = [slot_name_name.as_ptr(), slot_age_name.as_ptr()];
-        let name_val = ferric_value_string(CString::new("Alice").unwrap().as_ptr());
+        let name_string = CString::new("Alice").unwrap();
+        let name_val = ferric_value_string(name_string.as_ptr());
         let age_val = ferric_value_integer(30);
         let slot_values = [name_val, age_val];
 
@@ -101,7 +102,8 @@ fn assert_template_defaults_filled() {
         let tmpl_name = CString::new("person").unwrap();
         let slot_name_str = CString::new("name").unwrap();
         let slot_names = [slot_name_str.as_ptr()];
-        let name_val = ferric_value_string(CString::new("Bob").unwrap().as_ptr());
+        let name_string = CString::new("Bob").unwrap();
+        let name_val = ferric_value_string(name_string.as_ptr());
         let slot_values = [name_val];
 
         let mut fact_id: u64 = 0;
@@ -244,7 +246,8 @@ fn get_slot_by_name_basic() {
         let slot_name = CString::new("name").unwrap();
         let slot_age = CString::new("age").unwrap();
         let slot_names = [slot_name.as_ptr(), slot_age.as_ptr()];
-        let name_val = ferric_value_string(CString::new("Charlie").unwrap().as_ptr());
+        let name_string = CString::new("Charlie").unwrap();
+        let name_val = ferric_value_string(name_string.as_ptr());
         let age_val = ferric_value_integer(25);
         let slot_values = [name_val, age_val];
 
@@ -437,7 +440,8 @@ fn assert_template_with_float_slot() {
         let slot_unit = CString::new("unit").unwrap();
         let slot_names = [slot_value.as_ptr(), slot_unit.as_ptr()];
         let val = ferric_value_float(98.6);
-        let unit = ferric_value_symbol(CString::new("celsius").unwrap().as_ptr());
+        let unit_string = CString::new("celsius").unwrap();
+        let unit = ferric_value_symbol(unit_string.as_ptr());
         let slot_values = [val, unit];
 
         let mut fact_id: u64 = 0;

--- a/crates/ferric-napi/Cargo.toml
+++ b/crates/ferric-napi/Cargo.toml
@@ -2,8 +2,7 @@
 name = "ferric-napi"
 version.workspace = true
 edition.workspace = true
-# napi-build 2.3.x requires cargo:: build script syntax (Rust 1.77+)
-rust-version = "1.77"
+rust-version.workspace = true
 license.workspace = true
 
 [lib]
@@ -21,7 +20,7 @@ default = ["serde"]
 serde = ["ferric-runtime/serde"]
 
 [build-dependencies]
-napi-build = "2"
+napi-build = { workspace = true }
 
 [lints.rust]
 # napi-rs proc macros generate unsafe code in expanded output

--- a/crates/ferric-runtime/Cargo.toml
+++ b/crates/ferric-runtime/Cargo.toml
@@ -28,7 +28,7 @@ tracing = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
-tempfile = "3.8"
+tempfile = { workspace = true }
 criterion = { workspace = true }
 serde_json = { workspace = true }
 ciborium = { workspace = true }

--- a/crates/ferric-runtime/src/actions.rs
+++ b/crates/ferric-runtime/src/actions.rs
@@ -1636,7 +1636,6 @@ fn execute_loop_body(
     eval_env: &mut ActionEvalEnv,
     collected_facts: &[FactId],
 ) -> Result<(), ActionError> {
-    use ferric_parser::ActionExpr;
     for (action_expr, rt_expr) in body {
         let (branch_call, branch_runtime): (
             ferric_parser::FunctionCall,

--- a/crates/ferric/Cargo.toml
+++ b/crates/ferric/Cargo.toml
@@ -18,6 +18,8 @@ ferric-runtime = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [[bench]]
 name = "engine_bench"

--- a/crates/ferric/tests/msrv_metadata.rs
+++ b/crates/ferric/tests/msrv_metadata.rs
@@ -1,0 +1,81 @@
+use std::collections::HashSet;
+use std::path::Path;
+use std::process::Command;
+
+use serde::Deserialize;
+
+const EXPECTED_MSRV: &str = "1.75";
+
+#[derive(Deserialize)]
+struct Metadata {
+    packages: Vec<Package>,
+    workspace_members: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct Package {
+    id: String,
+    name: String,
+    publish: Option<Vec<String>>,
+    rust_version: Option<String>,
+}
+
+impl Package {
+    fn is_publishable(&self) -> bool {
+        self.publish
+            .as_ref()
+            .map_or(true, |registries| !registries.is_empty())
+    }
+}
+
+#[test]
+fn publishable_workspace_members_share_the_declared_msrv() {
+    assert_eq!(env!("CARGO_PKG_RUST_VERSION"), EXPECTED_MSRV);
+
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let output = Command::new(env!("CARGO"))
+        .args(["metadata", "--format-version", "1", "--no-deps", "--locked"])
+        .current_dir(workspace_root)
+        .output()
+        .expect("cargo metadata should run");
+    assert!(
+        output.status.success(),
+        "cargo metadata failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let metadata: Metadata =
+        serde_json::from_slice(&output.stdout).expect("cargo metadata should emit valid JSON");
+    let workspace_members: HashSet<&str> = metadata
+        .workspace_members
+        .iter()
+        .map(String::as_str)
+        .collect();
+    let publishable: Vec<&Package> = metadata
+        .packages
+        .iter()
+        .filter(|package| workspace_members.contains(package.id.as_str()))
+        .filter(|package| package.is_publishable())
+        .collect();
+
+    assert!(
+        !publishable.is_empty(),
+        "workspace should contain publishable packages"
+    );
+
+    let mismatches: Vec<String> = publishable
+        .iter()
+        .filter(|package| package.rust_version.as_deref() != Some(EXPECTED_MSRV))
+        .map(|package| {
+            format!(
+                "{} declares {:?}, expected {EXPECTED_MSRV}",
+                package.name, package.rust_version
+            )
+        })
+        .collect();
+    assert!(
+        mismatches.is_empty(),
+        "publishable package MSRV mismatch:\n{}",
+        mismatches.join("\n")
+    );
+}


### PR DESCRIPTION
Closes #101

## Summary

- preserve the declared Rust 1.75 MSRV by pinning or feature-isolating dependencies whose latest releases require newer Cargo or rustc
- align ferric-napi with the workspace MSRV and use an MSRV-aware committed lockfile
- add a dedicated Rust 1.75 CI job covering the locked workspace, all features, serialization, CLI, and the complete workspace test suite
- add a metadata regression test requiring every publishable workspace crate to declare Rust 1.75
- document the lockfile update and oldest-toolchain validation procedure
- regenerate dependency notices and C headers from the compatible graph
- resolve deterministic Rust 1.75 warnings, including extending four CString lifetimes across their FFI calls

## Pre-fix failures

Rust 1.75 could not parse the locked manifests for getrandom 0.4.1, rmp 0.8.15, or home 0.5.12 because those releases use edition 2024. The napi-build version also made ferric-napi declare Rust 1.77. These were dependency-resolution conflicts, not language requirements in Ferric itself.

## Validation

- just preflight-pr
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo +1.75.0 check --workspace --locked
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 RUSTFLAGS=-Dwarnings cargo +1.75.0 check --workspace --all-features --locked
- RUSTFLAGS=-Dwarnings cargo +1.75.0 check -p ferric-runtime --features serde --locked
- RUSTFLAGS=-Dwarnings cargo +1.75.0 check -p ferric-cli --locked
- PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 RUSTFLAGS=-Dwarnings cargo +1.75.0 test --workspace --locked

Local ABI-forward compatibility is needed because this machine defaults to Python 3.14; CI installs Python 3.12 explicitly.