### PR TITLE
[FR-RETE-004] Evaluate test CEs during matching

### DIFF
--- a/crates/ferric-rules-core/src/beta.rs
+++ b/crates/ferric-rules-core/src/beta.rs
@@ -302,6 +302,18 @@ pub enum BetaNode {
         memory: BetaMemoryId,
         children: Rc<[NodeId]>,
     },
+    /// Predicate node: filters a partial match using a runtime-owned condition.
+    ///
+    /// Core stores only the condition's rule-local index. The runtime evaluates
+    /// the expression when the parent token arrives, then tells the network
+    /// whether to create this node's pass-through token.
+    Predicate {
+        parent: NodeId,
+        rule: RuleId,
+        condition_index: u32,
+        memory: BetaMemoryId,
+        children: Rc<[NodeId]>,
+    },
     /// Terminal node: produces activations for a rule.
     Terminal {
         parent: NodeId,
@@ -448,6 +460,38 @@ impl BetaNetwork {
             .entry(alpha_memory)
             .or_default()
             .push(node_id);
+
+        (node_id, memory_id)
+    }
+
+    /// Create a predicate node as a child of the given parent.
+    ///
+    /// Returns the new node and its pass-through beta memory.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn create_predicate_node(
+        &mut self,
+        parent: NodeId,
+        rule: RuleId,
+        condition_index: u32,
+    ) -> (NodeId, BetaMemoryId) {
+        let node_id = NodeId(self.next_node_id);
+        self.next_node_id += 1;
+
+        let memory_id = BetaMemoryId(self.next_memory_id);
+        self.next_memory_id += 1;
+
+        let node = BetaNode::Predicate {
+            parent,
+            rule,
+            condition_index,
+            memory: memory_id,
+            children: Rc::from([]),
+        };
+
+        self.nodes.insert(node_id, node);
+        debug_assert_eq!(self.memories.len(), memory_id.0 as usize);
+        self.memories.push(BetaMemory::new(memory_id));
+        self.attach_child_to_parent(parent, node_id);
 
         (node_id, memory_id)
     }
