### PR TITLE
[FR-RETE-001] Make fact duplication CLIPS-compatible

### DIFF
--- a/.github/workflows/compat-compare.yml
+++ b/.github/workflows/compat-compare.yml
@@ -74,8 +74,7 @@ jobs:
         run: |
           git checkout ${{ inputs.base_sha }}
           git checkout ${{ inputs.head_sha }} -- tools/ferric-tools/
-          # This checkout is the pre-rename base revision.
-          cargo build --release -p ferric-cli
+          cargo build --release -p ferric-rules-cli
           uv run --project tools/ferric-tools ferric-compat-scan
           # Materialize head-format harnesses for base sources without modifying
           # the base branch's tracked harnesses.

--- a/bindings/go/pinned_engine_test.go
+++ b/bindings/go/pinned_engine_test.go
@@ -531,14 +531,14 @@ func TestPinnedEngine_ConcurrentAccess(t *testing.T) {
 
 	errs := make(chan error, goroutines)
 
-	for range goroutines {
-		go func() {
+	for i := range goroutines {
+		go func(value int64) {
 			defer wg.Done()
-			_, err := p.AssertFact("color", Symbol("red"))
+			_, err := p.AssertFact("color", value)
 			if err != nil {
 				errs <- err
 			}
-		}()
+		}(int64(i))
 	}
 
 	wg.Wait()

--- a/crates/ferric-rules-cli/tests/compat_observe.rs
+++ b/crates/ferric-rules-cli/tests/compat_observe.rs
@@ -15,8 +15,6 @@ const SOURCE: &str = r#"
 
 (deffacts seed
   (person (name "Ada") (tags))
-  (signal "ready" 7)
-  (signal "ready" 7)
   (go))
 
 (defrule report-person
@@ -25,6 +23,9 @@ const SOURCE: &str = r#"
   =>
   (retract ?g)
   (modify ?p (tags (create$ alpha 2 3.5)))
+  (set-fact-duplication TRUE)
+  (assert (signal "ready" 7))
+  (assert (signal "ready" 7))
   (printout t "hello" crlf)
   (printout stderr "problem" crlf))
 "#;

--- a/crates/ferric-rules-core/src/fact.rs
+++ b/crates/ferric-rules-core/src/fact.rs
@@ -55,6 +55,22 @@ where
     }
 }
 
+fn remove_from_candidate_index(
+    index: &mut HashMap<u64, SmallVec<[FactId; 1]>>,
+    fingerprint: u64,
+    id: FactId,
+) {
+    let mut remove_fingerprint = false;
+    if let Some(candidates) = index.get_mut(&fingerprint) {
+        candidates.retain(|candidate| *candidate != id);
+        remove_fingerprint = candidates.is_empty();
+    }
+
+    if remove_fingerprint {
+        index.remove(&fingerprint);
+    }
+}
+
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct SymbolMap<T> {
@@ -318,6 +334,15 @@ pub struct FactEntry {
     pub timestamp: Timestamp,
 }
 
+/// Result of inserting a fact through [`FactBase::assert_fact`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FactInsertionResult {
+    /// A new fact was inserted.
+    Inserted(FactId),
+    /// Duplicate rejection was requested and an equivalent fact exists.
+    Duplicate(FactId),
+}
+
 /// Fact base: storage and indexing for all facts in working memory.
 ///
 /// Maintains indices for fast lookup by relation and template.
@@ -335,11 +360,14 @@ pub struct FactBase {
     /// Fingerprints are only an accelerator. Every lookup confirms the full
     /// structural equality contract, so hash collisions cannot cause a valid
     /// assertion to be rejected.
-    #[cfg_attr(
-        feature = "serde",
-        serde(with = "crate::serde_helpers::fx_hash_map_of_fx_hash_set")
-    )]
-    by_structural_fingerprint: HashMap<u64, HashSet<FactId>>,
+    ///
+    /// The index is derived state, so snapshots omit it and rebuild it lazily.
+    /// It is also invalidated while duplicates are allowed, avoiding any
+    /// duplicate-checking cost until the policy is disabled again. The common
+    /// no-duplicate case keeps its sole candidate inline without a heap
+    /// allocation.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    by_structural_fingerprint: Option<HashMap<u64, SmallVec<[FactId; 1]>>>,
     next_timestamp: Timestamp,
 }
 
@@ -351,13 +379,12 @@ impl FactBase {
             facts: SlotMap::with_key(),
             by_template: HashMap::default(),
             by_relation: SymbolMap::new(),
-            by_structural_fingerprint: HashMap::default(),
+            by_structural_fingerprint: Some(HashMap::default()),
             next_timestamp: Timestamp::ZERO,
         }
     }
 
-    fn insert_fact(&mut self, fact: Fact) -> FactId {
-        let fingerprint = structural_fingerprint(&fact);
+    fn insert_fact(&mut self, fact: Fact, fingerprint: Option<u64>) -> FactId {
         let timestamp = self.next_timestamp;
         self.next_timestamp = self.next_timestamp.next();
 
@@ -366,11 +393,55 @@ impl FactBase {
             id,
             timestamp,
         });
-        self.by_structural_fingerprint
-            .entry(fingerprint)
-            .or_default()
-            .insert(id);
+        if let (Some(index), Some(fingerprint)) = (&mut self.by_structural_fingerprint, fingerprint)
+        {
+            index.entry(fingerprint).or_default().push(id);
+        }
         id
+    }
+
+    fn ensure_structural_index(&mut self) {
+        if self.by_structural_fingerprint.is_some() {
+            return;
+        }
+
+        let mut index: HashMap<u64, SmallVec<[FactId; 1]>> = HashMap::default();
+        for (id, entry) in &self.facts {
+            index
+                .entry(structural_fingerprint(&entry.fact))
+                .or_default()
+                .push(id);
+        }
+
+        // SlotMap iteration follows slot order, which may differ from assertion
+        // order after slot reuse. Keep candidates oldest-first so lookups remain
+        // deterministic after lazy rebuilds and snapshot restoration.
+        for candidates in index.values_mut() {
+            if candidates.len() > 1 {
+                candidates.sort_unstable_by_key(|id| {
+                    self.facts
+                        .get(*id)
+                        .expect("structural index only contains active facts")
+                        .timestamp
+                });
+            }
+        }
+
+        self.by_structural_fingerprint = Some(index);
+    }
+
+    fn find_equivalent_with_fingerprint(&self, fact: &Fact, fingerprint: u64) -> Option<FactId> {
+        self.by_structural_fingerprint
+            .as_ref()
+            .expect("structural index must be initialized before lookup")
+            .get(&fingerprint)?
+            .iter()
+            .copied()
+            .find(|id| {
+                self.facts
+                    .get(*id)
+                    .is_some_and(|entry| entry.fact.structural_eq(fact))
+            })
     }
 
     /// Find the oldest active fact structurally equivalent to `fact`.
