### PR TITLE
[FR-RETE-007] Make rule installation failure-atomic

### DIFF
--- a/crates/ferric-rules-core/src/alpha.rs
+++ b/crates/ferric-rules-core/src/alpha.rs
@@ -355,6 +355,10 @@ impl AlphaNetwork {
         }
     }
 
+    pub(crate) fn structural_counts(&self) -> (usize, usize) {
+        (self.nodes.len(), self.memories.len())
+    }
+
     /// Get or create an entry node for a given entry type.
     ///
     /// Entry nodes are unique per entry type (idempotent).

--- a/crates/ferric-rules-core/src/beta.rs
+++ b/crates/ferric-rules-core/src/beta.rs
@@ -423,6 +423,22 @@ impl BetaNetwork {
         }
     }
 
+    pub(crate) fn structural_counts(&self) -> (usize, usize, usize, usize, usize) {
+        (
+            self.nodes.len(),
+            self.memories.len(),
+            self.neg_memories.len(),
+            self.ncc_memories.len(),
+            self.exists_memories.len(),
+        )
+    }
+
+    /// Iterate over all beta nodes and their IDs.
+    #[doc(hidden)]
+    pub fn iter_nodes(&self) -> impl Iterator<Item = (NodeId, &BetaNode)> {
+        self.nodes.iter().map(|(node_id, node)| (*node_id, node))
+    }
+
     /// Create a join node as a child of the given parent.
     ///
     /// Returns the new join node's ID and the ID of its associated beta memory.

--- a/crates/ferric-rules-core/src/compiler.rs
+++ b/crates/ferric-rules-core/src/compiler.rs
@@ -72,6 +72,25 @@ pub struct CompileResult {
     pub var_map: VarMap,
 }
 
+/// A fully validated rule installation that has not mutated a Rete network.
+///
+/// Planning owns every fallible structural input so installation can be a
+/// single infallible commit after runtime metadata is ready.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConditionCompilationPlan {
+    salience: Salience,
+    conditions: Vec<CompilableCondition>,
+    var_map: VarMap,
+}
+
+impl ConditionCompilationPlan {
+    /// Return the variable mapping prepared for this rule.
+    #[must_use]
+    pub fn var_map(&self) -> &VarMap {
+        &self.var_map
+    }
+}
+
 /// Errors from compilation.
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum CompileError {
@@ -225,6 +244,44 @@ impl ReteCompiler {
         let var_map = Self::prepare_var_map(conditions)?;
         Ok(self
             .compile_conditions_unchecked(rete, fact_base, rule_id, salience, conditions, var_map))
+    }
+
+    /// Validate and prepare conditional elements without mutating compiler or
+    /// network state.
+    pub fn plan_conditions(
+        &self,
+        salience: Salience,
+        conditions: Vec<CompilableCondition>,
+    ) -> Result<ConditionCompilationPlan, CompileError> {
+        Self::ensure_non_empty(&conditions)?;
+        Self::validate_conditions(&conditions)?;
+        let var_map = Self::prepare_var_map(&conditions)?;
+        Ok(ConditionCompilationPlan {
+            salience,
+            conditions,
+            var_map,
+        })
+    }
+
+    /// Install a previously validated condition plan.
+    ///
+    /// All validation and capacity checks occur in [`Self::plan_conditions`],
+    /// so this commit phase cannot return a partial-installation error.
+    pub fn install_condition_plan(
+        &mut self,
+        rete: &mut ReteNetwork,
+        fact_base: &FactBase,
+        rule_id: RuleId,
+        plan: ConditionCompilationPlan,
+    ) -> CompileResult {
+        self.compile_conditions_unchecked(
+            rete,
+            fact_base,
+            rule_id,
+            plan.salience,
+            &plan.conditions,
+            plan.var_map,
+        )
     }
 
     fn ensure_non_empty<T>(items: &[T]) -> Result<(), CompileError> {
@@ -2029,6 +2086,66 @@ mod tests {
                 ..
             }) if *rule == rule_id
         ));
