### PR TITLE
[FR-RETE-003] Backfill online rule installations

### DIFF
--- a/crates/ferric-rules-core/src/alpha.rs
+++ b/crates/ferric-rules-core/src/alpha.rs
@@ -425,6 +425,52 @@ impl AlphaNetwork {
         memory_id
     }
 
+    /// Populate a newly created alpha memory from the current working memory.
+    ///
+    /// This is used when rules are compiled after facts have already been
+    /// asserted. It updates both the memory and the fact-to-memory reverse
+    /// index without replaying facts through pre-existing alpha descendants.
+    pub(crate) fn backfill_memory(
+        &mut self,
+        memory_id: AlphaMemoryId,
+        entry_type: &AlphaEntryType,
+        tests: &[ConstantTest],
+        fact_base: &FactBase,
+    ) {
+        debug_assert!(
+            self.memory(memory_id).is_some_and(AlphaMemory::is_empty),
+            "only newly created alpha memories may be backfilled"
+        );
+
+        let mut matching_facts: Vec<(FactId, crate::fact::Timestamp)> = fact_base
+            .iter()
+            .filter(|(_, entry)| {
+                fact_matches_entry_type(&entry.fact, entry_type)
+                    && tests.iter().all(|test| evaluate_test(&entry.fact, test))
+            })
+            .map(|(fact_id, entry)| (fact_id, entry.timestamp))
+            .collect();
+        matching_facts.sort_unstable_by_key(|(_, timestamp)| *timestamp);
+
+        for (fact_id, _) in matching_facts {
+            let entry = fact_base
+                .get(fact_id)
+                .expect("backfill candidate must remain in the fact base");
+            self.memory_mut(memory_id)
+                .expect("new alpha memory must exist")
+                .insert(fact_id, &entry.fact);
+
+            if let Some(memories) = self.fact_to_memories.get_mut(fact_id) {
+                if !memories.contains(&memory_id) {
+                    memories.push(memory_id);
+                }
+            } else {
+                self.fact_to_memories
+                    .insert(fact_id, SmallVec::from_slice(&[memory_id]));
+            }
+        }
+    }
+
     /// Get a reference to a memory.
     #[must_use]
     pub fn get_memory(&self, id: AlphaMemoryId) -> Option<&AlphaMemory> {
@@ -643,6 +689,18 @@ impl Default for AlphaNetwork {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn fact_matches_entry_type(fact: &Fact, entry_type: &AlphaEntryType) -> bool {
+    matches!(
+        (fact, entry_type),
+        (Fact::Ordered(ordered), AlphaEntryType::OrderedRelation(relation))
+            if ordered.relation == *relation
+    ) || matches!(
+        (fact, entry_type),
+        (Fact::Template(template), AlphaEntryType::Template(template_id))
+            if template.template_id == *template_id
+    )
 }
 
 /// Evaluate a constant test against a fact.

--- a/crates/ferric-rules-core/src/beta.rs
+++ b/crates/ferric-rules-core/src/beta.rs
@@ -699,43 +699,27 @@ impl BetaNetwork {
     /// Initializing only this frontier populates every new descendant through
     /// normal propagation while leaving pre-existing children and terminals
     /// untouched.
-    pub(crate) fn installation_frontier(
-        &self,
-        first_new_node: NodeId,
-    ) -> Vec<(NodeId, Vec<NodeId>)> {
-        let mut children_by_parent: HashMap<NodeId, Vec<NodeId>> = HashMap::default();
-
+    pub(crate) fn installation_frontier(&self, first_new_node: NodeId) -> Vec<(NodeId, NodeId)> {
         // Node IDs are allocated monotonically, so inspect only nodes created by
         // this installation. Reading each new node's parent avoids an O(total
-        // network size) scan after every rule in a cold-start rule set.
-        for raw_node_id in first_new_node.0..self.next_node_id {
-            let child_id = NodeId(raw_node_id);
-            let Some(child) = self.nodes.get(&child_id) else {
-                continue;
-            };
-            let parent_id = match child {
-                BetaNode::Join { parent, .. }
-                | BetaNode::Terminal { parent, .. }
-                | BetaNode::Negative { parent, .. }
-                | BetaNode::Ncc { parent, .. }
-                | BetaNode::NccPartner { parent, .. }
-                | BetaNode::Exists { parent, .. } => *parent,
-                BetaNode::Root { .. } => continue,
-            };
-
-            if parent_id.0 < first_new_node.0 {
-                children_by_parent
-                    .entry(parent_id)
-                    .or_default()
-                    .push(child_id);
-            }
-        }
-
-        let mut frontier: Vec<_> = children_by_parent.into_iter().collect();
-        frontier.sort_unstable_by_key(|(_, children)| {
-            children.first().map_or(u32::MAX, |child_id| child_id.0)
-        });
-        frontier
+        // network size) scan after every rule in a cold-start rule set. Direct
+        // edges also preserve allocation order without a temporary hash map.
+        (first_new_node.0..self.next_node_id)
+            .filter_map(|raw_node_id| {
+                let child_id = NodeId(raw_node_id);
+                let child = self.nodes.get(&child_id)?;
+                let parent_id = match child {
+                    BetaNode::Join { parent, .. }
+                    | BetaNode::Terminal { parent, .. }
+                    | BetaNode::Negative { parent, .. }
+                    | BetaNode::Ncc { parent, .. }
+                    | BetaNode::NccPartner { parent, .. }
+                    | BetaNode::Exists { parent, .. } => *parent,
+                    BetaNode::Root { .. } => return None,
+                };
+                (parent_id.0 < first_new_node.0).then_some((parent_id, child_id))
+            })
+            .collect()
     }
 
     /// Get the beta memory ID associated with a node.
@@ -1271,7 +1255,7 @@ mod tests {
 
         assert_eq!(
             net.installation_frontier(first_new_node),
-            vec![(old_join, vec![new_terminal]), (root, vec![new_join])]
+            vec![(old_join, new_terminal), (root, new_join)]
         );
     }
 }

--- a/crates/ferric-rules-core/src/beta.rs
+++ b/crates/ferric-rules-core/src/beta.rs
@@ -703,31 +703,35 @@ impl BetaNetwork {
         &self,
         first_new_node: NodeId,
     ) -> Vec<(NodeId, Vec<NodeId>)> {
-        let mut frontier = Vec::new();
+        let mut children_by_parent: HashMap<NodeId, Vec<NodeId>> = HashMap::default();
 
-        for (&parent_id, parent) in &self.nodes {
-            if parent_id.0 >= first_new_node.0 {
+        // Node IDs are allocated monotonically, so inspect only nodes created by
+        // this installation. Reading each new node's parent avoids an O(total
+        // network size) scan after every rule in a cold-start rule set.
+        for raw_node_id in first_new_node.0..self.next_node_id {
+            let child_id = NodeId(raw_node_id);
+            let Some(child) = self.nodes.get(&child_id) else {
                 continue;
-            }
-
-            let children = match parent {
-                BetaNode::Root { children, .. }
-                | BetaNode::Join { children, .. }
-                | BetaNode::Negative { children, .. }
-                | BetaNode::Ncc { children, .. }
-                | BetaNode::Exists { children, .. } => children,
-                BetaNode::Terminal { .. } | BetaNode::NccPartner { .. } => continue,
             };
-            let new_children: Vec<NodeId> = children
-                .iter()
-                .copied()
-                .filter(|child_id| child_id.0 >= first_new_node.0)
-                .collect();
-            if !new_children.is_empty() {
-                frontier.push((parent_id, new_children));
+            let parent_id = match child {
+                BetaNode::Join { parent, .. }
+                | BetaNode::Terminal { parent, .. }
+                | BetaNode::Negative { parent, .. }
+                | BetaNode::Ncc { parent, .. }
+                | BetaNode::NccPartner { parent, .. }
+                | BetaNode::Exists { parent, .. } => *parent,
+                BetaNode::Root { .. } => continue,
+            };
+
+            if parent_id.0 < first_new_node.0 {
+                children_by_parent
+                    .entry(parent_id)
+                    .or_default()
+                    .push(child_id);
             }
         }
 
+        let mut frontier: Vec<_> = children_by_parent.into_iter().collect();
         frontier.sort_unstable_by_key(|(_, children)| {
             children.first().map_or(u32::MAX, |child_id| child_id.0)
         });
@@ -1251,6 +1255,24 @@ mod tests {
         } else {
             panic!("Expected Join node");
         }
+    }
+
+    #[test]
+    fn installation_frontier_contains_only_new_children_of_old_parents() {
+        let root = NodeId(100);
+        let mut net = BetaNetwork::new(root);
+        let (old_join, _) = net.create_join_node(root, AlphaMemoryId(1), Vec::new(), Vec::new());
+        net.create_terminal_node(old_join, RuleId(1), Salience::DEFAULT);
+
+        let first_new_node = net.next_node_id();
+        let new_terminal = net.create_terminal_node(old_join, RuleId(2), Salience::DEFAULT);
+        let (new_join, _) = net.create_join_node(root, AlphaMemoryId(2), Vec::new(), Vec::new());
+        net.create_terminal_node(new_join, RuleId(3), Salience::DEFAULT);
+
+        assert_eq!(
+            net.installation_frontier(first_new_node),
+            vec![(old_join, vec![new_terminal]), (root, vec![new_join])]
+        );
     }
 }
 

--- a/crates/ferric-rules-core/src/beta.rs
+++ b/crates/ferric-rules-core/src/beta.rs
@@ -12,8 +12,7 @@ use crate::binding::{BindingSet, VarId};
 use crate::exists::{ExistsMemory, ExistsMemoryId};
 use crate::ncc::{NccMemory, NccMemoryId};
 use crate::negative::{NegativeMemory, NegativeMemoryId};
-use crate::token::NodeId;
-use crate::token::TokenId;
+use crate::token::{NodeId, TokenId, TokenStore};
 use crate::value::AtomKey;
 
 type FanoutNodes = SmallVec<[NodeId; 4]>;
@@ -127,12 +126,43 @@ impl BetaMemory {
         }
     }
 
-    /// Request indexing on a particular variable binding.
+    /// Request indexing on a particular variable binding and backfill existing tokens.
     ///
-    /// Called during compilation when a child join node has an equality test on
-    /// `var_id`. Idempotent — duplicate requests are ignored. No backfill is needed
-    /// because beta memories are always empty at compile time.
-    pub fn request_var_index(&mut self, var_id: VarId) {
+    /// Called during online rule compilation when a new child join may be
+    /// attached to an already-populated beta memory. Idempotent — duplicate
+    /// requests are ignored.
+    pub fn request_var_index(&mut self, var_id: VarId, token_store: &TokenStore) {
+        if self.indexed_vars.contains(&var_id) {
+            return;
+        }
+
+        self.indexed_vars.push(var_id);
+
+        for token_id in self.tokens.iter().copied() {
+            let Some(value) = token_store
+                .get(token_id)
+                .and_then(|token| token.bindings.get(var_id))
+            else {
+                continue;
+            };
+            let Some(key) = AtomKey::from_value(value) else {
+                continue;
+            };
+            self.var_indices
+                .entry(var_id)
+                .or_default()
+                .entry(key)
+                .or_default()
+                .push(token_id);
+        }
+    }
+
+    /// Request indexing when the beta memory is known to be empty.
+    pub fn request_var_index_empty(&mut self, var_id: VarId) {
+        assert!(
+            self.tokens.is_empty(),
+            "request_var_index_empty called on non-empty beta memory; use request_var_index() to backfill"
+        );
         if !self.indexed_vars.contains(&var_id) {
             self.indexed_vars.push(var_id);
         }
@@ -653,6 +683,55 @@ impl BetaNetwork {
     #[must_use]
     pub fn root_id(&self) -> NodeId {
         self.root_id
+    }
+
+    /// Return the first node ID that has not yet been allocated.
+    ///
+    /// The compiler records this boundary before installing a rule so the
+    /// initialization phase can identify only edges added by that installation.
+    #[must_use]
+    pub(crate) fn next_node_id(&self) -> NodeId {
+        NodeId(self.next_node_id)
+    }
+
+    /// Find newly attached children whose parents predate an installation boundary.
+    ///
+    /// Initializing only this frontier populates every new descendant through
+    /// normal propagation while leaving pre-existing children and terminals
+    /// untouched.
+    pub(crate) fn installation_frontier(
+        &self,
+        first_new_node: NodeId,
+    ) -> Vec<(NodeId, Vec<NodeId>)> {
+        let mut frontier = Vec::new();
+
+        for (&parent_id, parent) in &self.nodes {
+            if parent_id.0 >= first_new_node.0 {
+                continue;
+            }
+
+            let children = match parent {
+                BetaNode::Root { children, .. }
+                | BetaNode::Join { children, .. }
+                | BetaNode::Negative { children, .. }
+                | BetaNode::Ncc { children, .. }
+                | BetaNode::Exists { children, .. } => children,
+                BetaNode::Terminal { .. } | BetaNode::NccPartner { .. } => continue,
+            };
+            let new_children: Vec<NodeId> = children
+                .iter()
+                .copied()
+                .filter(|child_id| child_id.0 >= first_new_node.0)
+                .collect();
+            if !new_children.is_empty() {
+                frontier.push((parent_id, new_children));
+            }
+        }
+
+        frontier.sort_unstable_by_key(|(_, children)| {
+            children.first().map_or(u32::MAX, |child_id| child_id.0)
+        });
+        frontier
     }
 
     /// Get the beta memory ID associated with a node.
@@ -1422,7 +1501,7 @@ mod proptests {
 
             let indexed_var = VarId(0);
             let mut mem = BetaMemory::new(BetaMemoryId(0));
-            mem.request_var_index(indexed_var);
+            mem.request_var_index_empty(indexed_var);
 
             let mut model = IndexedBetaModel::default();
 
@@ -1501,7 +1580,7 @@ mod proptests {
 
             let indexed_var = VarId(0);
             let mut mem = BetaMemory::new(BetaMemoryId(0));
-            mem.request_var_index(indexed_var);
+            mem.request_var_index_empty(indexed_var);
 
             // Build a map from TokenId -> key_val for brute-force scanning
             let mut tid_to_key: std::collections::HashMap<TokenId, i64> =
@@ -1548,7 +1627,7 @@ mod proptests {
 
             let indexed_var = VarId(0);
             let mut mem = BetaMemory::new(BetaMemoryId(0));
-            mem.request_var_index(indexed_var);
+            mem.request_var_index_empty(indexed_var);
 
             for (i, &kv) in key_vals.iter().enumerate() {
                 let bindings = make_bindings(0, kv);
@@ -1579,10 +1658,10 @@ mod proptests {
             let mut mem = BetaMemory::new(BetaMemoryId(0));
             let vid = VarId(var_id);
 
-            mem.request_var_index(vid);
+            mem.request_var_index_empty(vid);
             prop_assert!(mem.is_var_indexed(vid));
 
-            mem.request_var_index(vid);
+            mem.request_var_index_empty(vid);
             prop_assert!(mem.is_var_indexed(vid));
 
             // indexed_vars should have exactly one entry for this var

--- a/crates/ferric-rules-core/src/compiler.rs
+++ b/crates/ferric-rules-core/src/compiler.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
 
 use crate::alpha::{AlphaEntryType, AlphaMemoryId, AlphaNetwork, ConstantTest, SlotIndex};
-use crate::beta::{BetaNetwork, BetaNode, JoinTest, JoinTestType, RuleId, Salience};
+use crate::beta::{BetaNetwork, JoinTest, JoinTestType, RuleId, Salience};
 use crate::binding::{VarId, VarMap};
 use crate::fact::FactBase;
 use crate::rete::ReteNetwork;
@@ -94,6 +94,12 @@ struct JoinNodeKey {
     alpha_memory: AlphaMemoryId,
     tests: Vec<JoinTest>,
     bindings: Vec<(SlotIndex, VarId)>,
+}
+
+struct NewAlphaMemory {
+    id: AlphaMemoryId,
+    entry_type: AlphaEntryType,
+    tests: Vec<ConstantTest>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -195,7 +201,15 @@ impl ReteCompiler {
         Self::ensure_non_empty(&rule.patterns)?;
         Self::validate_rule_patterns(&rule.patterns)?;
         let conditions = Self::patterns_as_conditions(&rule.patterns);
-        self.compile_conditions_unchecked(rete, fact_base, rule.rule_id, rule.salience, &conditions)
+        let var_map = Self::prepare_var_map(&conditions)?;
+        Ok(self.compile_conditions_unchecked(
+            rete,
+            fact_base,
+            rule.rule_id,
+            rule.salience,
+            &conditions,
+            var_map,
+        ))
     }
 
     /// Compile a sequence of conditional elements into the rete network.
@@ -209,7 +223,9 @@ impl ReteCompiler {
     ) -> Result<CompileResult, CompileError> {
         Self::ensure_non_empty(conditions)?;
         Self::validate_conditions(conditions)?;
-        self.compile_conditions_unchecked(rete, fact_base, rule_id, salience, conditions)
+        let var_map = Self::prepare_var_map(conditions)?;
+        Ok(self
+            .compile_conditions_unchecked(rete, fact_base, rule_id, salience, conditions, var_map))
     }
 
     fn ensure_non_empty<T>(items: &[T]) -> Result<(), CompileError> {
@@ -227,6 +243,45 @@ impl ReteCompiler {
             .collect()
     }
 
+    /// Build the complete variable map before mutating the network.
+    ///
+    /// Variable overflow is the only fallible step in the structural compiler
+    /// after validation. Completing it up front makes installation failure-atomic:
+    /// once node construction starts, every remaining step is infallible.
+    fn prepare_var_map(conditions: &[CompilableCondition]) -> Result<VarMap, CompileError> {
+        fn register_condition(
+            condition: &CompilableCondition,
+            var_map: &mut VarMap,
+        ) -> Result<(), CompileError> {
+            match condition {
+                CompilableCondition::Pattern(pattern) => {
+                    for &(_, variable) in &pattern.variable_slots {
+                        var_map
+                            .get_or_create(variable)
+                            .map_err(|_| CompileError::VarMapOverflow)?;
+                    }
+                    for &(_, variable, _) in &pattern.negated_variable_slots {
+                        var_map
+                            .get_or_create(variable)
+                            .map_err(|_| CompileError::VarMapOverflow)?;
+                    }
+                }
+                CompilableCondition::Ncc(subconditions) => {
+                    for subcondition in subconditions {
+                        register_condition(subcondition, var_map)?;
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        let mut var_map = VarMap::new();
+        for condition in conditions {
+            register_condition(condition, &mut var_map)?;
+        }
+        Ok(var_map)
+    }
+
     fn compile_conditions_unchecked(
         &mut self,
         rete: &mut ReteNetwork,
@@ -234,15 +289,13 @@ impl ReteCompiler {
         rule_id: RuleId,
         salience: Salience,
         conditions: &[CompilableCondition],
-    ) -> Result<CompileResult, CompileError> {
+        mut var_map: VarMap,
+    ) -> CompileResult {
         let mut alpha_memories = Vec::new();
-        let mut var_map = VarMap::new();
+        let mut new_alpha_memories = Vec::new();
         let mut bound_vars = SymbolSet::new();
         let mut current_parent = rete.beta.root_id();
-        let existing_root_children = match rete.beta.get_node(rete.beta.root_id()) {
-            Some(BetaNode::Root { children, .. }) => children.len(),
-            _ => 0,
-        };
+        let first_new_beta_node = rete.beta.next_node_id();
 
         for condition in conditions {
             match condition {
@@ -255,7 +308,8 @@ impl ReteCompiler {
                         &mut var_map,
                         &mut bound_vars,
                         &mut alpha_memories,
-                    )?;
+                        &mut new_alpha_memories,
+                    );
                 }
                 CompilableCondition::Ncc(subpatterns) => {
                     current_parent = self.compile_ncc_condition(
@@ -266,7 +320,8 @@ impl ReteCompiler {
                         &mut var_map,
                         &bound_vars,
                         &mut alpha_memories,
-                    )?;
+                        &mut new_alpha_memories,
+                    );
                 }
             }
         }
@@ -275,26 +330,22 @@ impl ReteCompiler {
             .beta
             .create_terminal_node(current_parent, rule_id, salience);
 
-        // The beta root's dummy token predates compilation. Left-activate only
-        // children added while compiling this rule so leading negative, exists,
-        // and NCC CEs observe the empty prefix immediately without replaying
-        // already-compiled rules.
-        let new_root_children: Vec<NodeId> = match rete.beta.get_node(rete.beta.root_id()) {
-            Some(BetaNode::Root { children, .. }) => children
-                .iter()
-                .skip(existing_root_children)
-                .copied()
-                .collect(),
-            _ => Vec::new(),
-        };
-        rete.activate_root_children(&new_root_children, fact_base);
+        // Initialize only structures added by this installation. New alpha
+        // memories receive current WMEs directly; then the new beta frontier is
+        // left-activated from existing parent tokens. Old descendants never see
+        // replayed facts or tokens.
+        for memory in new_alpha_memories {
+            rete.alpha
+                .backfill_memory(memory.id, &memory.entry_type, &memory.tests, fact_base);
+        }
+        rete.initialize_beta_frontier(first_new_beta_node, fact_base);
 
-        Ok(CompileResult {
+        CompileResult {
             rule_id,
             terminal_node: terminal,
             alpha_memories,
             var_map,
-        })
+        }
     }
 
     fn validate_rule_patterns(patterns: &[CompilablePattern]) -> Result<(), CompileError> {
@@ -399,16 +450,6 @@ impl ReteCompiler {
         }
     }
 
-    fn unsupported_structure_compile_error(description: impl Into<String>) -> CompileError {
-        CompileError::Validation(vec![PatternValidationError::new(
-            PatternViolation::UnsupportedNestingCombination {
-                description: description.into(),
-            },
-            None,
-            ValidationStage::ReteCompilation,
-        )])
-    }
-
     #[allow(clippy::too_many_arguments)]
     fn validate_pattern_structure(
         pattern: &CompilablePattern,
@@ -456,14 +497,14 @@ impl ReteCompiler {
         &mut self,
         alpha: &mut AlphaNetwork,
         pattern: &CompilablePattern,
-    ) -> AlphaMemoryId {
+    ) -> (AlphaMemoryId, bool) {
         let key = AlphaPathKey {
             entry_type: pattern.entry_type.clone(),
             tests: pattern.constant_tests.clone(),
         };
 
         if let Some(&mem_id) = self.alpha_path_cache.get(&key) {
-            return mem_id;
+            return (mem_id, false);
         }
 
         // Build the path: entry node → constant test chain → memory
@@ -476,7 +517,7 @@ impl ReteCompiler {
 
         let mem_id = alpha.create_memory(current_node);
         self.alpha_path_cache.insert(key, mem_id);
-        mem_id
+        (mem_id, true)
     }
 
     /// Ensure a positive join node exists for the given structure.
@@ -514,9 +555,17 @@ impl ReteCompiler {
         var_map: &mut VarMap,
         bound_vars: &mut SymbolSet,
         alpha_memories: &mut Vec<AlphaMemoryId>,
-    ) -> Result<NodeId, CompileError> {
-        let alpha_mem = self.ensure_alpha_path(&mut rete.alpha, pattern);
+        new_alpha_memories: &mut Vec<NewAlphaMemory>,
+    ) -> NodeId {
+        let (alpha_mem, alpha_created) = self.ensure_alpha_path(&mut rete.alpha, pattern);
         alpha_memories.push(alpha_mem);
+        if alpha_created {
+            new_alpha_memories.push(NewAlphaMemory {
+                id: alpha_mem,
+                entry_type: pattern.entry_type.clone(),
+                tests: pattern.constant_tests.clone(),
+            });
+        }
 
         let mut join_tests = SmallVec::<[JoinTest; 8]>::new();
         let mut binding_extractions = SmallVec::<[(SlotIndex, VarId); 8]>::new();
@@ -524,8 +573,8 @@ impl ReteCompiler {
 
         for &(slot, var_sym) in &pattern.variable_slots {
             let var_id = var_map
-                .get_or_create(var_sym)
-                .map_err(|_| CompileError::VarMapOverflow)?;
+                .lookup(var_sym)
+                .expect("all rule variables must be prepared before node construction");
 
             if bound_vars.contains(var_sym) {
                 join_tests.push(JoinTest {
@@ -542,8 +591,8 @@ impl ReteCompiler {
         // Non-binding variable comparisons produce join tests.
         for &(slot, var_sym, test_type) in &pattern.negated_variable_slots {
             let var_id = var_map
-                .get_or_create(var_sym)
-                .map_err(|_| CompileError::VarMapOverflow)?;
+                .lookup(var_sym)
+                .expect("all rule variables must be prepared before node construction");
 
             join_tests.push(JoinTest {
                 alpha_slot: slot,
@@ -569,7 +618,7 @@ impl ReteCompiler {
                 for test in &join_tests {
                     if test.test_type == JoinTestType::Equal {
                         if let Some(parent_mem) = rete.beta.get_memory_mut(parent_mem_id) {
-                            parent_mem.request_var_index(test.beta_var);
+                            parent_mem.request_var_index(test.beta_var, &rete.token_store);
                         }
                     }
                 }
@@ -580,22 +629,21 @@ impl ReteCompiler {
             let (neg_id, _beta_mem, _neg_mem) =
                 rete.beta
                     .create_negative_node(current_parent, alpha_mem, join_tests.into_vec());
-            Ok(neg_id)
+            neg_id
         } else if pattern.exists {
             let (exists_id, _beta_mem, _exists_mem) =
                 rete.beta
                     .create_exists_node(current_parent, alpha_mem, join_tests.into_vec());
-            Ok(exists_id)
+            exists_id
         } else {
             bound_vars.extend(new_bindings);
-            let join_id = self.ensure_join_node(
+            self.ensure_join_node(
                 &mut rete.beta,
                 current_parent,
                 alpha_mem,
                 join_tests.into_vec(),
                 binding_extractions.into_vec(),
-            );
-            Ok(join_id)
+            )
         }
     }
 
@@ -609,12 +657,12 @@ impl ReteCompiler {
         var_map: &mut VarMap,
         bound_vars: &SymbolSet,
         alpha_memories: &mut Vec<AlphaMemoryId>,
-    ) -> Result<NodeId, CompileError> {
-        if subconditions.is_empty() {
-            return Err(Self::unsupported_structure_compile_error(
-                "NCC requires at least one subpattern",
-            ));
-        }
+        new_alpha_memories: &mut Vec<NewAlphaMemory>,
+    ) -> NodeId {
+        debug_assert!(
+            !subconditions.is_empty(),
+            "NCC structure must be validated before node construction"
+        );
 
         // Create the main-chain NCC node first, then wire its partner once the
         // subnetwork bottom is known.
@@ -637,7 +685,8 @@ impl ReteCompiler {
                         var_map,
                         &mut sub_bound_vars,
                         alpha_memories,
-                    )?;
+                        new_alpha_memories,
+                    );
                 }
                 CompilableCondition::Ncc(inner_conditions) => {
                     sub_parent = self.compile_ncc_condition(
@@ -648,7 +697,8 @@ impl ReteCompiler {
                         var_map,
                         &sub_bound_vars,
                         alpha_memories,
-                    )?;
+                        new_alpha_memories,
+                    );
                 }
             }
         }
@@ -658,7 +708,7 @@ impl ReteCompiler {
             .create_ncc_partner(sub_parent, ncc_id, ncc_memory_id);
         rete.beta.set_ncc_partner(ncc_id, partner_id);
 
-        Ok(ncc_id)
+        ncc_id
     }
 }
 
@@ -763,6 +813,55 @@ mod tests {
             rete.agenda.len(),
             1,
             "retracting the last blocker should reactivate"
+        );
+        rete.debug_assert_consistency();
+    }
+
+    #[test]
+    fn fr_rete_003_late_single_pattern_rule_backfills_core_network() {
+        let mut compiler = ReteCompiler::new();
+        let mut rete = ReteNetwork::new();
+        let mut fact_base = FactBase::new();
+        let mut table = new_table();
+        let foo_relation = intern(&mut table, "foo");
+
+        let fact_id = fact_base.assert_ordered(foo_relation, SmallVec::new());
+        let fact = fact_base.get(fact_id).expect("fact").fact.clone();
+        assert!(
+            rete.assert_fact(fact_id, &fact, &fact_base).is_empty(),
+            "no rule exists when the fact is asserted"
+        );
+
+        let rule = CompilableRule {
+            rule_id: compiler.allocate_rule_id(),
+            salience: Salience::DEFAULT,
+            patterns: vec![CompilablePattern {
+                entry_type: AlphaEntryType::OrderedRelation(foo_relation),
+                constant_tests: vec![],
+                variable_slots: vec![],
+                negated_variable_slots: vec![],
+                negated: false,
+                exists: false,
+            }],
+        };
+        let result = compiler
+            .compile_rule(&mut rete, &fact_base, &rule)
+            .expect("compile late rule");
+
+        assert_eq!(rete.agenda.len(), 1, "existing fact should activate rule");
+        assert!(
+            rete.alpha
+                .get_memory(result.alpha_memories[0])
+                .expect("alpha memory")
+                .contains(fact_id),
+            "new alpha memory should contain the existing fact"
+        );
+
+        rete.retract_fact(fact_id, &fact, &fact_base);
+        fact_base.retract(fact_id);
+        assert!(
+            rete.agenda.is_empty(),
+            "backfilled reverse indexes must support retraction"
         );
         rete.debug_assert_consistency();
     }

--- a/crates/ferric-rules-core/src/compiler.rs
+++ b/crates/ferric-rules-core/src/compiler.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashMap as HashMap;
 use smallvec::SmallVec;
 
 use crate::alpha::{AlphaEntryType, AlphaMemoryId, AlphaNetwork, ConstantTest, SlotIndex};
-use crate::beta::{BetaNetwork, JoinTest, JoinTestType, RuleId, Salience};
+use crate::beta::{BetaNetwork, BetaNode, JoinTest, JoinTestType, RuleId, Salience};
 use crate::binding::{VarId, VarMap};
 use crate::fact::FactBase;
 use crate::rete::ReteNetwork;
@@ -94,12 +94,6 @@ struct JoinNodeKey {
     alpha_memory: AlphaMemoryId,
     tests: Vec<JoinTest>,
     bindings: Vec<(SlotIndex, VarId)>,
-}
-
-struct NewAlphaMemory {
-    id: AlphaMemoryId,
-    entry_type: AlphaEntryType,
-    tests: Vec<ConstantTest>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -292,10 +286,18 @@ impl ReteCompiler {
         mut var_map: VarMap,
     ) -> CompileResult {
         let mut alpha_memories = Vec::new();
-        let mut new_alpha_memories = Vec::new();
         let mut bound_vars = SymbolSet::new();
         let mut current_parent = rete.beta.root_id();
         let first_new_beta_node = rete.beta.next_node_id();
+        let root_only_runtime = fact_base.is_empty() && rete.token_store.len() == 1;
+        let existing_root_children = if root_only_runtime {
+            match rete.beta.get_node(rete.beta.root_id()) {
+                Some(BetaNode::Root { children, .. }) => children.len(),
+                _ => 0,
+            }
+        } else {
+            0
+        };
 
         for condition in conditions {
             match condition {
@@ -308,7 +310,6 @@ impl ReteCompiler {
                         &mut var_map,
                         &mut bound_vars,
                         &mut alpha_memories,
-                        &mut new_alpha_memories,
                     );
                 }
                 CompilableCondition::Ncc(subpatterns) => {
@@ -320,7 +321,6 @@ impl ReteCompiler {
                         &mut var_map,
                         &bound_vars,
                         &mut alpha_memories,
-                        &mut new_alpha_memories,
                     );
                 }
             }
@@ -330,15 +330,22 @@ impl ReteCompiler {
             .beta
             .create_terminal_node(current_parent, rule_id, salience);
 
-        // Initialize only structures added by this installation. New alpha
-        // memories receive current WMEs directly; then the new beta frontier is
-        // left-activated from existing parent tokens. Old descendants never see
-        // replayed facts or tokens.
-        for memory in new_alpha_memories {
-            rete.alpha
-                .backfill_memory(memory.id, &memory.entry_type, &memory.tests, fact_base);
+        // Cold-start compilation has no existing partial matches beyond the
+        // root token, so retain the direct root-child path. Online installation
+        // uses the wider frontier to seed descendants of populated old nodes.
+        if root_only_runtime {
+            let new_root_children: Vec<NodeId> = match rete.beta.get_node(rete.beta.root_id()) {
+                Some(BetaNode::Root { children, .. }) => children
+                    .iter()
+                    .skip(existing_root_children)
+                    .copied()
+                    .collect(),
+                _ => Vec::new(),
+            };
+            rete.activate_root_children(&new_root_children, fact_base);
+        } else {
+            rete.initialize_beta_frontier(first_new_beta_node, fact_base);
         }
-        rete.initialize_beta_frontier(first_new_beta_node, fact_base);
 
         CompileResult {
             rule_id,
@@ -555,16 +562,16 @@ impl ReteCompiler {
         var_map: &mut VarMap,
         bound_vars: &mut SymbolSet,
         alpha_memories: &mut Vec<AlphaMemoryId>,
-        new_alpha_memories: &mut Vec<NewAlphaMemory>,
     ) -> NodeId {
         let (alpha_mem, alpha_created) = self.ensure_alpha_path(&mut rete.alpha, pattern);
         alpha_memories.push(alpha_mem);
-        if alpha_created {
-            new_alpha_memories.push(NewAlphaMemory {
-                id: alpha_mem,
-                entry_type: pattern.entry_type.clone(),
-                tests: pattern.constant_tests.clone(),
-            });
+        if alpha_created && !fact_base.is_empty() {
+            rete.alpha.backfill_memory(
+                alpha_mem,
+                &pattern.entry_type,
+                &pattern.constant_tests,
+                fact_base,
+            );
         }
 
         let mut join_tests = SmallVec::<[JoinTest; 8]>::new();
@@ -657,7 +664,6 @@ impl ReteCompiler {
         var_map: &mut VarMap,
         bound_vars: &SymbolSet,
         alpha_memories: &mut Vec<AlphaMemoryId>,
-        new_alpha_memories: &mut Vec<NewAlphaMemory>,
     ) -> NodeId {
         debug_assert!(
             !subconditions.is_empty(),
@@ -685,7 +691,6 @@ impl ReteCompiler {
                         var_map,
                         &mut sub_bound_vars,
                         alpha_memories,
-                        new_alpha_memories,
                     );
                 }
                 CompilableCondition::Ncc(inner_conditions) => {
@@ -697,7 +702,6 @@ impl ReteCompiler {
                         var_map,
                         &sub_bound_vars,
                         alpha_memories,
-                        new_alpha_memories,
                     );
                 }
             }

--- a/crates/ferric-rules-core/src/rete.rs
+++ b/crates/ferric-rules-core/src/rete.rs
@@ -230,16 +230,34 @@ impl ReteNetwork {
         );
     }
 
-    /// Activate newly compiled children of the beta root from the empty LHS
-    /// prefix token.
-    pub(crate) fn activate_root_children(&mut self, children: &[NodeId], fact_base: &FactBase) {
-        if children.is_empty() {
-            return;
-        }
+    /// Populate the beta frontier added by an online rule installation.
+    ///
+    /// Each frontier edge has a parent that existed before compilation and a
+    /// child created by this installation. Left-activating those children from
+    /// the parent's current tokens recursively fills every new descendant
+    /// without replaying into old siblings or terminals.
+    pub(crate) fn initialize_beta_frontier(
+        &mut self,
+        first_new_node: NodeId,
+        fact_base: &FactBase,
+    ) {
+        self.seed_root_token();
 
-        let root_token = self.seed_root_token();
-        let mut new_activations = Vec::new();
-        self.propagate_token(root_token, children, fact_base, &mut new_activations);
+        for (parent_id, new_children) in self.beta.installation_frontier(first_new_node) {
+            let Some(parent_memory_id) = self.beta.memory_id_for_node(parent_id) else {
+                continue;
+            };
+            let parent_tokens: SmallVec<[TokenId; 8]> = self
+                .beta
+                .get_memory(parent_memory_id)
+                .map(|memory| memory.iter().collect())
+                .unwrap_or_default();
+
+            for parent_token in parent_tokens {
+                let mut new_activations = Vec::new();
+                self.propagate_token(parent_token, &new_children, fact_base, &mut new_activations);
+            }
+        }
     }
 
     /// Ensure the root beta memory contains its single empty-prefix token.
@@ -3993,7 +4011,7 @@ mod tests {
             // Request var index on join1's memory for var_x
             // (this simulates what the compiler does for the child join's equality test)
             if let Some(mem) = rete.beta.get_memory_mut(join1_mem_id) {
-                mem.request_var_index(var_x);
+                mem.request_var_index_empty(var_x);
             }
 
             // Request alpha memory indexing

--- a/crates/ferric-rules-core/src/rete.rs
+++ b/crates/ferric-rules-core/src/rete.rs
@@ -230,6 +230,18 @@ impl ReteNetwork {
         );
     }
 
+    /// Activate newly compiled children of the beta root from the empty LHS
+    /// prefix token.
+    pub(crate) fn activate_root_children(&mut self, children: &[NodeId], fact_base: &FactBase) {
+        if children.is_empty() {
+            return;
+        }
+
+        let root_token = self.seed_root_token();
+        let mut new_activations = Vec::new();
+        self.propagate_token(root_token, children, fact_base, &mut new_activations);
+    }
+
     /// Populate the beta frontier added by an online rule installation.
     ///
     /// Each frontier edge has a parent that existed before compilation and a
@@ -241,9 +253,15 @@ impl ReteNetwork {
         first_new_node: NodeId,
         fact_base: &FactBase,
     ) {
-        self.seed_root_token();
+        let root_id = self.beta.root_id();
+        let mut new_activations = Vec::new();
 
-        for (parent_id, new_children) in self.beta.installation_frontier(first_new_node) {
+        for (parent_id, new_child) in self.beta.installation_frontier(first_new_node) {
+            if parent_id == root_id {
+                self.activate_root_children(&[new_child], fact_base);
+                continue;
+            }
+
             let Some(parent_memory_id) = self.beta.memory_id_for_node(parent_id) else {
                 continue;
             };
@@ -254,8 +272,7 @@ impl ReteNetwork {
                 .unwrap_or_default();
 
             for parent_token in parent_tokens {
-                let mut new_activations = Vec::new();
-                self.propagate_token(parent_token, &new_children, fact_base, &mut new_activations);
+                self.propagate_token(parent_token, &[new_child], fact_base, &mut new_activations);
             }
         }
     }

--- a/crates/ferric-rules-runtime/src/engine.rs
+++ b/crates/ferric-rules-runtime/src/engine.rs
@@ -1768,6 +1768,211 @@ mod tests {
         assert_single_root_prefix_token(&engine);
     }
 
+    fn activation_count_for_rule(engine: &Engine, rule_name: &str) -> usize {
+        engine
+            .rete
+            .agenda
+            .iter_activations()
+            .filter(|activation| engine.rule_name(activation.rule) == Some(rule_name))
+            .count()
+    }
+
+    #[test]
+    fn fr_rete_003_late_single_pattern_rule_backfills() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine.assert_ordered("foo", vec![]).unwrap();
+
+        engine
+            .load_str(
+                r#"
+                (defrule late
+                    (foo)
+                    =>
+                    (printout t "late" crlf))
+                "#,
+            )
+            .unwrap();
+
+        assert_eq!(engine.agenda_len(), 1);
+        assert_eq!(activation_count_for_rule(&engine, "late"), 1);
+        assert_eq!(engine.run(RunLimit::Unlimited).unwrap().rules_fired, 1);
+        assert_eq!(engine.get_output("t"), Some("late\n"));
+    }
+
+    #[test]
+    fn fr_rete_003_late_join_backfills() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine.load_str("(defrule prefix (left ?x) =>)").unwrap();
+        engine.load_str("(assert (left 1) (right 1 old))").unwrap();
+        assert_eq!(activation_count_for_rule(&engine, "prefix"), 1);
+
+        engine
+            .load_str(
+                r#"
+                (defrule late-join
+                    (left ?x)
+                    (right ?x ?tag)
+                    =>
+                    (printout t "late " ?tag crlf))
+                "#,
+            )
+            .unwrap();
+
+        assert_eq!(
+            activation_count_for_rule(&engine, "prefix"),
+            1,
+            "initialization must not replay into the old terminal"
+        );
+        assert_eq!(activation_count_for_rule(&engine, "late-join"), 1);
+        assert_eq!(engine.run(RunLimit::Unlimited).unwrap().rules_fired, 2);
+        assert_eq!(engine.get_output("t"), Some("late old\n"));
+
+        engine.load_str("(assert (right 1 new))").unwrap();
+        assert_eq!(
+            activation_count_for_rule(&engine, "late-join"),
+            1,
+            "the populated parent memory's equality index must serve future facts"
+        );
+        assert_eq!(engine.run(RunLimit::Unlimited).unwrap().rules_fired, 1);
+        assert_eq!(engine.get_output("t"), Some("late old\nlate new\n"));
+    }
+
+    #[test]
+    fn fr_rete_003_late_negative_and_exists_backfill() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        let blocker = engine.assert_ordered("blocked", vec![]).unwrap();
+        engine.assert_ordered("seed", vec![]).unwrap();
+        engine.assert_ordered("ready", vec![]).unwrap();
+
+        engine
+            .load_str(
+                r#"
+                (defrule late-negative
+                    (seed)
+                    (not (blocked))
+                    =>
+                    (printout t "negative" crlf))
+                (defrule late-exists
+                    (seed)
+                    (exists (ready))
+                    =>
+                    (printout t "exists" crlf))
+                "#,
+            )
+            .unwrap();
+
+        assert_eq!(activation_count_for_rule(&engine, "late-negative"), 0);
+        assert_eq!(activation_count_for_rule(&engine, "late-exists"), 1);
+        assert_eq!(engine.run(RunLimit::Unlimited).unwrap().rules_fired, 1);
+        assert_eq!(engine.get_output("t"), Some("exists\n"));
+
+        engine.retract(blocker).unwrap();
+        assert_eq!(activation_count_for_rule(&engine, "late-negative"), 1);
+        assert_eq!(engine.run(RunLimit::Unlimited).unwrap().rules_fired, 1);
+        assert_eq!(engine.get_output("t"), Some("exists\nnegative\n"));
+    }
+
+    #[test]
+    fn fr_rete_003_backfill_does_not_duplicate_old_activations() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine.load_str("(defrule old-rule (item ?x) =>)").unwrap();
+        engine.load_str("(assert (item 1))").unwrap();
+        assert_eq!(activation_count_for_rule(&engine, "old-rule"), 1);
+
+        engine.load_str("(defrule new-rule (item ?x) =>)").unwrap();
+
+        assert_eq!(activation_count_for_rule(&engine, "old-rule"), 1);
+        assert_eq!(activation_count_for_rule(&engine, "new-rule"), 1);
+        assert_eq!(engine.agenda_len(), 2);
+    }
+
+    #[test]
+    fn fr_rete_003_rule_loaded_after_retractions_sees_current_state() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        let stale = engine.assert_ordered_symbol("item", "stale").unwrap();
+        engine.assert_ordered_symbol("item", "current").unwrap();
+        engine.retract(stale).unwrap();
+
+        engine
+            .load_str(
+                r"
+                (defrule late-current
+                    (item ?value)
+                    =>
+                    (printout t ?value crlf))
+                ",
+            )
+            .unwrap();
+
+        assert_eq!(activation_count_for_rule(&engine, "late-current"), 1);
+        assert_eq!(engine.run(RunLimit::Unlimited).unwrap().rules_fired, 1);
+        assert_eq!(engine.get_output("t"), Some("current\n"));
+    }
+
+    #[test]
+    fn fr_rete_003_late_ncc_and_empty_prefix_rules_backfill() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .load_str("(assert (item 1) (block 1) (reason 1) (item 2))")
+            .unwrap();
+
+        engine
+            .load_str(
+                r#"
+                (defrule late-ncc
+                    (item ?x)
+                    (not (and (block ?x) (reason ?x)))
+                    =>
+                    (printout t "item " ?x crlf))
+                (defrule late-empty
+                    =>
+                    (printout t "empty" crlf))
+                (defrule late-test-only
+                    (test (> 2 1))
+                    =>
+                    (printout t "test" crlf))
+                "#,
+            )
+            .unwrap();
+
+        assert_eq!(activation_count_for_rule(&engine, "late-ncc"), 1);
+        assert_eq!(activation_count_for_rule(&engine, "late-empty"), 1);
+        assert_eq!(activation_count_for_rule(&engine, "late-test-only"), 1);
+        assert_eq!(engine.run(RunLimit::Unlimited).unwrap().rules_fired, 3);
+        let output = engine.get_output("t").unwrap_or_default();
+        assert!(output.contains("item 2\n"));
+        assert!(output.contains("empty\n"));
+        assert!(output.contains("test\n"));
+    }
+
+    #[test]
+    fn fr_rete_003_failed_installation_leaves_no_terminal_or_activation() {
+        let mut engine = Engine::new(EngineConfig::ascii());
+        engine.load_str("(assert (foo 1))").unwrap();
+        let baseline_tokens = engine.rete.token_store.len();
+
+        let result = engine.load_str(
+            r#"
+            (defrule broken
+                (foo ?x)
+                =>
+                (printout t "é" crlf))
+            "#,
+        );
+        assert!(result.is_err(), "non-ASCII RHS must fail in ASCII mode");
+        assert!(engine.rules().is_empty());
+        assert_eq!(engine.agenda_len(), 0);
+        assert_eq!(engine.rete.token_store.len(), baseline_tokens);
+
+        engine.load_str("(assert (foo 2))").unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            0,
+            "future facts must not reach a failed rule installation"
+        );
+        assert_eq!(engine.rete.token_store.len(), baseline_tokens);
+    }
+
     #[test]
     fn retract_fact() {
         let mut engine = Engine::new(EngineConfig::utf8());

--- a/crates/ferric-rules-runtime/src/loader.rs
+++ b/crates/ferric-rules-runtime/src/loader.rs
@@ -1798,6 +1798,23 @@ impl Engine {
     ) -> Result<CompileResult, LoadError> {
         self.validate_rule_action_callables(rule, self.module_registry.current_module())?;
 
+        // Complete every fallible RHS translation before exposing any LHS
+        // nodes. Once core compilation begins, a load error cannot leave a
+        // terminal or activation without executable rule metadata.
+        let mut runtime_actions = Vec::with_capacity(rule.actions.len());
+        for action in &rule.actions {
+            let expr = ActionExpr::FunctionCall(action.call.clone());
+            let runtime_expr =
+                crate::evaluator::from_action_expr(&expr, &mut self.symbol_table, &self.config)
+                    .map_err(|error| {
+                        LoadError::Compile(format!(
+                            "rule `{}` action `{}` at line {}: {error}",
+                            rule.name, action.call.name, action.call.span.start.line
+                        ))
+                    })?;
+            runtime_actions.push(Some(runtime_expr));
+        }
+
         let translated = self
             .translate_rule_construct(rule)
             .map_err(|e| LoadError::Compile(format!("{e}")))?;
@@ -1812,20 +1829,6 @@ impl Engine {
                 &translated.conditions,
             )
             .map_err(|e| LoadError::Compile(format!("{e}")))?;
-
-        let mut runtime_actions = Vec::with_capacity(rule.actions.len());
-        for action in &rule.actions {
-            let expr = ActionExpr::FunctionCall(action.call.clone());
-            let runtime_expr =
-                crate::evaluator::from_action_expr(&expr, &mut self.symbol_table, &self.config)
-                    .map_err(|error| {
-                        LoadError::Compile(format!(
-                            "rule `{}` action `{}` at line {}: {error}",
-                            rule.name, action.call.name, action.call.span.start.line
-                        ))
-                    })?;
-            runtime_actions.push(Some(runtime_expr));
-        }
 
         let source_definition = source
             .get(rule.span.start.offset..rule.span.end.offset)
@@ -2541,7 +2544,6 @@ impl Engine {
         &mut self,
         rule: &RuleConstruct,
     ) -> Result<TranslatedRule, LoadError> {
-        let rule_id = self.compiler.allocate_rule_id();
         let mut conditions = Vec::new();
         let mut fact_address_vars = HashMap::new();
         let mut test_conditions: Vec<CompiledTestCondition> = Vec::new();
@@ -2661,7 +2663,7 @@ impl Engine {
         }
 
         Ok(TranslatedRule {
-            rule_id,
+            rule_id: self.compiler.allocate_rule_id(),
             salience: Salience::new(rule.salience),
             conditions,
             fact_address_vars,

--- a/crates/ferric-rules-runtime/src/loader.rs
+++ b/crates/ferric-rules-runtime/src/loader.rs
@@ -28,8 +28,8 @@ use crate::qualified_name::{parse_qualified_name, QualifiedName};
 
 use ferric_rules_core::{
     AlphaEntryType, AtomKey, CompilableCondition, CompilablePattern, CompileResult, ConstantTest,
-    ConstantTestType, Fact, FactId, FerricString, JoinTestType, RuleId, Salience, SlotIndex,
-    TemplateFact, Value,
+    ConstantTestType, Fact, FactId, FerricString, JoinTestType, Salience, SlotIndex, TemplateFact,
+    Value,
 };
 use ferric_rules_parser::{
     interpret_constructs, parse_sexprs, ActionExpr, Atom, Constraint, Construct, FactBody,
@@ -50,7 +50,6 @@ use crate::tracing_support::{ferric_event, ferric_span};
 
 /// Translated rule data including fact-address variable bindings.
 struct TranslatedRule {
-    rule_id: RuleId,
     salience: Salience,
     conditions: Vec<CompilableCondition>,
     fact_address_vars: HashMap<String, usize>,
@@ -1798,9 +1797,13 @@ impl Engine {
     ) -> Result<CompileResult, LoadError> {
         self.validate_rule_action_callables(rule, self.module_registry.current_module())?;
 
-        // Complete every fallible RHS translation before exposing any LHS
-        // nodes. Once core compilation begins, a load error cannot leave a
-        // terminal or activation without executable rule metadata.
+        // Translate the LHS first to preserve source-order symbol interning, but
+        // do not expose any Rete nodes or consume a rule ID until every fallible
+        // RHS translation has also completed.
+        let translated = self
+            .translate_rule_construct(rule)
+            .map_err(|e| LoadError::Compile(format!("{e}")))?;
+
         let mut runtime_actions = Vec::with_capacity(rule.actions.len());
         for action in &rule.actions {
             let expr = ActionExpr::FunctionCall(action.call.clone());
@@ -1815,16 +1818,14 @@ impl Engine {
             runtime_actions.push(Some(runtime_expr));
         }
 
-        let translated = self
-            .translate_rule_construct(rule)
-            .map_err(|e| LoadError::Compile(format!("{e}")))?;
+        let rule_id = self.compiler.allocate_rule_id();
 
         let compile_result = self
             .compiler
             .compile_conditions(
                 &mut self.rete,
                 &self.fact_base,
-                translated.rule_id,
+                rule_id,
                 translated.salience,
                 &translated.conditions,
             )
@@ -2663,7 +2664,6 @@ impl Engine {
         }
 
         Ok(TranslatedRule {
-            rule_id: self.compiler.allocate_rule_id(),
             salience: Salience::new(rule.salience),
             conditions,
             fact_address_vars,

--- a/crates/ferric-rules/benches/compile_bench.rs
+++ b/crates/ferric-rules/benches/compile_bench.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write as FmtWrite;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use ferric_rules::runtime::{Engine, EngineConfig};
 
 /// Compilation scaling benchmark: cold-start parse + Rete network construction
@@ -99,6 +99,60 @@ fn bench_compile_500r_50t(c: &mut Criterion) {
     group.finish();
 }
 
+fn generate_existing_wmes(n_wmes: usize) -> String {
+    let mut source = String::new();
+    for index in 0..n_wmes {
+        writeln!(source, "(assert (item {index} bucket-{}))", index % 10).unwrap();
+    }
+    source
+}
+
+fn generate_late_rules(n_rules: usize) -> String {
+    let mut source = String::new();
+    for index in 0..n_rules {
+        writeln!(
+            source,
+            "(defrule late-{index} (item ?value bucket-{}) =>)",
+            index % 10
+        )
+        .unwrap();
+    }
+    source
+}
+
+/// Online installation benchmark: compile rules after working memory is
+/// populated. Setup is excluded so the measurement covers alpha-memory
+/// backfill, beta-frontier initialization, and terminal activation only.
+fn bench_online_rule_install(c: &mut Criterion) {
+    let mut group = c.benchmark_group("online_rule_install");
+    group.sample_size(10);
+
+    for &(n_wmes, n_rules) in &[(100, 1), (100, 10), (1_000, 1), (1_000, 10)] {
+        let fact_source = generate_existing_wmes(n_wmes);
+        let rule_source = generate_late_rules(n_rules);
+        group.bench_with_input(
+            BenchmarkId::new(format!("{n_wmes}_wmes"), format!("{n_rules}_rules")),
+            &(n_wmes, n_rules),
+            |b, _| {
+                b.iter_batched(
+                    || {
+                        let mut engine = Engine::new(EngineConfig::utf8());
+                        engine.load_str(&fact_source).expect("load existing WMEs");
+                        engine
+                    },
+                    |mut engine| {
+                        engine
+                            .load_str(black_box(&rule_source))
+                            .expect("install late rules");
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_compile_10r_5t,
@@ -106,5 +160,6 @@ criterion_group!(
     bench_compile_100r_20t,
     bench_compile_200r_30t,
     bench_compile_500r_50t,
+    bench_online_rule_install,
 );
 criterion_main!(benches);

--- a/crates/ferric-rules/tests/clips_compat.rs
+++ b/crates/ferric-rules/tests/clips_compat.rs
@@ -779,6 +779,32 @@ fn test_compat_negation_forall_fail() {
 // Core domain — deeper coverage
 // ===========================================================================
 
+#[test]
+fn fr_rete_003_clips_staged_late_rule_backfill_fixture() {
+    // These two files are also run sequentially against the pinned CLIPS 6.30
+    // image. Keeping assertion and rule-definition stages separate is essential:
+    // a single load would compile all Ferric rules before processing assertions.
+    let fixture_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("core");
+    let prelude = std::fs::read_to_string(fixture_root.join("late_rule_backfill_prelude.clp"))
+        .expect("read staged backfill prelude");
+    let rules = std::fs::read_to_string(fixture_root.join("late_rule_backfill_rules.clp"))
+        .expect("read staged backfill rules");
+
+    let mut engine = Engine::new(EngineConfig::utf8());
+    engine.load_str(&prelude).expect("load pre-existing WMEs");
+    engine.load_str(&rules).expect("load late rules");
+    let rules_fired = run_compat_with_guard(&mut engine, "FR-RETE-003 staged fixture");
+
+    assert_eq!(rules_fired, 3);
+    assert_eq!(
+        engine.get_output("t"),
+        Some("single\njoin 1\nstate alice\n")
+    );
+}
+
 /// Multi-pattern join: a rule with two patterns joined by a shared variable.
 #[test]
 fn test_compat_core_multi_pattern_join() {

--- a/crates/ferric-rules/tests/fixtures/core/late_rule_backfill_prelude.clp
+++ b/crates/ferric-rules/tests/fixtures/core/late_rule_backfill_prelude.clp
@@ -1,0 +1,6 @@
+; FR-RETE-003 stage 1: establish working memory before rule definitions.
+(assert
+    (seed alice)
+    (left 1)
+    (right 1)
+    (ready alice))

--- a/crates/ferric-rules/tests/fixtures/core/late_rule_backfill_rules.clp
+++ b/crates/ferric-rules/tests/fixtures/core/late_rule_backfill_rules.clp
@@ -1,0 +1,21 @@
+; FR-RETE-003 stage 2: rules must activate from the existing working memory.
+(defrule late-single
+    (declare (salience 30))
+    (seed alice)
+    =>
+    (printout t "single" crlf))
+
+(defrule late-join
+    (declare (salience 20))
+    (left ?value)
+    (right ?value)
+    =>
+    (printout t "join " ?value crlf))
+
+(defrule late-negative-exists
+    (declare (salience 10))
+    (seed ?value)
+    (not (blocked ?value))
+    (exists (ready ?value))
+    =>
+    (printout t "state " ?value crlf))

--- a/scripts/expected-ferric-rules-package-files.txt
+++ b/scripts/expected-ferric-rules-package-files.txt
@@ -29,6 +29,8 @@ tests/fixtures/core/bind_in_rhs.clp
 tests/fixtures/core/chain_rules.clp
 tests/fixtures/core/fact_duplication_policy.clp
 tests/fixtures/core/halt_stops_execution.clp
+tests/fixtures/core/late_rule_backfill_prelude.clp
+tests/fixtures/core/late_rule_backfill_rules.clp
 tests/fixtures/core/modify_duplicate.clp
 tests/fixtures/core/multi_pattern_join.clp
 tests/fixtures/core/multiple_activations_depth.clp


### PR DESCRIPTION
Closes #105

## What changed

- Backfill newly created alpha memories from the current fact base, including the reverse indexes needed for later retraction.
- Initialize only the new beta-network frontier from existing parent tokens, so late rules receive current matches without replaying facts or tokens into older rules.
- Discover that frontier from only the node IDs allocated by the current installation and stream direct frontier edges in allocation order, avoiding repeated whole-network scans and temporary grouping maps.
- Preserve the direct root-child path when compilation has no existing working-memory or partial-match state, while using the wider frontier for true online installation.
- Backfill equality indexes when a new join is attached to a populated beta memory, preserving correct matching for subsequent assertions.
- Complete fallible LHS/RHS translation and variable-map allocation before structural compilation or rule-ID allocation, preventing the audited failed-install path from leaving a terminal, activation, or consumed ID behind.
- Add FR-RETE-003 coverage for late single-pattern, joins, negative/exists, NCC, empty-prefix/test-only rules, retractions, old-activation isolation, future assertions, failed installation, and frontier isolation.
- Add a staged fixture verified against pinned CLIPS 6.30 and a Criterion release benchmark matrix for online installation.

## Root cause and impact

The compiler built new alpha and beta nodes after working memory had already been populated, but only future assertions traversed those nodes. Replaying every existing fact through the whole network would duplicate activations in pre-existing rules, so installation now backfills only newly created alpha memories and propagates only across edges introduced by the current installation. Applications can now define rules online and immediately match the engine's current state while existing agenda entries remain unchanged.

This change makes the individual audited failure path safe but does not claim the broader source-unit transaction work tracked by #109 and #159.

## Validation

- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 just preflight-pr`
- `just scaling-check` — all 5 checks passed; 4× input ratios were 2.54–3.72×
- `cargo test -p ferric-rules-core --lib -q` — 417 passed
- `cargo test -p ferric-rules-runtime --lib -q` — 798 passed
- `cargo test -p ferric-rules --test clips_compat -q` — 73 passed
- staged late-rule fixture produced the same 3-line output under pinned CLIPS 6.30
- `cargo bench -p ferric-rules --bench compile_bench -- 'online_rule_install|compile_500r_50t$' --measurement-time 10`
  - 100 WMEs / 1 rule: 7.6208 µs median
  - 100 WMEs / 10 rules: 53.922 µs median
  - 1000 WMEs / 1 rule: 37.435 µs median
  - 1000 WMEs / 10 rules: 326.17 µs median
  - `compile_500r_50t`: 5.0688 ms median
- same-machine release before/after measurements for the whole-network-scan optimization:
  - `alpha_fanout_500r_5000f`: 50.010 ms → 39.770 ms median
  - `compile_500r_50t`: 5.5446 ms → 5.0688 ms median