@@ -379,41 +450,72 @@ impl FactBase {
     /// resolves collisions. Choosing the oldest assertion makes the returned
     /// existing ID deterministic when duplicates were previously enabled.
     #[must_use]
-    pub fn find_equivalent(&self, fact: &Fact) -> Option<FactId> {
+    pub fn find_equivalent(&mut self, fact: &Fact) -> Option<FactId> {
+        self.ensure_structural_index();
         let fingerprint = structural_fingerprint(fact);
-        self.by_structural_fingerprint
-            .get(&fingerprint)?
-            .iter()
-            .filter_map(|id| self.facts.get(*id))
-            .filter(|entry| entry.fact.structural_eq(fact))
-            .min_by_key(|entry| entry.timestamp)
-            .map(|entry| entry.id)
+        self.find_equivalent_with_fingerprint(fact, fingerprint)
+    }
+
+    /// Insert `fact`, optionally rejecting an equivalent active fact.
+    ///
+    /// When `allow_duplicates` is `false`, lookup and insertion share one
+    /// structural fingerprint calculation. When it is `true`, the derived
+    /// duplicate index is invalidated and no structural hashing is performed.
+    pub fn assert_fact(&mut self, fact: Fact, allow_duplicates: bool) -> FactInsertionResult {
+        let fingerprint = if allow_duplicates {
+            self.by_structural_fingerprint = None;
+            None
+        } else {
+            self.ensure_structural_index();
+            let fingerprint = structural_fingerprint(&fact);
+            if let Some(existing) = self.find_equivalent_with_fingerprint(&fact, fingerprint) {
+                return FactInsertionResult::Duplicate(existing);
+            }
+            Some(fingerprint)
+        };
+
+        let id = match &fact {
+            Fact::Ordered(ordered) => {
+                let relation = ordered.relation;
+                let id = self.insert_fact(fact, fingerprint);
+                self.by_relation
+                    .get_or_insert_with(relation, HashSet::default)
+                    .insert(id);
+                id
+            }
+            Fact::Template(template) => {
+                let template_id = template.template_id;
+                let id = self.insert_fact(fact, fingerprint);
+                self.by_template.entry(template_id).or_default().insert(id);
+                id
+            }
+        };
+
+        FactInsertionResult::Inserted(id)
     }
 
     /// Assert an ordered fact into working memory.
     ///
     /// Returns the unique `FactId` assigned to the fact.
     pub fn assert_ordered(&mut self, relation: Symbol, fields: SmallVec<[Value; 8]>) -> FactId {
-        let id = self.insert_fact(Fact::Ordered(OrderedFact { relation, fields }));
-
-        // Update relation index
-        self.by_relation
-            .get_or_insert_with(relation, HashSet::default)
-            .insert(id);
-
-        id
+        match self.assert_fact(Fact::Ordered(OrderedFact { relation, fields }), true) {
+            FactInsertionResult::Inserted(id) => id,
+            FactInsertionResult::Duplicate(_) => {
+                unreachable!("allowing duplicates always inserts the fact")
+            }
+        }
     }
 
     /// Assert a template fact into working memory.
     ///
     /// Returns the unique `FactId` assigned to the fact.
     pub fn assert_template(&mut self, template_id: TemplateId, slots: Box<[Value]>) -> FactId {
-        let id = self.insert_fact(Fact::Template(TemplateFact { template_id, slots }));
-
-        // Update template index
-        self.by_template.entry(template_id).or_default().insert(id);
-
-        id
+        match self.assert_fact(Fact::Template(TemplateFact { template_id, slots }), true) {
+            FactInsertionResult::Inserted(id) => id,
+            FactInsertionResult::Duplicate(_) => {
+                unreachable!("allowing duplicates always inserts the fact")
+            }
+        }
     }
 
     /// Retract a fact from working memory.
@@ -421,7 +523,10 @@ impl FactBase {
     /// Returns the removed fact entry if it existed, or `None` if not found.
     pub fn retract(&mut self, id: FactId) -> Option<FactEntry> {
         let entry = self.facts.remove(id)?;
-        let fingerprint = structural_fingerprint(&entry.fact);
+        let fingerprint = self
+            .by_structural_fingerprint
+            .as_ref()
+            .map(|_| structural_fingerprint(&entry.fact));
 
         // Clean up indices
         match &entry.fact {
@@ -432,7 +537,10 @@ impl FactBase {
                 remove_from_set_index(&mut self.by_template, template.template_id, id);
             }
         }
-        remove_from_set_index(&mut self.by_structural_fingerprint, fingerprint, id);
+        if let (Some(index), Some(fingerprint)) = (&mut self.by_structural_fingerprint, fingerprint)
+        {
+            remove_from_candidate_index(index, fingerprint, id);
+        }
 
         Some(entry)
     }
@@ -567,6 +675,24 @@ mod tests {
         assert_eq!(fb.find_equivalent(&equivalent), Some(second));
         fb.retract(second).unwrap();
         assert_eq!(fb.find_equivalent(&equivalent), None);
+    }
+
+    #[test]
+    fn structural_lookup_rebuild_keeps_oldest_duplicate_after_slot_reuse() {
+        let mut table = SymbolTable::new();
+        let mut fb = FactBase::new();
+        let relation = table.intern_symbol("item", StringEncoding::Ascii).unwrap();
+        let filler = fb.assert_ordered(relation, smallvec::smallvec![Value::Integer(0)]);
+        let oldest = fb.assert_ordered(relation, smallvec::smallvec![Value::Integer(1)]);
+        fb.retract(filler).unwrap();
+        let newest = fb.assert_ordered(relation, smallvec::smallvec![Value::Integer(1)]);
+        let equivalent = Fact::Ordered(OrderedFact {
+            relation,
+            fields: smallvec::smallvec![Value::Integer(1)],
+        });
+
+        assert_ne!(oldest, newest);
+        assert_eq!(fb.find_equivalent(&equivalent), Some(oldest));
     }
 
     #[test]

--- a/crates/ferric-rules-core/src/fact.rs
+++ b/crates/ferric-rules-core/src/fact.rs
@@ -3,9 +3,10 @@
 //! Facts are the working memory of the rules engine. This module provides
 //! ordered facts, template facts, and the fact base that stores and indexes them.
 
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 use slotmap::SlotMap;
 use smallvec::SmallVec;
+use std::hash::{Hash, Hasher};
 
 use crate::symbol::{Symbol, SymbolId};
 use crate::value::Value;
@@ -176,6 +177,18 @@ impl AsMut<[Value]> for OrderedFact {
     }
 }
 
+impl OrderedFact {
+    /// Compare ordered facts by relation and field contents.
+    ///
+    /// Fact identity and assertion timestamp are intentionally not part of
+    /// structural equality. Float fields use their bit representation, and
+    /// multifields are compared recursively through [`Value::structural_eq`].
+    #[must_use]
+    pub fn structural_eq(&self, other: &Self) -> bool {
+        self.relation == other.relation && values_structural_eq(&self.fields, &other.fields)
+    }
+}
+
 /// A template fact: template ID + slot values.
 ///
 /// The template defines the slot names and types; this fact holds the values.
@@ -198,12 +211,102 @@ impl AsMut<[Value]> for TemplateFact {
     }
 }
 
+impl TemplateFact {
+    /// Compare template facts by template identity and positional slot values.
+    ///
+    /// Slot order is the canonical order from the template definition. Fact
+    /// identity and assertion timestamp are intentionally ignored.
+    #[must_use]
+    pub fn structural_eq(&self, other: &Self) -> bool {
+        self.template_id == other.template_id && values_structural_eq(&self.slots, &other.slots)
+    }
+}
+
 /// A fact: either ordered or template-based.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Fact {
     Ordered(OrderedFact),
     Template(TemplateFact),
+}
+
+impl Fact {
+    /// Compare facts by their CLIPS-visible structure.
+    ///
+    /// Ordered facts compare relation plus ordered fields. Template facts
+    /// compare template identity plus positional slot values. Facts of
+    /// different kinds are never structurally equal.
+    #[must_use]
+    pub fn structural_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Ordered(lhs), Self::Ordered(rhs)) => lhs.structural_eq(rhs),
+            (Self::Template(lhs), Self::Template(rhs)) => lhs.structural_eq(rhs),
+            _ => false,
+        }
+    }
+}
+
+fn values_structural_eq(lhs: &[Value], rhs: &[Value]) -> bool {
+    lhs.len() == rhs.len() && lhs.iter().zip(rhs).all(|(lhs, rhs)| lhs.structural_eq(rhs))
+}
+
+fn hash_value_structurally(value: &Value, hasher: &mut FxHasher) {
+    match value {
+        Value::Symbol(symbol) => {
+            0_u8.hash(hasher);
+            symbol.hash(hasher);
+        }
+        Value::String(string) => {
+            1_u8.hash(hasher);
+            string.hash(hasher);
+        }
+        Value::Integer(integer) => {
+            2_u8.hash(hasher);
+            integer.hash(hasher);
+        }
+        Value::Float(float) => {
+            3_u8.hash(hasher);
+            float.to_bits().hash(hasher);
+        }
+        Value::Multifield(multifield) => {
+            4_u8.hash(hasher);
+            multifield.len().hash(hasher);
+            for value in multifield.iter() {
+                hash_value_structurally(value, hasher);
+            }
+        }
+        Value::ExternalAddress(address) => {
+            5_u8.hash(hasher);
+            address.type_id.hash(hasher);
+            (address.pointer as usize).hash(hasher);
+        }
+        Value::Void => {
+            6_u8.hash(hasher);
+        }
+    }
+}
+
+fn structural_fingerprint(fact: &Fact) -> u64 {
+    let mut hasher = FxHasher::default();
+    match fact {
+        Fact::Ordered(ordered) => {
+            0_u8.hash(&mut hasher);
+            ordered.relation.hash(&mut hasher);
+            ordered.fields.len().hash(&mut hasher);
+            for value in &ordered.fields {
+                hash_value_structurally(value, &mut hasher);
+            }
+        }
+        Fact::Template(template) => {
+            1_u8.hash(&mut hasher);
+            template.template_id.hash(&mut hasher);
+            template.slots.len().hash(&mut hasher);
+            for value in &template.slots {
+                hash_value_structurally(value, &mut hasher);
+            }
+        }
+    }
+    hasher.finish()
 }
 
 /// A fact entry: the fact itself plus metadata.
@@ -227,6 +330,16 @@ pub struct FactBase {
     )]
     by_template: HashMap<TemplateId, HashSet<FactId>>,
     by_relation: SymbolMap<HashSet<FactId>>,