@@ -710,6 +754,7 @@ impl BetaNetwork {
                 let child = self.nodes.get(&child_id)?;
                 let parent_id = match child {
                     BetaNode::Join { parent, .. }
+                    | BetaNode::Predicate { parent, .. }
                     | BetaNode::Terminal { parent, .. }
                     | BetaNode::Negative { parent, .. }
                     | BetaNode::Ncc { parent, .. }
@@ -730,6 +775,7 @@ impl BetaNetwork {
         match self.get_node(node_id)? {
             BetaNode::Root { memory, .. }
             | BetaNode::Join { memory, .. }
+            | BetaNode::Predicate { memory, .. }
             | BetaNode::Negative { memory, .. }
             | BetaNode::Ncc { memory, .. }
             | BetaNode::Exists { memory, .. } => Some(*memory),
@@ -854,6 +900,7 @@ impl BetaNetwork {
             match parent_node {
                 BetaNode::Root { children, .. }
                 | BetaNode::Join { children, .. }
+                | BetaNode::Predicate { children, .. }
                 | BetaNode::Negative { children, .. }
                 | BetaNode::Ncc { children, .. }
                 | BetaNode::Exists { children, .. } => {
@@ -880,6 +927,7 @@ impl BetaNetwork {
             let children = match node {
                 BetaNode::Root { children, .. }
                 | BetaNode::Join { children, .. }
+                | BetaNode::Predicate { children, .. }
                 | BetaNode::Negative { children, .. }
                 | BetaNode::Ncc { children, .. }
                 | BetaNode::Exists { children, .. } => children,
@@ -898,6 +946,7 @@ impl BetaNetwork {
         for (node_id, node) in &self.nodes {
             let parent = match node {
                 BetaNode::Join { parent, .. }
+                | BetaNode::Predicate { parent, .. }
                 | BetaNode::Terminal { parent, .. }
                 | BetaNode::Negative { parent, .. }
                 | BetaNode::Ncc { parent, .. }
@@ -912,13 +961,19 @@ impl BetaNetwork {
             );
         }
 
-        // Check 3: All memory IDs in join/negative/ncc/exists nodes exist in memories map
+        // Check 3: All node-owned memory IDs exist.
         for (node_id, node) in &self.nodes {
             match node {
                 BetaNode::Join { memory, .. } => {
                     assert!(
                         self.memory(*memory).is_some(),
                         "Join node {node_id:?} references non-existent memory {memory:?}"
+                    );
+                }
+                BetaNode::Predicate { memory, .. } => {
+                    assert!(
+                        self.memory(*memory).is_some(),
+                        "Predicate node {node_id:?} references non-existent memory {memory:?}"
                     );
                 }
                 BetaNode::Negative {
@@ -1984,7 +2039,8 @@ mod proptests {
                             | BetaNode::Join { children, .. }
                             | BetaNode::Negative { children, .. }
                             | BetaNode::Ncc { children, .. }
-                            | BetaNode::Exists { children, .. } => Some(children),
+                            | BetaNode::Exists { children, .. }
+                            | BetaNode::Predicate { children, .. } => Some(children),
                             BetaNode::Terminal { .. } | BetaNode::NccPartner { .. } => None,
                         };
                         if let Some(children) = children {

--- a/crates/ferric-rules-core/src/compiler.rs
+++ b/crates/ferric-rules-core/src/compiler.rs
@@ -51,6 +51,11 @@ pub struct CompilablePattern {
 pub enum CompilableCondition {
     /// A single pattern CE (positive, not, or exists).
     Pattern(CompilablePattern),
+    /// A runtime-owned predicate evaluated for each incoming partial match.
+    Predicate {
+        /// Rule-local index into the runtime's compiled match conditions.
+        condition_index: u32,
+    },
     /// A negated conjunction CE: `(not (and ...))`.
     /// May contain nested NCCs for deeply nested `not(and(...not(and(...))))`.
     Ncc(Vec<CompilableCondition>),
@@ -260,6 +265,7 @@ impl ReteCompiler {
                             .map_err(|_| CompileError::VarMapOverflow)?;
                     }
                 }
+                CompilableCondition::Predicate { .. } => {}
                 CompilableCondition::Ncc(subconditions) => {
                     for subcondition in subconditions {
                         register_condition(subcondition, var_map)?;
@@ -311,6 +317,12 @@ impl ReteCompiler {
                         &mut bound_vars,
                         &mut alpha_memories,
                     );
+                }
+                CompilableCondition::Predicate { condition_index } => {
+                    let (predicate, _) =
+                        rete.beta
+                            .create_predicate_node(current_parent, rule_id, *condition_index);
+                    current_parent = predicate;
                 }
                 CompilableCondition::Ncc(subpatterns) => {
                     current_parent = self.compile_ncc_condition(
@@ -375,6 +387,7 @@ impl ReteCompiler {
                     let context = format!("condition {condition_idx}");
                     Self::validate_pattern_structure(pattern, &context, true, true, &mut errors);
                 }
+                CompilableCondition::Predicate { .. } => {}
                 CompilableCondition::Ncc(subconditions) => {
                     if subconditions.is_empty() {
                         Self::push_unsupported_structure_error(
@@ -411,6 +424,15 @@ impl ReteCompiler {
                         pattern, &context,
                         true, // Negated subpatterns in NCC are valid for forall(P, not(Q)) desugaring.
                         false, errors,
+                    );
+                }
+                CompilableCondition::Predicate { .. } => {
+                    Self::push_unsupported_structure_error(
+                        errors,
+                        format!(
+                            "{prefix} NCC subpattern {idx} contains a runtime predicate; \
+                             test CEs inside mixed negated conjunctions are not supported"
+                        ),
                     );
                 }
                 CompilableCondition::Ncc(inner) => {
@@ -692,6 +714,9 @@ impl ReteCompiler {
                         &mut sub_bound_vars,
                         alpha_memories,
                     );
+                }
+                CompilableCondition::Predicate { .. } => {
+                    unreachable!("predicate nodes inside NCC must fail validation")
                 }
                 CompilableCondition::Ncc(inner_conditions) => {
                     sub_parent = self.compile_ncc_condition(

--- a/crates/ferric-rules-core/src/lib.rs
+++ b/crates/ferric-rules-core/src/lib.rs
@@ -74,7 +74,7 @@ pub use fact::{
 };
 pub use ncc::{NccMemory, NccMemoryId};
 pub use negative::{NegativeMemory, NegativeMemoryId};
-pub use rete::ReteNetwork;
+pub use rete::{PendingPredicateMatch, ReteNetwork};
 pub use strategy::ConflictResolutionStrategy;
 pub use string::FerricString;
 pub use symbol::{Symbol, SymbolTable};

--- a/crates/ferric-rules-core/src/rete.rs
+++ b/crates/ferric-rules-core/src/rete.rs
@@ -5,18 +5,30 @@
 
 use smallvec::SmallVec;
 use std::cmp::Ordering;
+use std::collections::VecDeque;
 
 use crate::tracing_support::ferric_span;
 
 use crate::agenda::{Activation, ActivationId, ActivationSeq, Agenda};
 use crate::alpha::{get_slot_value, AlphaMemory, AlphaMemoryId, AlphaNetwork, SlotIndex};
-use crate::beta::{BetaMemory, BetaMemoryId, BetaNetwork, BetaNode, JoinTest, JoinTestType};
+use crate::beta::{
+    BetaMemory, BetaMemoryId, BetaNetwork, BetaNode, JoinTest, JoinTestType, RuleId,
+};
 use crate::binding::{BindingSet, ValueRef, VarId};
 use crate::fact::{Fact, FactBase, FactId, Timestamp};
 use crate::negative::NegativeMemoryId;
 use crate::strategy::ConflictResolutionStrategy;
 use crate::token::{NodeId, Token, TokenId, TokenStore};
 use crate::value::{AtomKey, Value};
+
+/// A partial match waiting for a runtime-owned predicate evaluation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PendingPredicateMatch {
+    pub node: NodeId,
+    pub parent_token: TokenId,
+    pub rule: RuleId,
+    pub condition_index: u32,
+}
 
 /// The complete Rete network.
 ///
@@ -30,6 +42,8 @@ pub struct ReteNetwork {
     pub agenda: Agenda,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_helpers::std_hash_set"))]
     disabled_rules: std::collections::HashSet<crate::beta::RuleId>,
+    #[cfg_attr(feature = "serde", serde(skip, default))]
+    pending_predicate_matches: VecDeque<PendingPredicateMatch>,
 }
 
 impl ReteNetwork {
@@ -58,6 +72,7 @@ impl ReteNetwork {
             token_store,
             agenda,
             disabled_rules: std::collections::HashSet::new(),
+            pending_predicate_matches: VecDeque::new(),
         };
         rete.seed_root_token();
         rete
@@ -213,6 +228,7 @@ impl ReteNetwork {
         self.alpha.clear_all_memories();
         self.token_store.clear();
         self.beta.clear_all_runtime();
+        self.pending_predicate_matches.clear();
         let strategy = self.agenda.strategy();
         self.agenda = Agenda::with_strategy(strategy);
 
@@ -321,6 +337,88 @@ impl ReteNetwork {
     pub fn disable_rule(&mut self, rule_id: crate::beta::RuleId) {
         self.disabled_rules.insert(rule_id);
         let _ = self.agenda.remove_activations_for_rule(rule_id);
+        self.pending_predicate_matches
+            .retain(|pending| pending.rule != rule_id);
+    }
+
+    /// Pop the next runtime predicate evaluation requested by token propagation.
+    pub fn pop_pending_predicate_match(&mut self) -> Option<PendingPredicateMatch> {
+        self.pending_predicate_matches.pop_front()
+    }
+
+    /// Resolve one pending predicate evaluation.
+    ///
+    /// A passing predicate creates a factless pass-through token owned by the
+    /// predicate node and continues normal propagation. A failing predicate
+    /// creates no token, so no terminal token or agenda activation can exist for
+    /// that partial match.
+    pub fn resolve_predicate_match(
+        &mut self,
+        pending: PendingPredicateMatch,
+        passed: bool,
+        fact_base: &FactBase,
+    ) -> Vec<ActivationId> {
+        let Some(parent_token) = self.token_store.get(pending.parent_token).cloned() else {
+            return Vec::new();
+        };
+        self.resolve_predicate_match_with_parent(pending, passed, parent_token, fact_base)
+    }
+
+    /// Resolve a predicate using a caller-owned snapshot of its parent token.
+    ///
+    /// This avoids cloning the same bindings twice when the runtime already
+    /// needed a token snapshot to evaluate the predicate. The live parent is
+    /// still checked before a passing token is admitted.
+    pub fn resolve_predicate_match_with_parent(
+        &mut self,
+        pending: PendingPredicateMatch,
+        passed: bool,
+        parent_token: Token,
+        fact_base: &FactBase,
+    ) -> Vec<ActivationId> {
+        if self.token_store.get(pending.parent_token).is_none() {
+            return Vec::new();
+        }
+        let Some(BetaNode::Predicate {
+            rule,
+            condition_index,
+            memory,
+            children,
+            ..
+        }) = self.beta.get_node(pending.node)
+        else {
+            return Vec::new();
+        };
+        if *rule != pending.rule || *condition_index != pending.condition_index {
+            return Vec::new();
+        }
+
+        let memory = *memory;
+        let children = children.clone();
+        if !passed {
+            return Vec::new();
+        }
+
+        let token = Token {
+            fact: None,
+            bindings: parent_token.bindings,
+            parent: Some(pending.parent_token),
+            owner_node: pending.node,
+        };
+        let token_id = self.token_store.insert(token);
+        let bindings = &self
+            .token_store
+            .get(token_id)
+            .expect("new predicate token must exist")
+            .bindings;
+        self.beta
+            .get_memory_mut(memory)
+            .expect("predicate beta memory must exist")
+            .insert_indexed(token_id, bindings);
+
+        let mut new_activations = Vec::new();
+        self.propagate_token(token_id, &children, fact_base, &mut new_activations);
+        new_activations
     }
 
     /// Perform a right activation on a join node.
@@ -1329,6 +1427,19 @@ impl ReteNetwork {
                     // Perform left activation: token enters as parent for this join
                     self.left_activate(child_id, token_id, fact_base, new_activations);
                 }
+                BetaNode::Predicate {
+                    rule,
+                    condition_index,
+                    ..
+                } => {
+                    self.pending_predicate_matches
+                        .push_back(PendingPredicateMatch {
+                            node: child_id,
+                            parent_token: token_id,
+                            rule: *rule,
+                            condition_index: *condition_index,
+                        });
+                }
                 BetaNode::Negative { .. } => {
                     // Perform negative left activation: token enters as parent for
                     // this negative node. It will be blocked or allowed through.
@@ -1786,6 +1897,86 @@ mod tests {
 
         let act = rete.agenda.pop().expect("Should have activation");
         assert_eq!(act.rule, rule_id);
+    }
+
+    #[test]
+    fn predicate_node_filters_before_terminal_and_tracks_parent_lifecycle() {
+        let mut rete = ReteNetwork::new();
+        let mut fact_base = FactBase::new();
+        let mut symbol_table = SymbolTable::new();
+        let candidate = make_symbol(&mut symbol_table, "candidate");
+
+        let entry = rete
+            .alpha
+            .create_entry_node(AlphaEntryType::OrderedRelation(candidate));
+        let alpha_memory = rete.alpha.create_memory(entry);
+        let root = rete.beta.root_id();
+        let (join, _) = rete
+            .beta
+            .create_join_node(root, alpha_memory, vec![], vec![]);
+        let rule = RuleId(1);
+        let (predicate, predicate_memory) = rete.beta.create_predicate_node(join, rule, 0);
+        rete.beta
+            .create_terminal_node(predicate, rule, Salience::DEFAULT);
+
+        let rejected_id = fact_base.assert_ordered(candidate, SmallVec::new());
+        let rejected_fact = fact_base
+            .get(rejected_id)
+            .expect("rejected fact should exist")
+            .fact
+            .clone();
+        let immediate = rete.assert_fact(rejected_id, &rejected_fact, &fact_base);
+        assert!(immediate.is_empty());
+        assert!(rete.agenda.is_empty());
+
+        let rejected = rete
+            .pop_pending_predicate_match()
+            .expect("partial match should request predicate evaluation");
+        let failed = rete.resolve_predicate_match(rejected, false, &fact_base);
+        assert!(failed.is_empty());
+        assert!(rete.agenda.is_empty());
+        assert!(
+            rete.beta
+                .get_memory(predicate_memory)
+                .expect("predicate memory should exist")
+                .is_empty(),
+            "a failing predicate must not retain a token"
+        );
+
+        rete.retract_fact(rejected_id, &rejected_fact, &fact_base);
+        fact_base
+            .retract(rejected_id)
+            .expect("rejected fact should retract");
+        assert_only_root_token(&rete);
+
+        let accepted_id = fact_base.assert_ordered(candidate, SmallVec::new());
+        let accepted_fact = fact_base
+            .get(accepted_id)
+            .expect("accepted fact should exist")
+            .fact
+            .clone();
+        let immediate = rete.assert_fact(accepted_id, &accepted_fact, &fact_base);
+        assert!(immediate.is_empty());
+        let accepted = rete
+            .pop_pending_predicate_match()
+            .expect("new partial match should reevaluate the predicate");
+        let activations = rete.resolve_predicate_match(accepted, true, &fact_base);
+        assert_eq!(activations.len(), 1);
+        assert_eq!(rete.agenda.len(), 1);
+        assert_eq!(
+            rete.beta
+                .get_memory(predicate_memory)
+                .expect("predicate memory should exist")
+                .len(),
+            1
+        );
+
+        rete.retract_fact(accepted_id, &accepted_fact, &fact_base);
+        fact_base
+            .retract(accepted_id)
+            .expect("accepted fact should retract");
+        assert!(rete.agenda.is_empty());
+        assert_only_root_token(&rete);
     }
 
     #[test]

--- a/crates/ferric-rules-runtime/src/actions.rs
+++ b/crates/ferric-rules-runtime/src/actions.rs
@@ -642,13 +642,7 @@ fn execute_single_action(
             eval_env,
             collected_facts,
         ),
-        "retract" => execute_retract(
-            &mut context.engine.fact_base,
-            &mut context.engine.rete,
-            collected_facts,
-            rule_info,
-            &call.args,
-        ),
+        "retract" => execute_retract(context, collected_facts, rule_info, &call.args),
         "modify" => execute_modify(
             token,
             rule_info,
@@ -2438,8 +2432,7 @@ fn execute_assert(
 }
 
 fn execute_retract(
-    fact_base: &mut FactBase,
-    rete: &mut ReteNetwork,
+    context: &mut ActionExecutionContext<'_>,
     collected_facts: &[FactId],
     rule_info: &CompiledRuleInfo,
     args: &[ActionExpr],
@@ -2448,13 +2441,19 @@ fn execute_retract(
         match arg {
             ActionExpr::Variable(var_name, _) => {
                 let fact_id = resolve_fact_address(collected_facts, rule_info, var_name)?;
-                let fact = get_fact_or_error(fact_base, fact_id)?;
-                rete.retract_fact(fact_id, &fact, fact_base);
-                fact_base.retract(fact_id);
+                let fact = get_fact_or_error(&context.engine.fact_base, fact_id)?;
+                context
+                    .engine
+                    .rete
+                    .retract_fact(fact_id, &fact, &context.engine.fact_base);
+                context.engine.fact_base.retract(fact_id);
             }
             _ => return Err(ActionError::InvalidRetract),
         }
     }
+    // A retract action is a matching boundary: evaluate any candidates it
+    // unblocked before a later RHS action can mutate globals or working memory.
+    context.engine.drain_pending_predicate_matches();
     Ok(())
 }
 

--- a/crates/ferric-rules-runtime/src/actions.rs
+++ b/crates/ferric-rules-runtime/src/actions.rs
@@ -16,10 +16,10 @@ use ferric_rules_core::beta::{RuleId, Salience};
 use ferric_rules_core::binding::{BindingSet, ValueRef, VarId, VarMap};
 use ferric_rules_core::token::Token;
 use ferric_rules_core::{
-    AtomKey, EncodingError, Fact, FactBase, FactId, OrderedFact, ReteNetwork, Symbol, SymbolTable,
+    EncodingError, Fact, FactBase, FactId, OrderedFact, ReteNetwork, Symbol, SymbolTable,
     TemplateId, Value,
 };
-use ferric_rules_parser::{Action, ActionExpr, Constraint, FunctionCall, LiteralKind};
+use ferric_rules_parser::{Action, ActionExpr, FunctionCall, LiteralKind};
 use slotmap::Key as _;
 
 use crate::modules::ModuleRegistry;
@@ -341,22 +341,11 @@ fn eval_fact_slot_ref_call(
     }
 }
 
-/// A compiled test condition evaluated before RHS actions.
+/// A compiled condition evaluated when a partial match reaches its predicate node.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub(crate) enum CompiledTestCondition {
     Expr(crate::evaluator::RuntimeExpr),
-    NegatedPatternRuntimeCheck(NegatedPatternRuntimeCheck),
-}
-
-/// Runtime fallback for negated ordered patterns with complex constraints.
-///
-/// This is used when compile-time lowering to join/alpha tests is not possible.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub(crate) struct NegatedPatternRuntimeCheck {
-    pub relation: String,
-    pub constraints: Vec<Constraint>,
 }
 
 /// Runtime hint for trailing ordered multi-variable captures (`$?var`).
@@ -391,7 +380,7 @@ pub(crate) struct CompiledRuleInfo {
     /// Rule salience (stored for informational purposes).
     #[allow(dead_code)] // May be used in future for debugging/logging
     pub salience: Salience,
-    /// Pre-translated test conditions, evaluated at firing time.
+    /// Pre-translated match conditions referenced by predicate-node indexes.
     pub test_conditions: Vec<CompiledTestCondition>,
     /// Pre-translated RHS action call expressions.
     pub runtime_actions: Vec<Option<crate::evaluator::RuntimeExpr>>,
@@ -430,9 +419,7 @@ pub enum ActionError {
 /// This is called with all the data needed pre-extracted to avoid borrow issues.
 ///
 /// Returns `(fired, reset_requested, clear_requested, errors)` where:
-/// - `fired` is `true` if test CE conditions all passed and actions were executed,
-///   `false` if a test CE was falsy (actions are skipped and the rule is not
-///   counted as having fired).
+/// - `fired` is `true` once the already-matched activation reaches execution.
 /// - `reset_requested` is `true` if a `(reset)` action was executed.
 /// - `clear_requested` is `true` if a `(clear)` action was executed.
 /// - `errors` is a list of non-fatal action errors that occurred during execution.
@@ -465,57 +452,6 @@ pub(crate) fn execute_actions(
         &rule_info.multifield_tail_bindings,
         &mut eval_env.runtime_bindings,
     );
-
-    // Evaluate test conditions first — if any is falsy, skip all actions and
-    // signal to the caller that the rule did NOT logically fire.
-    for test_condition in &rule_info.test_conditions {
-        let condition_passed = match test_condition {
-            CompiledTestCondition::Expr(test_expr) => {
-                match eval_env.eval_runtime_expr(token, rule_info, test_expr, context) {
-                    Ok(value) => crate::evaluator::is_truthy(&value, &context.engine.symbol_table),
-                    Err(e) => {
-                        ferric_event!(
-                            warn,
-                            rule = %rule_info.name,
-                            error = %e,
-                            "test_condition_eval_error"
-                        );
-                        flush_deferred_printout(context);
-                        errors.push(e);
-                        return (false, false, false, errors);
-                    }
-                }
-            }
-            CompiledTestCondition::NegatedPatternRuntimeCheck(check) => {
-                match evaluate_negated_pattern_runtime_check(
-                    token,
-                    rule_info,
-                    check,
-                    &mut eval_env,
-                    context,
-                ) {
-                    Ok(passed) => passed,
-                    Err(e) => {
-                        ferric_event!(
-                            warn,
-                            rule = %rule_info.name,
-                            error = %e,
-                            "test_condition_eval_error"
-                        );
-                        flush_deferred_printout(context);
-                        errors.push(e);
-                        return (false, false, false, errors);
-                    }
-                }
-            }
-        };
-        flush_deferred_printout(context);
-
-        if !condition_passed {
-            ferric_event!(debug, rule = %rule_info.name, "rule_skipped_by_test_condition");
-            return (false, false, false, errors); // Test CE falsy — rule did not fire
-        }
-    }
 
     for (index, action) in rule_info.actions.iter().enumerate() {
         let runtime_call = rule_info
@@ -585,51 +521,30 @@ pub(crate) fn execute_actions(
     (true, reset_requested, clear_requested, errors)
 }
 
-fn evaluate_negated_pattern_runtime_check(
+/// Evaluate one rule-local predicate for an incoming partial match.
+pub(crate) fn evaluate_test_condition(
     token: &Token,
     rule_info: &CompiledRuleInfo,
-    check: &NegatedPatternRuntimeCheck,
-    eval_env: &mut ActionEvalEnv,
+    test_condition: &CompiledTestCondition,
+    collected_facts: &[FactId],
     context: &mut ActionExecutionContext<'_>,
 ) -> Result<bool, ActionError> {
-    let Ok(relation) = context
-        .engine
-        .symbol_table
-        .intern_symbol(&check.relation, context.engine.config.string_encoding)
-    else {
-        return Ok(true);
+    let mut eval_env = ActionEvalEnv {
+        runtime_bindings: RuntimeBindingEnv::new(),
     };
+    seed_multifield_tail_bindings(
+        &context.engine.fact_base,
+        collected_facts,
+        &rule_info.multifield_tail_bindings,
+        &mut eval_env.runtime_bindings,
+    );
 
-    let base_env = collect_outer_runtime_bindings(token, rule_info, &context.engine.symbol_table);
-
-    let candidate_ids: Vec<_> = context
-        .engine
-        .fact_base
-        .facts_by_relation(relation)
-        .collect();
-
-    for fact_id in candidate_ids {
-        let Some(entry) = context.engine.fact_base.get(fact_id) else {
-            continue;
-        };
-        let Fact::Ordered(ordered) = &entry.fact else {
-            continue;
-        };
-        let ordered = ordered.clone();
-
-        if ordered_fact_matches_runtime_constraints(
-            &ordered,
-            &check.constraints,
-            &base_env,
-            eval_env,
-            context,
-        )? {
-            // Matching fact exists, so the negated condition fails.
-            return Ok(false);
-        }
-    }
-
-    Ok(true)
+    let CompiledTestCondition::Expr(test_expr) = test_condition;
+    let result = eval_env
+        .eval_runtime_expr(token, rule_info, test_expr, context)
+        .map(|value| crate::evaluator::is_truthy(&value, &context.engine.symbol_table));
+    flush_deferred_printout(context);
+    result
 }
 
 fn collect_outer_runtime_bindings(
@@ -683,174 +598,6 @@ fn seed_multifield_tail_bindings(
     }
 }
 
-fn ordered_fact_matches_runtime_constraints(
-    fact: &OrderedFact,
-    constraints: &[Constraint],
-    base_env: &RuntimeBindingEnv,
-    eval_env: &mut ActionEvalEnv,
-    context: &mut ActionExecutionContext<'_>,
-) -> Result<bool, ActionError> {
-    if fact.fields.len() < constraints.len() {
-        return Ok(false);
-    }
-
-    let mut envs = vec![base_env.clone()];
-    for (slot_index, constraint) in constraints.iter().enumerate() {
-        let Some(slot_value) = fact.fields.get(slot_index) else {
-            return Ok(false);
-        };
-
-        let mut next_envs = Vec::new();
-        for env in &envs {
-            let mut matched =
-                runtime_constraint_matches_envs(constraint, slot_value, env, eval_env, context)?;
-            next_envs.append(&mut matched);
-        }
-
-        if next_envs.is_empty() {
-            return Ok(false);
-        }
-
-        envs = next_envs;
-    }
-
-    Ok(!envs.is_empty())
-}
-
-fn runtime_constraint_matches_envs(
-    constraint: &Constraint,
-    slot_value: &Value,
-    env: &RuntimeBindingEnv,
-    eval_env: &mut ActionEvalEnv,
-    context: &mut ActionExecutionContext<'_>,
-) -> Result<Vec<RuntimeBindingEnv>, ActionError> {
-    match constraint {
-        Constraint::Literal(lit) => {
-            if value_equals_literal(slot_value, &lit.value, &context.engine.symbol_table) {
-                Ok(vec![env.clone()])
-            } else {
-                Ok(Vec::new())
-            }
-        }
-        Constraint::Variable(name, _) | Constraint::MultiVariable(name, _) => {
-            if let Some(existing) = env.get(name) {
-                if values_equal(existing, slot_value) {
-                    Ok(vec![env.clone()])
-                } else {
-                    Ok(Vec::new())
-                }
-            } else {
-                let mut bound = env.clone();
-                insert_runtime_binding(&mut bound, name, slot_value.clone());
-                Ok(vec![bound])
-            }
-        }
-        Constraint::Wildcard(_) | Constraint::MultiWildcard(_) => Ok(vec![env.clone()]),
-        Constraint::Not(inner, _) => match inner.as_ref() {
-            Constraint::Literal(lit) => {
-                if value_equals_literal(slot_value, &lit.value, &context.engine.symbol_table) {
-                    Ok(Vec::new())
-                } else {
-                    Ok(vec![env.clone()])
-                }
-            }
-            Constraint::Variable(name, _) | Constraint::MultiVariable(name, _) => {
-                let Some(existing) = env.get(name) else {
-                    return Ok(Vec::new());
-                };
-                if values_equal(existing, slot_value) {
-                    Ok(Vec::new())
-                } else {
-                    Ok(vec![env.clone()])
-                }
-            }
-            Constraint::Wildcard(_) | Constraint::MultiWildcard(_) => Ok(vec![env.clone()]),
-            other => {
-                let inner =
-                    runtime_constraint_matches_envs(other, slot_value, env, eval_env, context)?;
-                if inner.is_empty() {
-                    Ok(vec![env.clone()])
-                } else {
-                    Ok(Vec::new())
-                }
-            }
-        },
-        Constraint::And(parts, _) => {
-            let mut envs = vec![env.clone()];
-            for part in parts {
-                let mut next = Vec::new();
-                for candidate in &envs {
-                    let mut matched = runtime_constraint_matches_envs(
-                        part, slot_value, candidate, eval_env, context,
-                    )?;
-                    next.append(&mut matched);
-                }
-                if next.is_empty() {
-                    return Ok(Vec::new());
-                }
-                envs = next;
-            }
-            Ok(envs)
-        }
-        Constraint::Or(parts, _) => {
-            let mut results = Vec::new();
-            for part in parts {
-                let mut matched =
-                    runtime_constraint_matches_envs(part, slot_value, env, eval_env, context)?;
-                results.append(&mut matched);
-            }
-            Ok(results)
-        }
-        Constraint::Predicate(expr, _) => {
-            let Some(value) = runtime_constraint_expr_value(expr, env, eval_env, context)? else {
-                return Ok(Vec::new());
-            };
-            if crate::evaluator::is_truthy(&value, &context.engine.symbol_table) {
-                Ok(vec![env.clone()])
-            } else {
-                Ok(Vec::new())
-            }
-        }
-        Constraint::ReturnValue(expr, _) => {
-            let Some(value) = runtime_constraint_expr_value(expr, env, eval_env, context)? else {
-                return Ok(Vec::new());
-            };
-            if values_equal(&value, slot_value) {
-                Ok(vec![env.clone()])
-            } else {
-                Ok(Vec::new())
-            }
-        }
-    }
-}
-
-fn runtime_constraint_expr_value(
-    expr: &ferric_rules_parser::SExpr,
-    env: &RuntimeBindingEnv,
-    _eval_env: &mut ActionEvalEnv,
-    context: &mut ActionExecutionContext<'_>,
-) -> Result<Option<Value>, ActionError> {
-    let Ok(runtime_expr) = crate::evaluator::from_sexpr(
-        expr,
-        &mut context.engine.symbol_table,
-        &context.engine.config,
-    ) else {
-        return Ok(None);
-    };
-
-    let (bindings, var_map) = build_runtime_eval_bindings(env, context)?;
-    match ActionEvalEnv::eval_runtime_expr_with_bindings(
-        &runtime_expr,
-        &bindings,
-        &var_map,
-        context,
-    ) {
-        Ok(value) => Ok(Some(value)),
-        Err(ActionError::Evaluator(_) | ActionError::EvalError(_)) => Ok(None),
-        Err(other) => Err(other),
-    }
-}
-
 fn build_runtime_eval_bindings(
     env: &RuntimeBindingEnv,
     context: &mut ActionExecutionContext<'_>,
@@ -871,33 +618,6 @@ fn build_runtime_eval_bindings(
     }
 
     Ok((bindings, var_map))
-}
-
-fn value_equals_literal(value: &Value, literal: &LiteralKind, symbol_table: &SymbolTable) -> bool {
-    match literal {
-        LiteralKind::Integer(expected) => {
-            matches!(value, Value::Integer(actual) if actual == expected)
-        }
-        LiteralKind::Float(expected) => {
-            matches!(value, Value::Float(actual) if actual.to_bits() == expected.to_bits())
-        }
-        LiteralKind::String(expected) => {
-            matches!(value, Value::String(actual) if actual.as_str() == expected)
-        }
-        LiteralKind::Symbol(expected) => match value {
-            Value::Symbol(symbol) => {
-                symbol_table.resolve_symbol_str(*symbol) == Some(expected.as_str())
-            }
-            _ => false,
-        },
-    }
-}
-
-fn values_equal(lhs: &Value, rhs: &Value) -> bool {
-    match (AtomKey::from_value(lhs), AtomKey::from_value(rhs)) {
-        (Some(lhs_key), Some(rhs_key)) => lhs_key == rhs_key,
-        _ => lhs.structural_eq(rhs),
-    }
 }
 
 #[allow(clippy::too_many_arguments)] // Action dispatch needs full mutable engine/action context.

--- a/crates/ferric-rules-runtime/src/engine.rs
+++ b/crates/ferric-rules-runtime/src/engine.rs
@@ -182,6 +182,8 @@ pub struct Engine {
     pub(crate) initial_fact_id: Option<FactId>,
     /// Non-fatal action diagnostics captured during execution.
     pub(crate) action_diagnostics: Vec<ActionError>,
+    /// Guards match-time predicate draining against evaluator-triggered assertions.
+    pub(crate) processing_predicates: bool,
     /// Whether a halt has been requested.
     pub(crate) halted: bool,
     /// Input buffer for `read`/`readline` calls from rules.
@@ -219,6 +221,7 @@ impl Engine {
             generic_modules: HashMap::default(),
             initial_fact_id: None,
             action_diagnostics: Vec::new(),
+            processing_predicates: false,
             halted: false,
             input_buffer: VecDeque::new(),
             creator_thread: std::thread::current().id(),
@@ -281,10 +284,84 @@ impl Engine {
         match self.fact_base.assert_fact(fact, self.fact_duplication()) {
             FactInsertionResult::Inserted(fact_id) => {
                 propagate_fact_assertion(&mut self.rete, &self.fact_base, fact_id);
+                self.drain_pending_predicate_matches();
                 FactAssertionResult::Asserted(fact_id)
             }
             FactInsertionResult::Duplicate(fact_id) => FactAssertionResult::Duplicate(fact_id),
         }
+    }
+
+    pub(crate) fn drain_pending_predicate_matches(&mut self) {
+        if self.processing_predicates {
+            return;
+        }
+        self.processing_predicates = true;
+
+        while let Some(pending) = self.rete.pop_pending_predicate_match() {
+            let Some(token) = self.rete.token_store.get(pending.parent_token).cloned() else {
+                continue;
+            };
+            let Some(info) = rule_index_get(&self.rule_info, pending.rule).cloned() else {
+                continue;
+            };
+            let Some(condition) = info.test_conditions.get(pending.condition_index as usize) else {
+                self.action_diagnostics.push(ActionError::EvalError(format!(
+                    "rule `{}` references missing match condition {}",
+                    info.name, pending.condition_index
+                )));
+                continue;
+            };
+            let current_module = rule_index_get(&self.rule_modules, pending.rule)
+                .copied()
+                .unwrap_or_else(|| self.module_registry.main_module_id());
+            let collected_facts = if info.multifield_tail_bindings.is_empty() {
+                smallvec::SmallVec::new()
+            } else {
+                self.rete
+                    .token_store
+                    .collect_all_facts(pending.parent_token)
+            };
+
+            let mut focus_requests = Vec::new();
+            let evaluation = {
+                let mut context = actions::ActionExecutionContext {
+                    engine: self,
+                    focus_requests: &mut focus_requests,
+                    current_module,
+                };
+                actions::evaluate_test_condition(
+                    &token,
+                    info.as_ref(),
+                    condition,
+                    &collected_facts,
+                    &mut context,
+                )
+            };
+            let passed = match evaluation {
+                Ok(passed) => passed,
+                Err(error) => {
+                    ferric_event!(
+                        warn,
+                        rule = %info.name,
+                        error = %error,
+                        "match_condition_eval_error"
+                    );
+                    self.action_diagnostics.push(error);
+                    false
+                }
+            };
+
+            if !focus_requests.is_empty() {
+                self.action_diagnostics.push(ActionError::EvalError(format!(
+                    "rule `{}` test CE attempted a focus change during matching",
+                    info.name
+                )));
+            }
+            self.rete
+                .resolve_predicate_match_with_parent(pending, passed, token, &self.fact_base);
+        }
+
+        self.processing_predicates = false;
     }
 
     /// Assert an ordered fact into working memory.
@@ -511,6 +588,7 @@ impl Engine {
         self.fact_base
             .retract(fact_id)
             .ok_or(EngineError::FactNotFound(fact_id))?;
+        self.drain_pending_predicate_matches();
 
         Ok(())
     }
@@ -762,7 +840,7 @@ impl Engine {
     /// Execute RHS actions for a rule activation.
     ///
     /// Returns `(logically_fired, reset_requested, clear_requested, action_error)`.
-    /// - `logically_fired` is `true` if all test CEs passed and actions were executed.
+    /// - `logically_fired` is `true` if the already-matched activation executed.
     /// - `reset_requested` is `true` if a `(reset)` action was executed in the RHS.
     /// - `clear_requested` is `true` if a `(clear)` action was executed in the RHS.
     /// - `action_error` is `true` if evaluation produced an action diagnostic.
@@ -801,6 +879,9 @@ impl Engine {
             };
             actions::execute_actions(&token, info.as_ref(), &mut action_context, &collected_facts)
         };
+        // Retractions and modifications performed by RHS actions can unblock
+        // negative nodes and create new predicate candidates.
+        self.drain_pending_predicate_matches();
 
         // Apply focus requests (push in reverse order so first arg is on top)
         for module_name in focus_requests.iter().rev() {
@@ -868,7 +949,7 @@ impl Engine {
     ///
     /// Returns `None` when no activation is eligible under current focus
     /// semantics. Otherwise pops the highest-priority eligible activation and
-    /// fires it (executing RHS actions if all test CEs pass).
+    /// fires its already-matched RHS actions.
     ///
     /// # Errors
     ///
@@ -1093,6 +1174,7 @@ impl Engine {
         for (module_id, name, value) in &self.registered_globals {
             self.globals.set(*module_id, name, value.clone());
         }
+        self.drain_pending_predicate_matches();
 
         // Re-assert registered deffacts under the current duplication policy.
         // Clone the declarations so assertion can mutably update working memory.
@@ -1155,6 +1237,7 @@ impl Engine {
         self.generic_modules.clear();
         self.initial_fact_id = None;
         self.action_diagnostics.clear();
+        self.processing_predicates = false;
         self.halted = false;
         self.input_buffer.clear();
     }

--- a/crates/ferric-rules-runtime/src/lib.rs
+++ b/crates/ferric-rules-runtime/src/lib.rs
@@ -18,7 +18,7 @@
 //! ## Phase 3 complete
 //!
 //! - Shared expression evaluator for RHS actions and `test` CEs (Pass 002).
-//! - `test` CEs compile and evaluate at firing time (Pass 002).
+//! - `test` CEs compile into predicate nodes and evaluate during matching.
 //! - Nested function calls in RHS (arithmetic, comparison, boolean, type predicates).
 //! - Template-aware `modify`/`duplicate` (Pass 003).
 //! - `printout` with per-channel output capture via `OutputRouter` (Pass 004).

--- a/crates/ferric-rules-runtime/src/loader.rs
+++ b/crates/ferric-rules-runtime/src/loader.rs
@@ -3217,7 +3217,7 @@ impl Engine {
             }
             Constraint::Predicate(expr, span) => {
                 if in_negated_pattern {
-                    if self.try_lower_negated_predicate_constraint(
+                    if self.try_lower_simple_predicate_constraint(
                         expr,
                         slot,
                         constant_tests,
@@ -3232,6 +3232,16 @@ impl Engine {
                         span,
                         "predicate constraints inside negated patterns currently require a simple binary comparison involving the current slot variable",
                     ));
+                }
+                if self.try_lower_simple_predicate_constraint(
+                    expr,
+                    slot,
+                    constant_tests,
+                    variable_slots,
+                    negated_variable_slots,
+                    seen_variable_slots,
+                )? {
+                    return Ok(());
                 }
                 let runtime_expr =
                     crate::evaluator::from_sexpr(expr, &mut self.symbol_table, &self.config)
@@ -3286,7 +3296,7 @@ impl Engine {
         Ok(())
     }
 
-    fn try_lower_negated_predicate_constraint(
+    fn try_lower_simple_predicate_constraint(
         &mut self,
         expr: &SExpr,
         slot: SlotIndex,
@@ -4537,6 +4547,17 @@ mod tests {
               =>
               (assert (gt2 ?x)))
             ",
+        );
+
+        let rule_info = engine
+            .rule_info
+            .iter()
+            .flatten()
+            .find(|info| info.name == "gt-two")
+            .expect("compiled rule metadata");
+        assert!(
+            rule_info.test_conditions.is_empty(),
+            "simple slot comparisons should lower into alpha tests"
         );
 
         let run = run_to_completion(&mut engine);

--- a/crates/ferric-rules-runtime/src/loader.rs
+++ b/crates/ferric-rules-runtime/src/loader.rs
@@ -39,9 +39,7 @@ use ferric_rules_parser::{
     Span, TemplateConstruct, TemplateFactBody, TemplatePattern,
 };
 
-use crate::actions::{
-    CompiledRuleInfo, CompiledTestCondition, MultifieldTailBindingHint, NegatedPatternRuntimeCheck,
-};
+use crate::actions::{CompiledRuleInfo, CompiledTestCondition, MultifieldTailBindingHint};
 use crate::engine::{Engine, EngineError};
 use crate::functions::{get_or_insert_module_entry_with, insert_module_entry, UserFunction};
 use crate::templates::RegisteredTemplate;
@@ -53,7 +51,7 @@ struct TranslatedRule {
     salience: Salience,
     conditions: Vec<CompilableCondition>,
     fact_address_vars: HashMap<String, usize>,
-    /// Test conditions (not compiled into Rete; evaluated at firing time).
+    /// Test conditions referenced by match-time predicate nodes.
     test_conditions: Vec<CompiledTestCondition>,
     /// Action-time hints for trailing ordered multifield captures.
     multifield_tail_bindings: Vec<MultifieldTailBindingHint>,
@@ -1859,8 +1857,21 @@ impl Engine {
             compile_result.rule_id,
             self.module_registry.current_module(),
         );
+        self.drain_pending_predicate_matches();
 
         Ok(compile_result)
+    }
+
+    fn push_test_predicate(
+        conditions: &mut Vec<CompilableCondition>,
+        test_conditions: &mut Vec<CompiledTestCondition>,
+        test_condition: CompiledTestCondition,
+    ) -> Result<(), LoadError> {
+        let condition_index = u32::try_from(test_conditions.len())
+            .map_err(|_| LoadError::Compile("too many test CEs in one rule".to_string()))?;
+        test_conditions.push(test_condition);
+        conditions.push(CompilableCondition::Predicate { condition_index });
+        Ok(())
     }
 
     /// Recursively flatten a pattern for top-level condition processing.
@@ -2063,28 +2074,19 @@ impl Engine {
         }
     }
 
-    /// Build a runtime negated-pattern check for complex ordered constraints.
-    ///
-    /// This is a fallback for negated ordered patterns where predicate/return
-    /// expressions are too rich to lower into join/alpha tests.
-    fn try_build_negated_runtime_check(pattern: &Pattern) -> Option<NegatedPatternRuntimeCheck> {
+    /// Whether a negated ordered pattern contains an expression that cannot
+    /// currently be represented by the negative network.
+    fn has_complex_negated_expression(pattern: &Pattern) -> bool {
         match pattern {
-            Pattern::Assigned { pattern, .. } => Self::try_build_negated_runtime_check(pattern),
+            Pattern::Assigned { pattern, .. } => Self::has_complex_negated_expression(pattern),
             Pattern::Not(inner, _) => {
                 let Pattern::Ordered(ordered) = inner.as_ref() else {
-                    return None;
+                    return false;
                 };
 
-                if !Self::ordered_pattern_has_complex_negated_expression(ordered) {
-                    return None;
-                }
-
-                Some(NegatedPatternRuntimeCheck {
-                    relation: ordered.relation.clone(),
-                    constraints: ordered.constraints.clone(),
-                })
+                Self::ordered_pattern_has_complex_negated_expression(ordered)
             }
-            _ => None,
+            _ => false,
         }
     }
 
@@ -2541,6 +2543,7 @@ impl Engine {
     }
 
     /// Translate a `RuleConstruct` (parser types) into a `CompilableRule` (core types).
+    #[allow(clippy::too_many_lines)] // Preserves source-order CE translation in one pass.
     fn translate_rule_construct(
         &mut self,
         rule: &RuleConstruct,
@@ -2580,30 +2583,44 @@ impl Engine {
         let pattern_refs: Vec<&Pattern> = desugared_patterns.iter().collect();
 
         for pattern in &pattern_refs {
-            // Test CEs are handled separately: they do not generate alpha/beta
-            // nodes in the Rete network, and they do not consume a fact index.
-            // Instead they are collected and evaluated at rule-firing time.
+            // Test CEs do not consume a fact index. Their expressions are
+            // retained in rule metadata and referenced by predicate nodes at
+            // their source position in the beta network.
             if let Pattern::Test(sexpr, _span) = pattern {
                 let runtime_expr =
                     crate::evaluator::from_sexpr(sexpr, &mut self.symbol_table, &self.config)
                         .map_err(|e| LoadError::Compile(format!("test CE translation: {e}")))?;
-                test_conditions.push(CompiledTestCondition::Expr(runtime_expr));
+                Self::push_test_predicate(
+                    &mut conditions,
+                    &mut test_conditions,
+                    CompiledTestCondition::Expr(runtime_expr),
+                )?;
                 continue;
             }
 
             // Handle test CEs inside negation and NCC contexts by extracting
-            // them as rule-level test conditions.
+            // them as predicate nodes at their source position.
+            let previous_test_count = test_conditions.len();
             if self.try_extract_nested_test_ce(pattern, &mut test_conditions)? {
+                for condition_index in previous_test_count..test_conditions.len() {
+                    let condition_index = u32::try_from(condition_index).map_err(|_| {
+                        LoadError::Compile("too many test CEs in one rule".to_string())
+                    })?;
+                    conditions.push(CompilableCondition::Predicate { condition_index });
+                }
                 continue;
             }
 
             // Fallback path for complex negated ordered constraints that cannot
-            // be lowered to join/alpha tests in the negative network.
-            if let Some(runtime_check) = Self::try_build_negated_runtime_check(pattern) {
-                test_conditions.push(CompiledTestCondition::NegatedPatternRuntimeCheck(
-                    runtime_check,
+            // be lowered to join/alpha tests cannot remain a firing-time check:
+            // it would expose an invalid terminal activation and could not react
+            // to right-side assertion/retraction. Reject it until it has a real
+            // negative-network representation.
+            if Self::has_complex_negated_expression(pattern) {
+                return Err(LoadError::Compile(
+                    "complex constraints inside negated patterns are not supported at match time"
+                        .to_string(),
                 ));
-                continue;
             }
 
             // Check for Pattern::Assigned to track fact-address variables
@@ -2627,7 +2644,12 @@ impl Engine {
                 &mut generated_tests,
                 &mut internal_slot_var_seed,
             )?;
-            test_conditions.extend(generated_tests.into_iter().map(CompiledTestCondition::Expr));
+            if matches!(condition, CompilableCondition::Ncc(_)) && !generated_tests.is_empty() {
+                return Err(LoadError::Compile(
+                    "test CEs inside mixed negated conjunctions are not supported at match time"
+                        .to_string(),
+                ));
+            }
             if let Some(name) = var_name {
                 if !is_negated && Self::condition_has_fact_address(&condition) {
                     fact_address_vars.insert(name, fact_index);
@@ -2642,6 +2664,13 @@ impl Engine {
                 fact_index += 1;
             }
             conditions.push(condition);
+            for generated_test in generated_tests {
+                Self::push_test_predicate(
+                    &mut conditions,
+                    &mut test_conditions,
+                    CompiledTestCondition::Expr(generated_test),
+                )?;
+            }
         }
 
         // Empty-LHS and test-only rules use CLIPS' built-in (initial-fact)
@@ -2675,7 +2704,7 @@ impl Engine {
     fn condition_has_fact_address(condition: &CompilableCondition) -> bool {
         match condition {
             CompilableCondition::Pattern(pattern) => !pattern.negated && !pattern.exists,
-            CompilableCondition::Ncc(_) => false,
+            CompilableCondition::Predicate { .. } | CompilableCondition::Ncc(_) => false,
         }
     }
 
@@ -4723,36 +4752,25 @@ mod tests {
     }
 
     #[test]
-    fn negated_predicate_constraint_falls_back_for_non_linear_expression() {
+    fn negated_predicate_constraint_rejects_non_linear_expression() {
         let mut engine = new_utf8_engine();
-        load_ok(
-            &mut engine,
-            r"
-            (deffacts startup
-              (anchor 1)
-              (anchor 3)
-              (data 1)
-              (data 2))
+        let errors = engine
+            .load_str(
+                r"
             (defrule no-square-greater
               (anchor ?min)
               (not (data ?x&:(> (* ?x ?x) (* ?min ?min))))
               =>
               (assert (safe-square ?min)))
             ",
-        );
+            )
+            .expect_err("non-linear negated predicate must be rejected");
 
-        let run = run_to_completion(&mut engine);
-        assert_eq!(run.rules_fired, 1);
-        let safe = find_facts_by_relation(&engine, "safe-square");
-        assert_eq!(safe.len(), 1);
-        let Some(entry) = engine.fact_base.get(safe[0]) else {
-            panic!("safe-square fact should exist");
-        };
-        let Fact::Ordered(ordered) = &entry.fact else {
-            panic!("safe-square should be an ordered fact");
-        };
-        assert_eq!(ordered.fields.len(), 1);
-        assert!(matches!(ordered.fields[0], Value::Integer(3)));
+        assert!(errors.iter().any(|error| matches!(
+            error,
+            LoadError::Compile(message)
+                if message.contains("complex constraints inside negated patterns")
+        )));
     }
 
     #[test]
@@ -4806,24 +4824,24 @@ mod tests {
     }
 
     #[test]
-    fn negated_return_value_constraint_falls_back_for_non_linear_expression() {
+    fn negated_return_value_constraint_rejects_non_linear_expression() {
         let mut engine = new_utf8_engine();
-        load_ok(
-            &mut engine,
-            r"
-            (deffacts startup
-              (pair 2)
-              (pair 3))
+        let errors = engine
+            .load_str(
+                r"
             (defrule no-self-square
               (not (pair ?x&=(* ?x ?x)))
               =>
               (assert (safe-return)))
             ",
-        );
+            )
+            .expect_err("non-linear negated return value must be rejected");
 
-        let run = run_to_completion(&mut engine);
-        assert_eq!(run.rules_fired, 1);
-        assert_eq!(find_facts_by_relation(&engine, "safe-return").len(), 1);
+        assert!(errors.iter().any(|error| matches!(
+            error,
+            LoadError::Compile(message)
+                if message.contains("complex constraints inside negated patterns")
+        )));
     }
 
     #[test]

--- a/crates/ferric-rules-runtime/src/phase3_integration_tests.rs
+++ b/crates/ferric-rules-runtime/src/phase3_integration_tests.rs
@@ -306,6 +306,45 @@ mod tests {
     }
 
     #[test]
+    fn fr_rete_004_rhs_retraction_uses_state_at_action_boundary() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defglobal ?*gate* = TRUE)
+
+            (defrule candidate
+                (anchor)
+                (not (blocker))
+                (test (eq ?*gate* TRUE))
+                =>
+                (assert (candidate-fired)))
+
+            (defrule unblocker
+                (declare (salience 100))
+                ?blocker <- (blocker)
+                (go)
+                =>
+                (retract ?blocker)
+                (bind ?*gate* FALSE))
+
+            (deffacts startup
+                (anchor)
+                (blocker)
+                (go))
+        ",
+        );
+
+        let run = run_to_completion(&mut engine);
+
+        assert_eq!(
+            run.rules_fired, 2,
+            "the candidate created by retract must be matched before the later bind"
+        );
+        assert_has_fact_with_relation(&engine, "candidate-fired");
+    }
+
+    #[test]
     fn fr_rete_004_complex_negation_not_deferred_to_fire() {
         let mut engine = new_utf8_engine();
         let errors = engine

--- a/crates/ferric-rules-runtime/src/phase3_integration_tests.rs
+++ b/crates/ferric-rules-runtime/src/phase3_integration_tests.rs
@@ -216,6 +216,121 @@ mod tests {
     }
 
     #[test]
+    fn fr_rete_004_false_test_never_enters_agenda() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule positive
+                (value ?x)
+                (test (> ?x 0))
+                =>
+                (assert (positive ?x)))
+        ",
+        );
+
+        engine.assert_ordered("value", -1_i64).unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            0,
+            "a failing test CE must prevent terminal activation"
+        );
+    }
+
+    #[test]
+    fn fr_rete_004_test_uses_match_time_state() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defglobal ?*open* = FALSE)
+
+            (defrule candidate
+                (declare (salience 10))
+                (candidate)
+                (test (eq ?*open* TRUE))
+                =>
+                (assert (candidate-fired)))
+
+            (defrule opener
+                (declare (salience 100))
+                (open)
+                =>
+                (bind ?*open* TRUE))
+        ",
+        );
+
+        engine.assert_ordered("candidate", []).unwrap();
+        engine.assert_ordered("open", []).unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "only the opener should match while the global guard is false"
+        );
+        let run = run_to_completion(&mut engine);
+        assert_eq!(run.rules_fired, 1);
+        assert_no_fact_with_relation(&engine, "candidate-fired");
+    }
+
+    #[test]
+    fn fr_rete_004_test_retracts_and_reactivates_correctly() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule positive
+                (value ?x)
+                (test (> ?x 0))
+                =>
+                (assert (positive ?x)))
+        ",
+        );
+
+        let rejected = engine.assert_ordered("value", -1_i64).unwrap();
+        assert_eq!(engine.agenda_len(), 0);
+        engine.retract(rejected).unwrap();
+
+        let accepted = engine.assert_ordered("value", 1_i64).unwrap();
+        assert_eq!(engine.agenda_len(), 1);
+        engine.retract(accepted).unwrap();
+        assert_eq!(engine.agenda_len(), 0);
+
+        engine.assert_ordered("value", 1_i64).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "a new partial match must reevaluate and reactivate the test CE"
+        );
+    }
+
+    #[test]
+    fn fr_rete_004_complex_negation_not_deferred_to_fire() {
+        let mut engine = new_utf8_engine();
+        let errors = engine
+            .load_str(
+                r"
+                (defrule no-square-greater
+                    (anchor ?min)
+                    (not (data ?x&:(> (* ?x ?x) (* ?min ?min))))
+                    =>
+                    (assert (safe-square ?min)))
+            ",
+            )
+            .expect_err("unsupported complex negation must fail during load");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                crate::loader::LoadError::Compile(message)
+                    if message.contains("complex constraints inside negated patterns")
+            )),
+            "expected an explicit match-time support error, got {errors:?}"
+        );
+    }
+
+    #[test]
     fn nested_function_call_in_rhs_evaluates() {
         let mut engine = new_utf8_engine();
         load_ok(

--- a/crates/ferric-rules-runtime/src/serialization.rs
+++ b/crates/ferric-rules-runtime/src/serialization.rs
@@ -180,6 +180,7 @@ impl EngineSnapshotOwned {
             generic_modules: self.generic_modules,
             initial_fact_id: self.initial_fact_id,
             action_diagnostics: self.action_diagnostics,
+            processing_predicates: false,
             halted: self.halted,
             input_buffer: self.input_buffer,
             creator_thread: std::thread::current().id(),
@@ -542,6 +543,36 @@ mod tests {
                 "format {format:?} lost the structural duplicate index"
             );
             assert_eq!(restored.facts().unwrap().count(), 2);
+        }
+    }
+
+    #[test]
+    fn fr_rete_004_snapshot_preserves_predicate_nodes() {
+        let source = r"
+            (defrule positive
+                (value ?x)
+                (test (> ?x 0))
+                =>
+                (printout t ?x crlf))
+        ";
+
+        for &format in SerializationFormat::ALL {
+            let mut engine = Engine::new(EngineConfig::utf8());
+            engine.load_str(source).unwrap();
+            engine.reset().unwrap();
+            engine.assert_ordered("value", -1_i64).unwrap();
+            engine.assert_ordered("value", 1_i64).unwrap();
+            assert_eq!(engine.agenda_len(), 1);
+
+            let bytes = engine.serialize(format).unwrap();
+            let mut restored = Engine::deserialize(&bytes, format).unwrap();
+            let result = restored.run(RunLimit::Unlimited).unwrap();
+
+            assert_eq!(
+                result.rules_fired, 1,
+                "format {format:?} lost the passing predicate token"
+            );
+            assert_eq!(restored.get_output("t"), Some("1\n"));
         }
     }
 

--- a/crates/ferric-rules/benches/evaluator_bench.rs
+++ b/crates/ferric-rules/benches/evaluator_bench.rs
@@ -105,6 +105,29 @@ fn generate_string_source(n: usize) -> String {
     source
 }
 
+/// Match-time `test` CE throughput with an even split of accepted and rejected
+/// partial matches.
+fn generate_test_ce_source(n: usize) -> String {
+    let mut source = String::from(
+        "\
+(deffacts candidates\n",
+    );
+    for value in 0..n {
+        writeln!(source, "    (candidate {value})").unwrap();
+    }
+    source.push_str(
+        ")
+
+(defrule accept-even-positive
+    (candidate ?value)
+    (test (and (> ?value 0) (= (mod ?value 2) 0)))
+    =>
+    (assert (accepted ?value)))
+",
+    );
+    source
+}
+
 fn bench_evaluator_arithmetic(c: &mut Criterion) {
     let mut group = c.benchmark_group("eval_arithmetic");
 
@@ -263,11 +286,39 @@ fn bench_evaluator_string(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_test_ce_matching(c: &mut Criterion) {
+    let mut group = c.benchmark_group("test_ce_matching");
+
+    let source_100 = generate_test_ce_source(100);
+    group.bench_function("test_ce_100", |b| {
+        b.iter(|| {
+            let mut engine = Engine::new(EngineConfig::utf8());
+            engine.load_str(&source_100).unwrap();
+            engine.reset().unwrap();
+            engine.run(RunLimit::Unlimited).unwrap()
+        });
+    });
+
+    let source_1000 = generate_test_ce_source(1000);
+    group.sample_size(10);
+    group.bench_function("test_ce_1000", |b| {
+        b.iter(|| {
+            let mut engine = Engine::new(EngineConfig::utf8());
+            engine.load_str(&source_1000).unwrap();
+            engine.reset().unwrap();
+            engine.run(RunLimit::Unlimited).unwrap()
+        });
+    });
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_evaluator_arithmetic,
     bench_evaluator_deffunction,
     bench_evaluator_loop,
     bench_evaluator_string,
+    bench_test_ce_matching,
 );
 criterion_main!(benches);

--- a/crates/ferric-rules/tests/clips_compat.rs
+++ b/crates/ferric-rules/tests/clips_compat.rs
@@ -805,6 +805,18 @@ fn fr_rete_003_clips_staged_late_rule_backfill_fixture() {
     );
 }
 
+#[test]
+fn fr_rete_004_clips_match_time_transition_fixture() {
+    // Pinned against the repository's CLIPS 6.30 reference image. The absent
+    // "historical-fired" line is significant: changing a global does not
+    // retroactively admit a partial match that failed its test CE.
+    let _ = assert_fixture_output(
+        "core/test_ce_match_time_transitions.clp",
+        5,
+        "open\nfresh\nretract\nreassert\npositive 2\n",
+    );
+}
+
 /// Multi-pattern join: a rule with two patterns joined by a shared variable.
 #[test]
 fn test_compat_core_multi_pattern_join() {

--- a/crates/ferric-rules/tests/fixtures/core/test_ce_match_time_transitions.clp
+++ b/crates/ferric-rules/tests/fixtures/core/test_ce_match_time_transitions.clp
@@ -1,0 +1,62 @@
+; Match-time predicate transitions pinned against CLIPS 6.30.
+;
+; The historical fact does not match while the gate is FALSE and must not
+; become eligible merely because an unrelated RHS later changes the global.
+; Fresh partial matches evaluate the new state, retraction cancels an accepted
+; activation, and reassertion evaluates and activates again.
+
+(defglobal ?*gate* = FALSE)
+
+(deffacts startup
+    (historical)
+    (phase open))
+
+(defrule historical-match
+    (historical)
+    (test (eq ?*gate* TRUE))
+    =>
+    (printout t "historical-fired" crlf))
+
+(defrule open-gate
+    (declare (salience 100))
+    ?phase <- (phase open)
+    =>
+    (printout t "open" crlf)
+    (retract ?phase)
+    (bind ?*gate* TRUE)
+    (assert (fresh)))
+
+(defrule fresh-match
+    (declare (salience 80))
+    ?fresh <- (fresh)
+    (test (eq ?*gate* TRUE))
+    =>
+    (printout t "fresh" crlf)
+    (retract ?fresh)
+    (assert (positive 1))
+    (assert (phase retract)))
+
+(defrule retract-before-fire
+    (declare (salience 100))
+    ?phase <- (phase retract)
+    ?positive <- (positive ?value)
+    =>
+    (printout t "retract" crlf)
+    (retract ?phase)
+    (retract ?positive)
+    (assert (phase reassert)))
+
+(defrule reassert-positive
+    (declare (salience 100))
+    ?phase <- (phase reassert)
+    =>
+    (printout t "reassert" crlf)
+    (retract ?phase)
+    (assert (positive 2)))
+
+(defrule positive-match
+    (declare (salience 10))
+    (positive ?value)
+    (test (> ?value 0))
+    =>
+    (printout t "positive " ?value crlf))

--- a/scripts/expected-ferric-rules-package-files.txt
+++ b/scripts/expected-ferric-rules-package-files.txt
@@ -38,6 +38,7 @@ tests/fixtures/core/refraction.clp
 tests/fixtures/core/retract_chain.clp
 tests/fixtures/core/retract_cycle.clp
 tests/fixtures/core/salience_order.clp
+tests/fixtures/core/test_ce_match_time_transitions.clp
 tests/fixtures/examples/mobile_engagement.clp
 tests/fixtures/generics/.gitkeep
 tests/fixtures/generics/basic_dispatch.clp


### PR DESCRIPTION
Closes #106

## Scope

FR-RETE-004 moves `test` conditional elements from firing-time checks into rule-local beta predicate nodes so failing partial matches never reach terminals or the agenda. Complex negated constraints that cannot yet be represented by the negative network now fail explicitly during load instead of using a late fallback. Simple inline predicate comparisons are lowered into existing alpha/join tests so they avoid the general runtime predicate path.

The final review fix also makes an RHS `retract` a predicate-evaluation boundary: matches exposed by that action observe state at that point in the action sequence, before later RHS mutations.

## Stack

- Immediate predecessor: none
- Earlier included PRs: none
- Required merge order: this PR only
- Tests require predecessor code: no
- Branch point: `163b7590cae0aedf88b164e7562bc0098ad1caca`

## Red-before-fix evidence

`cargo test -p ferric-rules-runtime fr_rete_004 -- --nocapture` exited 101 before implementation: all four original contract tests failed. False predicates left agenda entries, historical matches observed later global state, retraction/reactivation started from an invalid activation, and complex negation loaded through the firing-time fallback.

Review then identified an RHS action-ordering case. The added `fr_rete_004_rhs_retraction_uses_state_at_action_boundary` regression failed before its fix (`expected 2` firings, observed `1`), proving that a candidate exposed by `(retract ?blocker)` was incorrectly evaluated after a later `(bind ?*gate* FALSE)`.

## Validation

- Final head: `337a470ea75f54b34affbf34e057fc0b44bcf335`
- `just preflight-pr` — passed on the final diff across the Rust workspace, examples, Python tooling and bindings, Go, TypeScript, and license checks
- `cargo test -p ferric-rules-runtime fr_rete_004` — 5 passed
- `cargo test -p ferric-rules-core --lib` — 418 passed
- `cargo test -p ferric-rules-runtime` — 803 passed
- Runtime all-feature suite in preflight — 832 passed
- `cargo test -p ferric-rules-runtime --features serde serialization::tests` — 29 passed, including predicate-node round trips in all five formats
- `cargo test -p ferric-rules --test clips_compat` — 74 passed
- `just scaling-check` — all five release scaling guards passed; the retraction-cascade ratio was 3.71 for 4× input
- Pinned CLIPS 6.30 reference fixture — `open`, `fresh`, `retract`, `reassert`, `positive 2`
- Hosted final-head assessment — all 29 checks passed; compatibility reported no regression; the independent Claude review passed
- Hosted release Criterion comparison across 135 benchmarks — 14 exceeded the 5% regression marker, 9 improved by more than 5%, and 112 were unchanged. Intended simple predicate workloads improved 14.4–15.7%: `424.7 µs → 358.2 µs`, `1.82 ms → 1.56 ms`, and `3.55 ms → 3.01 ms`. All absolute thresholds passed.

## Acceptance criteria

- A failing test CE creates no terminal token or activation: covered by the core predicate lifecycle test and `fr_rete_004_false_test_never_enters_agenda`.
- Agenda behavior agrees with CLIPS: the new CLIPS 6.30 transition fixture pins false-match exclusion, retraction, and reactivation output.
- State changes follow match-time dependency behavior: `fr_rete_004_test_uses_match_time_state` proves a later global update does not revive a rejected historical match.
- RHS action ordering is preserved: predicate work exposed by a retraction drains before the next RHS action.
- Supported test forms execute during matching: test expressions are compiled at their source position into predicate nodes; the existing `test_ce` suite remains green.
- Unsupported forms fail during load: non-linear complex constraints inside negated patterns now return an explicit compile error, covered by `fr_rete_004_complex_negation_not_deferred_to_fire` and loader regressions.

## Residual risks

- Complex non-linear predicate and return-value constraints inside negated ordered patterns are explicitly unsupported at load time until the negative network gains an equivalent node representation.
- The hosted release report records eight test-CE-heavy workload regressions of 10.7–14.3%, plus six other threshold crossings of 5.0–7.2%. Predicate-constraint workloads improve 14.4–15.7%, all absolute benchmark thresholds pass, compatibility has no regression, and all five scaling guards remain green. [#199](https://github.com/plx/ferric-rules/issues/199) is the existing scoped remediation for full binding-set cloning in pass-through beta tokens.