+    }
+
+    #[test]
+    fn fr_rete_007_condition_planning_is_detached_until_install() {
+        let mut compiler = ReteCompiler::new();
+        let mut rete = ReteNetwork::new();
+        let fact_base = FactBase::new();
+        let mut table = new_table();
+        let baseline = rete.cardinality();
+        let pattern = CompilablePattern {
+            entry_type: AlphaEntryType::OrderedRelation(intern(&mut table, "item")),
+            constant_tests: vec![],
+            variable_slots: vec![],
+            negated_variable_slots: Vec::new(),
+            negated: false,
+            exists: false,
+        };
+
+        let plan = compiler
+            .plan_conditions(
+                Salience::DEFAULT,
+                vec![CompilableCondition::Pattern(pattern)],
+            )
+            .expect("valid plan");
+
+        assert_eq!(
+            rete.cardinality(),
+            baseline,
+            "planning must not mutate the network"
+        );
+        let rule_id = compiler.allocate_rule_id();
+        assert_eq!(rule_id, RuleId(1), "planning must not consume a rule ID");
+
+        let result = compiler.install_condition_plan(&mut rete, &fact_base, rule_id, plan);
+
+        assert_eq!(result.rule_id, rule_id);
+        assert!(rete.cardinality().beta_nodes > baseline.beta_nodes);
+        rete.debug_assert_consistency();
+    }
+
+    #[test]
+    fn fr_rete_007_rejected_condition_plan_is_non_mutating() {
+        let mut compiler = ReteCompiler::new();
+        let rete = ReteNetwork::new();
+        let baseline = rete.cardinality();
+
+        let error = compiler
+            .plan_conditions(
+                Salience::DEFAULT,
+                vec![CompilableCondition::Ncc(Vec::new())],
+            )
+            .unwrap_err();
+
+        assert!(matches!(error, CompileError::Validation(_)));
+        assert_eq!(rete.cardinality(), baseline);
+        assert_eq!(
+            compiler.allocate_rule_id(),
+            RuleId(1),
+            "failed planning must not consume a rule ID"
+        );
     }
 
     #[test]

--- a/crates/ferric-rules-core/src/lib.rs
+++ b/crates/ferric-rules-core/src/lib.rs
@@ -64,7 +64,7 @@ pub use beta::{
 pub use binding::{BindingSet, VarId, VarMap};
 pub use compiler::{
     CompilableCondition, CompilablePattern, CompilableRule, CompileError, CompileResult,
-    ReteCompiler,
+    ConditionCompilationPlan, ReteCompiler,
 };
 pub use encoding::{EncodingError, StringEncoding};
 pub use exists::{ExistsMemory, ExistsMemoryId};
@@ -74,7 +74,7 @@ pub use fact::{
 };
 pub use ncc::{NccMemory, NccMemoryId};
 pub use negative::{NegativeMemory, NegativeMemoryId};
-pub use rete::{PendingPredicateMatch, ReteNetwork};
+pub use rete::{PendingPredicateMatch, ReteCardinality, ReteNetwork};
 pub use strategy::ConflictResolutionStrategy;
 pub use string::FerricString;
 pub use symbol::{Symbol, SymbolTable};

--- a/crates/ferric-rules-core/src/rete.rs
+++ b/crates/ferric-rules-core/src/rete.rs
@@ -30,6 +30,23 @@ pub struct PendingPredicateMatch {
     pub condition_index: u32,
 }
 
+/// Structural and runtime cardinalities used to verify atomic Rete changes.
+#[doc(hidden)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReteCardinality {
+    pub alpha_nodes: usize,
+    pub alpha_memories: usize,
+    pub beta_nodes: usize,
+    pub beta_memories: usize,
+    pub negative_memories: usize,
+    pub ncc_memories: usize,
+    pub exists_memories: usize,
+    pub tokens: usize,
+    pub activations: usize,
+    pub pending_predicate_matches: usize,
+    pub disabled_rules: usize,
+}
+
 /// The complete Rete network.
 ///
 /// Combines alpha network (fact discrimination), beta network (joins),
@@ -76,6 +93,27 @@ impl ReteNetwork {
         };
         rete.seed_root_token();
         rete
+    }
+
+    /// Capture all network cardinalities affected by rule installation.
+    #[must_use]
+    pub fn cardinality(&self) -> ReteCardinality {
+        let (alpha_nodes, alpha_memories) = self.alpha.structural_counts();
+        let (beta_nodes, beta_memories, negative_memories, ncc_memories, exists_memories) =
+            self.beta.structural_counts();
+        ReteCardinality {
+            alpha_nodes,
+            alpha_memories,
+            beta_nodes,
+            beta_memories,
+            negative_memories,
+            ncc_memories,
+            exists_memories,
+            tokens: self.token_store.len(),
+            activations: self.agenda.len(),
+            pending_predicate_matches: self.pending_predicate_matches.len(),
+            disabled_rules: self.disabled_rules.len(),
+        }
     }
 
     /// Assert a fact into the Rete network.