+    /// Structural fingerprint → candidate fact IDs.
+    ///
+    /// Fingerprints are only an accelerator. Every lookup confirms the full
+    /// structural equality contract, so hash collisions cannot cause a valid
+    /// assertion to be rejected.
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_helpers::fx_hash_map_of_fx_hash_set")
+    )]
+    by_structural_fingerprint: HashMap<u64, HashSet<FactId>>,
     next_timestamp: Timestamp,
 }
 
@@ -238,19 +351,43 @@ impl FactBase {
             facts: SlotMap::with_key(),
             by_template: HashMap::default(),
             by_relation: SymbolMap::new(),
+            by_structural_fingerprint: HashMap::default(),
             next_timestamp: Timestamp::ZERO,
         }
     }
 
     fn insert_fact(&mut self, fact: Fact) -> FactId {
+        let fingerprint = structural_fingerprint(&fact);
         let timestamp = self.next_timestamp;
         self.next_timestamp = self.next_timestamp.next();
 
-        self.facts.insert_with_key(|id| FactEntry {
+        let id = self.facts.insert_with_key(|id| FactEntry {
             fact,
             id,
             timestamp,
-        })
+        });
+        self.by_structural_fingerprint
+            .entry(fingerprint)
+            .or_default()
+            .insert(id);
+        id
+    }
+
+    /// Find the oldest active fact structurally equivalent to `fact`.
+    ///
+    /// The structural fingerprint narrows candidates, then full equality
+    /// resolves collisions. Choosing the oldest assertion makes the returned
+    /// existing ID deterministic when duplicates were previously enabled.
+    #[must_use]
+    pub fn find_equivalent(&self, fact: &Fact) -> Option<FactId> {
+        let fingerprint = structural_fingerprint(fact);
+        self.by_structural_fingerprint
+            .get(&fingerprint)?
+            .iter()
+            .filter_map(|id| self.facts.get(*id))
+            .filter(|entry| entry.fact.structural_eq(fact))
+            .min_by_key(|entry| entry.timestamp)
+            .map(|entry| entry.id)
     }
 
     /// Assert an ordered fact into working memory.
@@ -284,6 +421,7 @@ impl FactBase {
     /// Returns the removed fact entry if it existed, or `None` if not found.
     pub fn retract(&mut self, id: FactId) -> Option<FactEntry> {
         let entry = self.facts.remove(id)?;
+        let fingerprint = structural_fingerprint(&entry.fact);
 
         // Clean up indices
         match &entry.fact {
@@ -294,6 +432,7 @@ impl FactBase {
                 remove_from_set_index(&mut self.by_template, template.template_id, id);
             }
         }
+        remove_from_set_index(&mut self.by_structural_fingerprint, fingerprint, id);
 
         Some(entry)
     }
@@ -392,6 +531,42 @@ mod tests {
 
         assert_eq!(fb.get(id1).unwrap().timestamp, Timestamp::new(0));
         assert_eq!(fb.get(id2).unwrap().timestamp, Timestamp::new(1));
+    }
+
+    #[test]
+    fn structural_lookup_distinguishes_ordered_field_contents() {
+        let mut table = SymbolTable::new();
+        let mut fb = FactBase::new();
+        let relation = table.intern_symbol("item", StringEncoding::Ascii).unwrap();
+        let first = fb.assert_ordered(relation, smallvec::smallvec![Value::Integer(1)]);
+        let equivalent = Fact::Ordered(OrderedFact {
+            relation,
+            fields: smallvec::smallvec![Value::Integer(1)],
+        });
+        let different = Fact::Ordered(OrderedFact {
+            relation,
+            fields: smallvec::smallvec![Value::Integer(2)],
+        });
+
+        assert_eq!(fb.find_equivalent(&equivalent), Some(first));
+        assert_eq!(fb.find_equivalent(&different), None);
+    }
+
+    #[test]
+    fn structural_lookup_tracks_duplicate_retraction() {
+        let mut table = SymbolTable::new();
+        let mut fb = FactBase::new();
+        let relation = table.intern_symbol("item", StringEncoding::Ascii).unwrap();
+        let fields = smallvec::smallvec![Value::Integer(1)];
+        let first = fb.assert_ordered(relation, fields.clone());
+        let second = fb.assert_ordered(relation, fields.clone());
+        let equivalent = Fact::Ordered(OrderedFact { relation, fields });
+
+        assert_eq!(fb.find_equivalent(&equivalent), Some(first));
+        fb.retract(first).unwrap();
+        assert_eq!(fb.find_equivalent(&equivalent), Some(second));
+        fb.retract(second).unwrap();
+        assert_eq!(fb.find_equivalent(&equivalent), None);
     }
 
     #[test]

--- a/crates/ferric-rules-core/src/lib.rs
+++ b/crates/ferric-rules-core/src/lib.rs
@@ -69,7 +69,8 @@ pub use compiler::{
 pub use encoding::{EncodingError, StringEncoding};
 pub use exists::{ExistsMemory, ExistsMemoryId};
 pub use fact::{
-    Fact, FactBase, FactEntry, FactId, OrderedFact, TemplateFact, TemplateId, Timestamp,
+    Fact, FactBase, FactEntry, FactId, FactInsertionResult, OrderedFact, TemplateFact, TemplateId,
+    Timestamp,
 };
 pub use ncc::{NccMemory, NccMemoryId};
 pub use negative::{NegativeMemory, NegativeMemoryId};

--- a/crates/ferric-rules-ffi/src/tests/discriminant_validation.rs
+++ b/crates/ferric-rules-ffi/src/tests/discriminant_validation.rs
@@ -51,9 +51,9 @@ unsafe fn new_engine_with_template() -> *mut FerricEngine {
 }
 
 /// Assert a valid fact to prove the engine survived a rejected call.
-unsafe fn assert_engine_usable(engine: *mut FerricEngine) {
+unsafe fn assert_engine_usable(engine: *mut FerricEngine, probe_value: i64) {
     let relation = CString::new("probe").unwrap();
-    let field = ferric_value_integer(1);
+    let field = ferric_value_integer(probe_value);
     assert_eq!(
         ferric_engine_assert_ordered(engine, relation.as_ptr(), &field, 1, ptr::null_mut()),
         FerricError::Ok,
@@ -88,7 +88,7 @@ fn assert_ordered_rejects_invalid_top_level_discriminant() {
                 "discriminant {tag} must be rejected"
             );
             assert_global_diag_names_tag(tag);
-            assert_engine_usable(engine);
+            assert_engine_usable(engine, i64::from(tag));
         }
 
         // No `bad` fact must have been asserted (only the usable-probe facts).
@@ -127,7 +127,7 @@ fn assert_ordered_rejects_invalid_nested_discriminant() {
                 "nested discriminant {tag} must be rejected"
             );
             assert_global_diag_names_tag(tag);
-            assert_engine_usable(engine);
+            assert_engine_usable(engine, i64::from(tag));
         }
 
         ferric_engine_free(engine);
@@ -210,7 +210,7 @@ fn assert_template_rejects_invalid_discriminants() {
             FerricError::InvalidArgument
         );
 
-        assert_engine_usable(engine);
+        assert_engine_usable(engine, 1);
         ferric_engine_free(engine);
     }
 }

--- a/crates/ferric-rules-ffi/src/types.rs
+++ b/crates/ferric-rules-ffi/src/types.rs
@@ -133,11 +133,11 @@ impl TryFrom<&FerricConfig> for EngineConfig {
         let string_encoding = FerricStringEncoding::try_from(config.string_encoding)?;
         let strategy = FerricConflictStrategy::try_from(config.strategy)?;
 
-        Ok(Self {
-            string_encoding: string_encoding.into(),
-            strategy: strategy.into(),
-            max_call_depth: config.max_call_depth,
-        })
+        let mut runtime_config =
+            Self::from(ferric_rules_core::StringEncoding::from(string_encoding))
+                .with_strategy(strategy.into());
+        runtime_config.max_call_depth = config.max_call_depth;
+        Ok(runtime_config)
     }
 }
 

