### PR TITLE
[FR-ROBUST-001] Bound S-expression nesting

### DIFF
--- a/crates/ferric-rules-parser/src/error.rs
+++ b/crates/ferric-rules-parser/src/error.rs
@@ -73,6 +73,8 @@ pub enum ParseErrorKind {
     UnclosedParen,
     /// Closing parenthesis without matching opening parenthesis.
     UnexpectedCloseParen,
+    /// S-expression list nesting exceeded the supported safety limit.
+    NestingDepthExceeded,
 }
 
 define_diagnostic_error!(

--- a/crates/ferric-rules-parser/src/lib.rs
+++ b/crates/ferric-rules-parser/src/lib.rs
@@ -44,7 +44,7 @@ pub mod stage2;
 pub use error::{LexError, ParseError, ParseErrorKind};
 pub use lexer::{lex, SpannedToken, Token};
 pub use qualified_name::{parse_qualified_name, QualifiedName};
-pub use sexpr::{parse_sexprs, Atom, Connective, ParseResult, SExpr};
+pub use sexpr::{parse_sexprs, Atom, Connective, ParseResult, SExpr, MAX_SEXPR_NESTING_DEPTH};
 pub use span::{FileId, Position, Span};
 pub use stage2::{
     interpret_constructs, Action, ActionExpr, Constraint, Construct, DefaultValue, FactBody,

--- a/crates/ferric-rules-parser/src/sexpr.rs
+++ b/crates/ferric-rules-parser/src/sexpr.rs
@@ -4,6 +4,15 @@ use crate::error::{ParseError, ParseErrorKind};
 use crate::lexer::{lex, SpannedToken, Token};
 use crate::span::{FileId, Span};
 
+/// Maximum supported nesting depth for S-expression lists.
+///
+/// A top-level list has depth 1. Atoms outside lists have depth 0. Parsing is
+/// iterative at every depth, but this limit also keeps downstream Stage 2
+/// interpretation, typed AST construction, and destruction within a safe stack
+/// budget. The parser runs in O(source bytes + tokens) time and memory, while
+/// its open-list stack is bounded by this value.
+pub const MAX_SEXPR_NESTING_DEPTH: usize = 64;
+
 /// An S-expression: either an atom or a list.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -47,6 +56,39 @@ impl SExpr {
         match self {
             Self::Atom(Atom::Symbol(s), _) => Some(s),
             _ => None,
+        }
+    }
+
+    pub(crate) fn nesting_depth_violation(&self) -> Option<(usize, Span)> {
+        let mut pending = vec![(self, 0_usize)];
+        while let Some((expr, parent_depth)) = pending.pop() {
+            let Self::List(items, span) = expr else {
+                continue;
+            };
+            let depth = parent_depth + 1;
+            if depth > MAX_SEXPR_NESTING_DEPTH {
+                return Some((depth, *span));
+            }
+            pending.extend(items.iter().rev().map(|item| (item, depth)));
+        }
+        None
+    }
+}
+
+impl Drop for SExpr {
+    fn drop(&mut self) {
+        let Self::List(items, _) = self else {
+            return;
+        };
+
+        // Detach descendants before ordinary enum drop glue can recurse through
+        // them. Each popped list is emptied before it is dropped, so stack use
+        // remains constant even for programmatically constructed hostile trees.
+        let mut pending = std::mem::take(items);
+        while let Some(mut expr) = pending.pop() {
+            if let Self::List(children, _) = &mut expr {
+                pending.append(children);
+            }
         }
     }
 }
@@ -169,6 +211,11 @@ struct Parser {
     errors: Vec<ParseError>,
 }
 
