### PR TITLE
[FR-RETE-002] Seed leading simple negative conditional elements

### DIFF
--- a/crates/ferric-rules-core/src/beta.rs
+++ b/crates/ferric-rules-core/src/beta.rs
@@ -254,7 +254,15 @@ pub struct RuleId(pub u32);
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BetaNode {
     /// Root node: entry point for all matches.
-    Root { children: Rc<[NodeId]> },
+    ///
+    /// Its memory contains exactly one dummy token representing the empty LHS
+    /// prefix. Every first conditional element is left-activated from that
+    /// token, just like later conditional elements are activated from their
+    /// parent beta memories.
+    Root {
+        memory: BetaMemoryId,
+        children: Rc<[NodeId]>,
+    },
     /// Join node: combines left (parent beta memory) with right (alpha memory).
     Join {
         parent: NodeId,
@@ -343,9 +351,11 @@ impl BetaNetwork {
     #[must_use]
     pub fn new(root_node_id: NodeId) -> Self {
         let mut nodes = HashMap::default();
+        let root_memory_id = BetaMemoryId(0);
         nodes.insert(
             root_node_id,
             BetaNode::Root {
+                memory: root_memory_id,
                 children: Rc::from([]),
             },
         );
@@ -355,13 +365,13 @@ impl BetaNetwork {
 
         Self {
             nodes,
-            memories: Vec::new(),
+            memories: vec![BetaMemory::new(root_memory_id)],
             neg_memories: Vec::new(),
             ncc_memories: Vec::new(),
             exists_memories: Vec::new(),
             root_id: root_node_id,
             next_node_id,
-            next_memory_id: 0,
+            next_memory_id: 1,
             next_neg_memory_id: 0,
             next_ncc_memory_id: 0,
             next_exists_memory_id: 0,
@@ -647,11 +657,12 @@ impl BetaNetwork {
 
     /// Get the beta memory ID associated with a node.
     ///
-    /// Returns `None` for root nodes or nodes without a beta memory.
+    /// Returns `None` for nodes without a beta memory.
     #[must_use]
     pub fn memory_id_for_node(&self, node_id: NodeId) -> Option<BetaMemoryId> {
         match self.get_node(node_id)? {
-            BetaNode::Join { memory, .. }
+            BetaNode::Root { memory, .. }
+            | BetaNode::Join { memory, .. }
             | BetaNode::Negative { memory, .. }
             | BetaNode::Ncc { memory, .. }
             | BetaNode::Exists { memory, .. } => Some(*memory),
@@ -774,7 +785,7 @@ impl BetaNetwork {
     fn attach_child_to_parent(&mut self, parent: NodeId, child_id: NodeId) {
         if let Some(parent_node) = self.nodes.get_mut(&parent) {
             match parent_node {
-                BetaNode::Root { children }
+                BetaNode::Root { children, .. }
                 | BetaNode::Join { children, .. }
                 | BetaNode::Negative { children, .. }
                 | BetaNode::Ncc { children, .. }
@@ -800,7 +811,7 @@ impl BetaNetwork {
         // Check 1: All node IDs in children fields exist in nodes map
         for (node_id, node) in &self.nodes {
             let children = match node {
-                BetaNode::Root { children }
+                BetaNode::Root { children, .. }
                 | BetaNode::Join { children, .. }
                 | BetaNode::Negative { children, .. }
                 | BetaNode::Ncc { children, .. }
@@ -964,9 +975,12 @@ impl BetaNetwork {
             self.root_id
         );
 
+        let Some(BetaNode::Root { memory, .. }) = self.nodes.get(&self.root_id) else {
+            panic!("Root node {:?} is not a Root variant", self.root_id);
+        };
         assert!(
-            matches!(self.nodes.get(&self.root_id), Some(BetaNode::Root { .. })),
-            "Root node {:?} is not a Root variant",
+            self.memory(*memory).is_some(),
+            "Root node {:?} references non-existent beta memory {memory:?}",
             self.root_id
         );
 
@@ -1119,7 +1133,7 @@ mod tests {
         assert_eq!(memory.id, mem_id);
 
         // Verify root has join as child
-        if let Some(BetaNode::Root { children }) = net.get_node(root) {
+        if let Some(BetaNode::Root { children, .. }) = net.get_node(root) {
             assert_eq!(children.len(), 1);
             assert_eq!(children[0], join_id);
         } else {
@@ -1881,7 +1895,7 @@ mod proptests {
                 if let Some(node_id) = node_id_opt {
                     if let Some(parent_node) = net.get_node(parent_id) {
                         let children: Option<&Rc<[NodeId]>> = match parent_node {
-                            BetaNode::Root { children }
+                            BetaNode::Root { children, .. }
                             | BetaNode::Join { children, .. }
                             | BetaNode::Negative { children, .. }
                             | BetaNode::Ncc { children, .. }

--- a/crates/ferric-rules-core/src/compiler.rs
+++ b/crates/ferric-rules-core/src/compiler.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
 
 use crate::alpha::{AlphaEntryType, AlphaMemoryId, AlphaNetwork, ConstantTest, SlotIndex};
-use crate::beta::{BetaNetwork, JoinTest, JoinTestType, RuleId, Salience};
+use crate::beta::{BetaNetwork, BetaNode, JoinTest, JoinTestType, RuleId, Salience};
 use crate::binding::{VarId, VarMap};
 use crate::fact::FactBase;
 use crate::rete::ReteNetwork;
@@ -239,6 +239,10 @@ impl ReteCompiler {
         let mut var_map = VarMap::new();
         let mut bound_vars = SymbolSet::new();
         let mut current_parent = rete.beta.root_id();
+        let existing_root_children = match rete.beta.get_node(rete.beta.root_id()) {
+            Some(BetaNode::Root { children, .. }) => children.len(),
+            _ => 0,
+        };
 
         for condition in conditions {
             match condition {
@@ -270,6 +274,20 @@ impl ReteCompiler {
         let terminal = rete
             .beta
             .create_terminal_node(current_parent, rule_id, salience);
+
+        // The beta root's dummy token predates compilation. Left-activate only
+        // children added while compiling this rule so leading negative, exists,
+        // and NCC CEs observe the empty prefix immediately without replaying
+        // already-compiled rules.
+        let new_root_children: Vec<NodeId> = match rete.beta.get_node(rete.beta.root_id()) {
+            Some(BetaNode::Root { children, .. }) => children
+                .iter()
+                .skip(existing_root_children)
+                .copied()
+                .collect(),
+            _ => Vec::new(),
+        };
+        rete.activate_root_children(&new_root_children, fact_base);
 
         Ok(CompileResult {
             rule_id,
@@ -694,6 +712,62 @@ mod tests {
     }
 
     #[test]
+    fn fr_rete_002_leading_negative_uses_empty_root_prefix() {
+        let mut compiler = ReteCompiler::new();
+        let mut rete = ReteNetwork::new();
+        let mut fact_base = FactBase::new();
+        let mut table = new_table();
+        let blocked_relation = intern(&mut table, "blocked");
+
+        let rule = CompilableRule {
+            rule_id: compiler.allocate_rule_id(),
+            salience: Salience::DEFAULT,
+            patterns: vec![CompilablePattern {
+                entry_type: AlphaEntryType::OrderedRelation(blocked_relation),
+                constant_tests: vec![],
+                variable_slots: vec![],
+                negated_variable_slots: vec![],
+                negated: true,
+                exists: false,
+            }],
+        };
+
+        compiler
+            .compile_rule(&mut rete, &fact_base, &rule)
+            .expect("compile leading negative rule");
+        assert_eq!(
+            rete.agenda.len(),
+            1,
+            "absence should activate the leading negative"
+        );
+
+        let root_memory = rete
+            .beta
+            .memory_id_for_node(rete.beta.root_id())
+            .and_then(|memory_id| rete.beta.get_memory(memory_id))
+            .expect("root memory");
+        assert_eq!(root_memory.len(), 1, "one empty-prefix token");
+
+        let blocker_id = fact_base.assert_ordered(blocked_relation, SmallVec::new());
+        let blocking_fact = fact_base
+            .get(blocker_id)
+            .expect("blocking fact")
+            .fact
+            .clone();
+        rete.assert_fact(blocker_id, &blocking_fact, &fact_base);
+        assert!(rete.agenda.is_empty(), "matching fact should block");
+
+        fact_base.retract(blocker_id);
+        rete.retract_fact(blocker_id, &blocking_fact, &fact_base);
+        assert_eq!(
+            rete.agenda.len(),
+            1,
+            "retracting the last blocker should reactivate"
+        );
+        rete.debug_assert_consistency();
+    }
+
+    #[test]
     fn test_compile_empty_rule_error() {
         let mut compiler = ReteCompiler::new();
         let mut rete = ReteNetwork::new();
@@ -1082,7 +1156,7 @@ mod tests {
             other => panic!("Expected join node, got {other:?}"),
         };
 
-        if let Some(BetaNode::Root { children }) = rete.beta.get_node(rete.beta.root_id()) {
+        if let Some(BetaNode::Root { children, .. }) = rete.beta.get_node(rete.beta.root_id()) {
             assert_eq!(children.len(), 1);
             assert_eq!(children[0], join1_id);
         } else {

--- a/crates/ferric-rules-core/src/rete.rs
+++ b/crates/ferric-rules-core/src/rete.rs
@@ -3,7 +3,6 @@
 //! The Rete network combines all components of the pattern matcher to efficiently
 //! propagate facts through the network and produce rule activations.
 
-use slotmap::Key;
 use smallvec::SmallVec;
 use std::cmp::Ordering;
 
@@ -53,13 +52,15 @@ impl ReteNetwork {
         let token_store = TokenStore::new();
         let agenda = Agenda::with_strategy(strategy);
 
-        Self {
+        let mut rete = Self {
             alpha,
             beta,
             token_store,
             agenda,
             disabled_rules: std::collections::HashSet::new(),
-        }
+        };
+        rete.seed_root_token();
+        rete
     }
 
     /// Assert a fact into the Rete network.
@@ -214,6 +215,68 @@ impl ReteNetwork {
         self.beta.clear_all_runtime();
         let strategy = self.agenda.strategy();
         self.agenda = Agenda::with_strategy(strategy);
+
+        let root_token = self.seed_root_token();
+        let root_children = match self.beta.get_node(self.beta.root_id()) {
+            Some(BetaNode::Root { children, .. }) => children.clone(),
+            _ => return,
+        };
+        let mut new_activations = Vec::new();
+        self.propagate_token(
+            root_token,
+            &root_children,
+            &FactBase::new(),
+            &mut new_activations,
+        );
+    }
+
+    /// Activate newly compiled children of the beta root from the empty LHS
+    /// prefix token.
+    pub(crate) fn activate_root_children(&mut self, children: &[NodeId], fact_base: &FactBase) {
+        if children.is_empty() {
+            return;
+        }
+
+        let root_token = self.seed_root_token();
+        let mut new_activations = Vec::new();
+        self.propagate_token(root_token, children, fact_base, &mut new_activations);
+    }
+
+    /// Ensure the root beta memory contains its single empty-prefix token.
+    fn seed_root_token(&mut self) -> TokenId {
+        let root_id = self.beta.root_id();
+        let root_memory_id = self
+            .beta
+            .memory_id_for_node(root_id)
+            .expect("beta root must own a memory");
+
+        if let Some(token_id) = self
+            .beta
+            .get_memory(root_memory_id)
+            .and_then(|memory| memory.iter().next())
+        {
+            debug_assert_eq!(
+                self.beta
+                    .get_memory(root_memory_id)
+                    .map_or(0, BetaMemory::len),
+                1,
+                "beta root memory must contain exactly one token"
+            );
+            return token_id;
+        }
+
+        let root_token = Token {
+            fact: None,
+            bindings: BindingSet::new(),
+            parent: None,
+            owner_node: root_id,
+        };
+        let token_id = self.token_store.insert(root_token);
+        self.beta
+            .get_memory_mut(root_memory_id)
+            .expect("beta root memory must exist")
+            .insert(token_id);
+        token_id
     }
 
     /// Disable a compiled rule at runtime.
@@ -262,23 +325,22 @@ impl ReteNetwork {
             _ => return,
         };
 
-        // Get parent tokens (indexed when possible for O(1) lookup)
-        let parent_tokens: SmallVec<[TokenId; 8]> = if parent_id == self.beta.root_id() {
-            // Special case: root node has no memory, create dummy token
-            SmallVec::new()
-        } else {
-            self.find_memory_for_node(parent_id)
-                .and_then(|mem_id| self.beta.get_memory(mem_id))
-                .map(|mem| collect_candidate_parent_tokens(mem, &tests, fact))
-                .unwrap_or_default()
-        };
+        // Get parent tokens (indexed when possible for O(1) lookup). The root
+        // participates through its real one-token beta memory, so the same path
+        // handles the first join and every later join.
+        let parent_tokens: SmallVec<[TokenId; 8]> = self
+            .find_memory_for_node(parent_id)
+            .and_then(|mem_id| self.beta.get_memory(mem_id))
+            .map(|mem| collect_candidate_parent_tokens(mem, &tests, fact))
+            .unwrap_or_default();
 
-        // If parent is root, we need to handle specially (no parent tokens)
-        if parent_id == self.beta.root_id() {
-            // For root parent, create a token with just this fact
-            if evaluate_join(fact, None, &tests) {
-                // Extract bindings from the fact
-                let mut new_bindings = BindingSet::new();
+        for parent_token_id in parent_tokens {
+            let Some(parent_token) = self.token_store.get(parent_token_id) else {
+                continue;
+            };
+
+            if evaluate_join(fact, Some(parent_token), &tests) {
+                let mut new_bindings = parent_token.bindings.clone();
                 for &(slot, var_id) in bindings.iter() {
                     if let Some(value) = get_slot_value(fact, slot) {
                         new_bindings.set(var_id, ValueRef::new(value.clone()));
@@ -288,55 +350,18 @@ impl ReteNetwork {
                 let new_token = Token {
                     fact: Some(fact_id),
                     bindings: new_bindings,
-                    parent: None,
+                    parent: Some(parent_token_id),
                     owner_node: join_node_id,
                 };
 
                 let token_id = self.token_store.insert(new_token);
 
-                // Add to join's beta memory (with index maintenance)
                 if let Some(memory) = self.beta.get_memory_mut(join_memory_id) {
                     let bindings = &self.token_store.get(token_id).unwrap().bindings;
                     memory.insert_indexed(token_id, bindings);
                 }
 
-                // Propagate to children
                 self.propagate_token(token_id, &children, fact_base, new_activations);
-            }
-        } else {
-            // For non-root parent, iterate through parent tokens
-            for parent_token_id in parent_tokens {
-                let Some(parent_token) = self.token_store.get(parent_token_id) else {
-                    continue;
-                };
-
-                if evaluate_join(fact, Some(parent_token), &tests) {
-                    // Clone parent bindings and add new bindings from this fact
-                    let mut new_bindings = parent_token.bindings.clone();
-                    for &(slot, var_id) in bindings.iter() {
-                        if let Some(value) = get_slot_value(fact, slot) {
-                            new_bindings.set(var_id, ValueRef::new(value.clone()));
-                        }
-                    }
-
-                    let new_token = Token {
-                        fact: Some(fact_id),
-                        bindings: new_bindings,
-                        parent: Some(parent_token_id),
-                        owner_node: join_node_id,
-                    };
-
-                    let token_id = self.token_store.insert(new_token);
-
-                    // Add to join's beta memory (with index maintenance)
-                    if let Some(memory) = self.beta.get_memory_mut(join_memory_id) {
-                        let bindings = &self.token_store.get(token_id).unwrap().bindings;
-                        memory.insert_indexed(token_id, bindings);
-                    }
-
-                    // Propagate to children
-                    self.propagate_token(token_id, &children, fact_base, new_activations);
-                }
             }
         }
     }
@@ -1093,28 +1118,17 @@ impl ReteNetwork {
             _ => return,
         };
 
-        let root_parent = parent_id == self.beta.root_id();
-
-        // Get parent tokens.
-        // Root-parent exists nodes use a synthetic parent key for support tracking.
-        let parent_tokens: Vec<TokenId> = if root_parent {
-            vec![TokenId::null()]
-        } else {
-            self.find_memory_for_node(parent_id)
-                .and_then(|mem_id| self.beta.get_memory(mem_id))
-                .map(|mem| mem.iter().collect())
-                .unwrap_or_default()
-        };
+        let parent_tokens: Vec<TokenId> = self
+            .find_memory_for_node(parent_id)
+            .and_then(|mem_id| self.beta.get_memory(mem_id))
+            .map(|mem| mem.iter().collect())
+            .unwrap_or_default();
 
         for parent_token_id in parent_tokens {
-            let is_supported = if root_parent {
-                evaluate_join(fact, None, &tests)
-            } else {
-                let Some(parent_token) = self.token_store.get(parent_token_id) else {
-                    continue;
-                };
-                evaluate_join(fact, Some(parent_token), &tests)
+            let Some(parent_token) = self.token_store.get(parent_token_id) else {
+                continue;
             };
+            let is_supported = evaluate_join(fact, Some(parent_token), &tests);
 
             if is_supported {
                 // This fact supports this parent token
@@ -1127,19 +1141,14 @@ impl ReteNetwork {
 
                 if old_count == 0 && new_count > 0 {
                     // Support count went 0→1: create pass-through and propagate
-                    let (parent_bindings, parent_ref) = if root_parent {
-                        (BindingSet::new(), None)
-                    } else {
-                        let Some(parent_token) = self.token_store.get(parent_token_id) else {
-                            continue;
-                        };
-                        (parent_token.bindings.clone(), Some(parent_token_id))
+                    let Some(parent_token) = self.token_store.get(parent_token_id) else {
+                        continue;
                     };
 
                     let passthrough_token = Token {
                         fact: None,
-                        bindings: parent_bindings,
-                        parent: parent_ref,
+                        bindings: parent_token.bindings.clone(),
+                        parent: Some(parent_token_id),
                         owner_node: exists_node_id,
                     };
 
@@ -1225,16 +1234,9 @@ impl ReteNetwork {
 
     /// Find the beta memory associated with a node.
     ///
-    /// For join and negative nodes, returns the node's own beta memory.
-    /// For other node types, returns None.
+    /// Returns the node's own beta memory, including the root memory.
     fn find_memory_for_node(&self, node_id: NodeId) -> Option<BetaMemoryId> {
-        match self.beta.get_node(node_id)? {
-            BetaNode::Join { memory, .. }
-            | BetaNode::Negative { memory, .. }
-            | BetaNode::Ncc { memory, .. }
-            | BetaNode::Exists { memory, .. } => Some(*memory),
-            _ => None,
-        }
+        self.beta.memory_id_for_node(node_id)
     }
 
     /// Propagate a token to child nodes.
@@ -1344,6 +1346,33 @@ impl ReteNetwork {
                 }
             }
         }
+
+        // The root memory is the canonical empty LHS prefix and must contain
+        // exactly one factless, parentless token.
+        let root_id = self.beta.root_id();
+        let root_memory = self
+            .beta
+            .memory_id_for_node(root_id)
+            .and_then(|memory_id| self.beta.get_memory(memory_id))
+            .expect("beta root memory must exist");
+        assert_eq!(
+            root_memory.len(),
+            1,
+            "beta root memory must contain exactly one token"
+        );
+        let root_token = self
+            .token_store
+            .get(
+                root_memory
+                    .iter()
+                    .next()
+                    .expect("beta root token must exist"),
+            )
+            .expect("beta root token must be present in the token store");
+        assert_eq!(root_token.owner_node, root_id);
+        assert!(root_token.fact.is_none());
+        assert!(root_token.parent.is_none());
+        assert_eq!(root_token.bindings.bound_count(), 0);
 
         // Cross-check: every token referenced by an agenda activation exists.
         for activation in self.agenda.iter_activations() {
@@ -1645,6 +1674,29 @@ mod tests {
         table
             .intern_symbol(s, StringEncoding::Ascii)
             .expect("Failed to intern symbol")
+    }
+
+    fn assert_only_root_token(rete: &ReteNetwork) {
+        let root = rete.beta.root_id();
+        let root_memory = rete
+            .beta
+            .memory_id_for_node(root)
+            .and_then(|memory_id| rete.beta.get_memory(memory_id))
+            .expect("root beta memory must exist");
+        assert_eq!(root_memory.len(), 1, "root memory must have one token");
+        assert_eq!(
+            rete.token_store.len(),
+            1,
+            "only the root token should remain"
+        );
+        let root_token = rete
+            .token_store
+            .get(root_memory.iter().next().expect("root token must exist"))
+            .expect("root memory token must be stored");
+        assert_eq!(root_token.owner_node, root);
+        assert!(root_token.fact.is_none());
+        assert!(root_token.parent.is_none());
+        assert_eq!(root_token.bindings.bound_count(), 0);
     }
 
     #[test]
@@ -1991,7 +2043,7 @@ mod tests {
         // Verify everything is clean
         rete.debug_assert_consistency();
         assert!(rete.agenda.is_empty());
-        assert!(rete.token_store.is_empty());
+        assert_only_root_token(&rete);
     }
 
     #[test]
@@ -2067,7 +2119,7 @@ mod tests {
 
         // Verify clean state
         assert!(rete.agenda.is_empty());
-        assert!(rete.token_store.is_empty());
+        assert_only_root_token(&rete);
     }
 
     #[test]
@@ -2585,7 +2637,7 @@ mod tests {
         let removed = rete.retract_fact(person_fact_id, &person_fact, &fact_base);
         assert_eq!(removed.len(), 1, "Should remove one activation");
         assert!(rete.agenda.is_empty());
-        assert!(rete.token_store.is_empty());
+        assert_only_root_token(&rete);
         rete.debug_assert_consistency();
     }
 
@@ -2863,10 +2915,7 @@ mod tests {
         rete.retract_fact(item_id, &item_fact, &fact_base);
 
         assert_eq!(rete.agenda.len(), 0);
-        assert!(
-            rete.token_store.is_empty(),
-            "All tokens should be cleaned up"
-        );
+        assert_only_root_token(&rete);
         rete.debug_assert_consistency();
     }
 
@@ -3064,7 +3113,7 @@ mod tests {
         rete.retract_fact(block_id, &block_fact, &fact_base);
 
         assert_eq!(rete.agenda.len(), 0);
-        assert!(rete.token_store.is_empty());
+        assert_only_root_token(&rete);
         rete.debug_assert_consistency();
     }
 
@@ -3534,10 +3583,7 @@ mod tests {
         rete.retract_fact(item_id, &item_fact, &fact_base);
 
         assert_eq!(rete.agenda.len(), 0);
-        assert!(
-            rete.token_store.is_empty(),
-            "all descendant tokens should be removed"
-        );
+        assert_only_root_token(&rete);
         rete.debug_assert_consistency();
     }
 
@@ -3706,11 +3752,11 @@ mod tests {
                 rete.retract_fact(fid, &fact, &fact_base);
             }
 
-            // Postcondition: network is completely clean
+            // Postcondition: only the permanent empty-prefix token remains.
             prop_assert!(rete.agenda.is_empty(),
                 "agenda must be empty after all facts retracted");
-            prop_assert!(rete.token_store.is_empty(),
-                "token store must be empty after all facts retracted");
+            prop_assert_eq!(rete.token_store.len(), 1,
+                "only the root token may remain after all facts are retracted");
 
             // Structural oracle must still pass
             rete.debug_assert_consistency();
@@ -3995,9 +4041,10 @@ mod tests {
                 fact_base.retract(*fid);
             }
 
-            // After full retraction: agenda empty, token store empty
+            // After full retraction: agenda empty, only root token remains.
             prop_assert!(rete.agenda.is_empty(), "agenda must be empty after full retraction");
-            prop_assert!(rete.token_store.is_empty(), "token store must be empty after full retraction");
+            prop_assert_eq!(rete.token_store.len(), 1,
+                "only the root token may remain after full retraction");
 
             // Beta memory var indices must also be empty
             if let Some(mem) = rete.beta.get_memory(join1_mem_id) {

--- a/crates/ferric-rules-runtime/src/engine.rs
+++ b/crates/ferric-rules-runtime/src/engine.rs
@@ -126,7 +126,7 @@ impl FactAssertionResult {
 /// - `defgeneric`/`defmethod` runtime: type-based method dispatch with
 ///   index ordering and auto-index assignment.
 /// - `forall` CE (limited): single condition + single then-clause,
-///   desugared to NCC, with vacuous truth and initial-fact support.
+///   desugared to NCC, with vacuous truth and empty-prefix support.
 ///
 /// ## Phase 4 complete
 ///
@@ -176,9 +176,9 @@ pub struct Engine {
     pub(crate) generic_modules: ModuleNameMap<ModuleId>,
     /// The `FactId` of the synthetic `(initial-fact)` in working memory, if present.
     ///
-    /// `(initial-fact)` is asserted by the engine to provide a root token for
-    /// top-level NCC/negation/forall CEs (mirroring CLIPS' built-in mechanism).
-    /// It is tracked here so that `facts()` can exclude it from user-visible results.
+    /// `(initial-fact)` mirrors CLIPS' built-in fact and backs the implicit
+    /// condition used for empty-LHS and test-only rules. It is tracked here so
+    /// that `facts()` can exclude it from user-visible results.
     pub(crate) initial_fact_id: Option<FactId>,
     /// Non-fatal action diagnostics captured during execution.
     pub(crate) action_diagnostics: Vec<ActionError>,
@@ -529,8 +529,8 @@ impl Engine {
     /// Iterate over all user-visible facts in working memory.
     ///
     /// Returns an iterator of `(FactId, &Fact)` pairs. The synthetic
-    /// `(initial-fact)` inserted by the engine for internal NCC/forall support
-    /// is excluded from the results.
+    /// `(initial-fact)` inserted for CLIPS empty-LHS compatibility is excluded
+    /// from the results.
     ///
     /// # Errors
     ///
@@ -1103,8 +1103,8 @@ impl Engine {
             }
         }
 
-        // Re-assert (initial-fact) to restore the root token needed by NCC/forall CEs.
-        // Update initial_fact_id so that facts() continues to exclude it.
+        // Re-assert (initial-fact) for empty-LHS and test-only rules. Update
+        // initial_fact_id so that facts() continues to exclude it.
         if self.initial_fact_id.is_some() {
             let initial_sym = self
                 .symbol_table
@@ -1642,6 +1642,130 @@ mod tests {
         engine.set_fact_duplication(false);
         engine.clear();
         assert!(!engine.fact_duplication());
+    }
+
+    fn assert_single_root_prefix_token(engine: &Engine) {
+        let root = engine.rete.beta.root_id();
+        let root_memory = engine
+            .rete
+            .beta
+            .memory_id_for_node(root)
+            .and_then(|memory_id| engine.rete.beta.get_memory(memory_id))
+            .expect("root beta memory");
+        assert_eq!(
+            root_memory.len(),
+            1,
+            "root memory must contain exactly one empty-prefix token"
+        );
+        let root_token = engine
+            .rete
+            .token_store
+            .get(root_memory.iter().next().expect("root token"))
+            .expect("stored root token");
+        assert_eq!(root_token.owner_node, root);
+        assert!(root_token.fact.is_none());
+        assert!(root_token.parent.is_none());
+    }
+
+    #[test]
+    fn fr_rete_002_leading_not_activates_when_empty() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .load_str(
+                r#"
+                (defrule absent
+                    (not (blocked))
+                    =>
+                    (printout t "unblocked" crlf))
+                "#,
+            )
+            .unwrap();
+        engine.reset().unwrap();
+
+        assert_eq!(engine.agenda_len(), 1);
+        assert_single_root_prefix_token(&engine);
+        let result = engine.run(RunLimit::Unlimited).unwrap();
+        assert_eq!(result.rules_fired, 1);
+        assert_eq!(engine.get_output("t"), Some("unblocked\n"));
+    }
+
+    #[test]
+    fn fr_rete_002_leading_not_blocks_on_assert() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .load_str("(defrule absent (not (blocked)) => (assert (unexpected)))")
+            .unwrap();
+        engine.reset().unwrap();
+        assert_eq!(engine.agenda_len(), 1);
+
+        engine.assert_ordered("blocked", vec![]).unwrap();
+
+        assert_eq!(engine.agenda_len(), 0);
+        assert_eq!(engine.run(RunLimit::Unlimited).unwrap().rules_fired, 0);
+        assert!(engine.find_facts("unexpected").unwrap().is_empty());
+        assert_single_root_prefix_token(&engine);
+    }
+
+    #[test]
+    fn fr_rete_002_leading_not_reactivates_on_retract() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .load_str(
+                r#"
+                (defrule absent
+                    (not (blocked))
+                    =>
+                    (printout t "unblocked" crlf))
+                "#,
+            )
+            .unwrap();
+        engine.reset().unwrap();
+
+        let blocker = engine.assert_ordered("blocked", vec![]).unwrap();
+        assert_eq!(engine.agenda_len(), 0);
+        engine.retract(blocker).unwrap();
+
+        assert_eq!(engine.agenda_len(), 1);
+        let result = engine.run(RunLimit::Unlimited).unwrap();
+        assert_eq!(result.rules_fired, 1);
+        assert_eq!(engine.get_output("t"), Some("unblocked\n"));
+        assert_single_root_prefix_token(&engine);
+    }
+
+    #[test]
+    fn fr_rete_002_leading_not_two_rule_isolation_and_reset() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .load_str(
+                r#"
+                (defrule absent-a
+                    (not (blocked-a))
+                    =>
+                    (printout t "A" crlf))
+                (defrule absent-b
+                    (not (blocked-b))
+                    =>
+                    (printout t "B" crlf))
+                "#,
+            )
+            .unwrap();
+
+        for _ in 0..3 {
+            engine.reset().unwrap();
+            assert_eq!(engine.agenda_len(), 2);
+            assert_single_root_prefix_token(&engine);
+        }
+
+        let blocker_a = engine.assert_ordered("blocked-a", vec![]).unwrap();
+        assert_eq!(engine.agenda_len(), 1, "rule B remains independent");
+        assert_eq!(engine.run(RunLimit::Unlimited).unwrap().rules_fired, 1);
+        assert_eq!(engine.get_output("t"), Some("B\n"));
+
+        engine.retract(blocker_a).unwrap();
+        assert_eq!(engine.agenda_len(), 1, "rule A reactivates alone");
+        assert_eq!(engine.run(RunLimit::Unlimited).unwrap().rules_fired, 1);
+        assert_eq!(engine.get_output("t"), Some("B\nA\n"));
+        assert_single_root_prefix_token(&engine);
     }
 
     #[test]

--- a/crates/ferric-rules-runtime/src/lib.rs
+++ b/crates/ferric-rules-runtime/src/lib.rs
@@ -31,7 +31,7 @@
 //! - `defgeneric`/`defmethod` runtime: type-based method dispatch with
 //!   index ordering and auto-index assignment (Pass 009).
 //! - `forall` CE: limited subset (single condition + single then-clause),
-//!   desugared to NCC, vacuous truth, initial-fact support (Pass 010).
+//!   desugared to NCC, vacuous truth, and empty-prefix support (Pass 010).
 //!
 //! ## Phase 4 complete
 //!

--- a/crates/ferric-rules-runtime/src/loader.rs
+++ b/crates/ferric-rules-runtime/src/loader.rs
@@ -624,11 +624,10 @@ impl Engine {
             }
             self.module_registry.set_current_module(saved_module);
 
-            // Ensure (initial-fact) is present AFTER rules are compiled but BEFORE
-            // deffacts are asserted.  This mirrors CLIPS' built-in (initial-fact)
-            // mechanism: it provides the root token required by top-level NCC/forall
-            // subnetworks so that items asserted through deffacts are properly evaluated.
-            // Asserted only once; subsequent load_str calls skip if already present.
+            // Ensure (initial-fact) is present AFTER rules are compiled but
+            // BEFORE deffacts are asserted. This mirrors CLIPS' built-in fact
+            // and satisfies the implicit condition used for empty-LHS and
+            // test-only rules. It is asserted only once.
             if let Err(e) = self.ensure_initial_fact() {
                 errors.push(e);
             }
@@ -673,9 +672,9 @@ impl Engine {
 
     /// Ensure `(initial-fact)` is present in working memory.
     ///
-    /// `(initial-fact)` provides the root token for top-level NCC/negation/forall CEs,
-    /// mirroring CLIPS' built-in `(initial-fact)` mechanism.  It is asserted once;
-    /// subsequent calls are no-ops if it is already present.
+    /// `(initial-fact)` mirrors CLIPS' built-in fact and satisfies the implicit
+    /// condition used for empty-LHS and test-only rules. It is asserted once;
+    /// subsequent calls are no-ops.
     ///
     /// The `FactId` is stored in `self.initial_fact_id` so that `facts()` can
     /// exclude it from user-visible results.
@@ -2642,13 +2641,10 @@ impl Engine {
             conditions.push(condition);
         }
 
-        // If the condition list is empty (empty-LHS rule or test-only rule), or if the
-        // first condition is an NCC (e.g., forall or not/and as the leading CE), inject
-        // an implicit (initial-fact) join as the first condition, mirroring CLIPS' built-in
-        // (initial-fact) mechanism. Empty-LHS rules implicitly match (initial-fact) after
-        // (reset) in CLIPS.
-        if conditions.is_empty() || matches!(conditions.first(), Some(CompilableCondition::Ncc(_)))
-        {
+        // Empty-LHS and test-only rules use CLIPS' built-in (initial-fact)
+        // mechanism. Conditional elements, including a leading NCC, are seeded
+        // uniformly by the beta root's empty-prefix token.
+        if conditions.is_empty() {
             let initial_sym = self
                 .symbol_table
                 .intern_symbol("initial-fact", self.config.string_encoding)

--- a/crates/ferric-rules-runtime/src/test_helpers.rs
+++ b/crates/ferric-rules-runtime/src/test_helpers.rs
@@ -255,9 +255,19 @@ pub fn assert_engine_consistent(engine: &Engine) {
     engine.debug_assert_consistency();
 }
 
-/// Assert that the rete network is fully clean (no tokens, no activations).
+/// Assert that the rete network is fully clean (only its root token, no activations).
 pub fn assert_rete_clean(rete: &ReteNetwork) {
-    assert!(rete.token_store.is_empty(), "token store should be empty");
+    let root_memory = rete
+        .beta
+        .memory_id_for_node(rete.beta.root_id())
+        .and_then(|memory_id| rete.beta.get_memory(memory_id))
+        .expect("root beta memory should exist");
+    assert_eq!(root_memory.len(), 1, "root memory should have one token");
+    assert_eq!(
+        rete.token_store.len(),
+        1,
+        "only the root token should remain"
+    );
     assert!(rete.agenda.is_empty(), "agenda should be empty");
 }
 

--- a/crates/ferric-rules/tests/clips_compat.rs
+++ b/crates/ferric-rules/tests/clips_compat.rs
@@ -751,6 +751,16 @@ fn test_compat_negation_not_retract() {
 }
 
 #[test]
+fn fr_rete_002_clips_leading_not_transition_fixture() {
+    // Pinned against the repository's CLIPS 6.30 reference image.
+    let _ = assert_fixture_output(
+        "negation/leading_not_transitions.clp",
+        5,
+        "empty\nassert-blocker\nblocked\nretract-blocker\nreactivated\n",
+    );
+}
+
+#[test]
 fn test_compat_negation_exists() {
     let _ = assert_fixture_output("negation/exists_ce.clp", 1, "signal detected\n");
 }

--- a/crates/ferric-rules/tests/fixtures/negation/leading_not_transitions.clp
+++ b/crates/ferric-rules/tests/fixtures/negation/leading_not_transitions.clp
@@ -1,0 +1,49 @@
+; Pinned CLIPS 6.30 transition trace for a leading simple NOT CE.
+; The rule set observes the empty state, assertion blocking, and reactivation
+; after the last blocker is retracted.
+(deffacts startup
+    (phase initial))
+
+(defrule observe-empty
+    (declare (salience 40))
+    (not (blocker))
+    ?phase <- (phase initial)
+    =>
+    (printout t "empty" crlf)
+    (retract ?phase)
+    (assert (phase add-blocker)))
+
+(defrule add-blocker
+    (declare (salience 30))
+    ?phase <- (phase add-blocker)
+    =>
+    (printout t "assert-blocker" crlf)
+    (retract ?phase)
+    (assert (blocker))
+    (assert (phase observe-blocked)))
+
+(defrule observe-blocked
+    (declare (salience 20))
+    (blocker)
+    ?phase <- (phase observe-blocked)
+    =>
+    (printout t "blocked" crlf)
+    (retract ?phase)
+    (assert (phase retract-blocker)))
+
+(defrule retract-blocker
+    (declare (salience 10))
+    ?phase <- (phase retract-blocker)
+    ?blocker <- (blocker)
+    =>
+    (printout t "retract-blocker" crlf)
+    (retract ?phase ?blocker)
+    (assert (phase final)))
+
+(defrule observe-reactivated
+    (declare (salience 0))
+    (not (blocker))
+    ?phase <- (phase final)
+    =>
+    (printout t "reactivated" crlf)
+    (retract ?phase))

--- a/scripts/expected-ferric-rules-package-files.txt
+++ b/scripts/expected-ferric-rules-package-files.txt
@@ -61,6 +61,7 @@ tests/fixtures/negation/forall_basic.clp
 tests/fixtures/negation/forall_fail.clp
 tests/fixtures/negation/forall_retract_invalidation.clp
 tests/fixtures/negation/forall_vacuous_truth.clp
+tests/fixtures/negation/leading_not_transitions.clp
 tests/fixtures/negation/ncc_basic.clp
 tests/fixtures/negation/not_multiple_patterns.clp
 tests/fixtures/negation/not_retract.clp


### PR DESCRIPTION
Closes #104

## Summary

- give the beta root a real memory with one permanent empty-prefix token
- activate newly compiled root children and reseed them uniformly on reset
- remove root-specific Join/Exists token synthesis and the loader's leading-NCC initial-fact workaround
- cover leading `not` activation, assertion blocking, retraction reactivation, reset cardinality, and two-rule isolation
- add a transition fixture pinned against the repository's CLIPS 6.30 reference image

## Validation

- `cargo test -p ferric-rules-core --lib`
- `cargo test -p ferric-rules-runtime --lib`
- `cargo test -p ferric-rules --test clips_compat`
- `scripts/clips-reference.sh run --quiet --file crates/ferric-rules/tests/fixtures/negation/leading_not_transitions.clp`
- `just scaling-check`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 just preflight-pr`