--- a/crates/ferric-rules-ffi/tests/c/discriminant_abuse.c
+++ b/crates/ferric-rules-ffi/tests/c/discriminant_abuse.c
@@ -216,11 +216,11 @@ static void test_value_free_null_and_valid_return_ok(void) {
  * FFI-allocated multifield array: [Symbol(owned string), Integer].
  * Returns 0 on failure. The caller owns *out and the fact `*fact_id`. */
 static int read_back_multislot(FerricEngine *engine, FerricValue *out,
-                               uint64_t *fact_id) {
+                               uint64_t *fact_id, int64_t discriminator) {
     const char *slot_names[1] = {"tags"};
     FerricValue elems[2];
     elems[0] = ferric_value_symbol("owned-sibling");
-    elems[1] = ferric_value_integer(22);
+    elems[1] = ferric_value_integer(discriminator);
     FerricValue mf = ferric_value_void();
     mf.value_type = FERRIC_VALUE_TYPE_MULTIFIELD;
     mf.multifield_ptr = elems;
@@ -255,7 +255,7 @@ static void test_value_free_corrupted_nested_tag(FerricEngine *engine) {
      * and the containing array (a leaked sibling fails ASan leak checks). */
     FerricValue out;
     uint64_t fact_id = 0;
-    if (!read_back_multislot(engine, &out, &fact_id)) {
+    if (!read_back_multislot(engine, &out, &fact_id, 22)) {
         return;
     }
 
@@ -280,7 +280,7 @@ static void test_value_array_free_top_level_invalid(FerricEngine *engine) {
      * while freeing the known sibling string and the array allocation. */
     FerricValue out;
     uint64_t fact_id = 0;
-    if (!read_back_multislot(engine, &out, &fact_id)) {
+    if (!read_back_multislot(engine, &out, &fact_id, 23)) {
         return;
     }
 
@@ -307,8 +307,8 @@ static void test_value_array_free_nested_invalid(FerricEngine *engine) {
     FerricValue inner;
     uint64_t outer_fact = 0;
     uint64_t inner_fact = 0;
-    if (!read_back_multislot(engine, &outer, &outer_fact) ||
-        !read_back_multislot(engine, &inner, &inner_fact)) {
+    if (!read_back_multislot(engine, &outer, &outer_fact, 24) ||
+        !read_back_multislot(engine, &inner, &inner_fact, 25)) {
         return;
     }
 

--- a/crates/ferric-rules-runtime/Cargo.toml
+++ b/crates/ferric-rules-runtime/Cargo.toml
@@ -53,5 +53,9 @@ name = "serialization_bench"
 harness = false
 required-features = ["serde"]
 
+[[bench]]
+name = "fact_duplication_bench"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/ferric-rules-runtime/benches/fact_duplication_bench.rs
+++ b/crates/ferric-rules-runtime/benches/fact_duplication_bench.rs
@@ -1,0 +1,36 @@
+//! High-volume assertion benchmarks for both fact-duplication policies.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use ferric_rules_runtime::{Engine, EngineConfig};
+
+const ASSERTION_COUNT: usize = 10_000;
+
+fn benchmark_fact_duplication_policy(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fact_assertion/duplication_policy");
+
+    for enabled in [false, true] {
+        let label = if enabled { "enabled" } else { "disabled" };
+        group.bench_with_input(
+            BenchmarkId::new(label, ASSERTION_COUNT),
+            &enabled,
+            |b, &enabled| {
+                b.iter(|| {
+                    let config = EngineConfig::default().with_fact_duplication(enabled);
+                    let mut engine = Engine::new(config);
+                    for value in 0..ASSERTION_COUNT {
+                        #[allow(clippy::cast_possible_wrap)]
+                        engine
+                            .assert_ordered("item", black_box(value as i64))
+                            .unwrap();
+                    }
+                    black_box(engine);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_fact_duplication_policy);
+criterion_main!(benches);

--- a/crates/ferric-rules-runtime/src/actions.rs
+++ b/crates/ferric-rules-runtime/src/actions.rs
@@ -2709,12 +2709,7 @@ fn execute_assert(
                     }
                 }
 
-                assert_ordered_and_propagate(
-                    &mut context.engine.fact_base,
-                    &mut context.engine.rete,
-                    relation_sym,
-                    fields,
-                );
+                assert_ordered_and_propagate(context.engine, relation_sym, fields);
             }
             _ => return Err(ActionError::InvalidAssert),
         }
@@ -2829,12 +2824,7 @@ fn execute_fact_mutation(
                     &original_fact,
                 );
             }
-            assert_ordered_and_propagate(
-                &mut context.engine.fact_base,
-                &mut context.engine.rete,
-                relation,
-                fields,
-            );
+            assert_ordered_and_propagate(context.engine, relation, fields);
         }
         Fact::Template(template) => {
             let registered = context
@@ -2868,8 +2858,7 @@ fn execute_fact_mutation(
                 );
             }
             assert_template_and_propagate(
-                &mut context.engine.fact_base,
-                &mut context.engine.rete,
+                context.engine,
                 template.template_id,
                 slots.into_boxed_slice(),
             );
@@ -2880,33 +2869,22 @@ fn execute_fact_mutation(
 }
 
 fn assert_ordered_and_propagate(
-    fact_base: &mut FactBase,
-    rete: &mut ReteNetwork,
+    engine: &mut Engine,
     relation: Symbol,
     fields: OrderedFields,
-) -> FactId {
-    let fact_id = fact_base.assert_ordered(relation, fields);
-    let fact = &fact_base
-        .get(fact_id)
-        .expect("asserted fact should be present in fact base")
-        .fact;
-    rete.assert_fact(fact_id, fact, fact_base);
-    fact_id
+) -> crate::FactAssertionResult {
+    engine.assert_fact_internal(Fact::Ordered(OrderedFact { relation, fields }))
 }
 
 fn assert_template_and_propagate(
-    fact_base: &mut FactBase,
-    rete: &mut ReteNetwork,
+    engine: &mut Engine,
     template_id: TemplateId,
     slots: Box<[Value]>,
-) -> FactId {
-    let fact_id = fact_base.assert_template(template_id, slots);
-    let fact = &fact_base
-        .get(fact_id)
-        .expect("asserted fact should be present in fact base")
-        .fact;
-    rete.assert_fact(fact_id, fact, fact_base);
-    fact_id
+) -> crate::FactAssertionResult {
+    engine.assert_fact_internal(Fact::Template(ferric_rules_core::TemplateFact {
+        template_id,
+        slots,
+    }))
 }
 
 fn retract_original_fact(

--- a/crates/ferric-rules-runtime/src/config.rs
+++ b/crates/ferric-rules-runtime/src/config.rs
@@ -1,5 +1,7 @@
 //! Engine configuration types.
 
+use std::cell::Cell;
+
 use ferric_rules_core::{ConflictResolutionStrategy, StringEncoding};
 
 /// Engine configuration.
@@ -15,6 +17,12 @@ pub struct EngineConfig {
     /// Calls that exceed this depth return a `RecursionLimit` error rather than
     /// overflowing the stack.
     pub max_call_depth: usize,
+    /// Whether structurally equivalent facts may coexist in working memory.
+    ///
+    /// This is interior-mutable because evaluator contexts already borrow the
+    /// engine configuration immutably. `Engine` is thread-affine, so mutation
+    /// through `Cell` does not weaken its concurrency contract.
+    fact_duplication: Cell<bool>,
 }
 
 impl EngineConfig {
@@ -25,6 +33,7 @@ impl EngineConfig {
             string_encoding: StringEncoding::Ascii,
             strategy: ConflictResolutionStrategy::default(),
             max_call_depth: 64,
+            fact_duplication: Cell::new(false),
         }
     }
 
@@ -35,6 +44,7 @@ impl EngineConfig {
             string_encoding: StringEncoding::Utf8,
             strategy: ConflictResolutionStrategy::default(),
             max_call_depth: 64,
+            fact_duplication: Cell::new(false),
         }
     }
 
@@ -45,6 +55,7 @@ impl EngineConfig {
             string_encoding: StringEncoding::AsciiSymbolsUtf8Strings,
             strategy: ConflictResolutionStrategy::default(),
             max_call_depth: 64,
+            fact_duplication: Cell::new(false),
         }
     }
 
@@ -53,6 +64,26 @@ impl EngineConfig {
     pub fn with_strategy(mut self, strategy: ConflictResolutionStrategy) -> Self {
         self.strategy = strategy;
         self
+    }
+
+    /// Set the initial fact-duplication policy.
+    ///
+    /// CLIPS defaults this policy to disabled.
+    #[must_use]
+    pub fn with_fact_duplication(self, enabled: bool) -> Self {
+        self.fact_duplication.set(enabled);
+        self
+    }
+
+    /// Return whether structurally equivalent facts may coexist.
+    #[must_use]
+    pub(crate) fn fact_duplication(&self) -> bool {
+        self.fact_duplication.get()
+    }
+
+    /// Change the fact-duplication policy and return its previous value.
+    pub(crate) fn set_fact_duplication(&self, enabled: bool) -> bool {
+        self.fact_duplication.replace(enabled)
     }
 }
 
@@ -68,6 +99,7 @@ impl From<StringEncoding> for EngineConfig {
             string_encoding,
             strategy: ConflictResolutionStrategy::default(),
             max_call_depth: 64,
+            fact_duplication: Cell::new(false),
         }
     }
 }

--- a/crates/ferric-rules-runtime/src/engine.rs
+++ b/crates/ferric-rules-runtime/src/engine.rs
@@ -13,8 +13,8 @@ use thiserror::Error;
 
 use ferric_rules_core::beta::RuleId;
 use ferric_rules_core::{
-    EncodingError, Fact, FactBase, FactId, FerricString, IntoFieldValues, ReteCompiler,
-    ReteNetwork, Symbol, SymbolTable, TemplateFact, TemplateId, Value,
+    EncodingError, Fact, FactBase, FactId, FactInsertionResult, FerricString, IntoFieldValues,
+    ReteCompiler, ReteNetwork, Symbol, SymbolTable, TemplateFact, TemplateId, Value,
 };
 
 use crate::actions::{self, ActionError, CompiledRuleInfo};
@@ -278,22 +278,13 @@ impl Engine {
     }
 
     pub(crate) fn assert_fact_internal(&mut self, fact: Fact) -> FactAssertionResult {
-        if !self.fact_duplication() {
-            if let Some(existing) = self.fact_base.find_equivalent(&fact) {
-                return FactAssertionResult::Duplicate(existing);
+        match self.fact_base.assert_fact(fact, self.fact_duplication()) {
+            FactInsertionResult::Inserted(fact_id) => {
+                propagate_fact_assertion(&mut self.rete, &self.fact_base, fact_id);
+                FactAssertionResult::Asserted(fact_id)
             }
+            FactInsertionResult::Duplicate(fact_id) => FactAssertionResult::Duplicate(fact_id),
         }
-
-        let fact_id = match fact {
-            Fact::Ordered(ordered) => self
-                .fact_base
-                .assert_ordered(ordered.relation, ordered.fields),
-            Fact::Template(template) => self
-                .fact_base
-                .assert_template(template.template_id, template.slots),
-        };
-        propagate_fact_assertion(&mut self.rete, &self.fact_base, fact_id);
-        FactAssertionResult::Asserted(fact_id)
     }
 
     /// Assert an ordered fact into working memory.
@@ -1119,11 +1110,11 @@ impl Engine {
                 .symbol_table
                 .intern_symbol("initial-fact", self.config.string_encoding)
                 .expect("initial-fact symbol interning must succeed");
-            let initial_fid = self
-                .fact_base
-                .assert_ordered(initial_sym, smallvec::SmallVec::new());
-            propagate_fact_assertion(&mut self.rete, &self.fact_base, initial_fid);
-            self.initial_fact_id = Some(initial_fid);
+            let result = self.assert_fact_internal(Fact::Ordered(ferric_rules_core::OrderedFact {
+                relation: initial_sym,
+                fields: smallvec::SmallVec::new(),
+            }));
+            self.initial_fact_id = Some(result.fact_id());
         }
 
         Ok(())

--- a/crates/ferric-rules-runtime/src/engine.rs
+++ b/crates/ferric-rules-runtime/src/engine.rs
@@ -70,6 +70,31 @@ fn propagate_fact_assertion(rete: &mut ReteNetwork, fact_base: &FactBase, fact_i
     rete.assert_fact(fact_id, fact, fact_base);
 }
 
+/// Result of attempting to assert a fact.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FactAssertionResult {
+    /// A new fact was inserted and propagated through the RETE network.
+    Asserted(FactId),
+    /// Duplication was disabled and an equivalent active fact already existed.
+    Duplicate(FactId),
+}
+
+impl FactAssertionResult {
+    /// Return the newly asserted or existing equivalent fact ID.
+    #[must_use]
+    pub fn fact_id(self) -> FactId {
+        match self {
+            Self::Asserted(fact_id) | Self::Duplicate(fact_id) => fact_id,
+        }
+    }
+
+    /// Return whether this assertion created a new fact.
+    #[must_use]
+    pub fn was_asserted(self) -> bool {
+        matches!(self, Self::Asserted(_))
+    }
+}
+
 /// The Ferric rules engine.
 ///
 /// This is the main entry point for embedding applications. The engine is
@@ -235,6 +260,42 @@ impl Engine {
         Ok(engine)
     }
 
+    /// Return whether structurally equivalent facts may coexist.
+    ///
+    /// The CLIPS-compatible default is `false`.
+    #[must_use]
+    pub fn fact_duplication(&self) -> bool {
+        self.config.fact_duplication()
+    }
+
+    /// Change whether structurally equivalent facts may coexist.
+    ///
+    /// Returns the previous setting, matching CLIPS
+    /// `set-fact-duplication` semantics. Existing duplicates are not removed
+    /// when duplication is disabled.
+    pub fn set_fact_duplication(&mut self, enabled: bool) -> bool {
+        self.config.set_fact_duplication(enabled)
+    }
+
+    pub(crate) fn assert_fact_internal(&mut self, fact: Fact) -> FactAssertionResult {
+        if !self.fact_duplication() {
+            if let Some(existing) = self.fact_base.find_equivalent(&fact) {
+                return FactAssertionResult::Duplicate(existing);
+            }
+        }
+
+        let fact_id = match fact {
+            Fact::Ordered(ordered) => self
+                .fact_base
+                .assert_ordered(ordered.relation, ordered.fields),
+            Fact::Template(template) => self
+                .fact_base
+                .assert_template(template.template_id, template.slots),
+        };
+        propagate_fact_assertion(&mut self.rete, &self.fact_base, fact_id);
+        FactAssertionResult::Asserted(fact_id)
+    }
+
     /// Assert an ordered fact into working memory.
     ///
     /// The relation name is interned as a symbol. Fields can be passed as a
@@ -260,6 +321,25 @@ impl Engine {
         relation: &str,
         fields: F,
     ) -> Result<FactId, EngineError> {
+        Ok(self.assert_ordered_with_result(relation, fields)?.fact_id())
+    }
+
+    /// Assert an ordered fact and report whether it was newly inserted.
+    ///
+    /// When fact duplication is disabled, structural equality compares the
+    /// relation and every ordered field. A rejected duplicate returns
+    /// [`FactAssertionResult::Duplicate`] with the oldest equivalent active
+    /// fact ID and creates no new working-memory or RETE state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the relation violates encoding constraints or the
+    /// engine is called from the wrong thread.
+    pub fn assert_ordered_with_result<F: IntoFieldValues>(
+        &mut self,
+        relation: &str,
+        fields: F,
+    ) -> Result<FactAssertionResult, EngineError> {
         self.check_thread_affinity()?;
         ferric_span!(info_span, "engine_assert_ordered", relation);
 
@@ -268,12 +348,12 @@ impl Engine {
             .intern_symbol(relation, self.config.string_encoding)?;
 
         let fields_small = fields.into_field_values();
-        let id = self.fact_base.assert_ordered(relation_sym, fields_small);
-
-        // Propagate through rete network
-        propagate_fact_assertion(&mut self.rete, &self.fact_base, id);
-
-        Ok(id)
+        Ok(
+            self.assert_fact_internal(Fact::Ordered(ferric_rules_core::OrderedFact {
+                relation: relation_sym,
+                fields: fields_small,
+            })),
+        )
     }
 
     /// Assert a fully constructed fact into working memory.
@@ -282,22 +362,19 @@ impl Engine {
     ///
     /// Returns an error if the engine is called from the wrong thread.
     pub fn assert(&mut self, fact: Fact) -> Result<FactId, EngineError> {
+        Ok(self.assert_with_result(fact)?.fact_id())
+    }
+
+    /// Assert a fully constructed fact and report whether it was newly inserted.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the engine is called from the wrong thread.
+    pub fn assert_with_result(&mut self, fact: Fact) -> Result<FactAssertionResult, EngineError> {
         self.check_thread_affinity()?;
         ferric_span!(info_span, "engine_assert");
 
-        let id = match fact {
-            Fact::Ordered(ordered) => self
-                .fact_base
-                .assert_ordered(ordered.relation, ordered.fields),
-            Fact::Template(template) => self
-                .fact_base
-                .assert_template(template.template_id, template.slots),
-        };
-
-        // Propagate through rete network
-        propagate_fact_assertion(&mut self.rete, &self.fact_base, id);
-
-        Ok(id)
+        Ok(self.assert_fact_internal(fact))
     }
 
     /// Assert a template fact by template name and named slot values.
@@ -321,6 +398,26 @@ impl Engine {
         slot_names: &[&str],
         slot_values: Vec<Value>,
     ) -> Result<FactId, EngineError> {
+        Ok(self
+            .assert_template_with_result(template_name, slot_names, slot_values)?
+            .fact_id())
+    }
+
+    /// Assert a template fact and report whether it was newly inserted.
+    ///
+    /// When fact duplication is disabled, structural equality compares the
+    /// template identity and every positional slot value after defaults and
+    /// named overrides have been applied.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for an unknown template/slot or wrong-thread access.
+    pub fn assert_template_with_result(
+        &mut self,
+        template_name: &str,
+        slot_names: &[&str],
+        slot_values: Vec<Value>,
+    ) -> Result<FactAssertionResult, EngineError> {
         self.check_thread_affinity()?;
 
         let tid = *self
@@ -352,7 +449,7 @@ impl Engine {
             slots,
         });
 
-        self.assert(fact)
+        Ok(self.assert_fact_internal(fact))
     }
 
     /// Get the value of a template fact's slot by name.
@@ -562,11 +659,12 @@ impl Engine {
             .intern_symbol(symbol_name, self.config.string_encoding)?;
 
         let fields = smallvec::smallvec![Value::Symbol(value_sym)];
-        let id = self.fact_base.assert_ordered(relation_sym, fields);
-
-        propagate_fact_assertion(&mut self.rete, &self.fact_base, id);
-
-        Ok(id)
+        Ok(self
+            .assert_fact_internal(Fact::Ordered(ferric_rules_core::OrderedFact {
+                relation: relation_sym,
+                fields,
+            }))
+            .fact_id())
     }
 
     /// Return the CLIPS `TRUE` symbol as a [`Value`].
@@ -1005,19 +1103,12 @@ impl Engine {
             self.globals.set(*module_id, name, value.clone());
         }
 
-        // Re-assert registered deffacts
-        for deffacts in &self.registered_deffacts {
+        // Re-assert registered deffacts under the current duplication policy.
+        // Clone the declarations so assertion can mutably update working memory.
+        let registered_deffacts = self.registered_deffacts.clone();
+        for deffacts in &registered_deffacts {
             for fact in deffacts {
-                let fact_id = match fact {
-                    Fact::Ordered(ordered) => self
-                        .fact_base
-                        .assert_ordered(ordered.relation, ordered.fields.clone()),
-                    Fact::Template(template) => self
-                        .fact_base
-                        .assert_template(template.template_id, template.slots.clone()),
-                };
-                // Propagate through rete
-                propagate_fact_assertion(&mut self.rete, &self.fact_base, fact_id);
+                let _ = self.assert_fact_internal(fact.clone());
             }
         }
 
@@ -1401,6 +1492,168 @@ mod tests {
     }
 
     #[test]
+    fn fr_rete_001_default_rejects_duplicate_ordered_fact() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .load_str("(defrule r (x) => (printout t fired crlf))")
+            .unwrap();
+        engine.reset().unwrap();
+
+        let first = engine.assert_ordered_with_result("x", vec![]).unwrap();
+        let duplicate = engine.assert_ordered_with_result("x", vec![]).unwrap();
+
+        assert!(matches!(first, FactAssertionResult::Asserted(_)));
+        assert_eq!(duplicate, FactAssertionResult::Duplicate(first.fact_id()));
+        assert_eq!(engine.facts().unwrap().count(), 1);
+        assert_eq!(engine.agenda_len(), 1);
+
+        let result = engine.run(RunLimit::Unlimited).unwrap();
+        assert_eq!(result.rules_fired, 1);
+        assert_eq!(engine.get_output("t"), Some("fired\n"));
+    }
+
+    #[test]
+    fn fr_rete_001_default_rejects_duplicate_template_fact() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .load_str(
+                r"
+                (deftemplate person (slot name) (slot age (default 0)))
+                (defrule r (person (name Alice)) => (printout t fired crlf))
+                ",
+            )
+            .unwrap();
+        engine.reset().unwrap();
+        let alice = engine.intern_symbol("Alice").unwrap();
+
+        let first = engine
+            .assert_template_with_result("person", &["name"], vec![Value::Symbol(alice)])
+            .unwrap();
+        let duplicate = engine
+            .assert_template_with_result(
+                "person",
+                &["age", "name"],
+                vec![Value::Integer(0), Value::Symbol(alice)],
+            )
+            .unwrap();
+
+        assert!(matches!(first, FactAssertionResult::Asserted(_)));
+        assert_eq!(duplicate, FactAssertionResult::Duplicate(first.fact_id()));
+        assert_eq!(engine.facts().unwrap().count(), 1);
+        assert_eq!(engine.agenda_len(), 1);
+
+        let result = engine.run(RunLimit::Unlimited).unwrap();
+        assert_eq!(result.rules_fired, 1);
+    }
+
+    #[test]
+    fn fr_rete_001_toggle_allows_duplicates() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+
+        let first = engine.assert_ordered_with_result("x", 1_i64).unwrap();
+        let rejected = engine.assert_ordered_with_result("x", 1_i64).unwrap();
+        assert_eq!(rejected, FactAssertionResult::Duplicate(first.fact_id()));
+
+        assert!(!engine.set_fact_duplication(true));
+        let second = engine.assert_ordered_with_result("x", 1_i64).unwrap();
+        assert!(matches!(second, FactAssertionResult::Asserted(_)));
+        assert_ne!(first.fact_id(), second.fact_id());
+        assert_eq!(
+            engine
+                .fact_base
+                .get(second.fact_id())
+                .expect("second fact exists")
+                .timestamp,
+            ferric_rules_core::Timestamp::new(1),
+            "rejected duplicates must not consume assertion timestamps"
+        );
+
+        assert!(engine.set_fact_duplication(false));
+        let rejected_again = engine.assert_ordered_with_result("x", 1_i64).unwrap();
+        assert_eq!(
+            rejected_again,
+            FactAssertionResult::Duplicate(first.fact_id())
+        );
+
+        engine.retract(first.fact_id()).unwrap();
+        let rejected_after_retract = engine.assert_ordered_with_result("x", 1_i64).unwrap();
+        assert_eq!(
+            rejected_after_retract,
+            FactAssertionResult::Duplicate(second.fact_id())
+        );
+        assert_eq!(engine.facts().unwrap().count(), 1);
+    }
+
+    #[test]
+    fn fr_rete_001_getter_setter_return_semantics() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .load_str(
+                r#"
+                (defrule observe
+                    (go)
+                    =>
+                    (printout t
+                        (get-fact-duplication) " "
+                        (set-fact-duplication TRUE) " "
+                        (get-fact-duplication) " "
+                        (set-fact-duplication FALSE) " "
+                        (get-fact-duplication)
+                        crlf))
+                "#,
+            )
+            .unwrap();
+        engine.reset().unwrap();
+        engine.assert_ordered("go", vec![]).unwrap();
+
+        let result = engine.run(RunLimit::Unlimited).unwrap();
+        assert_eq!(result.rules_fired, 1);
+        assert_eq!(
+            engine.get_output("t"),
+            Some("FALSE FALSE TRUE TRUE FALSE\n")
+        );
+        assert!(!engine.fact_duplication());
+    }
+
+    #[test]
+    fn fr_rete_001_reset_preserves_policy_and_duplicate_index() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine.set_fact_duplication(true);
+        engine
+            .load_str(
+                r"
+                (deffacts duplicates
+                    (item 1)
+                    (item 1))
+                ",
+            )
+            .unwrap();
+
+        engine.reset().unwrap();
+        assert!(engine.fact_duplication());
+        assert_eq!(engine.find_facts("item").unwrap().len(), 2);
+
+        engine.set_fact_duplication(false);
+        let result = engine.assert_ordered_with_result("item", 1_i64).unwrap();
+        assert!(matches!(result, FactAssertionResult::Duplicate(_)));
+        assert_eq!(engine.find_facts("item").unwrap().len(), 2);
+    }
+
+    #[test]
+    fn fr_rete_001_clear_preserves_policy() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        assert!(!engine.fact_duplication());
+
+        engine.set_fact_duplication(true);
+        engine.clear();
+        assert!(engine.fact_duplication());
+
+        engine.set_fact_duplication(false);
+        engine.clear();
+        assert!(!engine.fact_duplication());
+    }
+
+    #[test]
     fn retract_fact() {
         let mut engine = Engine::new(EngineConfig::utf8());
         let id = engine.assert_ordered("test", vec![]).unwrap();
@@ -1475,6 +1728,7 @@ mod tests {
     #[test]
     fn iterate_facts() {
         let mut engine = Engine::new(EngineConfig::utf8());
+        engine.set_fact_duplication(true);
 
         let id1 = engine.assert_ordered("test", vec![]).unwrap();
         let id2 = engine.assert_ordered("test", vec![]).unwrap();
@@ -1845,6 +2099,7 @@ mod tests {
         #[test]
         fn fact_lifecycle_shadow_model(ops in proptest::collection::vec(arb_fact_op(), 0..40)) {
             let mut engine = Engine::new(EngineConfig::default());
+            engine.set_fact_duplication(true);
 
             // Pre-intern a small pool of relation symbols so we can refer to
             // them by index in the operation stream.
@@ -1941,6 +2196,7 @@ mod tests {
             shuffle in proptest::collection::vec(any::<usize>(), 0..20),
         ) {
             let mut engine = Engine::new(EngineConfig::default());
+            engine.set_fact_duplication(true);
 
             // Assert N ordered facts and collect their IDs.
             let mut live: Vec<FactId> = (0..n)

--- a/crates/ferric-rules-runtime/src/evaluator.rs
+++ b/crates/ferric-rules-runtime/src/evaluator.rs
@@ -2175,6 +2175,7 @@ pub(crate) fn is_builtin_callable(name: &str) -> bool {
             | "gensym*"
             | "setgen"
             | "set-fact-duplication"
+            | "get-fact-duplication"
             | "refresh-agenda"
             | "watch"
             | "unwatch"
@@ -2339,6 +2340,7 @@ fn dispatch_builtin(
         "gensym*" => builtin_gensym_star(ctx, args, span_ref),
         "setgen" => builtin_setgen(ctx, args, span_ref),
         "set-fact-duplication" => builtin_set_fact_duplication(ctx, args, span_ref),
+        "get-fact-duplication" => builtin_get_fact_duplication(ctx, args, span_ref),
         "refresh-agenda" => builtin_refresh_agenda(ctx, args, span_ref),
         "watch" => builtin_watch(ctx, args, span_ref),
         "unwatch" => builtin_unwatch(ctx, args, span_ref),
@@ -3696,7 +3698,7 @@ fn builtin_setgen(
     }
 }
 
-/// `set-fact-duplication` — accepted for compatibility; current runtime keeps duplicate assertions enabled.
+/// `set-fact-duplication` — change the engine policy and return its prior value.
 fn builtin_set_fact_duplication(
     ctx: &mut EvalContext<'_>,
     args: &[RuntimeExpr],
@@ -3704,8 +3706,25 @@ fn builtin_set_fact_duplication(
 ) -> Result<Value, EvalError> {
     check_arity_exact("set-fact-duplication", args, 1, span)?;
     let value = eval_inner(ctx, &args[0])?;
+    let previous = ctx
+        .config
+        .set_fact_duplication(is_truthy(&value, ctx.symbol_table));
     Ok(clips_bool(
-        is_truthy(&value, ctx.symbol_table),
+        previous,
+        ctx.symbol_table,
+        ctx.config.string_encoding,
+    ))
+}
+
+/// `get-fact-duplication` — return the engine's current duplication policy.
+fn builtin_get_fact_duplication(
+    ctx: &mut EvalContext<'_>,
+    args: &[RuntimeExpr],
+    span: Option<&SourceSpan>,
+) -> Result<Value, EvalError> {
+    check_arity_exact("get-fact-duplication", args, 0, span)?;
+    Ok(clips_bool(
+        ctx.config.fact_duplication(),
         ctx.symbol_table,
         ctx.config.string_encoding,
     ))

--- a/crates/ferric-rules-runtime/src/lib.rs
+++ b/crates/ferric-rules-runtime/src/lib.rs
@@ -87,7 +87,7 @@ pub use ferric_rules_core::{
 // Re-export primary types at crate root for convenience.
 pub use actions::ActionError;
 pub use config::EngineConfig;
-pub use engine::{Engine, EngineError, InitError};
+pub use engine::{Engine, EngineError, FactAssertionResult, InitError};
 pub use execution::{FiredRule, HaltReason, RunLimit, RunResult};
 pub use functions::{FunctionEnv, GenericRegistry, GlobalStore};
 pub use loader::{LoadError, LoadResult, RuleDef};

--- a/crates/ferric-rules-runtime/src/loader.rs
+++ b/crates/ferric-rules-runtime/src/loader.rs
@@ -28,7 +28,8 @@ use crate::qualified_name::{parse_qualified_name, QualifiedName};
 
 use ferric_rules_core::{
     AlphaEntryType, AtomKey, CompilableCondition, CompilablePattern, CompileResult, ConstantTest,
-    ConstantTestType, FactId, FerricString, JoinTestType, RuleId, Salience, SlotIndex, Value,
+    ConstantTestType, Fact, FactId, FerricString, JoinTestType, RuleId, Salience, SlotIndex,
+    TemplateFact, Value,
 };
 use ferric_rules_parser::{
     interpret_constructs, parse_sexprs, ActionExpr, Atom, Constraint, Construct, FactBody,
@@ -961,20 +962,12 @@ impl Engine {
         }
 
         // Assert as a proper template fact.
-        let fact_id = self
-            .fact_base
-            .assert_template(template_id, slots.into_boxed_slice());
-
-        // Propagate through rete.
-        let fact = self
-            .fact_base
-            .get(fact_id)
-            .expect("just-asserted fact must exist")
-            .fact
-            .clone();
-        self.rete.assert_fact(fact_id, &fact, &self.fact_base);
-
-        Ok(fact_id)
+        Ok(self
+            .assert_fact_internal(Fact::Template(TemplateFact {
+                template_id,
+                slots: slots.into_boxed_slice(),
+            }))
+            .fact_id())
     }
 
     fn is_ambiguous_empty_template_fact(template: &TemplateFactBody) -> bool {
@@ -1302,20 +1295,12 @@ impl Engine {
         }
 
         // Assert as a proper template fact.
-        let fact_id = self
-            .fact_base
-            .assert_template(template_id, slots.into_boxed_slice());
-
-        // Propagate through rete.
-        let fact = self
-            .fact_base
-            .get(fact_id)
-            .expect("just-asserted fact must exist")
-            .fact
-            .clone();
-        self.rete.assert_fact(fact_id, &fact, &self.fact_base);
-
-        Ok(fact_id)
+        Ok(self
+            .assert_fact_internal(Fact::Template(TemplateFact {
+                template_id,
+                slots: slots.into_boxed_slice(),
+            }))
+            .fact_id())
     }
 
     /// Convert an S-expression atom to a Value.
@@ -1770,6 +1755,7 @@ impl Engine {
                 | "unwatch"
                 | "refresh-agenda"
                 | "set-fact-duplication"
+                | "get-fact-duplication"
                 | "undefrule"
                 | "ppdefrule"
                 | "load"

--- a/crates/ferric-rules-runtime/src/loader.rs
+++ b/crates/ferric-rules-runtime/src/loader.rs
@@ -690,12 +690,11 @@ impl Engine {
             .intern_symbol("initial-fact", self.config.string_encoding)
             .map_err(|e| LoadError::Compile(format!("initial-fact symbol: {e}")))?;
 
-        let fid = self
-            .fact_base
-            .assert_ordered(initial_sym, smallvec::SmallVec::new());
-        let stored = self.fact_base.get(fid).unwrap().fact.clone();
-        self.rete.assert_fact(fid, &stored, &self.fact_base);
-        self.initial_fact_id = Some(fid);
+        let result = self.assert_fact_internal(Fact::Ordered(ferric_rules_core::OrderedFact {
+            relation: initial_sym,
+            fields: smallvec::SmallVec::new(),
+        }));
+        self.initial_fact_id = Some(result.fact_id());
 
         Ok(())
     }

--- a/crates/ferric-rules-runtime/src/phase2_integration_tests.rs
+++ b/crates/ferric-rules-runtime/src/phase2_integration_tests.rs
@@ -445,6 +445,7 @@ mod tests {
     #[test]
     fn negative_rule_multiple_blockers_need_all_retracted() {
         let mut engine = new_utf8_engine();
+        engine.set_fact_duplication(true);
         load_ok(
             &mut engine,
             "(defrule safe (item ?x) (not (danger)) => (printout t safe))",

--- a/crates/ferric-rules-runtime/src/serialization.rs
+++ b/crates/ferric-rules-runtime/src/serialization.rs
@@ -520,6 +520,32 @@ mod tests {
     }
 
     #[test]
+    fn fr_rete_001_snapshot_preserves_policy_and_duplicate_index() {
+        for &format in SerializationFormat::ALL {
+            let mut engine = Engine::new(EngineConfig::default());
+            engine.set_fact_duplication(true);
+            let first = engine.assert_ordered("item", 1_i64).unwrap();
+            let second = engine.assert_ordered("item", 1_i64).unwrap();
+            assert_ne!(first, second);
+
+            let bytes = engine.serialize(format).unwrap();
+            let mut restored = Engine::deserialize(&bytes, format).unwrap();
+            assert!(
+                restored.fact_duplication(),
+                "format {format:?} lost duplication policy"
+            );
+
+            assert!(restored.set_fact_duplication(false));
+            let rejected = restored.assert_ordered_with_result("item", 1_i64).unwrap();
+            assert!(
+                matches!(rejected, crate::FactAssertionResult::Duplicate(_)),
+                "format {format:?} lost the structural duplicate index"
+            );
+            assert_eq!(restored.facts().unwrap().count(), 2);
+        }
+    }
+
+    #[test]
     fn format_name() {
         assert_eq!(SerializationFormat::Bincode.name(), "bincode");
         assert_eq!(SerializationFormat::Json.name(), "json");

--- a/crates/ferric-rules/tests/clips_compat.rs
+++ b/crates/ferric-rules/tests/clips_compat.rs
@@ -720,6 +720,18 @@ fn test_compat_core_modify_duplicate() {
     let _ = assert_fixture_output("core/modify_duplicate.clp", 1, "Alice is now 31\n");
 }
 
+#[test]
+fn test_compat_core_fact_duplication_policy() {
+    // Pinned against CLIPS 6.30: duplicate assertions are rejected by
+    // default, allowed after enabling, and rejected immediately after
+    // disabling again. The setter reports the prior policy.
+    let _ = assert_fixture_output(
+        "core/fact_duplication_policy.clp",
+        4,
+        "default=FALSE\nenable-old=FALSE\ndisable-old=TRUE\nitem=enabled\nitem=enabled\nitem=default\n",
+    );
+}
+
 // ===========================================================================
 // Negation domain compatibility tests
 // ===========================================================================

--- a/crates/ferric-rules/tests/fixtures/core/fact_duplication_policy.clp
+++ b/crates/ferric-rules/tests/fixtures/core/fact_duplication_policy.clp
@@ -1,0 +1,20 @@
+(deffacts startup
+  (start))
+
+(defrule drive-duplication-policy
+  ?start <- (start)
+  =>
+  (retract ?start)
+  (printout t "default=" (get-fact-duplication) crlf)
+  (assert (item default))
+  (assert (item default))
+  (printout t "enable-old=" (set-fact-duplication TRUE) crlf)
+  (assert (item enabled))
+  (assert (item enabled))
+  (printout t "disable-old=" (set-fact-duplication FALSE) crlf)
+  (assert (item enabled)))
+
+(defrule observe-item
+  (item ?kind)
+  =>
+  (printout t "item=" ?kind crlf))

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -45,9 +45,30 @@ Template facts use named slots defined by `deftemplate`:
 
 ### Fact Identity
 
-Each asserted fact receives a unique fact index (monotonically increasing
-integer). Fact addresses can be captured via pattern-binding variables
-(`?f <- (pattern)`) and used in `retract`, `modify`, and `duplicate` actions.
+Each successfully asserted fact receives a unique fact index. Fact addresses
+can be captured via pattern-binding variables (`?f <- (pattern)`) and used in
+`retract`, `modify`, and `duplicate` actions.
+
+### Fact Duplication
+
+Like CLIPS, Ferric disables fact duplication by default. With duplication
+disabled, an assertion is rejected if an equivalent active fact exists; it
+creates no new fact ID, RETE token, activation, or existential support.
+
+Structural equality is defined as follows:
+
+- Ordered facts compare their relation and every positional field.
+- Template facts compare their template identity and every slot value in the
+  template's canonical slot order.
+- Nested multifields compare recursively. Floats compare by IEEE-754 bit
+  representation, including distinct signed-zero and NaN representations.
+- Fact IDs and assertion timestamps are never part of structural equality.
+
+`(get-fact-duplication)` reports the current policy.
+`(set-fact-duplication TRUE|FALSE)` changes it immediately and returns the
+previous setting. Existing duplicate facts are not collapsed when duplication
+is disabled. The setting survives `reset`, `clear`, and engine snapshot
+round-trips.
 
 ### initial-fact
 
@@ -58,7 +79,7 @@ standalone negation and `forall` patterns to activate correctly.
 ### Behavioral Notes
 
 - Duplicate fact detection: asserting an identical fact to one already in
-  working memory is silently ignored (no new fact created).
+  working memory is rejected by default (no new fact created).
 - Refraction: a rule fires at most once per unique token (set of matching
   facts). Retracting and re-asserting the same content creates a new fact
   identity, allowing re-firing.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -147,6 +147,25 @@ Unspecified slots pick up their declared defaults (or an empty multifield
 for `multislot`). The `person` template above will assert with
 `(age 0)` if you leave `age` out.
 
+Fact duplication is disabled by default, matching CLIPS. Reasserting the same
+ordered relation and fields—or the same template and fully resolved slot
+values—returns the existing fact ID through the convenience assertion APIs and
+does not create another activation. Use the detailed result when the
+distinction matters:
+
+```rust
+use ferric_rules::runtime::FactAssertionResult;
+
+match engine.assert_ordered_with_result("color", color_value)? {
+    FactAssertionResult::Asserted(id) => println!("created {id:?}"),
+    FactAssertionResult::Duplicate(id) => println!("already present as {id:?}"),
+}
+```
+
+You can opt into duplicates with `engine.set_fact_duplication(true)` or
+`(set-fact-duplication TRUE)`. The setter returns the previous setting, and
+the policy survives reset and serialization.
+
 > **Heads up:** the CLIPS literal form `(assert (person (name Alice) (age 30)))`
 > is currently rejected by ferric's RHS evaluator (it parses the slot specs as
 > function calls). Build template facts from Rust via `assert_template`, or use

--- a/examples/users-guide/05-rhs-actions/src/main.rs
+++ b/examples/users-guide/05-rhs-actions/src/main.rs
@@ -10,6 +10,8 @@ fn main() -> anyhow::Result<()> {
     let mut engine = Engine::with_rules(rules)?;
 
     engine.assert_template("counter", &[], vec![])?;
+    // This workload intentionally queues multiple structurally identical facts.
+    engine.set_fact_duplication(true);
     for _ in 0..5 {
         engine.assert_ordered("tick", vec![])?;
     }

--- a/examples/users-guide/07-globals/src/main.rs
+++ b/examples/users-guide/07-globals/src/main.rs
@@ -13,6 +13,8 @@ fn main() -> anyhow::Result<()> {
     let rules = include_str!("../rules/sessions.clp");
     let mut engine = Engine::with_rules(rules)?;
 
+    // Each identical fact represents a distinct session event in this example.
+    engine.set_fact_duplication(true);
     for _ in 0..3 {
         engine.assert_ordered("session-start", vec![])?;
         engine.run(RunLimit::Unlimited)?;

--- a/scripts/expected-ferric-rules-package-files.txt
+++ b/scripts/expected-ferric-rules-package-files.txt
@@ -27,6 +27,7 @@ tests/fixtures/core/.gitkeep
 tests/fixtures/core/basic_match.clp
 tests/fixtures/core/bind_in_rhs.clp
 tests/fixtures/core/chain_rules.clp
+tests/fixtures/core/fact_duplication_policy.clp
 tests/fixtures/core/halt_stops_execution.clp
 tests/fixtures/core/modify_duplicate.clp
 tests/fixtures/core/multi_pattern_join.clp


### PR DESCRIPTION
Fixes #103.

## What changed

- Default fact duplication to disabled, matching CLIPS, and reject structurally equivalent assertions before allocating a fact ID or producing RETE state.
- Add collision-safe structural indexing for ordered and template facts, including recursive multifield values and deterministic lookup of the oldest equivalent active fact.
- Keep that derived index lazy and allocation-light: disabled-policy assertions share one fingerprint between lookup and insertion, single candidates stay inline, enabled-policy assertions skip indexing, and snapshots rebuild the omitted index only when needed.
- Add observable Rust assertion results through `FactAssertionResult`, plus engine getter/setter APIs whose setter returns the previous policy.
- Implement `(get-fact-duplication)` and make `(set-fact-duplication ...)` update the live policy immediately and return the prior CLIPS boolean.
- Route direct, loader, RHS, and generated `initial-fact` assertion paths through one policy gate; preserve the policy and index semantics across reset, clear, retraction, and snapshot round-trips.
- Add the pinned CLIPS differential fixture, acceptance/lifecycle tests, documentation, and a release-profile benchmark for both policies.

## Why

The runtime previously accepted `set-fact-duplication` only as a compatibility stub while duplicate assertions remained enabled and unobservable. That differed from CLIPS and allowed equivalent facts to create separate working-memory entries, tokens, activations, and support. This change makes the policy effective at the assertion boundary while preserving the existing convenience APIs, which return the existing equivalent fact ID when a duplicate is rejected.

## Validation

- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 just preflight-pr`
- `just scaling-check` — all five asymptotic regression checks passed
- focused core, runtime, and all-format snapshot tests
- `cargo test -p ferric-rules --test clips_compat`
- `cargo bench -p ferric-rules-runtime --bench fact_duplication_bench -- --noplot`
- representative release-profile reset/run, churn, and serialization benchmarks

Release-profile Criterion medians for 10,000 unique assertions on the same local Apple Silicon machine, before and after the lazy-index optimization:

| Policy | Before | After | Change |
|---|---:|---:|---:|
| duplication disabled | 850.87 µs | 520.05 µs | -38.8% |
| duplication enabled | 821.88 µs | 350.20 µs | -56.5% |

Representative post-optimization release medians were 2.33 µs for `reset_run_simple`, 13.16 µs for `reset_run_20_facts`, 320.87 µs for `churn_100_facts`, 12.90 µs for `serde_small/serialize`, and 28.58 µs for `serde_small/deserialize`.
