### PR TITLE
[FR-RETE-005] Compile double negation with existential semantics

### DIFF
--- a/crates/ferric-rules-runtime/src/loader.rs
+++ b/crates/ferric-rules-runtime/src/loader.rs
@@ -1876,7 +1876,7 @@ impl Engine {
 
     /// Recursively flatten a pattern for top-level condition processing.
     /// - `And`/`Logical`: flatten children.
-    /// - `Not(Not(X))`: strip double negation (exists ≈ positive), then flatten X.
+    /// - Double negation remains intact so translation can compile it as exists.
     /// - Everything else: push as-is.
     fn flatten_pattern<'a>(pattern: &'a Pattern, out: &mut Vec<&'a Pattern>) {
         match pattern {
@@ -1885,15 +1885,365 @@ impl Engine {
                     Self::flatten_pattern(sub, out);
                 }
             }
-            Pattern::Not(inner, _) => {
-                if let Pattern::Not(doubly_inner, _) = inner.as_ref() {
-                    // (not (not X)) ≡ (exists X): strip double negation
-                    Self::flatten_pattern(doubly_inner, out);
-                } else {
-                    out.push(pattern);
+            _ => out.push(pattern),
+        }
+    }
+
+    fn collect_pattern_binding_variables(pattern: &Pattern, variables: &mut HashSet<String>) {
+        match pattern {
+            Pattern::Ordered(ordered) => {
+                for constraint in &ordered.constraints {
+                    Self::collect_constraint_binding_variables(constraint, variables);
                 }
             }
-            _ => out.push(pattern),
+            Pattern::Template(template) => {
+                for slot in &template.slot_constraints {
+                    Self::collect_constraint_binding_variables(&slot.constraint, variables);
+                }
+            }
+            Pattern::Assigned {
+                variable, pattern, ..
+            } => {
+                variables.insert(variable.clone());
+                Self::collect_pattern_binding_variables(pattern, variables);
+            }
+            Pattern::And(children, _)
+            | Pattern::Logical(children, _)
+            | Pattern::Or(children, _)
+            | Pattern::Exists(children, _)
+            | Pattern::Forall(children, _) => {
+                for child in children {
+                    Self::collect_pattern_binding_variables(child, variables);
+                }
+            }
+            Pattern::Not(inner, _) => {
+                Self::collect_pattern_binding_variables(inner, variables);
+            }
+            Pattern::Test(_, _) => {}
+        }
+    }
+
+    fn collect_constraint_binding_variables(
+        constraint: &Constraint,
+        variables: &mut HashSet<String>,
+    ) {
+        match constraint {
+            Constraint::Variable(name, _) | Constraint::MultiVariable(name, _) => {
+                variables.insert(name.clone());
+            }
+            Constraint::And(parts, _) | Constraint::Or(parts, _) => {
+                for part in parts {
+                    Self::collect_constraint_binding_variables(part, variables);
+                }
+            }
+            Constraint::Literal(_)
+            | Constraint::Wildcard(_)
+            | Constraint::MultiWildcard(_)
+            | Constraint::Predicate(_, _)
+            | Constraint::ReturnValue(_, _)
+            | Constraint::Not(_, _) => {}
+        }
+    }
+
+    fn collect_existential_local_variables(pattern: &Pattern, variables: &mut HashSet<String>) {
+        match pattern {
+            Pattern::Exists(children, _) => {
+                for child in children {
+                    Self::collect_pattern_binding_variables(child, variables);
+                }
+            }
+            Pattern::Not(inner, _) => {
+                if let Pattern::Not(existential, _) = inner.as_ref() {
+                    Self::collect_pattern_binding_variables(existential, variables);
+                } else {
+                    Self::collect_existential_local_variables(inner, variables);
+                }
+            }
+            Pattern::Assigned { pattern, .. } => {
+                Self::collect_existential_local_variables(pattern, variables);
+            }
+            Pattern::And(children, _)
+            | Pattern::Logical(children, _)
+            | Pattern::Or(children, _)
+            | Pattern::Forall(children, _) => {
+                for child in children {
+                    Self::collect_existential_local_variables(child, variables);
+                }
+            }
+            Pattern::Ordered(_) | Pattern::Template(_) | Pattern::Test(_, _) => {}
+        }
+    }
+
+    fn first_restricted_sexpr_variable(
+        expr: &SExpr,
+        restricted: &HashSet<String>,
+    ) -> Option<String> {
+        match expr {
+            SExpr::Atom(Atom::SingleVar(name) | Atom::MultiVar(name), _) => {
+                restricted.contains(name).then(|| name.clone())
+            }
+            SExpr::Atom(_, _) => None,
+            SExpr::List(items, _) => items
+                .iter()
+                .find_map(|item| Self::first_restricted_sexpr_variable(item, restricted)),
+        }
+    }
+
+    fn validate_existential_test_scope(
+        rule_name: &str,
+        expr: &SExpr,
+        existential_locals: &HashSet<String>,
+        exported_variables: &HashSet<String>,
+    ) -> Result<(), LoadError> {
+        let restricted: HashSet<String> = existential_locals
+            .difference(exported_variables)
+            .cloned()
+            .collect();
+        if let Some(variable) = Self::first_restricted_sexpr_variable(expr, &restricted) {
+            return Err(LoadError::Compile(format!(
+                "rule `{rule_name}` variable ?{variable} is not exported by existential conditional element"
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_existential_rhs_scope(
+        rule: &RuleConstruct,
+        existential_locals: &HashSet<String>,
+        exported_variables: &HashSet<String>,
+    ) -> Result<(), LoadError> {
+        let restricted: HashSet<String> = existential_locals
+            .difference(exported_variables)
+            .cloned()
+            .collect();
+        if restricted.is_empty() {
+            return Ok(());
+        }
+
+        let mut rhs_locals = HashSet::new();
+        for action in &rule.actions {
+            Self::validate_existential_rhs_call(
+                &rule.name,
+                &action.call,
+                &restricted,
+                &mut rhs_locals,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn existential_scope_variable_name(name: &str) -> &str {
+        name.strip_prefix("$?").unwrap_or(name)
+    }
+
+    fn validate_existential_rhs_call(
+        rule_name: &str,
+        call: &FunctionCall,
+        restricted: &HashSet<String>,
+        rhs_locals: &mut HashSet<String>,
+    ) -> Result<(), LoadError> {
+        if call.name == "bind" {
+            if let Some(ActionExpr::Variable(name, _)) = call.args.first() {
+                for value in call.args.iter().skip(1) {
+                    Self::validate_existential_rhs_expr(rule_name, value, restricted, rhs_locals)?;
+                }
+                rhs_locals.insert(Self::existential_scope_variable_name(name).to_string());
+                return Ok(());
+            }
+        }
+
+        for arg in &call.args {
+            Self::validate_existential_rhs_expr(rule_name, arg, restricted, rhs_locals)?;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_lines)] // Mirrors every structured RHS scope in ActionExpr.
+    fn validate_existential_rhs_expr(
+        rule_name: &str,
+        expr: &ActionExpr,
+        restricted: &HashSet<String>,
+        rhs_locals: &mut HashSet<String>,
+    ) -> Result<(), LoadError> {
+        match expr {
+            ActionExpr::Variable(name, span) => {
+                let scope_name = Self::existential_scope_variable_name(name);
+                if restricted.contains(scope_name) && !rhs_locals.contains(scope_name) {
+                    let display_name = if name.starts_with("$?") {
+                        name.clone()
+                    } else {
+                        format!("?{name}")
+                    };
+                    return Err(LoadError::Compile(format!(
+                        "rule `{rule_name}` variable {display_name} at line {} is not exported by existential conditional element",
+                        span.start.line
+                    )));
+                }
+                Ok(())
+            }
+            ActionExpr::FunctionCall(call) => {
+                Self::validate_existential_rhs_call(rule_name, call, restricted, rhs_locals)
+            }
+            ActionExpr::If {
+                condition,
+                then_actions,
+                else_actions,
+                ..
+            } => {
+                Self::validate_existential_rhs_expr(rule_name, condition, restricted, rhs_locals)?;
+                let mut then_locals = rhs_locals.clone();
+                for action in then_actions {
+                    Self::validate_existential_rhs_expr(
+                        rule_name,
+                        action,
+                        restricted,
+                        &mut then_locals,
+                    )?;
+                }
+                let mut else_locals = rhs_locals.clone();
+                for action in else_actions {
+                    Self::validate_existential_rhs_expr(
+                        rule_name,
+                        action,
+                        restricted,
+                        &mut else_locals,
+                    )?;
+                }
+                rhs_locals.extend(then_locals);
+                rhs_locals.extend(else_locals);
+                Ok(())
+            }
+            ActionExpr::While {
+                condition, body, ..
+            } => {
+                Self::validate_existential_rhs_expr(rule_name, condition, restricted, rhs_locals)?;
+                let mut body_locals = rhs_locals.clone();
+                for action in body {
+                    Self::validate_existential_rhs_expr(
+                        rule_name,
+                        action,
+                        restricted,
+                        &mut body_locals,
+                    )?;
+                }
+                rhs_locals.extend(body_locals);
+                Ok(())
+            }
+            ActionExpr::LoopForCount {
+                var_name,
+                start,
+                end,
+                body,
+                ..
+            } => {
+                Self::validate_existential_rhs_expr(rule_name, start, restricted, rhs_locals)?;
+                Self::validate_existential_rhs_expr(rule_name, end, restricted, rhs_locals)?;
+                let mut body_locals = rhs_locals.clone();
+                if let Some(name) = var_name {
+                    body_locals.insert(name.clone());
+                }
+                for action in body {
+                    Self::validate_existential_rhs_expr(
+                        rule_name,
+                        action,
+                        restricted,
+                        &mut body_locals,
+                    )?;
+                }
+                if let Some(name) = var_name {
+                    body_locals.remove(name);
+                }
+                rhs_locals.extend(body_locals);
+                Ok(())
+            }
+            ActionExpr::Progn {
+                var_name,
+                list_expr,
+                body,
+                ..
+            } => {
+                Self::validate_existential_rhs_expr(rule_name, list_expr, restricted, rhs_locals)?;
+                let mut body_locals = rhs_locals.clone();
+                body_locals.insert(var_name.clone());
+                body_locals.insert(format!("{var_name}-index"));
+                for action in body {
+                    Self::validate_existential_rhs_expr(
+                        rule_name,
+                        action,
+                        restricted,
+                        &mut body_locals,
+                    )?;
+                }
+                body_locals.remove(var_name);
+                body_locals.remove(&format!("{var_name}-index"));
+                rhs_locals.extend(body_locals);
+                Ok(())
+            }
+            ActionExpr::QueryAction {
+                bindings,
+                query,
+                body,
+                ..
+            } => {
+                let mut query_locals = rhs_locals.clone();
+                query_locals.extend(bindings.iter().map(|(name, _)| name.clone()));
+                Self::validate_existential_rhs_expr(
+                    rule_name,
+                    query,
+                    restricted,
+                    &mut query_locals,
+                )?;
+                for action in body {
+                    Self::validate_existential_rhs_expr(
+                        rule_name,
+                        action,
+                        restricted,
+                        &mut query_locals,
+                    )?;
+                }
+                for (name, _) in bindings {
+                    query_locals.remove(name);
+                }
+                rhs_locals.extend(query_locals);
+                Ok(())
+            }
+            ActionExpr::Switch {
+                expr,
+                cases,
+                default,
+                ..
+            } => {
+                Self::validate_existential_rhs_expr(rule_name, expr, restricted, rhs_locals)?;
+                for (case_expr, actions) in cases {
+                    Self::validate_existential_rhs_expr(
+                        rule_name, case_expr, restricted, rhs_locals,
+                    )?;
+                    let mut case_locals = rhs_locals.clone();
+                    for action in actions {
+                        Self::validate_existential_rhs_expr(
+                            rule_name,
+                            action,
+                            restricted,
+                            &mut case_locals,
+                        )?;
+                    }
+                    rhs_locals.extend(case_locals);
+                }
+                if let Some(actions) = default {
+                    let mut default_locals = rhs_locals.clone();
+                    for action in actions {
+                        Self::validate_existential_rhs_expr(
+                            rule_name,
+                            action,
+                            restricted,
+                            &mut default_locals,
+                        )?;
+                    }
+                    rhs_locals.extend(default_locals);
+                }
+                Ok(())
+            }
+            ActionExpr::Literal(_) | ActionExpr::GlobalVariable(_, _) => Ok(()),
         }
     }
 
@@ -2554,12 +2904,14 @@ impl Engine {
         let mut multifield_tail_bindings = Vec::new();
         let mut fact_index = 0usize;
         let mut internal_slot_var_seed = 0usize;
+        let mut exported_variables = HashSet::new();
+        let mut existential_locals = HashSet::new();
 
         // Flatten top-level Pattern::And and Pattern::Logical into their children.
         // CLIPS treats (and ...) as a grouping CE equivalent to listing sub-patterns directly.
         // (logical ...) is a truth-maintenance wrapper; we strip it (no TMS yet) and treat
         // children as top-level conditions.
-        // Also flatten (not (not X)) → X (double negation = exists, approximated as positive).
+        // Double negation stays intact and is translated through an exists node.
         let mut flat_patterns: Vec<&Pattern> = Vec::new();
         for pattern in &rule.patterns {
             Self::flatten_pattern(pattern, &mut flat_patterns);
@@ -2587,6 +2939,12 @@ impl Engine {
             // retained in rule metadata and referenced by predicate nodes at
             // their source position in the beta network.
             if let Pattern::Test(sexpr, _span) = pattern {
+                Self::validate_existential_test_scope(
+                    &rule.name,
+                    sexpr,
+                    &existential_locals,
+                    &exported_variables,
+                )?;
                 let runtime_expr =
                     crate::evaluator::from_sexpr(sexpr, &mut self.symbol_table, &self.config)
                         .map_err(|e| LoadError::Compile(format!("test CE translation: {e}")))?;
@@ -2597,6 +2955,8 @@ impl Engine {
                 )?;
                 continue;
             }
+
+            Self::collect_existential_local_variables(pattern, &mut existential_locals);
 
             // Handle test CEs inside negation and NCC contexts by extracting
             // them as predicate nodes at their source position.
@@ -2644,6 +3004,16 @@ impl Engine {
                 &mut generated_tests,
                 &mut internal_slot_var_seed,
             )?;
+            if matches!(
+                &condition,
+                CompilableCondition::Pattern(compilable) if compilable.exists
+            ) && !generated_tests.is_empty()
+            {
+                return Err(LoadError::Compile(
+                    "complex constraints inside existential patterns are not supported at match time"
+                        .to_string(),
+                ));
+            }
             if matches!(condition, CompilableCondition::Ncc(_)) && !generated_tests.is_empty() {
                 return Err(LoadError::Compile(
                     "test CEs inside mixed negated conjunctions are not supported at match time"
@@ -2656,6 +3026,7 @@ impl Engine {
                 }
             }
             if Self::condition_has_fact_address(&condition) {
+                Self::collect_pattern_binding_variables(pattern, &mut exported_variables);
                 Self::collect_multifield_tail_bindings(
                     pattern,
                     fact_index,
@@ -2691,6 +3062,8 @@ impl Engine {
             };
             conditions.insert(0, CompilableCondition::Pattern(initial_pattern));
         }
+
+        Self::validate_existential_rhs_scope(rule, &existential_locals, &exported_variables)?;
 
         Ok(TranslatedRule {
             salience: Salience::new(rule.salience),
@@ -2769,12 +3142,25 @@ impl Engine {
                     }
                     Pattern::Not(doubly_inner, _) => {
                         // (not (not X)) ≡ (exists X) in CLIPS.
-                        // Strip double negation and translate as a positive condition.
-                        self.translate_condition(
-                            doubly_inner,
-                            generated_tests,
-                            internal_slot_var_seed,
-                        )
+                        // Preserve further nested negation parity, but compile
+                        // an ordinary doubly-negated fact pattern through the
+                        // support-counted exists node.
+                        if matches!(doubly_inner.as_ref(), Pattern::Not(..)) {
+                            self.translate_condition(
+                                doubly_inner,
+                                generated_tests,
+                                internal_slot_var_seed,
+                            )
+                        } else {
+                            let mut compilable = self.translate_pattern(
+                                doubly_inner,
+                                generated_tests,
+                                internal_slot_var_seed,
+                                false,
+                            )?;
+                            compilable.exists = true;
+                            Ok(CompilableCondition::Pattern(compilable))
+                        }
                     }
                     _ => {
                         let mut compilable = self.translate_pattern(

--- a/crates/ferric-rules-runtime/src/phase2_integration_tests.rs
+++ b/crates/ferric-rules-runtime/src/phase2_integration_tests.rs
@@ -1096,7 +1096,7 @@ mod tests {
                 r"
             (defrule r1 (a ?x) => (printout t ?x))
             (defrule r2 (b ?x) (not (c ?x)) => (printout t ?x))
-            (defrule r3 (d) (exists (e ?x)) => (printout t ?x))
+            (defrule r3 (d) (exists (e ?x)) => (printout t exists))
         ",
             )
             .unwrap();

--- a/crates/ferric-rules-runtime/src/phase3_integration_tests.rs
+++ b/crates/ferric-rules-runtime/src/phase3_integration_tests.rs
@@ -370,6 +370,354 @@ mod tests {
     }
 
     #[test]
+    fn fr_rete_005_double_not_has_one_activation() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule any-foo
+                (not (not (foo ?x)))
+                =>
+                (assert (found-foo)))
+        ",
+        );
+
+        engine.assert_ordered("foo", 1_i64).unwrap();
+        engine.assert_ordered("foo", 2_i64).unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "double negation must contribute one Boolean activation"
+        );
+    }
+
+    #[test]
+    fn fr_rete_005_double_not_survives_partial_support_retract() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule any-foo
+                (not (not (foo ?x)))
+                =>
+                (assert (found-foo)))
+        ",
+        );
+
+        let first = engine.assert_ordered("foo", 1_i64).unwrap();
+        engine.assert_ordered("foo", 2_i64).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "two supports must still produce one existential activation"
+        );
+        engine.retract(first).unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "one remaining support must keep the existential activation alive"
+        );
+        assert_rete_consistent(engine.rete());
+    }
+
+    #[test]
+    fn fr_rete_005_double_not_retracts_after_last_support() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule any-foo
+                (not (not (foo ?x)))
+                =>
+                (assert (found-foo)))
+        ",
+        );
+
+        let first = engine.assert_ordered("foo", 1_i64).unwrap();
+        let second = engine.assert_ordered("foo", 2_i64).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "two supports must still produce one existential activation"
+        );
+        engine.retract(first).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "the activation must survive until the final support is removed"
+        );
+        engine.retract(second).unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            0,
+            "the existential activation must retract with its final support"
+        );
+        assert_rete_consistent(engine.rete());
+    }
+
+    #[test]
+    fn fr_rete_005_double_not_rejects_escaped_binding() {
+        let mut engine = new_utf8_engine();
+        let errors = engine
+            .load_str(
+                r"
+                (defrule invalid
+                    (not (not (foo ?x)))
+                    =>
+                    (printout t ?x crlf))
+            ",
+            )
+            .expect_err("an existential-local variable must not escape to the RHS");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                crate::loader::LoadError::Compile(message)
+                    if message.contains("not exported by existential")
+            )),
+            "expected an existential binding-scope diagnostic, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn fr_rete_005_double_not_rejects_escaped_multifield_binding() {
+        let mut engine = new_utf8_engine();
+        let errors = engine
+            .load_str(
+                r"
+                (defrule invalid
+                    (not (not (foo $?items)))
+                    =>
+                    (printout t $?items crlf))
+            ",
+            )
+            .expect_err("an existential-local multifield variable must not escape to the RHS");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                crate::loader::LoadError::Compile(message)
+                    if message.contains("not exported by existential")
+            )),
+            "expected an existential multifield binding-scope diagnostic, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn fr_rete_005_double_not_rejects_local_binding_in_later_test() {
+        let mut engine = new_utf8_engine();
+        let errors = engine
+            .load_str(
+                r"
+                (defrule invalid
+                    (not (not (foo ?x)))
+                    (test (> ?x 0))
+                    =>
+                    (assert (unexpected)))
+            ",
+            )
+            .expect_err("an existential-local variable must not escape to a later test CE");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                crate::loader::LoadError::Compile(message)
+                    if message.contains("not exported by existential")
+            )),
+            "expected an existential test-scope diagnostic, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn fr_rete_005_explicit_exists_rejects_the_same_escaped_binding() {
+        let mut engine = new_utf8_engine();
+        let errors = engine
+            .load_str(
+                r"
+                (defrule invalid
+                    (exists (foo ?x))
+                    =>
+                    (printout t ?x crlf))
+            ",
+            )
+            .expect_err("explicit exists and double negation must share binding scope");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                crate::loader::LoadError::Compile(message)
+                    if message.contains("not exported by existential")
+            )),
+            "expected an existential binding-scope diagnostic, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn fr_rete_005_complex_existential_constraint_fails_during_load() {
+        let mut engine = new_utf8_engine();
+        let errors = engine
+            .load_str(
+                r"
+                (defrule invalid
+                    (not (not (foo ?x&:(> (* ?x ?x) 4))))
+                    =>
+                    (assert (unexpected)))
+            ",
+            )
+            .expect_err("an existential-local runtime predicate must not fail silently");
+
+        assert!(
+            errors.iter().any(|error| matches!(
+                error,
+                crate::loader::LoadError::Compile(message)
+                    if message.contains("complex constraints inside existential patterns")
+            )),
+            "expected an explicit existential match-time diagnostic, got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn fr_rete_005_rhs_can_rebind_existential_local_name() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule valid
+                (not (not (foo ?x)))
+                =>
+                (bind ?x rebound)
+                (assert (rebound-value ?x)))
+        ",
+        );
+
+        engine.assert_ordered("foo", 1_i64).unwrap();
+        let run = run_to_completion(&mut engine);
+        assert_eq!(run.rules_fired, 1);
+        assert_has_fact_with_relation(&engine, "rebound-value");
+    }
+
+    #[test]
+    fn fr_rete_005_rhs_can_rebind_existential_local_multifield_name() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule valid
+                (not (not (foo $?items)))
+                =>
+                (bind $?items (create$ rebound values))
+                (assert (rebound-value $?items)))
+        ",
+        );
+
+        engine.assert_ordered("foo", 1_i64).unwrap();
+        let run = run_to_completion(&mut engine);
+        assert_eq!(run.rules_fired, 1);
+        assert_has_fact_with_relation(&engine, "rebound-value");
+    }
+
+    #[test]
+    fn fr_rete_005_rhs_branch_bind_can_rebind_existential_local_name() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule valid
+                (not (not (foo ?x)))
+                =>
+                (if TRUE then (bind ?x rebound))
+                (assert (rebound-value ?x)))
+        ",
+        );
+
+        engine.assert_ordered("foo", 1_i64).unwrap();
+        let run = run_to_completion(&mut engine);
+        assert_eq!(run.rules_fired, 1);
+        assert_has_fact_with_relation(&engine, "rebound-value");
+    }
+
+    #[test]
+    fn fr_rete_005_later_positive_pattern_exports_its_own_binding() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule valid
+                (not (not (foo ?x)))
+                (bar ?x)
+                =>
+                (assert (matched ?x)))
+        ",
+        );
+
+        engine.assert_ordered("foo", 1_i64).unwrap();
+        engine.assert_ordered("bar", 2_i64).unwrap();
+        let run = run_to_completion(&mut engine);
+        assert_eq!(run.rules_fired, 1);
+        assert_has_fact_with_relation(&engine, "matched");
+    }
+
+    #[test]
+    fn fr_rete_005_double_not_correlates_previously_bound_variable() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule matching-foo
+                (key ?x)
+                (not (not (foo ?x)))
+                =>
+                (assert (matched ?x)))
+        ",
+        );
+
+        engine.assert_ordered("key", 1_i64).unwrap();
+        engine.assert_ordered("key", 2_i64).unwrap();
+        engine.assert_ordered("foo", 2_i64).unwrap();
+
+        assert_eq!(engine.agenda_len(), 1);
+        let run = run_to_completion(&mut engine);
+        assert_eq!(run.rules_fired, 1);
+        assert_has_fact_with_relation(&engine, "matched");
+    }
+
+    #[test]
+    fn fr_rete_005_double_not_handles_online_compile_and_reset() {
+        let mut engine = new_utf8_engine();
+        engine.assert_ordered("foo", 1_i64).unwrap();
+        engine.assert_ordered("foo", 2_i64).unwrap();
+
+        load_ok(
+            &mut engine,
+            r"
+            (defrule any-foo
+                (not (not (foo ?x)))
+                =>
+                (assert (found-foo)))
+        ",
+        );
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "online compilation must backfill one existential activation"
+        );
+
+        engine.reset().unwrap();
+        assert_eq!(engine.agenda_len(), 0);
+        engine.assert_ordered("foo", 3_i64).unwrap();
+        engine.assert_ordered("foo", 4_i64).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "reset must preserve existential cardinality for new supports"
+        );
+        assert_rete_consistent(engine.rete());
+    }
+
+    #[test]
     fn nested_function_call_in_rhs_evaluates() {
         let mut engine = new_utf8_engine();
         load_ok(

--- a/crates/ferric-rules/tests/clips_compat.rs
+++ b/crates/ferric-rules/tests/clips_compat.rs
@@ -817,6 +817,18 @@ fn fr_rete_004_clips_match_time_transition_fixture() {
     );
 }
 
+#[test]
+fn fr_rete_005_clips_double_not_existential_transition_fixture() {
+    // Pinned against the repository's CLIPS 6.30 reference image. The single
+    // "one" line is significant: a second support does not create a second
+    // activation, and retracting only the first support keeps the match true.
+    let _ = assert_fixture_output(
+        "core/double_not_existential_transitions.clp",
+        5,
+        "zero\none\ntwo\npartial\nzero-again\n",
+    );
+}
+
 /// Multi-pattern join: a rule with two patterns joined by a shared variable.
 #[test]
 fn test_compat_core_multi_pattern_join() {

--- a/crates/ferric-rules/tests/fixtures/core/double_not_existential_transitions.clp
+++ b/crates/ferric-rules/tests/fixtures/core/double_not_existential_transitions.clp
@@ -1,0 +1,52 @@
+; Double-negation transitions pinned against CLIPS 6.30.
+;
+; The existential rule is initially false, becomes true with its first
+; support, remains one Boolean match after a second support is asserted and
+; the first is retracted, then becomes false after the last support is
+; retracted. The single "one" line proves that the two supporting facts never
+; create duplicate activations.
+
+(deffacts startup
+    (phase zero))
+
+(defrule zero-support
+    (declare (salience 100))
+    ?phase <- (phase zero)
+    =>
+    (printout t "zero" crlf)
+    (retract ?phase)
+    (assert (support one)))
+
+(defrule existential-match
+    (declare (salience 80))
+    (not (not (support ?value)))
+    =>
+    (printout t "one" crlf)
+    (assert (support two))
+    (assert (phase two)))
+
+(defrule two-supports
+    (declare (salience 60))
+    ?phase <- (phase two)
+    ?first <- (support one)
+    =>
+    (printout t "two" crlf)
+    (retract ?phase)
+    (retract ?first)
+    (assert (phase partial)))
+
+(defrule partial-support-retract
+    (declare (salience 40))
+    ?phase <- (phase partial)
+    ?last <- (support two)
+    =>
+    (printout t "partial" crlf)
+    (retract ?phase)
+    (retract ?last)
+    (assert (phase zero-again)))
+
+(defrule zero-support-again
+    (declare (salience 20))
+    (phase zero-again)
+    =>
+    (printout t "zero-again" crlf))

--- a/scripts/expected-ferric-rules-package-files.txt
+++ b/scripts/expected-ferric-rules-package-files.txt
@@ -27,6 +27,7 @@ tests/fixtures/core/.gitkeep
 tests/fixtures/core/basic_match.clp
 tests/fixtures/core/bind_in_rhs.clp
 tests/fixtures/core/chain_rules.clp
+tests/fixtures/core/double_not_existential_transitions.clp
 tests/fixtures/core/fact_duplication_policy.clp
 tests/fixtures/core/halt_stops_execution.clp
 tests/fixtures/core/late_rule_backfill_prelude.clp


### PR DESCRIPTION
Closes #107

## Scope

FR-RETE-005 keeps double negation intact through loader normalization and compiles `(not (not (pattern)))` through the existing support-counted `Exists` beta node. Multiple supporting facts now contribute one Boolean activation, partial support retraction preserves it, and final support retraction removes it.

Existential-local variables no longer escape into later test CEs or the RHS. Single-field and multifield names are normalized consistently for that scope check, while an explicit RHS-local `bind` remains valid. Previously bound outer variables still correlate through join tests, a later positive pattern may bind the same name independently, and RHS-local bindings retain their normal CLIPS scope. Complex existential constraints that require an unexported runtime binding now fail during load instead of silently producing a false match; alpha/join-lowerable constraints remain supported.

## Stack

- Immediate predecessor: none
- Earlier included PRs: none
- Required merge order: this PR only
- Tests require predecessor code: no
- Branch point: `5fde533311d906178a99a6d29f884c8611ed6b55`

## Red-before-fix evidence

`cargo test -p ferric-rules-runtime fr_rete_005 -- --nocapture` exited 101 before implementation. Five contracts failed for the intended reasons: each cardinality/retraction/online-backfill test observed two activations for two supports (`left: 2`, `right: 1`), and the escaped-binding rule loaded successfully instead of returning a scope diagnostic. The previously-bound correlation control passed.

The review follow-up test `fr_rete_005_double_not_rejects_escaped_multifield_binding` also exited 101 before its fix: `(not (not (foo $?items)))` stored the LHS name as `items`, while the RHS reference was `$?items`, so the invalid rule loaded instead of receiving the existential-scope diagnostic.

## Validation

- Final head: `268f2f1e25b496235aad13919ba0067d8f43af84`
- `just preflight-pr` — passed on the exact final commit across Rust, examples, Python tooling and bindings, native sanitizers, Go, Node/TypeScript, packaging, and notices
- `cargo test -p ferric-rules-runtime fr_rete_005` — 14 passed
- `cargo test -p ferric-rules-core exists` — 35 passed
- Core library suite — 418 passed
- Runtime all-feature suite in preflight — 846 passed
- `cargo test -p ferric-rules --test clips_compat` — 75 passed
- `just scaling-check` — all five release scaling guards passed
- Pinned CLIPS 6.30 fixture — `zero`, `one`, `two`, `partial`, `zero-again`
- Hosted PR Assessment — compatibility passed with no regressions; performance passed across 135 release Criterion benchmarks on GitHub-hosted Ubuntu 24.04 (132 unchanged). The report classified `strategy_churn1000_lex` at 5.78 ms → 6.09 ms (+5.4%) and `load_and_run_simple` at 17.6 µs → 18.6 µs (+5.3%) as regressions, and `engine_create` at 882 ns → 818 ns (-7.3%) as an improvement.

## Acceptance criteria

- Boolean cardinality: two matching facts create one activation.
- Support lifecycle: retracting one of two supports preserves the activation; retracting the last removes it.
- Scope: existential-local single-field and multifield names are rejected in later test CEs and the RHS, while outer correlation, later positive rebinding, and RHS-local binding remain valid.
- Reset and online compilation: both paths create at most one existential activation after backfill or new assertions.
- Differential behavior: the zero/one/two-support transition fixture matches the pinned CLIPS 6.30 trace.
- No silent fallback: complex constraints that require an inner-only runtime binding receive an explicit match-time support diagnostic.

## Residual risks

- Tuple-level multi-pattern existential semantics remain scoped to FR-RETE-006 (#108); this PR intentionally uses the existing single-pattern exists node.
- Complex existential constraints that cannot lower into alpha or join tests remain explicitly unsupported until an exists-aware predicate representation can evaluate right-side local bindings.