+struct ListFrame {
+    items: Vec<SExpr>,
+    start_span: Span,
+}
+
 impl Parser {
     fn new(tokens: Vec<SpannedToken>) -> Self {
         Self {
@@ -180,29 +227,60 @@ impl Parser {
 
     fn parse_all(mut self) -> ParseResult {
         let mut exprs = Vec::new();
+        let mut frames: Vec<ListFrame> = Vec::new();
 
         while self.position < self.tokens.len() {
-            match self.parse_expr() {
-                Some(expr) => exprs.push(expr),
-                None => {
-                    // Error recovery: skip unexpected tokens
-                    if let Some(token) = self.current() {
-                        if matches!(token.token, Token::RightParen) {
-                            self.errors.push(ParseError::new(
-                                "unexpected closing parenthesis",
-                                token.span,
-                                ParseErrorKind::UnexpectedCloseParen,
-                            ));
-                            self.position += 1;
-                        } else {
-                            // Should not happen in normal cases
-                            self.position += 1;
-                        }
+            let token = self.current().expect("position is in bounds");
+            match token.token {
+                Token::LeftParen => {
+                    if frames.len() == MAX_SEXPR_NESTING_DEPTH {
+                        let depth = frames.len() + 1;
+                        self.errors.push(ParseError::new(
+                            nesting_depth_message(depth),
+                            token.span,
+                            ParseErrorKind::NestingDepthExceeded,
+                        ));
+                        self.skip_current_list();
                     } else {
-                        break;
+                        let start_span = token.span;
+                        self.position += 1;
+                        frames.push(ListFrame {
+                            items: Vec::new(),
+                            start_span,
+                        });
                     }
                 }
+                Token::RightParen => {
+                    let end_span = token.span;
+                    self.position += 1;
+                    if let Some(frame) = frames.pop() {
+                        let expr = build_list_expr(frame.items, frame.start_span, end_span);
+                        append_expr(expr, &mut frames, &mut exprs);
+                    } else {
+                        self.errors.push(ParseError::new(
+                            "unexpected closing parenthesis",
+                            end_span,
+                            ParseErrorKind::UnexpectedCloseParen,
+                        ));
+                    }
+                }
+                _ => {
+                    let expr = self
+                        .parse_atom()
+                        .expect("non-parenthesis token must parse as an atom");
+                    append_expr(expr, &mut frames, &mut exprs);
+                }
             }
+        }
+
+        while let Some(frame) = frames.pop() {
+            self.errors.push(ParseError::new(
+                "unclosed parenthesis",
+                frame.start_span,
+                ParseErrorKind::UnclosedParen,
+            ));
+            let expr = SExpr::List(frame.items, frame.start_span);
+            append_expr(expr, &mut frames, &mut exprs);
         }
 
         ParseResult {
@@ -215,23 +293,12 @@ impl Parser {
         self.tokens.get(self.position)
     }
 
-    fn advance(&mut self) -> Option<&SpannedToken> {
-        if self.position < self.tokens.len() {
-            let token = &self.tokens[self.position];
-            self.position += 1;
-            Some(token)
-        } else {
-            None
-        }
-    }
-
-    fn parse_expr(&mut self) -> Option<SExpr> {
+    fn parse_atom(&mut self) -> Option<SExpr> {
         let (atom, span) = {
             let token = self.current()?;
             let span = token.span;
             let atom = match &token.token {
-                Token::LeftParen => return self.parse_list(),
-                Token::RightParen => return None, // Handled by caller
+                Token::LeftParen | Token::RightParen => return None,
                 Token::Integer(n) => Atom::Integer(*n),
                 Token::Float(f) => Atom::Float(*f),
                 Token::String(s) => Atom::String(s.clone()),
@@ -249,45 +316,39 @@ impl Parser {
             (atom, span)
         };
 
-        self.advance();
+        self.position += 1;
         Some(SExpr::Atom(atom, span))
     }
 
-    fn parse_list(&mut self) -> Option<SExpr> {
-        let open_token = self.current()?;
-        debug_assert!(matches!(open_token.token, Token::LeftParen));
-        let start_span = open_token.span;
-        self.advance();
-
-        let mut items = Vec::new();
-
-        loop {
-            if let Some(token) = self.current() {
-                if matches!(token.token, Token::RightParen) {
-                    let end_span = token.span;
-                    self.advance();
-                    return Some(build_list_expr(items, start_span, end_span));
+    fn skip_current_list(&mut self) {
+        debug_assert!(matches!(
+            self.current().map(|token| &token.token),
+            Some(Token::LeftParen)
+        ));
+        let mut depth = 0_usize;
+        while let Some(token) = self.current() {
+            match token.token {
+                Token::LeftParen => depth += 1,
+                Token::RightParen => {
+                    depth -= 1;
+                    self.position += 1;
+                    if depth == 0 {
+                        return;
+                    }
+                    continue;
                 }
-            } else {
-                // EOF without closing paren
-                self.errors.push(ParseError::new(
-                    "unclosed parenthesis",
-                    start_span,
-                    ParseErrorKind::UnclosedParen,
-                ));
-                return Some(SExpr::List(items, start_span));
+                _ => {}
             }
-
-            if let Some(expr) = self.parse_expr() {
-                items.push(expr);
-            } else {
-                // Unexpected token; caller handles recovery.
-                break;
-            }
+            self.position += 1;
         }
+    }
+}
 
-        // Should not reach here in normal cases
-        Some(SExpr::List(items, start_span))
+fn append_expr(expr: SExpr, frames: &mut [ListFrame], roots: &mut Vec<SExpr>) {
+    if let Some(parent) = frames.last_mut() {
+        parent.items.push(expr);
+    } else {
+        roots.push(expr);
     }
 }
 
@@ -295,12 +356,27 @@ fn build_list_expr(items: Vec<SExpr>, start_span: Span, end_span: Span) -> SExpr
     SExpr::List(items, start_span.merge(end_span))
 }
 
+pub(crate) fn nesting_depth_message(depth: usize) -> String {
+    format!("S-expression nesting depth {depth} exceeds maximum of {MAX_SEXPR_NESTING_DEPTH}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const EXTREME_NESTING_DEPTH: usize = 50_000;
+    const SMALL_TEST_STACK_BYTES: usize = 64 * 1024;
+
     fn file() -> FileId {
         FileId(0)
+    }
+
+    fn nested_list_source(depth: usize) -> String {
+        let mut source = String::with_capacity(depth.saturating_mul(2).saturating_add(1));
+        source.extend(std::iter::repeat('(').take(depth));
+        source.push('x');
+        source.extend(std::iter::repeat(')').take(depth));
+        source
     }
 
     #[test]
@@ -469,6 +545,102 @@ mod tests {
         let result = parse_sexprs("(a (b (c (d))))", file());
         assert!(result.errors.is_empty());
         assert_eq!(result.exprs.len(), 1);
+    }
+
+    #[test]
+    fn fr_robust_001_parser_nesting_boundaries() {
+        for depth in [1, MAX_SEXPR_NESTING_DEPTH - 1, MAX_SEXPR_NESTING_DEPTH] {
+            let result = parse_sexprs(&nested_list_source(depth), file());
+            assert!(
+                result.errors.is_empty(),
+                "depth {depth} must be accepted: {:?}",
+                result.errors
+            );
+            assert_eq!(result.exprs.len(), 1);
+        }
+
+        let rejected_depth = MAX_SEXPR_NESTING_DEPTH + 1;
+        let result = parse_sexprs(&nested_list_source(rejected_depth), file());
+        assert_eq!(result.errors.len(), 1);
+        let error = &result.errors[0];
+        assert_eq!(error.kind, ParseErrorKind::NestingDepthExceeded);
+        assert_eq!(
+            error.message,
+            nesting_depth_message(rejected_depth),
+            "the public-boundary diagnostic must remain stable"
+        );
+        assert_eq!(error.span.start.line, 1);
+        assert_eq!(
+            error.span.start.column as usize, rejected_depth,
+            "diagnostic must point at the first disallowed opening parenthesis"
+        );
+    }
+
+    #[test]
+    fn fr_robust_001_extreme_unclosed_nesting_has_bounded_errors() {
+        let result = parse_sexprs(&"(".repeat(EXTREME_NESTING_DEPTH), file());
+
+        assert_eq!(
+            result.errors.len(),
+            MAX_SEXPR_NESTING_DEPTH + 1,
+            "one depth error plus one error per retained open-list frame"
+        );
+        assert_eq!(result.errors[0].kind, ParseErrorKind::NestingDepthExceeded);
+        assert_eq!(
+            result.errors[0].message,
+            nesting_depth_message(MAX_SEXPR_NESTING_DEPTH + 1)
+        );
+        assert!(result.errors[1..]
+            .iter()
+            .all(|error| error.kind == ParseErrorKind::UnclosedParen));
+    }
+
+    #[test]
+    fn fr_robust_001_extreme_parse_and_drop_survive_small_stack_subprocess() {
+        const CHILD_ENV: &str = "FERRIC_ROBUST_001_SMALL_STACK_CHILD";
+        const TEST_NAME: &str =
+            "sexpr::tests::fr_robust_001_extreme_parse_and_drop_survive_small_stack_subprocess";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            std::thread::Builder::new()
+                .name("fr-robust-001-small-stack".to_string())
+                .stack_size(SMALL_TEST_STACK_BYTES)
+                .spawn(|| {
+                    let result = parse_sexprs(&nested_list_source(EXTREME_NESTING_DEPTH), file());
+                    assert_eq!(result.errors.len(), 1);
+                    assert_eq!(result.errors[0].kind, ParseErrorKind::NestingDepthExceeded);
+                    assert_eq!(
+                        result.errors[0].message,
+                        nesting_depth_message(MAX_SEXPR_NESTING_DEPTH + 1)
+                    );
+
+                    // Exercise destruction independently of the parser limit.
+                    // Public SExpr values can be built programmatically, so drop
+                    // itself must not recurse through an adversarial tree.
+                    let mut expr =
+                        SExpr::Atom(Atom::Symbol("leaf".to_string()), result.errors[0].span);
+                    for _ in 0..EXTREME_NESTING_DEPTH {
+                        expr = SExpr::List(vec![expr], result.errors[0].span);
+                    }
+                    drop(expr);
+                })
+                .expect("small-stack thread must start")
+                .join()
+                .expect("small-stack parser/drop thread must not panic");
+            return;
+        }
+
+        let status =
+            std::process::Command::new(std::env::current_exe().expect("current test executable"))
+                .args(["--exact", TEST_NAME, "--nocapture"])
+                .env(CHILD_ENV, "1")
+                .status()
+                .expect("isolated parser test subprocess must start");
+
+        assert!(
+            status.success(),
+            "extreme nesting must not abort the isolated subprocess: {status}"
+        );
     }
 
     #[test]

--- a/crates/ferric-rules-parser/src/stage2.rs
+++ b/crates/ferric-rules-parser/src/stage2.rs
@@ -16,7 +16,7 @@
 //! - `deffunction` and `defglobal` interpretation (Pass 005).
 //! - Add interpretation for `defmodule`, `defgeneric`, `defmethod`.
 
-use crate::sexpr::{Atom, Connective, SExpr};
+use crate::sexpr::{nesting_depth_message, Atom, Connective, SExpr};
 use crate::span::Span;
 use std::fmt;
 
@@ -512,6 +512,8 @@ pub enum InterpretErrorKind {
     MissingElement,
     /// Invalid construct structure.
     InvalidStructure,
+    /// S-expression list nesting exceeded the shared parser safety limit.
+    NestingDepthExceeded,
 }
 
 impl InterpretError {
@@ -576,6 +578,17 @@ impl InterpretError {
             suggestions: Vec::new(),
         }
     }
+
+    /// Creates an error for an S-expression that exceeds the shared nesting
+    /// safety limit.
+    pub fn nesting_depth_exceeded(depth: usize, span: Span) -> Self {
+        Self {
+            message: nesting_depth_message(depth),
+            span,
+            kind: InterpretErrorKind::NestingDepthExceeded,
+            suggestions: vec!["reduce S-expression list nesting".to_string()],
+        }
+    }
 }
 
 impl fmt::Display for InterpretError {
@@ -620,6 +633,20 @@ pub fn interpret_constructs(sexprs: &[SExpr], config: &InterpreterConfig) -> Int
     let mut result = InterpretResult::default();
 
     for sexpr in sexprs {
+        // Stage 2 is also a public boundary for callers that construct or
+        // deserialize S-expression trees without using Stage 1. Validate
+        // iteratively before any recursive interpretation or typed AST clone.
+        if let Some((depth, span)) = sexpr.nesting_depth_violation() {
+            if push_interpret_error(
+                &mut result,
+                config,
+                InterpretError::nesting_depth_exceeded(depth, span),
+            ) {
+                return result;
+            }
+            continue;
+        }
+
         // Each top-level element must be a list
         let Some(list) = sexpr.as_list() else {
             if push_interpret_error(
@@ -3030,12 +3057,97 @@ fn edit_distance(a: &str, b: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::sexpr::parse_sexprs;
+    use crate::sexpr::{parse_sexprs, MAX_SEXPR_NESTING_DEPTH};
     use crate::span::FileId;
     use proptest::prelude::*;
 
     fn file() -> FileId {
         FileId(0)
+    }
+
+    fn maximum_depth_action_construct() -> String {
+        let action_depth = MAX_SEXPR_NESTING_DEPTH - 1;
+        let mut source = String::from("(deffunction depth-safe () ");
+        for _ in 0..action_depth {
+            source.push_str("(+ 1 ");
+        }
+        source.push('1');
+        source.extend(std::iter::repeat(')').take(action_depth));
+        source.push(')');
+        source
+    }
+
+    #[test]
+    fn fr_robust_001_stage2_rejects_programmatic_over_limit_tree() {
+        let mut parsed = parse_sexprs("leaf", file());
+        let mut expr = parsed.exprs.pop().expect("leaf expression");
+        let span = expr.span();
+        for _ in 0..=MAX_SEXPR_NESTING_DEPTH {
+            expr = SExpr::List(vec![expr], span);
+        }
+
+        let result = interpret_constructs(&[expr], &InterpreterConfig::default());
+
+        assert!(result.constructs.is_empty());
+        assert_eq!(result.errors.len(), 1);
+        assert_eq!(
+            result.errors[0].kind,
+            InterpretErrorKind::NestingDepthExceeded
+        );
+        assert_eq!(
+            result.errors[0].message,
+            nesting_depth_message(MAX_SEXPR_NESTING_DEPTH + 1)
+        );
+    }
+
+    #[test]
+    fn fr_robust_001_stage2_maximum_depth_parses_and_drops_on_small_stack() {
+        const CHILD_ENV: &str = "FERRIC_ROBUST_001_STAGE2_SMALL_STACK_CHILD";
+        const TEST_NAME: &str =
+            "stage2::tests::fr_robust_001_stage2_maximum_depth_parses_and_drops_on_small_stack";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            std::thread::Builder::new()
+                .name("fr-robust-001-stage2-stack".to_string())
+                // Rust's debug-build Stage 2 frames are substantially larger
+                // than optimized frames. One MiB remains deliberately small
+                // relative to common multi-megabyte native thread stacks.
+                .stack_size(1024 * 1024)
+                .spawn(|| {
+                    let parsed = parse_sexprs(&maximum_depth_action_construct(), file());
+                    assert!(
+                        parsed.errors.is_empty(),
+                        "documented maximum must parse: {:?}",
+                        parsed.errors
+                    );
+                    let interpreted =
+                        interpret_constructs(&parsed.exprs, &InterpreterConfig::default());
+                    assert!(
+                        interpreted.errors.is_empty(),
+                        "documented maximum must interpret: {:?}",
+                        interpreted.errors
+                    );
+                    assert_eq!(interpreted.constructs.len(), 1);
+                    drop(interpreted);
+                    drop(parsed);
+                })
+                .expect("small-stack Stage 2 thread must start")
+                .join()
+                .expect("maximum-depth Stage 2 thread must not panic");
+            return;
+        }
+
+        let status =
+            std::process::Command::new(std::env::current_exe().expect("current test executable"))
+                .args(["--exact", TEST_NAME, "--nocapture"])
+                .env(CHILD_ENV, "1")
+                .status()
+                .expect("isolated Stage 2 test subprocess must start");
+
+        assert!(
+            status.success(),
+            "maximum-depth Stage 2 work must not abort the isolated subprocess: {status}"
+        );
     }
 
     /// Strategy that produces valid CLIPS identifiers: a letter followed by up to 10

--- a/crates/ferric-rules-runtime/src/loader.rs
+++ b/crates/ferric-rules-runtime/src/loader.rs
@@ -4551,6 +4551,119 @@ mod tests {
         ferric_rules_parser::Span::new(pos, pos, FileId(0))
     }
 
+    fn parser_depth_nested_list_source(depth: usize) -> String {
+        let mut source = String::with_capacity(depth.saturating_mul(2).saturating_add(1));
+        source.extend(std::iter::repeat('(').take(depth));
+        source.push('x');
+        source.extend(std::iter::repeat(')').take(depth));
+        source
+    }
+
+    fn parser_depth_action_rule(action_depth: usize) -> String {
+        let mut source = String::from("(defrule depth-action (trigger) => ");
+        for _ in 0..action_depth {
+            source.push_str("(+ 1 ");
+        }
+        source.push('1');
+        source.extend(std::iter::repeat(')').take(action_depth));
+        source.push(')');
+        source
+    }
+
+    fn parser_depth_conditional_rule(not_depth: usize) -> String {
+        let mut source = String::from("(defrule depth-ce ");
+        for _ in 0..not_depth {
+            source.push_str("(not ");
+        }
+        source.push_str("(leaf)");
+        source.extend(std::iter::repeat(')').take(not_depth));
+        source.push_str(" => (assert (ok)))");
+        source
+    }
+
+    #[test]
+    fn parser_depth_accepts_documented_maximum_action() {
+        let action_depth = ferric_rules_parser::MAX_SEXPR_NESTING_DEPTH - 1;
+        let mut engine = new_utf8_engine();
+
+        let result = engine.load_str(&parser_depth_action_rule(action_depth));
+
+        assert!(
+            result.is_ok(),
+            "an action at the documented maximum must load: {result:?}"
+        );
+        assert_eq!(engine.rules().len(), 1);
+    }
+
+    #[test]
+    fn parser_depth_rejects_maximum_plus_one_actions_and_conditional_elements() {
+        let rejected_action =
+            parser_depth_action_rule(ferric_rules_parser::MAX_SEXPR_NESTING_DEPTH);
+        let rejected_ce =
+            parser_depth_conditional_rule(ferric_rules_parser::MAX_SEXPR_NESTING_DEPTH);
+
+        for source in [rejected_action, rejected_ce] {
+            let mut engine = new_utf8_engine();
+            let errors = engine
+                .load_str(&source)
+                .expect_err("maximum plus one must be rejected");
+            assert_eq!(errors.len(), 1, "diagnostics must remain bounded");
+            assert!(matches!(
+                &errors[0],
+                LoadError::Parse(error)
+                    if error.kind == ferric_rules_parser::ParseErrorKind::NestingDepthExceeded
+                        && error.message
+                            == format!(
+                                "S-expression nesting depth {} exceeds maximum of {}",
+                                ferric_rules_parser::MAX_SEXPR_NESTING_DEPTH + 1,
+                                ferric_rules_parser::MAX_SEXPR_NESTING_DEPTH
+                            )
+            ));
+        }
+    }
+
+    #[test]
+    fn parser_depth_extreme_is_bounded_in_small_stack_subprocess() {
+        const CHILD_ENV: &str = "FERRIC_ROBUST_001_RUNTIME_SMALL_STACK_CHILD";
+        const TEST_NAME: &str =
+            "loader::tests::parser_depth_extreme_is_bounded_in_small_stack_subprocess";
+
+        if std::env::var_os(CHILD_ENV).is_some() {
+            std::thread::Builder::new()
+                .name("fr-robust-001-runtime-stack".to_string())
+                .stack_size(64 * 1024)
+                .spawn(|| {
+                    let mut engine = new_utf8_engine();
+                    let errors = engine
+                        .load_str(&parser_depth_nested_list_source(50_000))
+                        .expect_err("extreme nesting must be rejected");
+                    assert_eq!(errors.len(), 1);
+                    assert!(matches!(
+                        &errors[0],
+                        LoadError::Parse(error)
+                            if error.kind
+                                == ferric_rules_parser::ParseErrorKind::NestingDepthExceeded
+                    ));
+                })
+                .expect("small-stack runtime thread must start")
+                .join()
+                .expect("small-stack runtime load must not panic");
+            return;
+        }
+
+        let status =
+            std::process::Command::new(std::env::current_exe().expect("current test executable"))
+                .args(["--exact", TEST_NAME, "--nocapture"])
+                .env(CHILD_ENV, "1")
+                .status()
+                .expect("isolated runtime test subprocess must start");
+
+        assert!(
+            status.success(),
+            "extreme runtime input must not abort the isolated subprocess: {status}"
+        );
+    }
+
     #[test]
     fn load_empty_string_returns_empty_result() {
         let mut engine = new_utf8_engine();

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -334,6 +334,20 @@ A few rules of thumb:
   is rejected. If you need an inequality test inside an NCC, derive a
   helper fact that captures the predicate and reference it instead.
 
+### Parser nesting limit
+
+Ferric accepts at most 64 nested S-expression lists at every rule-source
+boundary. A top-level list has depth 1; an atom outside a list has depth 0.
+Depth 64 parses, interprets, and drops normally. The opening parenthesis at
+depth 65 is rejected with a source-located
+`S-expression nesting depth 65 exceeds maximum of 64` diagnostic.
+
+Parsing is linear in the source byte/token count. Tokens and accepted syntax
+trees use linear memory, while the open-list parser stack is capped at 64
+frames. This makes extreme balanced or unbalanced nesting reject without
+native-stack growth; applications do not need process isolation merely to
+protect against deeply parenthesized rule source.
+
 ---
 
 ## 6. RHS actions: modify, retract, duplicate, bind


### PR DESCRIPTION
Closes #110.

## What changed

- replace recursive S-expression parsing with an iterative, frame-bounded parser
- accept at most 64 nested lists and return a stable, source-located diagnostic at depth 65
- validate programmatically constructed or deserialized `SExpr` trees at the Stage 2 public boundary
- make `SExpr` destruction iterative so hostile programmatic trees do not recurse through drop glue
- cover empty, boundary, maximum-plus-one, 50,000-level balanced and unbalanced inputs, nested actions/conditional elements, and small-stack parse/interpret/drop paths
- document the public limit and linear time/memory behavior

## Why

The parser previously descended recursively for every opening parenthesis. Public, adversarial rule input could therefore exhaust the process stack before Ferric could return a diagnostic. Public `SExpr` construction also left deep-tree destruction vulnerable to the same failure mode.

## User impact

Depth 64 continues to parse and load. The first list at depth 65 is rejected at its opening parenthesis with:

```
S-expression nesting depth 65 exceeds maximum of 64
```

Extreme balanced or unbalanced nesting now terminates with bounded diagnostics rather than overflowing or hanging, including on a 64 KiB parser/runtime test stack. Stage 2 maximum-depth interpretation is also exercised on a deliberately small 1 MiB debug-build stack.

## Validation

- `just preflight-pr`
- `just scaling-check`
- `cargo test -p ferric-rules-parser --all-features -- --nocapture`
- `cargo test -p ferric-rules-runtime --all-features --lib`
- `cargo test -p ferric-rules-runtime parser_depth -- --nocapture`
- strict Clippy for parser and runtime with all features/targets
- release CLI `check`: depth 64 succeeds; 50,000 levels exits cleanly with the stable `1:65` diagnostic

`cargo fuzz run parser -- -runs=100000` is not runnable in this checkout because the workspace currently has no fuzz package or fuzz target. The dedicated fuzz-harness work is tracked separately by #165.