@@ -339,6 +377,13 @@ impl ReteNetwork {
         let _ = self.agenda.remove_activations_for_rule(rule_id);
         self.pending_predicate_matches
             .retain(|pending| pending.rule != rule_id);
+    }
+
+    /// Return whether a rule's retained network nodes have been disabled.
+    #[must_use]
+    #[doc(hidden)]
+    pub fn is_rule_disabled(&self, rule_id: crate::beta::RuleId) -> bool {
+        self.disabled_rules.contains(&rule_id)
     }
 
     /// Pop the next runtime predicate evaluation requested by token propagation.

--- a/crates/ferric-rules-core/src/symbol.rs
+++ b/crates/ferric-rules-core/src/symbol.rs
@@ -43,6 +43,13 @@ pub struct SymbolTable {
     utf8_strings: Vec<Box<str>>,
 }
 
+/// An opaque rollback point for symbol interning.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SymbolTableCheckpoint {
+    ascii_len: usize,
+    utf8_len: usize,
+}
+
 impl SymbolTable {
     /// Create a new, empty symbol table.
     #[must_use]
@@ -52,6 +59,41 @@ impl SymbolTable {
             ascii_strings: Vec::new(),
             utf8_to_id: HashMap::default(),
             utf8_strings: Vec::new(),
+        }
+    }
+
+    /// Capture a rollback point without cloning existing interned strings.
+    #[must_use]
+    pub fn checkpoint(&self) -> SymbolTableCheckpoint {
+        SymbolTableCheckpoint {
+            ascii_len: self.ascii_strings.len(),
+            utf8_len: self.utf8_strings.len(),
+        }
+    }
+
+    /// Remove every symbol interned after `checkpoint`.
+    ///
+    /// Checkpoints may only be restored on the table that created them, before
+    /// any symbols from the discarded suffix are exposed to callers.
+    pub fn restore(&mut self, checkpoint: SymbolTableCheckpoint) {
+        assert!(
+            checkpoint.ascii_len <= self.ascii_strings.len()
+                && checkpoint.utf8_len <= self.utf8_strings.len(),
+            "symbol-table checkpoint is newer than the current table"
+        );
+        while self.ascii_strings.len() > checkpoint.ascii_len {
+            let symbol = self
+                .ascii_strings
+                .pop()
+                .expect("length check guarantees an ASCII symbol");
+            self.ascii_to_id.remove(symbol.as_ref());
+        }
+        while self.utf8_strings.len() > checkpoint.utf8_len {
+            let symbol = self
+                .utf8_strings
+                .pop()
+                .expect("length check guarantees a UTF-8 symbol");
+            self.utf8_to_id.remove(symbol.as_ref());
         }
     }
 
@@ -437,6 +479,32 @@ mod tests {
         let table = SymbolTable::new();
         assert!(table.is_empty());
         assert_eq!(table.len(), 0);
+    }
+
+    #[test]
+    fn checkpoint_restore_discards_only_new_symbols_from_both_pools() {
+        let mut table = SymbolTable::new();
+        let retained_ascii = table.intern_ascii(b"retained-ascii");
+        let retained_utf8 = table.intern_utf8("retained-utf8");
+        let checkpoint = table.checkpoint();
+        let discarded_ascii = table.intern_ascii(b"discarded-ascii");
+        let discarded_utf8 = table.intern_utf8("discarded-utf8");
+
+        table.restore(checkpoint);
+
+        assert_eq!(table.len(), 2);
+        assert_eq!(table.resolve(retained_ascii), b"retained-ascii");
+        assert_eq!(table.resolve_str(retained_utf8), Some("retained-utf8"));
+        assert_eq!(
+            table.intern_ascii(b"replacement-ascii"),
+            discarded_ascii,
+            "rollback must make the discarded ASCII ID reusable"
+        );
+        assert_eq!(
+            table.intern_utf8("replacement-utf8"),
+            discarded_utf8,
+            "rollback must make the discarded UTF-8 ID reusable"
+        );
     }
 
     #[test]

--- a/crates/ferric-rules-runtime/src/engine.rs
+++ b/crates/ferric-rules-runtime/src/engine.rs
@@ -302,6 +302,10 @@ impl Engine {
                 continue;
             };
             let Some(info) = rule_index_get(&self.rule_info, pending.rule).cloned() else {
+                self.action_diagnostics.push(ActionError::EvalError(format!(
+                    "internal invariant violation: predicate for rule {:?} has no executable metadata",
+                    pending.rule
+                )));
                 continue;
             };
             let Some(condition) = info.test_conditions.get(pending.condition_index as usize) else {
@@ -311,9 +315,14 @@ impl Engine {
                 )));
                 continue;
             };
