### PR TITLE
[FR-ROBUST-002] Share one action loop iteration budget

### DIFF
--- a/crates/ferric-rules-runtime/src/actions.rs
+++ b/crates/ferric-rules-runtime/src/actions.rs
@@ -32,8 +32,6 @@ use crate::Engine;
 type OrderedFields = smallvec::SmallVec<[Value; 8]>;
 type RuntimeBindingEnv = HashMap<String, Value>;
 
-/// Maximum iterations for action-level loops (while, loop-for-count, progn$).
-const MAX_ACTION_LOOP_ITERATIONS: usize = 1_000_000;
 /// Internal callable emitted by parser for compact fact-slot references (`?f:slot`).
 const FACT_SLOT_REF_FN: &str = "__fact_slot_ref";
 
@@ -430,6 +428,7 @@ pub(crate) fn execute_actions(
     context: &mut ActionExecutionContext<'_>,
     collected_facts: &[FactId],
 ) -> (bool, bool, bool, Vec<ActionError>) {
+    context.engine.config.begin_action_loop_budget();
     ferric_span!(
         debug_span,
         "execute_actions",
@@ -518,6 +517,7 @@ pub(crate) fn execute_actions(
         clear_requested,
         "execute_actions_complete"
     );
+    context.engine.config.end_action_loop_budget();
     (true, reset_requested, clear_requested, errors)
 }
 
@@ -947,10 +947,11 @@ fn execute_single_action(
             };
 
             if let Some(crate::evaluator::RuntimeExpr::While {
-                condition, body, ..
+                condition,
+                body,
+                span,
             }) = while_runtime
             {
-                let mut iterations = 0usize;
                 loop {
                     // Evaluate condition.
                     let cond_value = {
@@ -960,12 +961,12 @@ fn execute_single_action(
                     if !crate::evaluator::is_truthy(&cond_value, &context.engine.symbol_table) {
                         break;
                     }
-                    iterations += 1;
-                    if iterations > MAX_ACTION_LOOP_ITERATIONS {
-                        return Err(ActionError::EvalError(format!(
-                            "while loop exceeded maximum iterations ({MAX_ACTION_LOOP_ITERATIONS})"
-                        )));
-                    }
+                    crate::evaluator::consume_action_loop_iteration(
+                        &context.engine.config,
+                        "while",
+                        span.clone(),
+                    )
+                    .map_err(ActionError::from)?;
                     // Execute body items.
                     execute_loop_body(
                         reset_requested,
@@ -1037,6 +1038,12 @@ fn execute_single_action(
                 };
 
                 for counter in start_int..=end_int {
+                    crate::evaluator::consume_action_loop_iteration(
+                        &context.engine.config,
+                        "loop-for-count",
+                        span.clone(),
+                    )
+                    .map_err(ActionError::from)?;
                     // Build an augmented token and rule_info with the loop variable bound.
                     let (loop_token, loop_rule_info) = if let Some(var) = var_name {
                         augment_bindings_with_var(
@@ -1065,7 +1072,6 @@ fn execute_single_action(
                         break;
                     }
                 }
-                let _ = span; // suppress unused variable warning
                 Ok(())
             } else if let Some(runtime_expr) = runtime_call {
                 eval_env

--- a/crates/ferric-rules-runtime/src/config.rs
+++ b/crates/ferric-rules-runtime/src/config.rs
@@ -4,9 +4,13 @@ use std::cell::Cell;
 
 use ferric_rules_core::{ConflictResolutionStrategy, StringEncoding};
 
+/// Default number of `while` and `loop-for-count` iterations allowed while
+/// executing one rule activation.
+pub const DEFAULT_MAX_ACTION_LOOP_ITERATIONS: usize = 1_000_000;
+
 /// Engine configuration.
 ///
-/// Includes encoding mode, conflict resolution strategy, and recursion limits.
+/// Includes encoding mode, conflict resolution strategy, and execution limits.
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EngineConfig {
@@ -17,12 +21,32 @@ pub struct EngineConfig {
     /// Calls that exceed this depth return a `RecursionLimit` error rather than
     /// overflowing the stack.
     pub max_call_depth: usize,
+    /// Maximum combined `while` and `loop-for-count` iterations per rule
+    /// activation.
+    ///
+    /// The budget is shared by RHS loops and loops reached through
+    /// deffunctions or generic functions. Each entered loop body consumes one
+    /// iteration, including nested loop bodies.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default = "default_max_action_loop_iterations")
+    )]
+    pub max_action_loop_iterations: usize,
     /// Whether structurally equivalent facts may coexist in working memory.
     ///
     /// This is interior-mutable because evaluator contexts already borrow the
     /// engine configuration immutably. `Engine` is thread-affine, so mutation
     /// through `Cell` does not weaken its concurrency contract.
     fact_duplication: Cell<bool>,
+    /// Remaining iterations in the current action execution, or `None` when
+    /// no action/evaluator root owns a budget.
+    #[cfg_attr(feature = "serde", serde(skip, default))]
+    action_loop_iterations_remaining: Cell<Option<usize>>,
+}
+
+#[cfg(feature = "serde")]
+const fn default_max_action_loop_iterations() -> usize {
+    DEFAULT_MAX_ACTION_LOOP_ITERATIONS
 }
 
 impl EngineConfig {
@@ -33,7 +57,9 @@ impl EngineConfig {
             string_encoding: StringEncoding::Ascii,
             strategy: ConflictResolutionStrategy::default(),
             max_call_depth: 64,
+            max_action_loop_iterations: DEFAULT_MAX_ACTION_LOOP_ITERATIONS,
             fact_duplication: Cell::new(false),
+            action_loop_iterations_remaining: Cell::new(None),
         }
     }
 
@@ -44,7 +70,9 @@ impl EngineConfig {
             string_encoding: StringEncoding::Utf8,
             strategy: ConflictResolutionStrategy::default(),
             max_call_depth: 64,
+            max_action_loop_iterations: DEFAULT_MAX_ACTION_LOOP_ITERATIONS,
             fact_duplication: Cell::new(false),
+            action_loop_iterations_remaining: Cell::new(None),
         }
     }
 
@@ -55,7 +83,9 @@ impl EngineConfig {
             string_encoding: StringEncoding::AsciiSymbolsUtf8Strings,
             strategy: ConflictResolutionStrategy::default(),
             max_call_depth: 64,
+            max_action_loop_iterations: DEFAULT_MAX_ACTION_LOOP_ITERATIONS,
             fact_duplication: Cell::new(false),
+            action_loop_iterations_remaining: Cell::new(None),
         }
     }
 
@@ -85,6 +115,43 @@ impl EngineConfig {
     pub(crate) fn set_fact_duplication(&self, enabled: bool) -> bool {
         self.fact_duplication.replace(enabled)
     }
+
+    /// Start a fresh per-action loop budget.
+    pub(crate) fn begin_action_loop_budget(&self) {
+        self.action_loop_iterations_remaining
+            .set(Some(self.max_action_loop_iterations));
+    }
+
+    /// Start a loop budget only when no enclosing action/evaluation owns one.
+    ///
+    /// Returns whether this call started the budget.
+    pub(crate) fn begin_action_loop_budget_if_inactive(&self) -> bool {
+        if self.action_loop_iterations_remaining.get().is_some() {
+            false
+        } else {
+            self.begin_action_loop_budget();
+            true
+        }
+    }
+
+    /// Finish the active per-action loop budget.
+    pub(crate) fn end_action_loop_budget(&self) {
+        self.action_loop_iterations_remaining.set(None);
+    }
+
+    /// Consume one iteration, returning `false` when the active budget is
+    /// exhausted.
+    pub(crate) fn take_action_loop_iteration(&self) -> bool {
+        let Some(remaining) = self.action_loop_iterations_remaining.get() else {
+            debug_assert!(false, "loop iteration consumed without an active budget");
+            return false;
+        };
+        let Some(next) = remaining.checked_sub(1) else {
+            return false;
+        };
+        self.action_loop_iterations_remaining.set(Some(next));
+        true
+    }
 }
 
 impl Default for EngineConfig {
@@ -99,7 +166,9 @@ impl From<StringEncoding> for EngineConfig {
             string_encoding,
             strategy: ConflictResolutionStrategy::default(),
             max_call_depth: 64,
+            max_action_loop_iterations: DEFAULT_MAX_ACTION_LOOP_ITERATIONS,
             fact_duplication: Cell::new(false),
+            action_loop_iterations_remaining: Cell::new(None),
         }
     }
 }
@@ -147,6 +216,14 @@ mod tests {
         assert_eq!(encoding, StringEncoding::AsciiSymbolsUtf8Strings);
     }
 
+    #[test]
+    fn default_action_loop_budget_is_one_million() {
+        assert_eq!(
+            EngineConfig::default().max_action_loop_iterations,
+            DEFAULT_MAX_ACTION_LOOP_ITERATIONS
+        );
+    }
+
     // -----------------------------------------------------------------------
     // Property-based tests
     // -----------------------------------------------------------------------
@@ -182,7 +259,7 @@ mod tests {
                 prop_assert_eq!(recovered, enc);
             }
 
-            /// `with_strategy` preserves the encoding and max_call_depth.
+            /// `with_strategy` preserves the encoding and execution limits.
             #[test]
             fn with_strategy_preserves_other_fields(
                 enc in arb_encoding(),
@@ -190,10 +267,15 @@ mod tests {
             ) {
                 let base = EngineConfig::from(enc);
                 let original_depth = base.max_call_depth;
+                let original_loop_budget = base.max_action_loop_iterations;
                 let modified = base.with_strategy(strategy);
                 prop_assert_eq!(modified.string_encoding, enc);
                 prop_assert_eq!(modified.strategy, strategy);
                 prop_assert_eq!(modified.max_call_depth, original_depth);
+                prop_assert_eq!(
+                    modified.max_action_loop_iterations,
+                    original_loop_budget
+                );
             }
 
             /// Named constructors always produce the advertised encoding.
@@ -206,6 +288,10 @@ mod tests {
                 };
                 prop_assert_eq!(config.string_encoding, expected);
                 prop_assert_eq!(config.max_call_depth, 64);
+                prop_assert_eq!(
+                    config.max_action_loop_iterations,
+                    DEFAULT_MAX_ACTION_LOOP_ITERATIONS
+                );
             }
         }
     }

--- a/crates/ferric-rules-runtime/src/evaluator.rs
+++ b/crates/ferric-rules-runtime/src/evaluator.rs
@@ -104,6 +104,13 @@ pub enum EvalError {
         span: Option<SourceSpan>,
     },
 
+    #[error("action iteration limit exceeded in `{function}` (limit {limit}) at {}", format_span(.span.as_ref()))]
+    ActionIterationLimit {
+        function: String,
+        limit: usize,
+        span: Option<SourceSpan>,
+    },
+
     #[error("no applicable method for `{name}` with argument types ({actual_types}) at {}", format_span(.span.as_ref()))]
     NoApplicableMethod {
         name: String,
@@ -133,16 +140,6 @@ pub enum EvalError {
         span: Option<SourceSpan>,
     },
 }
-
-// ---------------------------------------------------------------------------
-// Loop safety cap
-// ---------------------------------------------------------------------------
-
-/// Maximum number of loop iterations before an error is raised.
-///
-/// Applies to `while` loops and `loop-for-count` ranges. Prevents infinite
-/// loops and overly large iteration counts from hanging the engine.
-const MAX_LOOP_ITERATIONS: usize = 1_000_000;
 
 // ---------------------------------------------------------------------------
 // Runtime expression model
@@ -461,21 +458,26 @@ impl Drop for EvalRunGuard {
 /// through `eval_inner`, which keeps tracing lightweight on deep call stacks.
 #[allow(clippy::too_many_lines)] // The visibility checks add necessary verbosity
 pub fn eval(ctx: &mut EvalContext<'_>, expr: &RuntimeExpr) -> Result<Value, EvalError> {
-    #[cfg(feature = "tracing")]
-    {
-        if EvalRunGuard::is_active() {
-            return finish_root_evaluation(eval_inner(ctx, expr));
-        }
+    let owns_action_loop_budget = ctx.config.begin_action_loop_budget_if_inactive();
 
-        let _run_guard = EvalRunGuard::enter_root();
-        ferric_span!(debug_span, "eval_root", call_depth = ctx.call_depth);
-        finish_root_evaluation(eval_inner(ctx, expr))
-    }
+    #[cfg(feature = "tracing")]
+    let result = {
+        if EvalRunGuard::is_active() {
+            finish_root_evaluation(eval_inner(ctx, expr))
+        } else {
+            let _run_guard = EvalRunGuard::enter_root();
+            ferric_span!(debug_span, "eval_root", call_depth = ctx.call_depth);
+            finish_root_evaluation(eval_inner(ctx, expr))
+        }
+    };
 
     #[cfg(not(feature = "tracing"))]
-    {
-        finish_root_evaluation(eval_inner(ctx, expr))
+    let result = { finish_root_evaluation(eval_inner(ctx, expr)) };
+
+    if owns_action_loop_budget {
+        ctx.config.end_action_loop_budget();
     }
+    result
 }
 
 fn finish_root_evaluation(result: Result<Value, EvalError>) -> Result<Value, EvalError> {
@@ -652,24 +654,17 @@ fn eval_inner(ctx: &mut EvalContext<'_>, expr: &RuntimeExpr) -> Result<Value, Ev
             Ok(result)
         }
         RuntimeExpr::While {
-            condition, body, ..
+            condition,
+            body,
+            span,
         } => {
             let mut result = clips_false(ctx.symbol_table, ctx.config.string_encoding);
-            let mut iterations = 0usize;
             loop {
                 let cond_value = eval_inner(ctx, condition)?;
                 if !is_truthy(&cond_value, ctx.symbol_table) {
                     break;
                 }
-                iterations += 1;
-                if iterations > MAX_LOOP_ITERATIONS {
-                    return Err(EvalError::TypeError {
-                        function: "while".to_string(),
-                        expected: "loop to terminate".to_string(),
-                        actual: format!("exceeded maximum iterations ({MAX_LOOP_ITERATIONS})"),
-                        span: None,
-                    });
-                }
+                consume_action_loop_iteration(ctx.config, "while", span.clone())?;
                 for (action_expr, rt_expr) in body {
                     if let Some(rt) = rt_expr {
                         result = eval_inner(ctx, rt)?;
@@ -723,21 +718,9 @@ fn eval_inner(ctx: &mut EvalContext<'_>, expr: &RuntimeExpr) -> Result<Value, Ev
                 return Ok(false_val);
             }
 
-            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-            let total_iters = (end_int - start_int + 1) as usize;
-            if total_iters > MAX_LOOP_ITERATIONS {
-                return Err(EvalError::TypeError {
-                    function: "loop-for-count".to_string(),
-                    expected: "loop range within limits".to_string(),
-                    actual: format!(
-                        "range {start_int}..{end_int} exceeds maximum ({MAX_LOOP_ITERATIONS})"
-                    ),
-                    span: span.clone(),
-                });
-            }
-
             let mut result = clips_false(ctx.symbol_table, ctx.config.string_encoding);
             for counter in start_int..=end_int {
+                consume_action_loop_iteration(ctx.config, "loop-for-count", span.clone())?;
                 // Build a binding frame for this iteration.
                 let mut iter_var_map = ctx.var_map.clone();
                 let mut iter_bindings = ctx.bindings.clone();
@@ -957,6 +940,22 @@ fn eval_inner(ctx: &mut EvalContext<'_>, expr: &RuntimeExpr) -> Result<Value, Ev
                 _ => Ok(clips_false(ctx.symbol_table, ctx.config.string_encoding)),
             }
         }
+    }
+}
+
+pub(crate) fn consume_action_loop_iteration(
+    config: &EngineConfig,
+    function: &str,
+    span: Option<SourceSpan>,
+) -> Result<(), EvalError> {
+    if config.take_action_loop_iteration() {
+        Ok(())
+    } else {
+        Err(EvalError::ActionIterationLimit {
+            function: function.to_string(),
+            limit: config.max_action_loop_iterations,
+            span,
+        })
     }
 }
 
@@ -8140,6 +8139,19 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("inf"));
         assert!(msg.contains("256"));
+    }
+
+    #[test]
+    fn eval_error_display_action_iteration_limit() {
+        let err = EvalError::ActionIterationLimit {
+            function: "loop-for-count".to_string(),
+            limit: 10,
+            span: Some(SourceSpan { line: 4, column: 9 }),
+        };
+        assert_eq!(
+            err.to_string(),
+            "action iteration limit exceeded in `loop-for-count` (limit 10) at line 4:9"
+        );
     }
 
     // -------------------------------------------------------------------

--- a/crates/ferric-rules-runtime/src/phase4_integration_tests.rs
+++ b/crates/ferric-rules-runtime/src/phase4_integration_tests.rs
@@ -2824,6 +2824,39 @@ fn if_in_deffunction_body_else_branch() {
 // Loop special forms: while, loop-for-count, progn$ / foreach
 // ===========================================================================
 
+fn run_with_action_loop_budget(
+    source: &str,
+    max_action_loop_iterations: usize,
+) -> (crate::Engine, crate::execution::RunResult) {
+    let mut config = crate::config::EngineConfig::utf8();
+    config.max_action_loop_iterations = max_action_loop_iterations;
+    let mut engine = crate::Engine::new(config);
+    load_ok(&mut engine, source);
+    engine.reset().expect("reset");
+    let run = run_to_completion(&mut engine);
+    (engine, run)
+}
+
+fn assert_action_iteration_limit(
+    engine: &crate::Engine,
+    expected_function: &str,
+    expected_limit: usize,
+) {
+    let [crate::ActionError::Evaluator(crate::evaluator::EvalError::ActionIterationLimit {
+        function,
+        limit,
+        ..
+    })] = engine.action_diagnostics()
+    else {
+        panic!(
+            "expected one action-iteration diagnostic, got {:?}",
+            engine.action_diagnostics()
+        );
+    };
+    assert_eq!(function, expected_function);
+    assert_eq!(*limit, expected_limit);
+}
+
 #[test]
 fn load_rule_with_while_loop() {
     let mut engine = new_utf8_engine();
@@ -3060,6 +3093,274 @@ fn loop_for_count_in_deffunction() {
     let output = output.trim_end_matches('\n');
     // sum 1+2+3+4 = 10
     assert_eq!(output, "10", "sum-to 4 should be 10, got {output:?}");
+}
+
+#[test]
+fn loop_for_count_handles_zero_descending_and_negative_ranges() {
+    for (label, start, end, expected) in [
+        ("zero", 0, 0, "0|"),
+        ("descending", 2, 1, ""),
+        ("negative", -2, 0, "-2|-1|0|"),
+        (
+            "maximum-singleton",
+            i64::MAX,
+            i64::MAX,
+            "9223372036854775807|",
+        ),
+    ] {
+        let source = format!(
+            r#"
+(defrule range-{label}
+    =>
+    (loop-for-count (?i {start} {end}) do
+        (printout t ?i "|")))
+"#
+        );
+        let (engine, run) = run_with_action_loop_budget(&source, 4);
+        assert_eq!(run.halt_reason, crate::HaltReason::AgendaEmpty, "{label}");
+        assert!(
+            engine.action_diagnostics().is_empty(),
+            "{label}: {:?}",
+            engine.action_diagnostics()
+        );
+        assert_eq!(engine.get_output("t").unwrap_or(""), expected, "{label}");
+    }
+}
+
+#[test]
+fn loop_for_count_accepts_exact_budget_and_rejects_budget_plus_one() {
+    let exact_source = r#"
+(defrule exact
+    =>
+    (loop-for-count (?i 1 3) do
+        (printout t "x"))
+    (assert (after-loop)))
+"#;
+    let (exact_engine, exact_run) = run_with_action_loop_budget(exact_source, 3);
+    assert_eq!(exact_run.halt_reason, crate::HaltReason::AgendaEmpty);
+    assert_eq!(exact_engine.get_output("t"), Some("xxx"));
+    assert_has_fact_with_relation(&exact_engine, "after-loop");
+
+    let over_source = r#"
+(defrule over
+    =>
+    (loop-for-count (?i 1 4) do
+        (printout t "x"))
+    (assert (after-loop)))
+"#;
+    let (over_engine, over_run) = run_with_action_loop_budget(over_source, 3);
+    assert_eq!(over_run.halt_reason, crate::HaltReason::ActionError);
+    assert_eq!(over_engine.get_output("t"), Some("xxx"));
+    assert_no_fact_with_relation(&over_engine, "after-loop");
+    assert_action_iteration_limit(&over_engine, "loop-for-count", 3);
+}
+
+#[test]
+fn loop_for_count_i64_max_terminates_with_action_error() {
+    const CHILD_ENV: &str = "FERRIC_LOOP_FOR_COUNT_I64_MAX_CHILD";
+
+    if std::env::var_os(CHILD_ENV).is_some() {
+        let mut config = crate::config::EngineConfig::utf8();
+        config.max_action_loop_iterations = 8;
+        let mut engine = crate::Engine::new(config);
+        load_ok(
+            &mut engine,
+            r"
+(defglobal ?*last* = 0)
+(defrule maximum-range
+    (go)
+    =>
+    (loop-for-count (?i 1 9223372036854775807) do
+        (bind ?*last* ?i)))
+(deffacts startup (go))
+",
+        );
+        engine.reset().expect("reset");
+        let run = run_to_completion(&mut engine);
+        assert_eq!(run.halt_reason, crate::HaltReason::ActionError);
+        return;
+    }
+
+    let current_exe = std::env::current_exe().expect("current test executable");
+    let mut child = std::process::Command::new(current_exe)
+        .args([
+            "--exact",
+            "phase4_integration_tests::loop_for_count_i64_max_terminates_with_action_error",
+            "--nocapture",
+        ])
+        .env(CHILD_ENV, "1")
+        .spawn()
+        .expect("spawn maximum-range child");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+
+    loop {
+        if let Some(status) = child.try_wait().expect("poll maximum-range child") {
+            assert!(status.success(), "maximum-range child failed: {status}");
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            child.kill().expect("kill hung maximum-range child");
+            let _ = child.wait();
+            panic!("maximum loop-for-count range did not terminate within 2 seconds");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn loop_for_count_full_i64_range_is_overflow_safe() {
+    let (engine, run) = run_with_action_loop_budget(
+        r#"
+(defrule full-integer-range
+    =>
+    (loop-for-count (?i -9223372036854775808 9223372036854775807) do
+        (printout t "x"))
+    (assert (after-loop)))
+"#,
+        2,
+    );
+    assert_eq!(run.halt_reason, crate::HaltReason::ActionError);
+    assert_eq!(engine.get_output("t"), Some("xx"));
+    assert_no_fact_with_relation(&engine, "after-loop");
+    assert_action_iteration_limit(&engine, "loop-for-count", 2);
+}
+
+#[test]
+fn nested_while_and_loop_for_count_share_one_budget() {
+    let while_outer = r#"
+(defglobal ?*outer* = 0)
+(defrule while-outer
+    =>
+    (while (< ?*outer* 2) do
+        (bind ?*outer* (+ ?*outer* 1))
+        (loop-for-count (?i 1 2) do
+            (printout t "x")))
+    (assert (after-loop)))
+"#;
+    let (engine, run) = run_with_action_loop_budget(while_outer, 4);
+    assert_eq!(run.halt_reason, crate::HaltReason::ActionError);
+    assert_eq!(engine.get_output("t"), Some("xx"));
+    assert_no_fact_with_relation(&engine, "after-loop");
+    assert_action_iteration_limit(&engine, "loop-for-count", 4);
+
+    let count_outer = r#"
+(defglobal ?*inner* = 0)
+(defrule count-outer
+    =>
+    (loop-for-count (?i 1 2) do
+        (bind ?*inner* 0)
+        (while (< ?*inner* 2) do
+            (bind ?*inner* (+ ?*inner* 1))
+            (printout t "x")))
+    (assert (after-loop)))
+"#;
+    let (engine, run) = run_with_action_loop_budget(count_outer, 4);
+    assert_eq!(run.halt_reason, crate::HaltReason::ActionError);
+    assert_eq!(engine.get_output("t"), Some("xx"));
+    assert_no_fact_with_relation(&engine, "after-loop");
+    assert_action_iteration_limit(&engine, "while", 4);
+}
+
+#[test]
+fn rhs_and_deffunction_loops_have_equivalent_budget_errors() {
+    for (label, source, expected_function) in [
+        (
+            "rhs-count",
+            r#"
+(defrule rhs-count
+    =>
+    (loop-for-count (?i 1 3) do (printout t "x"))
+    (assert (after-loop)))
+"#,
+            "loop-for-count",
+        ),
+        (
+            "function-count",
+            r#"
+(deffunction counted ()
+    (loop-for-count (?i 1 3) do (printout t "x")))
+(defrule function-count
+    =>
+    (counted)
+    (assert (after-loop)))
+"#,
+            "loop-for-count",
+        ),
+        (
+            "rhs-while",
+            r#"
+(defglobal ?*counter* = 0)
+(defrule rhs-while
+    =>
+    (while (< ?*counter* 3) do
+        (bind ?*counter* (+ ?*counter* 1))
+        (printout t "x"))
+    (assert (after-loop)))
+"#,
+            "while",
+        ),
+        (
+            "function-while",
+            r#"
+(defglobal ?*counter* = 0)
+(deffunction repeated ()
+    (while (< ?*counter* 3) do
+        (bind ?*counter* (+ ?*counter* 1))
+        (printout t "x")))
+(defrule function-while
+    =>
+    (repeated)
+    (assert (after-loop)))
+"#,
+            "while",
+        ),
+    ] {
+        let (engine, run) = run_with_action_loop_budget(source, 2);
+        assert_eq!(run.halt_reason, crate::HaltReason::ActionError, "{label}");
+        assert_eq!(engine.get_output("t"), Some("xx"), "{label}");
+        assert_no_fact_with_relation(&engine, "after-loop");
+        assert_action_iteration_limit(&engine, expected_function, 2);
+    }
+}
+
+#[test]
+fn rhs_loop_and_nested_deffunction_loop_share_one_budget() {
+    let (engine, run) = run_with_action_loop_budget(
+        r#"
+(deffunction inner-loop ()
+    (loop-for-count (?j 1 3) do
+        (printout t "x")))
+(defrule cross-path
+    =>
+    (loop-for-count (?i 1 1) do
+        (inner-loop))
+    (assert (after-loop)))
+"#,
+        3,
+    );
+    assert_eq!(run.halt_reason, crate::HaltReason::ActionError);
+    assert_eq!(engine.get_output("t"), Some("xx"));
+    assert_no_fact_with_relation(&engine, "after-loop");
+    assert_action_iteration_limit(&engine, "loop-for-count", 3);
+}
+
+#[test]
+fn action_loop_budget_resets_for_each_activation() {
+    let (engine, run) = run_with_action_loop_budget(
+        r#"
+(deffacts inputs (item a) (item b))
+(defrule per-activation
+    (item ?value)
+    =>
+    (loop-for-count (?i 1 2) do
+        (printout t "x")))
+"#,
+        2,
+    );
+    assert_eq!(run.halt_reason, crate::HaltReason::AgendaEmpty);
+    assert_eq!(run.rules_fired, 2);
+    assert_eq!(engine.get_output("t"), Some("xxxx"));
+    assert!(engine.action_diagnostics().is_empty());
 }
 
 #[test]

--- a/crates/ferric-rules/tests/clips_compat.rs
+++ b/crates/ferric-rules/tests/clips_compat.rs
@@ -542,6 +542,65 @@ fn test_compat_return_unwinds_only_the_current_callable() {
 }
 
 #[test]
+fn test_compat_action_loop_budget_preserves_boundary_and_stops_overrun() {
+    let mut config = EngineConfig::utf8();
+    config.max_action_loop_iterations = 3;
+
+    let mut exact = Engine::new(config.clone());
+    exact
+        .load_str(
+            r#"
+(defrule exact-loop
+    =>
+    (loop-for-count (?i 1 3) do
+        (printout t ?i "|"))
+    (assert (completed)))
+"#,
+        )
+        .expect("load exact loop");
+    exact.reset().expect("reset exact loop");
+    let exact_run = exact.run(RunLimit::Unlimited).expect("run exact loop");
+    assert_eq!(exact_run.halt_reason, HaltReason::AgendaEmpty);
+    assert_eq!(exact.get_output("t"), Some("1|2|3|"));
+    assert_eq!(
+        exact
+            .find_facts("completed")
+            .expect("completed facts")
+            .len(),
+        1
+    );
+    assert!(exact.action_diagnostics().is_empty());
+
+    let mut over = Engine::new(config);
+    over.load_str(
+        r#"
+(defrule over-budget-loop
+    =>
+    (loop-for-count (?i 1 4) do
+        (printout t ?i "|"))
+    (assert (completed)))
+"#,
+    )
+    .expect("load over-budget loop");
+    over.reset().expect("reset over-budget loop");
+    let over_run = over.run(RunLimit::Unlimited).expect("run over-budget loop");
+    assert_eq!(over_run.halt_reason, HaltReason::ActionError);
+    assert_eq!(over.get_output("t"), Some("1|2|3|"));
+    assert!(over
+        .find_facts("completed")
+        .expect("completed facts")
+        .is_empty());
+    assert!(matches!(
+        over.action_diagnostics(),
+        [ActionError::Evaluator(EvalError::ActionIterationLimit {
+            function,
+            limit: 3,
+            ..
+        })] if function == "loop-for-count"
+    ));
+}
+
+#[test]
 fn test_compat_return_stops_the_current_rule_rhs() {
     // CLIPS permits `return` in a rule RHS and uses it to stop the remaining
     // action sequence. Its value is discarded; it does not assert the sentinel

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -189,8 +189,8 @@ chosen conflict resolution strategy:
 | `reset` | Deferred: sets a flag checked after action execution |
 | `clear` | Deferred: sets a flag checked after action execution |
 | `if`/`then`/`else` | Conditional action execution |
-| `while` | Conditional loop with `do` keyword |
-| `loop-for-count` | Indexed loop with optional variable binding |
+| `while` | Conditional loop with `do`; shares the configured per-activation action-loop budget |
+| `loop-for-count` | Indexed loop with optional variable binding; shares the configured per-activation action-loop budget |
 | `progn$` / `foreach` | Multifield iteration with element and index binding |
 | `switch`/`case`/`default` | Multi-branch dispatch |
 | `do-for-fact` | Iterate first matching fact |

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -68,7 +68,7 @@ Engine, loader, execution loop, evaluator, modules, I/O.
 - `modules.rs` — module registry, focus stack, cross-module visibility.
 - `router.rs` — `OutputRouter`, per-channel output capture, `read`/`readline`
   input buffers.
-- `config.rs` — `EngineConfig` and encoding/strategy/call-depth settings.
+- `config.rs` — `EngineConfig` and encoding/strategy/execution-limit settings.
 - `qualified_name.rs` — runtime-side module-qualified resolution.
 - `serialization.rs` (feature `serde`) — `EngineSnapshotRef`/`Owned`,
   bincode/JSON/CBOR/MessagePack/Postcard payloads, ExternalAddress

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -642,22 +642,32 @@ string. To actually print it, pipe it through `printout`:
 _Runnable example: [`examples/users-guide/11-configuration/`](../examples/users-guide/11-configuration/)._
 
 `EngineConfig` controls string encoding, conflict resolution strategy,
-and the user-function recursion limit. The factory helpers cover the
-common cases:
+the user-function recursion limit, and the per-activation action-loop
+budget. The factory helpers cover the common cases:
 
 <!-- example: 11-configuration/src/main.rs -->
 ```rust
-// UTF-8 symbols and strings, Depth strategy, 64-frame recursion limit.
+// UTF-8 symbols and strings, Depth strategy, 64-frame recursion limit,
+// and a 1,000,000-iteration action-loop budget.
 let _engine = Engine::new(EngineConfig::default());
 
 // CLIPS-strict ASCII mode with LEX strategy.
 let _engine = Engine::new(EngineConfig::ascii().with_strategy(ConflictResolutionStrategy::Lex));
 
-// Increase recursion depth for deeply recursive deffunctions.
+// Increase recursion depth and reduce the per-activation budget shared by
+// while/loop-for-count, including nested loops in deffunctions.
 let mut cfg = EngineConfig::utf8();
 cfg.max_call_depth = 256;
+cfg.max_action_loop_iterations = 10_000;
 let _engine = Engine::new(cfg);
 ```
+
+`max_action_loop_iterations` is the combined budget for `while` and
+`loop-for-count` during one fired rule activation. Every entered loop body
+costs one iteration, so nested loops and loops called through deffunctions or
+generic functions draw from the same budget. A false initial `while` condition
+or an empty/descending count range costs nothing. Exhaustion stops the
+activation with `EvalError::ActionIterationLimit`; the default is 1,000,000.
 
 Available strategies: `Depth` (default), `Breadth`, `Lex`, `Mea`.
 `Simplicity`, `Complexity`, and `Random` are not implemented — they are

--- a/examples/users-guide/11-configuration/README.md
+++ b/examples/users-guide/11-configuration/README.md
@@ -12,5 +12,5 @@ What it shows:
 
 - `EngineConfig::default()`, `::ascii()`, and `::utf8()` factories.
 - `with_strategy(ConflictResolutionStrategy::Lex)` builder method.
-- Manually setting `max_call_depth`.
+- Manually setting `max_call_depth` and `max_action_loop_iterations`.
 - `Engine::with_rules_config(source, config)` for combining config and load.

--- a/examples/users-guide/11-configuration/src/main.rs
+++ b/examples/users-guide/11-configuration/src/main.rs
@@ -10,15 +10,18 @@ use ferric_rules::core::ConflictResolutionStrategy;
 use ferric_rules::runtime::{Engine, EngineConfig};
 
 fn main() -> anyhow::Result<()> {
-    // UTF-8 symbols and strings, Depth strategy, 64-frame recursion limit.
+    // UTF-8 symbols and strings, Depth strategy, 64-frame recursion limit,
+    // and a 1,000,000-iteration action-loop budget.
     let _engine = Engine::new(EngineConfig::default());
 
     // CLIPS-strict ASCII mode with LEX strategy.
     let _engine = Engine::new(EngineConfig::ascii().with_strategy(ConflictResolutionStrategy::Lex));
 
-    // Increase recursion depth for deeply recursive deffunctions.
+    // Increase recursion depth and reduce the per-activation budget shared by
+    // while/loop-for-count, including nested loops in deffunctions.
     let mut cfg = EngineConfig::utf8();
     cfg.max_call_depth = 256;
+    cfg.max_action_loop_iterations = 10_000;
     let _engine = Engine::new(cfg);
 
     // Combine config with one-call rule loading.


### PR DESCRIPTION
Closes #111

## Scope

FR-ROBUST-002 replaces the independent RHS/evaluator loop caps with one configurable per-activation budget for `while` and `loop-for-count`. Every entered loop body consumes one unit across nested RHS, deffunction, and generic-function execution. Exhaustion now produces the typed `EvalError::ActionIterationLimit` diagnostic and stops the current RHS consistently.

The previous RHS `loop-for-count` path had no cap, and the evaluator precomputed inclusive range length with overflow-prone signed arithmetic. The new remaining-budget counter uses checked subtraction and avoids range-length arithmetic entirely.

## Stack

- Immediate predecessor: none
- Earlier included PRs: none
- Required merge order: this PR only
- Tests require predecessor code: no
- Branch point: `ba81ff46109e878cb45e3b4cf7856283aff40621`

## Red-before-fix evidence

`cargo test -p ferric-rules-runtime loop_for_count_i64_max_terminates_with_action_error -- --nocapture` — exit 101. The timeout-controlled parent killed the child after 2 seconds because RHS `(loop-for-count (?i 1 9223372036854775807) ...)` did not terminate.

## Validation

- `just preflight-pr` — passed
- `just check-examples-sync` — passed (22 annotated blocks matched)
- `cargo test -p ferric-rules-runtime loop_for_count -- --nocapture` — passed
- `cargo test -p ferric-rules-runtime while_loop -- --nocapture` — passed
- `cargo test -p ferric-rules --test clips_compat loop -- --nocapture` — passed
- `cargo test -p ferric-rules-runtime` — passed (847 tests plus doctests)
- `cargo test -p ferric-rules --test clips_compat` — passed (78 tests)
- `cargo check -p ferric-rules-runtime --all-features` — passed
- `just scaling-check` — passed (5 release-profile scaling checks)

## Acceptance criteria

- Both loop forms and both execution paths debit `EngineConfig::max_action_loop_iterations`.
- The budget is reset per activation and shared across nested RHS/callable work under the documented one-body-entry/one-unit policy.
- A checked remaining counter handles zero, descending, negative, exact-limit, limit-plus-one, maximum-singleton, `i64::MAX`, and full signed-range cases without arithmetic overflow.
- All exhaustion paths return `ActionError::Evaluator(EvalError::ActionIterationLimit { .. })`, stop the current RHS, and skip later actions.
- Existing ordinary loop compatibility remains covered by runtime and facade compatibility suites.

## Residual risks

The current merge-ref Criterion comparison passed, but its three directly affected `eval_loop_*` benchmarks were 6.8–7.7% slower; the safety control adds one shared-budget debit per entered loop body. Absolute benchmark thresholds and release-profile scaling checks passed. Non-Rust bindings retain the safe default budget.