### PR TITLE
[FR-RETE-006] Give multi-pattern exists tuple-level semantics

### DIFF
--- a/crates/ferric-rules-core/src/compiler.rs
+++ b/crates/ferric-rules-core/src/compiler.rs
@@ -328,6 +328,7 @@ impl ReteCompiler {
                     current_parent = self.compile_ncc_condition(
                         rete,
                         fact_base,
+                        rule_id,
                         current_parent,
                         subpatterns,
                         &mut var_map,
@@ -426,15 +427,7 @@ impl ReteCompiler {
                         false, errors,
                     );
                 }
-                CompilableCondition::Predicate { .. } => {
-                    Self::push_unsupported_structure_error(
-                        errors,
-                        format!(
-                            "{prefix} NCC subpattern {idx} contains a runtime predicate; \
-                             test CEs inside mixed negated conjunctions are not supported"
-                        ),
-                    );
-                }
+                CompilableCondition::Predicate { .. } => {}
                 CompilableCondition::Ncc(inner) => {
                     if inner.is_empty() {
                         Self::push_unsupported_structure_error(
@@ -681,6 +674,7 @@ impl ReteCompiler {
         &mut self,
         rete: &mut ReteNetwork,
         fact_base: &FactBase,
+        rule_id: RuleId,
         current_parent: NodeId,
         subconditions: &[CompilableCondition],
         var_map: &mut VarMap,
@@ -715,13 +709,17 @@ impl ReteCompiler {
                         alpha_memories,
                     );
                 }
-                CompilableCondition::Predicate { .. } => {
-                    unreachable!("predicate nodes inside NCC must fail validation")
+                CompilableCondition::Predicate { condition_index } => {
+                    let (predicate, _) =
+                        rete.beta
+                            .create_predicate_node(sub_parent, rule_id, *condition_index);
+                    sub_parent = predicate;
                 }
                 CompilableCondition::Ncc(inner_conditions) => {
                     sub_parent = self.compile_ncc_condition(
                         rete,
                         fact_base,
+                        rule_id,
                         sub_parent,
                         inner_conditions,
                         var_map,
@@ -1980,6 +1978,57 @@ mod tests {
             matches!(partner, BetaNode::NccPartner { .. }),
             "NCC partner should exist"
         );
+    }
+
+    #[test]
+    fn test_ncc_condition_compiles_runtime_predicate_in_subnetwork() {
+        let mut compiler = ReteCompiler::new();
+        let mut rete = ReteNetwork::new();
+        let fact_base = FactBase::new();
+        let mut table = new_table();
+        let rule_id = compiler.allocate_rule_id();
+        let pattern = CompilablePattern {
+            entry_type: AlphaEntryType::OrderedRelation(intern(&mut table, "item")),
+            constant_tests: vec![],
+            variable_slots: vec![],
+            negated_variable_slots: Vec::new(),
+            negated: false,
+            exists: false,
+        };
+
+        let result = compiler
+            .compile_conditions(
+                &mut rete,
+                &fact_base,
+                rule_id,
+                Salience::DEFAULT,
+                &[CompilableCondition::Ncc(vec![
+                    CompilableCondition::Pattern(pattern),
+                    CompilableCondition::Predicate { condition_index: 3 },
+                ])],
+            )
+            .unwrap();
+
+        let ncc_id = match rete.beta.get_node(result.terminal_node).unwrap() {
+            BetaNode::Terminal { parent, .. } => *parent,
+            other => panic!("expected terminal node, got {other:?}"),
+        };
+        let partner_id = match rete.beta.get_node(ncc_id).unwrap() {
+            BetaNode::Ncc { partner, .. } => *partner,
+            other => panic!("expected NCC node, got {other:?}"),
+        };
+        let predicate_id = match rete.beta.get_node(partner_id).unwrap() {
+            BetaNode::NccPartner { parent, .. } => *parent,
+            other => panic!("expected NCC partner, got {other:?}"),
+        };
+        assert!(matches!(
+            rete.beta.get_node(predicate_id),
+            Some(BetaNode::Predicate {
+                rule,
+                condition_index: 3,
+                ..
+            }) if *rule == rule_id
+        ));
     }
 
     #[test]

--- a/crates/ferric-rules-runtime/src/loader.rs
+++ b/crates/ferric-rules-runtime/src/loader.rs
@@ -2247,69 +2247,6 @@ impl Engine {
         }
     }
 
-    /// Desugar multi-pattern exists into individual patterns.
-    ///
-    /// `exists(P1, P2, ..., Pn)` is desugared to `P1, P2, ..., Pn-1, exists(Pn)`.
-    /// The inner patterns become regular joins and only the last is an exists join.
-    /// Single-element `And` wrappers inside exists are flattened: `And([P])` → `P`.
-    fn desugar_multi_pattern_exists(patterns: &[&Pattern]) -> Vec<Pattern> {
-        let mut result = Vec::new();
-        for pattern in patterns {
-            if let Pattern::Exists(sub_patterns, span) = pattern {
-                if sub_patterns.len() > 1 {
-                    // Flatten single-element Ands within the exists sub-patterns
-                    let flattened: Vec<Pattern> = sub_patterns
-                        .iter()
-                        .map(|p| {
-                            if let Pattern::And(children, _) = p {
-                                if children.len() == 1 {
-                                    return children[0].clone();
-                                }
-                            }
-                            p.clone()
-                        })
-                        .collect();
-
-                    // Choose a non-negated anchor for the existential join when
-                    // possible; this avoids constructing `exists(not(...))`
-                    // artifacts for mixed forms like:
-                    //   (exists A B (not ...))
-                    // which are better approximated as:
-                    //   A (not ...) (exists B)
-                    let anchor_idx = flattened
-                        .iter()
-                        .rposition(|p| !matches!(p, Pattern::Not(..)))
-                        .unwrap_or(flattened.len() - 1);
-
-                    for (idx, p) in flattened.iter().enumerate() {
-                        if idx != anchor_idx {
-                            result.push(p.clone());
-                        }
-                    }
-                    // Wrap the anchor in exists
-                    let anchor = flattened[anchor_idx].clone();
-                    result.push(Pattern::Exists(vec![anchor], *span));
-                    continue;
-                }
-
-                if let Some(Pattern::Exists(inner, inner_span)) = sub_patterns.first() {
-                    // Collapse redundant nesting so fixed-point passes can desugar
-                    // cases like (exists (exists A B C)).
-                    result.push(Pattern::Exists(inner.clone(), *inner_span));
-                    continue;
-                }
-            }
-            result.push((*pattern).clone());
-        }
-        result
-    }
-
-    fn has_top_level_multi_pattern_exists(patterns: &[Pattern]) -> bool {
-        patterns
-            .iter()
-            .any(|pattern| matches!(pattern, Pattern::Exists(sub, _) if sub.len() > 1))
-    }
-
     /// Try to extract test CEs from nested contexts (negation, NCC, exists)
     /// and add them as rule-level test conditions.
     ///
@@ -2917,24 +2854,7 @@ impl Engine {
             Self::flatten_pattern(pattern, &mut flat_patterns);
         }
 
-        // Desugar multi-pattern exists into individual patterns:
-        // exists(P1, P2, ..., Pn) → P1, P2, ..., Pn-1, exists(Pn)
-        // This makes the inner patterns regular joins and only the last is exists,
-        // approximating CLIPS' "at most one activation" semantics.
-        let mut desugared_patterns: Vec<Pattern> =
-            Self::desugar_multi_pattern_exists(&flat_patterns);
-        // Nested exists normalizations can leave multi-pattern `exists` CEs as
-        // newly emitted top-level patterns. Re-run the pass to fixed-point.
-        for _ in 0..32 {
-            if !Self::has_top_level_multi_pattern_exists(&desugared_patterns) {
-                break;
-            }
-            let refs: Vec<&Pattern> = desugared_patterns.iter().collect();
-            desugared_patterns = Self::desugar_multi_pattern_exists(&refs);
-        }
-        let pattern_refs: Vec<&Pattern> = desugared_patterns.iter().collect();
-
-        for pattern in &pattern_refs {
+        for pattern in &flat_patterns {
             // Test CEs do not consume a fact index. Their expressions are
             // retained in rule metadata and referenced by predicate nodes at
             // their source position in the beta network.
@@ -2999,10 +2919,13 @@ impl Engine {
             };
 
             let mut generated_tests = Vec::new();
+            let mut embedded_generated_tests = HashSet::new();
             let condition = self.translate_condition(
                 pattern,
                 &mut generated_tests,
                 &mut internal_slot_var_seed,
+                test_conditions.len(),
+                &mut embedded_generated_tests,
             )?;
             if matches!(
                 &condition,
@@ -3014,9 +2937,11 @@ impl Engine {
                         .to_string(),
                 ));
             }
-            if matches!(condition, CompilableCondition::Ncc(_)) && !generated_tests.is_empty() {
+            if matches!(condition, CompilableCondition::Ncc(_))
+                && generated_tests.len() != embedded_generated_tests.len()
+            {
                 return Err(LoadError::Compile(
-                    "test CEs inside mixed negated conjunctions are not supported at match time"
+                    "complex constraints inside NCC patterns are not supported at match time"
                         .to_string(),
                 ));
             }
@@ -3035,12 +2960,16 @@ impl Engine {
                 fact_index += 1;
             }
             conditions.push(condition);
-            for generated_test in generated_tests {
-                Self::push_test_predicate(
-                    &mut conditions,
-                    &mut test_conditions,
-                    CompiledTestCondition::Expr(generated_test),
-                )?;
+            for (generated_index, generated_test) in generated_tests.into_iter().enumerate() {
+                if embedded_generated_tests.contains(&generated_index) {
+                    test_conditions.push(CompiledTestCondition::Expr(generated_test));
+                } else {
+                    Self::push_test_predicate(
+                        &mut conditions,
+                        &mut test_conditions,
+                        CompiledTestCondition::Expr(generated_test),
+                    )?;
+                }
             }
         }
 
@@ -3113,11 +3042,17 @@ impl Engine {
         pattern: &Pattern,
         generated_tests: &mut Vec<crate::evaluator::RuntimeExpr>,
         internal_slot_var_seed: &mut usize,
+        test_condition_base: usize,
+        embedded_generated_tests: &mut HashSet<usize>,
     ) -> Result<CompilableCondition, LoadError> {
         match pattern {
-            Pattern::Assigned { pattern, .. } => {
-                self.translate_condition(pattern, generated_tests, internal_slot_var_seed)
-            }
+            Pattern::Assigned { pattern, .. } => self.translate_condition(
+                pattern,
+                generated_tests,
+                internal_slot_var_seed,
+                test_condition_base,
+                embedded_generated_tests,
+            ),
             Pattern::Not(inner, span) => {
                 match inner.as_ref() {
                     Pattern::And(inner_patterns, _) => {
@@ -3135,6 +3070,8 @@ impl Engine {
                                 sub,
                                 generated_tests,
                                 internal_slot_var_seed,
+                                test_condition_base,
+                                embedded_generated_tests,
                             )?;
                             subconditions.push(condition);
                         }
@@ -3150,6 +3087,8 @@ impl Engine {
                                 doubly_inner,
                                 generated_tests,
                                 internal_slot_var_seed,
+                                test_condition_base,
+                                embedded_generated_tests,
                             )
                         } else {
                             let mut compilable = self.translate_pattern(
@@ -3173,6 +3112,79 @@ impl Engine {
                         Ok(CompilableCondition::Pattern(compilable))
                     }
                 }
+            }
+            Pattern::Exists(sub_patterns, span) => {
+                if sub_patterns.is_empty() {
+                    return Err(Self::unsupported_pattern(
+                        "exists",
+                        span,
+                        "exists requires at least one inner pattern",
+                    ));
+                }
+
+                if sub_patterns.len() == 1
+                    && matches!(
+                        &sub_patterns[0],
+                        Pattern::Ordered(_) | Pattern::Template(_) | Pattern::Assigned { .. }
+                    )
+                {
+                    let mut compilable = self.translate_pattern(
+                        &sub_patterns[0],
+                        generated_tests,
+                        internal_slot_var_seed,
+                        false,
+                    )?;
+                    compilable.exists = true;
+                    return Ok(CompilableCondition::Pattern(compilable));
+                }
+
+                let mut tuple_conditions = Vec::new();
+                for sub_pattern in sub_patterns {
+                    match sub_pattern {
+                        Pattern::And(children, _) | Pattern::Logical(children, _) => {
+                            for child in children {
+                                tuple_conditions.push(self.translate_condition(
+                                    child,
+                                    generated_tests,
+                                    internal_slot_var_seed,
+                                    test_condition_base,
+                                    embedded_generated_tests,
+                                )?);
+                            }
+                        }
+                        _ => tuple_conditions.push(self.translate_condition(
+                            sub_pattern,
+                            generated_tests,
+                            internal_slot_var_seed,
+                            test_condition_base,
+                            embedded_generated_tests,
+                        )?),
+                    }
+                }
+
+                // An NCC emits one pass-through only while its tuple subnetwork
+                // has no complete results. Watching that NCC with a second NCC
+                // complements the condition: the outer token propagates exactly
+                // while one or more complete tuples exist. Both NCC memories are
+                // keyed by their owner token, so tuple support stays isolated per
+                // outer match and follows only zero/nonzero transitions.
+                Ok(CompilableCondition::Ncc(vec![
+                    CompilableCondition::Ncc(tuple_conditions),
+                ]))
+            }
+            Pattern::Test(sexpr, _) => {
+                let condition_index = test_condition_base
+                    .checked_add(generated_tests.len())
+                    .and_then(|index| u32::try_from(index).ok())
+                    .ok_or_else(|| {
+                        LoadError::Compile("too many test CEs in one rule".to_string())
+                    })?;
+                let runtime_expr =
+                    crate::evaluator::from_sexpr(sexpr, &mut self.symbol_table, &self.config)
+                        .map_err(|e| LoadError::Compile(format!("test CE translation: {e}")))?;
+                embedded_generated_tests.insert(generated_tests.len());
+                generated_tests.push(runtime_expr);
+                Ok(CompilableCondition::Predicate { condition_index })
             }
             Pattern::Forall(sub_patterns, span) => {
                 // Phase 3 restriction: exactly 2 sub-patterns (condition + then-clause).
@@ -4410,8 +4422,8 @@ fn validate_pattern_recursive(
             }
 
             // Check for unsupported combination: single-pattern exists containing not.
-            // Multi-pattern exists forms are desugared later, and mixed branches
-            // like `(exists A (not B))` are handled by that pass.
+            // Multi-pattern exists groups compile as a tuple subnetwork, where
+            // mixed branches like `(exists A (not B))` are supported.
             let enforce_exists_not_guard = inner_patterns.len() == 1;
             for inner in inner_patterns {
                 if enforce_exists_not_guard && matches!(inner, Pattern::Not(..)) {

--- a/crates/ferric-rules-runtime/src/phase3_integration_tests.rs
+++ b/crates/ferric-rules-runtime/src/phase3_integration_tests.rs
@@ -718,6 +718,413 @@ mod tests {
     }
 
     #[test]
+    fn fr_rete_006_exists_multiple_tuples_one_activation() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule joined
+                (exists (a ?x) (b ?x))
+                =>
+                (assert (found-join)))
+        ",
+        );
+
+        engine.assert_ordered("a", 1_i64).unwrap();
+        engine.assert_ordered("b", 1_i64).unwrap();
+        engine.assert_ordered("a", 2_i64).unwrap();
+        engine.assert_ordered("b", 2_i64).unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "complete inner tuples must collapse to one Boolean activation"
+        );
+        assert_rete_consistent(engine.rete());
+    }
+
+    #[test]
+    fn fr_rete_006_exists_partial_retract_keeps_activation() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule joined
+                (exists (a ?x) (b ?x))
+                =>
+                (assert (found-join)))
+        ",
+        );
+
+        engine.assert_ordered("a", 1_i64).unwrap();
+        let first_b = engine.assert_ordered("b", 1_i64).unwrap();
+        engine.assert_ordered("a", 2_i64).unwrap();
+        engine.assert_ordered("b", 2_i64).unwrap();
+        assert_eq!(engine.agenda_len(), 1);
+
+        engine.retract(first_b).unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "one remaining complete tuple must keep the activation alive"
+        );
+        assert_rete_consistent(engine.rete());
+    }
+
+    #[test]
+    fn fr_rete_006_exists_last_retract_removes_activation() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule joined
+                (exists (a ?x) (b ?x))
+                =>
+                (assert (found-join)))
+        ",
+        );
+
+        engine.assert_ordered("a", 1_i64).unwrap();
+        let first_b = engine.assert_ordered("b", 1_i64).unwrap();
+        engine.assert_ordered("a", 2_i64).unwrap();
+        let second_b = engine.assert_ordered("b", 2_i64).unwrap();
+        assert_eq!(engine.agenda_len(), 1);
+        engine.retract(first_b).unwrap();
+        assert_eq!(engine.agenda_len(), 1);
+
+        engine.retract(second_b).unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            0,
+            "the activation must retract with the final complete tuple"
+        );
+        assert_rete_consistent(engine.rete());
+    }
+
+    #[test]
+    fn fr_rete_006_exists_isolated_per_outer_token() {
+        use ferric_rules_core::Value;
+
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule joined
+                (outer ?owner)
+                (exists (a ?owner ?x) (b ?owner ?x))
+                =>
+                (assert (found-owner ?owner)))
+        ",
+        );
+
+        engine.assert_ordered("outer", 1_i64).unwrap();
+        engine.assert_ordered("outer", 2_i64).unwrap();
+        engine
+            .assert_ordered("a", [Value::Integer(1), Value::Integer(10)])
+            .unwrap();
+        let owner_one_first = engine
+            .assert_ordered("b", [Value::Integer(1), Value::Integer(10)])
+            .unwrap();
+        engine
+            .assert_ordered("a", [Value::Integer(1), Value::Integer(11)])
+            .unwrap();
+        let owner_one_second = engine
+            .assert_ordered("b", [Value::Integer(1), Value::Integer(11)])
+            .unwrap();
+        engine
+            .assert_ordered("a", [Value::Integer(2), Value::Integer(20)])
+            .unwrap();
+        engine
+            .assert_ordered("b", [Value::Integer(2), Value::Integer(20)])
+            .unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            2,
+            "each outer token must contribute at most one activation"
+        );
+        engine.retract(owner_one_first).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            2,
+            "one remaining owner-one tuple must preserve only that owner's activation"
+        );
+        engine.retract(owner_one_second).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "removing owner one's final tuple must not affect owner two"
+        );
+        assert_rete_consistent(engine.rete());
+    }
+
+    #[test]
+    fn fr_rete_006_exists_isolated_per_outer_token_after_reset() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (deffacts startup
+                (outer one)
+                (a one 10)
+                (b one 10)
+                (outer two)
+                (a two 20)
+                (b two 20))
+
+            (defrule joined
+                (outer ?owner)
+                (exists (a ?owner ?x) (b ?owner ?x))
+                =>
+                (assert (found-owner ?owner)))
+        ",
+        );
+
+        engine.reset().unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            2,
+            "reset-time support tuples must remain isolated per outer token"
+        );
+        assert_engine_consistent(&engine);
+    }
+
+    #[test]
+    fn fr_rete_006_template_exists_isolated_per_outer_token_after_reset() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (deftemplate sensor (slot id))
+            (deftemplate reading (slot sensor-id) (slot reading-id))
+            (deftemplate calibration (slot sensor-id) (slot reading-id))
+
+            (deffacts startup
+                (sensor (id one))
+                (reading (sensor-id one) (reading-id 10))
+                (calibration (sensor-id one) (reading-id 10))
+                (sensor (id two))
+                (reading (sensor-id two) (reading-id 20))
+                (calibration (sensor-id two) (reading-id 20)))
+
+            (defrule joined
+                (sensor (id ?owner))
+                (exists
+                    (reading (sensor-id ?owner) (reading-id ?reading))
+                    (calibration (sensor-id ?owner) (reading-id ?reading)))
+                =>
+                (assert (ready ?owner)))
+        ",
+        );
+
+        engine.reset().unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            2,
+            "template support tuples must remain isolated per outer token"
+        );
+        let run = run_to_completion(&mut engine);
+        assert_eq!(
+            run.rules_fired, 2,
+            "firing one outer activation must not invalidate another"
+        );
+        assert_engine_consistent(&engine);
+    }
+
+    #[test]
+    fn fr_rete_006_exists_nested_join_variant() {
+        use ferric_rules_core::Value;
+
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule chained
+                (exists (a ?x) (b ?x ?y) (c ?y))
+                =>
+                (assert (found-chain)))
+        ",
+        );
+
+        engine.assert_ordered("a", 1_i64).unwrap();
+        engine
+            .assert_ordered("b", [Value::Integer(1), Value::Integer(10)])
+            .unwrap();
+        engine.assert_ordered("c", 10_i64).unwrap();
+        engine.assert_ordered("a", 2_i64).unwrap();
+        engine
+            .assert_ordered("b", [Value::Integer(2), Value::Integer(20)])
+            .unwrap();
+        engine.assert_ordered("c", 20_i64).unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "multiple chained join results must collapse to one activation"
+        );
+        assert_rete_consistent(engine.rete());
+    }
+
+    #[test]
+    fn fr_rete_006_exists_tuple_test_filters_before_boolean_collapse() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule filtered
+                (exists
+                    (a ?x)
+                    (test (> ?x 1))
+                    (b ?x))
+                =>
+                (assert (found-filtered-join)))
+        ",
+        );
+
+        engine.assert_ordered("a", 1_i64).unwrap();
+        engine.assert_ordered("b", 1_i64).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            0,
+            "a complete tuple that fails its test must not support exists"
+        );
+
+        engine.assert_ordered("a", 2_i64).unwrap();
+        let second_b = engine.assert_ordered("b", 2_i64).unwrap();
+        engine.assert_ordered("a", 3_i64).unwrap();
+        let third_b = engine.assert_ordered("b", 3_i64).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "passing tuples must still collapse to one activation"
+        );
+
+        engine.retract(second_b).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "one remaining tuple that passes its test must preserve the activation"
+        );
+        engine.retract(third_b).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            0,
+            "the activation must retract with the final passing tuple"
+        );
+        assert_engine_consistent(&engine);
+    }
+
+    #[test]
+    fn fr_rete_006_nested_exists_preserves_tuple_scope() {
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule nested
+                (exists
+                    (a ?x)
+                    (exists (b ?x) (c ?x)))
+                =>
+                (assert (found-nested)))
+        ",
+        );
+
+        engine.assert_ordered("a", 1_i64).unwrap();
+        engine.assert_ordered("b", 1_i64).unwrap();
+        engine.assert_ordered("c", 1_i64).unwrap();
+        engine.assert_ordered("a", 2_i64).unwrap();
+        engine.assert_ordered("b", 2_i64).unwrap();
+        engine.assert_ordered("c", 2_i64).unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "nested exists groups must remain Boolean at every level"
+        );
+        assert_rete_consistent(engine.rete());
+    }
+
+    #[test]
+    fn fr_rete_006_exists_handles_online_compile_and_reset() {
+        let mut engine = new_utf8_engine();
+        engine.assert_ordered("a", 1_i64).unwrap();
+        engine.assert_ordered("b", 1_i64).unwrap();
+        engine.assert_ordered("a", 2_i64).unwrap();
+        engine.assert_ordered("b", 2_i64).unwrap();
+
+        load_ok(
+            &mut engine,
+            r"
+            (defrule joined
+                (exists (a ?x) (b ?x))
+                =>
+                (assert (found-join)))
+        ",
+        );
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "online compilation must collapse existing support tuples"
+        );
+        assert_engine_consistent(&engine);
+
+        engine.reset().unwrap();
+        assert_eq!(engine.agenda_len(), 0);
+        engine.assert_ordered("a", 3_i64).unwrap();
+        engine.assert_ordered("b", 3_i64).unwrap();
+        engine.assert_ordered("a", 4_i64).unwrap();
+        engine.assert_ordered("b", 4_i64).unwrap();
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "reset must clear old owners and preserve Boolean cardinality"
+        );
+        assert_engine_consistent(&engine);
+    }
+
+    #[test]
+    fn fr_rete_006_supported_outer_retract_cleans_owner_state() {
+        use ferric_rules_core::Value;
+
+        let mut engine = new_utf8_engine();
+        load_ok(
+            &mut engine,
+            r"
+            (defrule joined
+                (outer ?owner)
+                (exists (a ?owner ?x) (b ?owner ?x))
+                =>
+                (assert (found-owner ?owner)))
+        ",
+        );
+
+        let outer_one = engine.assert_ordered("outer", 1_i64).unwrap();
+        engine.assert_ordered("outer", 2_i64).unwrap();
+        for (owner, value) in [(1, 10), (1, 11), (2, 20)] {
+            engine
+                .assert_ordered("a", [Value::Integer(owner), Value::Integer(value)])
+                .unwrap();
+            engine
+                .assert_ordered("b", [Value::Integer(owner), Value::Integer(value)])
+                .unwrap();
+        }
+        assert_eq!(engine.agenda_len(), 2);
+
+        engine.retract(outer_one).unwrap();
+
+        assert_eq!(
+            engine.agenda_len(),
+            1,
+            "retracting a supported parent must remove only its owned activation"
+        );
+        assert_engine_consistent(&engine);
+    }
+
+    #[test]
     fn nested_function_call_in_rhs_evaluates() {
         let mut engine = new_utf8_engine();
         load_ok(

--- a/crates/ferric-rules/benches/exists_bench.rs
+++ b/crates/ferric-rules/benches/exists_bench.rs
@@ -43,6 +43,52 @@ fn generate_exists_source(n_sensors: usize, m_readings: usize) -> String {
     source
 }
 
+/// Multi-pattern exists benchmark: scales complete support tuples per outer token.
+///
+/// Each sensor owns M reading/calibration pairs. Every pair completes the
+/// existential tuple subnetwork, while the terminal must still receive exactly
+/// one activation per sensor.
+fn generate_tuple_exists_source(n_sensors: usize, m_support_tuples: usize) -> String {
+    let mut source = String::from(
+        "\
+(deftemplate sensor (slot id))
+(deftemplate reading (slot sensor-id) (slot reading-id))
+(deftemplate calibration (slot sensor-id) (slot reading-id))
+
+(deffacts setup\n",
+    );
+
+    for sensor in 0..n_sensors {
+        writeln!(source, "    (sensor (id s{sensor}))").unwrap();
+        for support in 0..m_support_tuples {
+            writeln!(
+                source,
+                "    (reading (sensor-id s{sensor}) (reading-id r{support}))"
+            )
+            .unwrap();
+            writeln!(
+                source,
+                "    (calibration (sensor-id s{sensor}) (reading-id r{support}))"
+            )
+            .unwrap();
+        }
+    }
+
+    source.push_str(
+        ")
+
+(defrule sensor-ready
+    (sensor (id ?sid))
+    (exists
+        (reading (sensor-id ?sid) (reading-id ?rid))
+        (calibration (sensor-id ?sid) (reading-id ?rid)))
+    =>
+    (assert (ready ?sid)))
+",
+    );
+    source
+}
+
 fn bench_exists_10s_5r(c: &mut Criterion) {
     let source = generate_exists_source(10, 5);
     c.bench_function("exists_10s_5r", |b| {
@@ -136,6 +182,29 @@ fn bench_exists_10s_5r_run_only(c: &mut Criterion) {
     });
 }
 
+fn bench_tuple_exists_50s_50t(c: &mut Criterion) {
+    const SENSOR_COUNT: usize = 50;
+    let source = generate_tuple_exists_source(SENSOR_COUNT, 50);
+
+    let mut oracle = Engine::new(EngineConfig::utf8());
+    oracle.load_str(&source).unwrap();
+    oracle.reset().unwrap();
+    assert_eq!(
+        oracle.run(RunLimit::Unlimited).unwrap().rules_fired,
+        SENSOR_COUNT,
+        "tuple supports must collapse to one activation per sensor"
+    );
+
+    c.bench_function("tuple_exists_50s_50t", |b| {
+        b.iter(|| {
+            let mut engine = Engine::new(EngineConfig::utf8());
+            engine.load_str(&source).unwrap();
+            engine.reset().unwrap();
+            engine.run(RunLimit::Unlimited).unwrap()
+        });
+    });
+}
+
 criterion_group!(
     benches,
     bench_exists_10s_5r,
@@ -145,5 +214,6 @@ criterion_group!(
     bench_exists_500s_100r,
     bench_exists_1000s_50r,
     bench_exists_10s_5r_run_only,
+    bench_tuple_exists_50s_50t,
 );
 criterion_main!(benches);

--- a/crates/ferric-rules/tests/clips_compat.rs
+++ b/crates/ferric-rules/tests/clips_compat.rs
@@ -829,6 +829,26 @@ fn fr_rete_005_clips_double_not_existential_transition_fixture() {
     );
 }
 
+#[test]
+fn fr_rete_006_clips_multi_pattern_exists_transition_fixture() {
+    // Pinned against the repository's CLIPS 6.30 reference image. Complete
+    // joined tuples are Boolean support for the whole exists CE, so only one
+    // "one" line appears and partial tuple retraction preserves the match.
+    let _ = assert_fixture_output(
+        "core/multi_pattern_exists_transitions.clp",
+        5,
+        "zero\none\ntwo\npartial\nzero-again\n",
+    );
+}
+
+#[test]
+fn fr_rete_006_clips_multi_pattern_exists_nested_join_fixture() {
+    // Pinned against the repository's CLIPS 6.30 reference image. The test CE
+    // participates in each three-pattern tuple before both complete tuples
+    // collapse to one existential activation.
+    let _ = assert_fixture_output("core/multi_pattern_exists_nested_join.clp", 1, "nested\n");
+}
+
 /// Multi-pattern join: a rule with two patterns joined by a shared variable.
 #[test]
 fn test_compat_core_multi_pattern_join() {

--- a/crates/ferric-rules/tests/fixtures/core/multi_pattern_exists_nested_join.clp
+++ b/crates/ferric-rules/tests/fixtures/core/multi_pattern_exists_nested_join.clp
@@ -1,0 +1,22 @@
+; Nested multi-pattern exists join pinned against CLIPS 6.30.
+;
+; Two complete three-pattern tuples satisfy the existential CE, but the rule
+; must still receive exactly one activation. The tuple-local test is evaluated
+; before the existential result is collapsed to Boolean support.
+
+(deffacts startup
+    (a one)
+    (b one 10)
+    (c 10)
+    (a two)
+    (b two 20)
+    (c 20))
+
+(defrule nested-join
+    (exists
+        (a ?x)
+        (b ?x ?y)
+        (test (> ?y 0))
+        (c ?y))
+    =>
+    (printout t "nested" crlf))

--- a/crates/ferric-rules/tests/fixtures/core/multi_pattern_exists_transitions.clp
+++ b/crates/ferric-rules/tests/fixtures/core/multi_pattern_exists_transitions.clp
@@ -1,0 +1,56 @@
+; Multi-pattern exists transitions pinned against CLIPS 6.30.
+;
+; One complete inner tuple makes the existential rule true. Adding a second
+; tuple must not create another activation, retracting the first tuple must
+; preserve the match, and retracting the final tuple must make it false.
+
+(deffacts startup
+    (phase zero))
+
+(defrule zero-support
+    (declare (salience 100))
+    ?phase <- (phase zero)
+    =>
+    (printout t "zero" crlf)
+    (retract ?phase)
+    (assert (a one))
+    (assert (b one)))
+
+(defrule existential-match
+    (declare (salience 80))
+    (exists (a ?value) (b ?value))
+    =>
+    (printout t "one" crlf)
+    (assert (a two))
+    (assert (b two))
+    (assert (phase two)))
+
+(defrule two-supports
+    (declare (salience 60))
+    ?phase <- (phase two)
+    ?first-a <- (a one)
+    ?first-b <- (b one)
+    =>
+    (printout t "two" crlf)
+    (retract ?phase)
+    (retract ?first-a)
+    (retract ?first-b)
+    (assert (phase partial)))
+
+(defrule partial-support-retract
+    (declare (salience 40))
+    ?phase <- (phase partial)
+    ?last-a <- (a two)
+    ?last-b <- (b two)
+    =>
+    (printout t "partial" crlf)
+    (retract ?phase)
+    (retract ?last-a)
+    (retract ?last-b)
+    (assert (phase zero-again)))
+
+(defrule zero-support-again
+    (declare (salience 20))
+    (phase zero-again)
+    =>
+    (printout t "zero-again" crlf))

--- a/scripts/expected-ferric-rules-package-files.txt
+++ b/scripts/expected-ferric-rules-package-files.txt
@@ -33,6 +33,8 @@ tests/fixtures/core/halt_stops_execution.clp
 tests/fixtures/core/late_rule_backfill_prelude.clp
 tests/fixtures/core/late_rule_backfill_rules.clp
 tests/fixtures/core/modify_duplicate.clp
+tests/fixtures/core/multi_pattern_exists_nested_join.clp
+tests/fixtures/core/multi_pattern_exists_transitions.clp
 tests/fixtures/core/multi_pattern_join.clp
 tests/fixtures/core/multiple_activations_depth.clp
 tests/fixtures/core/refraction.clp


### PR DESCRIPTION
Closes #108

## Summary

- preserve multi-pattern `exists` as a tuple subnetwork and complement it through nested NCC nodes, so each outer token propagates only on zero/nonzero support transitions
- keep support ownership isolated per outer token and reuse NCC cleanup for partial support retraction, final support retraction, parent retraction, reset, and online compilation
- compile tuple-local `test` CEs inside NCC subnetworks so nested joins retain their local bindings instead of hoisting predicates out of scope
- add Rust lifecycle/isolation regressions, two CLIPS 6.30-pinned oracle fixtures, and a release Criterion workload with many complete support tuples per outer token

## Validation

- `just preflight-pr`
- `just scaling-check` (all 5 scaling checks passed)
- `cargo test -p ferric-rules-core -p ferric-rules-runtime`
- `cargo test -p ferric-rules --test clips_compat` (77 passed)
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo bench -p ferric-rules --bench exists_bench tuple_exists_50s_50t`
  - Criterion release median estimate: **10.933 ms** for 50 outer tokens × 50 complete support tuples on Apple M4 Max, Darwin arm64
  - correctness oracle verifies exactly 50 firings; this is a new workload, not an improvement claim
- CLIPS 6.30 oracle outputs pinned for both transition and nested-join fixtures