-            let current_module = rule_index_get(&self.rule_modules, pending.rule)
-                .copied()
-                .unwrap_or_else(|| self.module_registry.main_module_id());
+            let Some(current_module) = rule_index_get(&self.rule_modules, pending.rule).copied()
+            else {
+                self.action_diagnostics.push(ActionError::EvalError(format!(
+                    "internal invariant violation: predicate for rule {:?} has no module metadata",
+                    pending.rule
+                )));
+                continue;
+            };
             let collected_facts = if info.multifield_tail_bindings.is_empty() {
                 smallvec::SmallVec::new()
             } else {
@@ -851,22 +860,29 @@ impl Engine {
     ) -> (bool, bool, bool, bool) {
         ferric_span!(debug_span, "fire_rule", rule = rule_id.0);
         let Some(token) = self.rete.token_store.get(token_id).cloned() else {
-            // No token — treat as not fired.
             ferric_event!(debug, rule = rule_id.0, token = ?token_id, "activation_missing_token");
-            return (false, false, false, false);
+            self.action_diagnostics.push(ActionError::EvalError(format!(
+                "internal invariant violation: activation for rule {rule_id:?} references missing token {token_id:?}"
+            )));
+            return (false, false, false, true);
         };
 
         // Clone the handle so we can pass both this rule and the full map to
         // action helpers without deep-cloning `CompiledRuleInfo`.
         let Some(info) = rule_index_get(&self.rule_info, rule_id).cloned() else {
-            // No compiled rule info — treat as not fired.
             ferric_event!(debug, rule = rule_id.0, "activation_missing_rule_info");
-            return (false, false, false, false);
+            self.action_diagnostics.push(ActionError::EvalError(format!(
+                "internal invariant violation: activation for rule {rule_id:?} has no executable metadata"
+            )));
+            return (false, false, false, true);
         };
 
-        let current_module = rule_index_get(&self.rule_modules, rule_id)
-            .copied()
-            .unwrap_or_else(|| self.module_registry.main_module_id());
+        let Some(current_module) = rule_index_get(&self.rule_modules, rule_id).copied() else {
+            self.action_diagnostics.push(ActionError::EvalError(format!(
+                "internal invariant violation: activation for rule {rule_id:?} has no module metadata"
+            )));
+            return (false, false, false, true);
+        };
 
         let collected_facts = self.rete.token_store.collect_all_facts(token_id);
 
@@ -928,10 +944,17 @@ impl Engine {
     fn pop_next_focus_activation(&mut self) -> Option<ferric_rules_core::Activation> {
         loop {
             let focus_module = self.module_registry.current_focus()?;
+            let rule_info = &self.rule_info;
             let rule_modules = &self.rule_modules;
 
             if let Some(activation) = self.rete.agenda.pop_matching(|a| {
-                rule_index_get(rule_modules, a.rule).copied() == Some(focus_module)
+                if rule_index_get(rule_info, a.rule).is_none() {
+                    return true;
+                }
+                match rule_index_get(rule_modules, a.rule) {
+                    Some(module) => *module == focus_module,
+                    None => true,
+                }
             }) {
                 return Some(activation);
             }
@@ -1368,6 +1391,7 @@ impl Engine {
     /// This extends rete consistency checks with Phase 3 registries
     /// (modules/focus, functions, globals, generics).
     #[cfg(any(test, debug_assertions))]
+    #[allow(clippy::too_many_lines)]
     pub fn debug_assert_consistency(&self) {
         use std::collections::HashSet;
         self.rete.debug_assert_consistency();
@@ -1375,6 +1399,17 @@ impl Engine {
         self.functions.debug_assert_consistency();
         self.globals.debug_assert_consistency();
         self.generics.debug_assert_consistency();
+
+        let rule_slot_count = self.rule_info.len().max(self.rule_modules.len());
+        for index in 0..rule_slot_count {
+            let info = self.rule_info.get(index).and_then(Option::as_ref);
+            let module = self.rule_modules.get(index).and_then(Option::as_ref);
+            assert_eq!(
+                info.is_some(),
+                module.is_some(),
+                "rule metadata/module presence differs at rule slot {index}"
+            );
+        }
 
         for (index, maybe_module_id) in self.rule_modules.iter().enumerate() {
             let Some(module_id) = maybe_module_id else {
@@ -1385,6 +1420,73 @@ impl Engine {
             assert!(
                 self.module_registry.get(*module_id).is_some(),
                 "rule {rule_id:?} points to unknown module {module_id:?}"
+            );
+        }
+
+        let mut rules_with_terminals = HashSet::new();
+        for (node_id, node) in self.rete.beta.iter_nodes() {
+            let (rule_id, condition_index) = match node {
+                ferric_rules_core::BetaNode::Predicate {
+                    rule,
+                    condition_index,
+                    ..
+                } => (*rule, Some(*condition_index)),
+                ferric_rules_core::BetaNode::Terminal { rule, .. } => {
+                    rules_with_terminals.insert(*rule);
+                    (*rule, None)
+                }
+                _ => continue,
+            };
+            if self.rete.is_rule_disabled(rule_id) {
+                continue;
+            }
+            let info = rule_index_get(&self.rule_info, rule_id).unwrap_or_else(|| {
+                panic!("active beta node {node_id:?} references rule {rule_id:?} without metadata")
+            });
+            assert!(
+                rule_index_get(&self.rule_modules, rule_id).is_some(),
+                "active beta node {node_id:?} references rule {rule_id:?} without module metadata"
+            );
+            if let Some(condition_index) = condition_index {
+                assert!(
+                    info.test_conditions
+                        .get(condition_index as usize)
+                        .is_some(),
+                    "predicate node {node_id:?} references missing condition {condition_index} for rule {rule_id:?}"
+                );
+            }
+        }
+
+        for (index, maybe_info) in self.rule_info.iter().enumerate() {
+            if maybe_info.is_none() {
+                continue;
+            }
+            #[allow(clippy::cast_possible_truncation)]
+            let rule_id = RuleId(index as u32);
+            assert!(
+                rules_with_terminals.contains(&rule_id),
+                "live rule {rule_id:?} has no terminal node"
+            );
+        }
+
+        for activation in self.rete.agenda.iter_activations() {
+            assert!(
+                self.rete.token_store.get(activation.token).is_some(),
+                "activation {:?} references missing token {:?}",
+                activation.id,
+                activation.token
+            );
+            assert!(
+                rule_index_get(&self.rule_info, activation.rule).is_some(),
+                "activation {:?} references rule {:?} without executable metadata",
+                activation.id,
+                activation.rule
+            );
+            assert!(
+                rule_index_get(&self.rule_modules, activation.rule).is_some(),
+                "activation {:?} references rule {:?} without module metadata",
+                activation.id,
+                activation.rule
             );
         }
 
@@ -2054,6 +2156,231 @@ mod tests {
             "future facts must not reach a failed rule installation"
         );
         assert_eq!(engine.rete.token_store.len(), baseline_tokens);
+    }
+
+    fn rule_install_state(
+        engine: &Engine,
+    ) -> (ferric_rules_core::ReteCardinality, usize, usize, usize) {
+        (
+            engine.rete.cardinality(),
+            engine.rule_info.len(),
+            engine.rule_modules.len(),
+            engine.symbol_table.len(),
+        )
+    }
+
+    const LATE_OR_FAILURE: &str = r"
+        (defrule broken-or
+            (or
+                (candidate ?x)
+                (missing-template (value ?x)))
+            =>
+            (assert (accepted ?x)))
+    ";
+
+    #[test]
+    fn fr_rete_007_bad_rhs_leaves_no_terminal() {
+        let mut engine = Engine::new(EngineConfig::ascii());
+        engine
+            .assert_ordered("initial-fact", Vec::<Value>::new())
+            .unwrap();
+        let baseline = rule_install_state(&engine);
+
+        let result = engine.load_str(
+            r#"
+            (defrule broken-rhs
+                (trigger ?x)
+                =>
+                (printout t "é" ?x crlf))
+            "#,
+        );
+
+        assert!(result.is_err(), "non-ASCII RHS must fail in ASCII mode");
+        assert_eq!(engine.rules(), Vec::<(&str, i32)>::new());
+        assert_eq!(
+            rule_install_state(&engine),
+            baseline,
+            "a rejected RHS must not expose any rule installation state"
+        );
+        engine.debug_assert_consistency();
+    }
+
+    #[test]
+    fn fr_rete_007_bad_rhs_cannot_create_activation_later() {
+        let mut engine = Engine::new(EngineConfig::ascii());
+        engine
+            .assert_ordered("initial-fact", Vec::<Value>::new())
+            .unwrap();
+        let result = engine.load_str(
+            r#"
+            (defrule broken-rhs
+                (trigger ?x)
+                =>
+                (printout t "é" ?x crlf))
+            "#,
+        );
+        assert!(result.is_err());
+        let baseline = engine.rete.cardinality();
+
+        engine.assert_ordered("trigger", 1_i64).unwrap();
+
+        let after_assert = engine.rete.cardinality();
+        assert_eq!(after_assert.beta_nodes, baseline.beta_nodes);
+        assert_eq!(after_assert.beta_memories, baseline.beta_memories);
+        assert_eq!(after_assert.tokens, baseline.tokens);
+        assert_eq!(after_assert.activations, 0);
+        let run = engine.run(RunLimit::Unlimited).unwrap();
+        assert_eq!(run.rules_fired, 0);
+        assert_eq!(run.halt_reason, HaltReason::AgendaEmpty);
+        engine.debug_assert_consistency();
+    }
+
+    #[test]
+    fn fr_rete_007_failed_compile_preserves_existing_rules() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .load_str(
+                r"
+                (defrule existing
+                    (good ?x)
+                    =>
+                    (assert (preserved ?x)))
+                ",
+            )
+            .unwrap();
+        let baseline = rule_install_state(&engine);
+        let existing_rules: Vec<(String, i32)> = engine
+            .rules()
+            .into_iter()
+            .map(|(name, salience)| (name.to_string(), salience))
+            .collect();
+
+        let result = engine.load_str(LATE_OR_FAILURE);
+
+        assert!(
+            result.is_err(),
+            "the second expanded branch must reject its unknown template"
+        );
+        assert_eq!(
+            engine.rules(),
+            existing_rules
+                .iter()
+                .map(|(name, salience)| (name.as_str(), *salience))
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            rule_install_state(&engine),
+            baseline,
+            "failure in a later expansion must roll back the whole source rule"
+        );
+
+        engine.assert_ordered("good", 7_i64).unwrap();
+        let run = engine.run(RunLimit::Unlimited).unwrap();
+        assert_eq!(run.rules_fired, 1);
+        assert!(engine
+            .facts()
+            .unwrap()
+            .any(|(_, fact)| matches!(fact, Fact::Ordered(ordered) if engine
+                .resolve_symbol(ordered.relation) == Some("preserved"))));
+        engine.debug_assert_consistency();
+    }
+
+    #[test]
+    fn fr_rete_007_repeated_failure_has_constant_network_size() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .assert_ordered("initial-fact", Vec::<Value>::new())
+            .unwrap();
+        let baseline = rule_install_state(&engine);
+
+        for attempt in 0..32 {
+            assert!(
+                engine.load_str(LATE_OR_FAILURE).is_err(),
+                "attempt {attempt} must fail"
+            );
+            assert_eq!(
+                rule_install_state(&engine),
+                baseline,
+                "attempt {attempt} leaked rule installation state"
+            );
+        }
+
+        engine.assert_ordered("candidate", 42_i64).unwrap();
+        assert_eq!(engine.agenda_len(), 0);
+        engine.debug_assert_consistency();
+    }
+
+    #[test]
+    fn fr_rete_007_failures_before_each_commit_phase_are_non_mutating() {
+        let mut engine = Engine::new(EngineConfig::ascii());
+        engine
+            .assert_ordered("initial-fact", Vec::<Value>::new())
+            .unwrap();
+        let baseline = rule_install_state(&engine);
+        let failures = [
+            // Action callable validation.
+            "(defrule bad-callable (x) => (missing-function))",
+            // LHS translation/template resolution.
+            "(defrule bad-lhs (missing-template (value ?x)) => (assert (x ?x)))",
+            // RHS translation/encoding.
+            "(defrule bad-rhs (x) => (printout t \"é\" crlf))",
+            // A late expanded variant after an earlier variant plans cleanly.
+            LATE_OR_FAILURE,
+        ];
+
+        for source in failures {
+            assert!(engine.load_str(source).is_err(), "{source} must fail");
+            assert_eq!(
+                rule_install_state(&engine),
+                baseline,
+                "failed phase leaked installation state for {source}"
+            );
+        }
+        engine.debug_assert_consistency();
+    }
+
+    #[test]
+    fn fr_rete_007_missing_activation_metadata_is_action_error() {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .load_str(
+                r"
+                (defmodule OTHER)
+                (defrule doomed (trigger) => (assert (should-not-run)))
+                ",
+            )
+            .unwrap();
+        engine
+            .assert_ordered("trigger", Vec::<Value>::new())
+            .unwrap();
+        let rule_id = engine
+            .rete
+            .agenda
+            .iter_activations()
+            .next()
+            .expect("activation")
+            .rule;
+        engine.rule_info[rule_id.0 as usize] = None;
+        assert_ne!(
+            engine.rule_modules[rule_id.0 as usize],
+            Some(engine.module_registry.current_focus().unwrap()),
+            "test requires an invalid activation outside the active focus"
+        );
+
+        let run = engine.run(RunLimit::Unlimited).unwrap();
+
+        assert_eq!(run.rules_fired, 0);
+        assert_eq!(run.halt_reason, HaltReason::ActionError);
+        assert_eq!(
+            engine.agenda_len(),
+            0,
+            "invalid activation must be consumed"
+        );
+        assert!(engine.action_diagnostics().iter().any(
+            |error| matches!(error, ActionError::EvalError(message)
+                if message.contains("internal invariant violation")
+                    && message.contains("no executable metadata"))
+        ));
     }
 
     #[test]

--- a/crates/ferric-rules-runtime/src/loader.rs
+++ b/crates/ferric-rules-runtime/src/loader.rs
@@ -27,9 +27,9 @@ use thiserror::Error;
 use crate::qualified_name::{parse_qualified_name, QualifiedName};
 
 use ferric_rules_core::{
-    AlphaEntryType, AtomKey, CompilableCondition, CompilablePattern, CompileResult, ConstantTest,
-    ConstantTestType, Fact, FactId, FerricString, JoinTestType, Salience, SlotIndex, TemplateFact,
-    Value,
+    AlphaEntryType, AtomKey, CompilableCondition, CompilablePattern, CompileResult,
+    ConditionCompilationPlan, ConstantTest, ConstantTestType, Fact, FactId, FerricString,
+    JoinTestType, Salience, SlotIndex, TemplateFact, Value,
 };
 use ferric_rules_parser::{
     interpret_constructs, parse_sexprs, ActionExpr, Atom, Constraint, Construct, FactBody,
@@ -55,6 +55,12 @@ struct TranslatedRule {
     test_conditions: Vec<CompiledTestCondition>,
     /// Action-time hints for trailing ordered multifield captures.
     multifield_tail_bindings: Vec<MultifieldTailBindingHint>,
+}
+
+struct PreparedRuleInstallation {
+    plan: ConditionCompilationPlan,
+    info: Rc<CompiledRuleInfo>,
+    module: crate::modules::ModuleId,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1375,15 +1381,36 @@ impl Engine {
         // N internal rules, each with one branch substituted. Multiple or CEs produce
         // the Cartesian product.
         let expanded_rules = Self::expand_or_patterns(&rule);
-        let mut last_result = None;
-
-        for variant in &expanded_rules {
-            let result = self.compile_single_rule(variant, source)?;
-            last_result = Some(result);
+        if expanded_rules.is_empty() {
+            return Err(LoadError::Compile("empty or-expansion".to_string()));
         }
 
-        // Return the last compile result (all variants share the same name/semantics)
-        last_result.ok_or_else(|| LoadError::Compile("empty or-expansion".to_string()))
+        // Translation interns symbols, so include that table in the detached
+        // planning transaction. No compiler, Rete, rule ID, or metadata state is
+        // touched until every expansion is ready to install.
+        let symbol_table_checkpoint = self.symbol_table.checkpoint();
+        let mut prepared_rules = Vec::with_capacity(expanded_rules.len());
+        for variant in &expanded_rules {
+            match self.prepare_single_rule(variant, source) {
+                Ok(prepared) => prepared_rules.push(prepared),
+                Err(error) => {
+                    self.symbol_table.restore(symbol_table_checkpoint);
+                    return Err(error);
+                }
+            }
+        }
+
+        // Every operation from this point through installation is infallible.
+        // Return the last result because all expansions share source semantics.
+        let mut installed = prepared_rules.into_iter();
+        let first = installed
+            .next()
+            .expect("non-empty expansion must produce a prepared rule");
+        let mut last_result = self.install_prepared_rule(first);
+        for prepared in installed {
+            last_result = self.install_prepared_rule(prepared);
+        }
+        Ok(last_result)
     }
 
     fn validate_rule_action_callables(
@@ -1788,11 +1815,11 @@ impl Engine {
         )
     }
 
-    fn compile_single_rule(
+    fn prepare_single_rule(
         &mut self,
         rule: &RuleConstruct,
         source: &str,
-    ) -> Result<CompileResult, LoadError> {
+    ) -> Result<PreparedRuleInstallation, LoadError> {
         self.validate_rule_action_callables(rule, self.module_registry.current_module())?;
 
         // Translate the LHS first to preserve source-order symbol interning, but
@@ -1816,17 +1843,9 @@ impl Engine {
             runtime_actions.push(Some(runtime_expr));
         }
 
-        let rule_id = self.compiler.allocate_rule_id();
-
-        let compile_result = self
+        let plan = self
             .compiler
-            .compile_conditions(
-                &mut self.rete,
-                &self.fact_base,
-                rule_id,
-                translated.salience,
-                &translated.conditions,
-            )
+            .plan_conditions(translated.salience, translated.conditions)
             .map_err(|e| LoadError::Compile(format!("{e}")))?;
 
         let source_definition = source
@@ -1840,26 +1859,37 @@ impl Engine {
             name: rule.name.clone(),
             source_definition,
             actions: rule.actions.clone(),
-            var_map: compile_result.var_map.clone(),
+            var_map: plan.var_map().clone(),
             fact_address_vars: translated.fact_address_vars,
             salience: Salience::new(rule.salience),
             test_conditions: translated.test_conditions,
             runtime_actions,
             multifield_tail_bindings: translated.multifield_tail_bindings,
         };
-        crate::engine::rule_index_insert(
-            &mut self.rule_info,
-            compile_result.rule_id,
-            Rc::new(info),
-        );
-        crate::engine::rule_index_insert(
-            &mut self.rule_modules,
-            compile_result.rule_id,
-            self.module_registry.current_module(),
+        Ok(PreparedRuleInstallation {
+            plan,
+            info: Rc::new(info),
+            module: self.module_registry.current_module(),
+        })
+    }
+
+    fn install_prepared_rule(&mut self, prepared: PreparedRuleInstallation) -> CompileResult {
+        let rule_id = self.compiler.allocate_rule_id();
+
+        // Publish executable metadata before network initialization can produce
+        // a predicate candidate or terminal activation for this rule.
+        crate::engine::rule_index_insert(&mut self.rule_info, rule_id, prepared.info);
+        crate::engine::rule_index_insert(&mut self.rule_modules, rule_id, prepared.module);
+
+        let compile_result = self.compiler.install_condition_plan(
+            &mut self.rete,
+            &self.fact_base,
+            rule_id,
+            prepared.plan,
         );
         self.drain_pending_predicate_matches();
 
-        Ok(compile_result)
+        compile_result
     }
 
     fn push_test_predicate(


### PR DESCRIPTION
Closes #109

## Root cause

Rule compilation committed each expanded `or` branch independently. Although prior work moved RHS translation ahead of an individual branch's Rete mutation, a later branch could still fail after an earlier branch had installed nodes, tokens, activations, rule metadata, and consumed a rule ID. The focus-aware agenda path also silently skipped activations whose executable metadata was absent.

## What changed

- split core condition compilation into a detached, fallible planning phase and an infallible installation phase
- prepare every expansion of one source rule before committing any expansion
- checkpoint and roll back symbol interning on preparation failure without cloning the full symbol table
- publish rule/module metadata before online network initialization can produce predicate candidates or terminal activations
- surface missing activation metadata as an internal invariant diagnostic and `ActionError`, including when the corrupt activation belongs to an unfocused module
- extend engine consistency checks across live rule metadata, terminal/predicate nodes, agenda activations, modules, and tokens
- add network-cardinality diagnostics and FR-RETE-007 regressions for RHS failure, later assertions, preservation of existing rules, repeated failures, phase-by-phase failures, and corrupt activations

## Impact

An error while compiling any expansion of an individual rule now leaves that rule's external metadata, symbol state, rule-ID sequence, and full Rete cardinalities unchanged. Future facts cannot reach failed artifacts, and invalid agenda entries can no longer masquerade as an empty agenda.

## Validation

- `cargo test -p ferric-rules-core fr_rete_007 --no-fail-fast`
- `cargo test -p ferric-rules-runtime fr_rete_007 --no-fail-fast`
- `cargo clippy -p ferric-rules-core -p ferric-rules-runtime --all-targets --all-features -- -D warnings`
- `just scaling-check`
- `just preflight-pr`