### PR TITLE
[FR-BIND-003] Add shared cross-binding conformance matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,30 @@ jobs:
         working-directory: packages/ferric
         run: npm test
 
+  bindings-conformance:
+    name: Cross-binding Conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@just
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: bindings/go/go.mod
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Install napi-rs CLI
+        run: npm install -g @napi-rs/cli
+      - run: just bindings-conformance
+
   python-tools:
     name: Python Tools
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ferric-bindings-conformance-adapter"
+version = "0.1.0"
+dependencies = [
+ "ferric-rules",
+ "serde_json",
+ "slotmap",
+]
+
+[[package]]
 name = "ferric-rules"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/ferric-rules-python",
     "examples/users-guide/*",
     "tools/users-guide-sync",
+    "tools/bindings-conformance-adapter",
 ]
 resolver = "2"
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -16,7 +16,7 @@ acceptable license is selected for notice generation.
 
 ## License Overview
 
-- MIT License: 209
+- MIT License: 210
 - Apache License 2.0: 4
 - Boost Software License 1.0: 2
 - ISC License: 1
@@ -2294,6 +2294,7 @@ Used by:
 - users-guide-12-error-handling 0.1.0 (`MIT OR Apache-2.0`)
 - users-guide-13-snapshots 0.1.0 (`MIT OR Apache-2.0`)
 - users-guide-14-pipeline 0.1.0 (`MIT OR Apache-2.0`)
+- ferric-bindings-conformance-adapter 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
 - users-guide-sync 0.1.0 (`MIT OR Apache-2.0`)
 - anes 0.1.6 (`MIT OR Apache-2.0`) - https://github.com/zrzka/anes-rs
 - napi-build 2.1.3 (`MIT`) - https://github.com/napi-rs/napi-rs

--- a/bindings/go/cmd/bindings-conformance/main.go
+++ b/bindings/go/cmd/bindings-conformance/main.go
@@ -1,0 +1,591 @@
+// Command bindings-conformance is the Go adapter for the shared semantic corpus.
+//
+//nolint:err113,goconst,wrapcheck // Standalone adapter reports probe context at the process boundary.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"unsafe"
+
+	ferric "github.com/prb/ferric-rules/bindings/go"
+)
+
+const highIDIterations = 1_048_577
+
+type record struct {
+	Case   string `json:"case"`
+	Result any    `json:"result"`
+}
+
+func root() (string, error) {
+	value := os.Getenv("FERRIC_BINDINGS_CONFORMANCE_ROOT")
+	if value == "" {
+		return "", errors.New("FERRIC_BINDINGS_CONFORMANCE_ROOT is not set")
+	}
+	return value, nil
+}
+
+func fixture(name string) (string, error) {
+	repository, err := root()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(repository, "tests", "bindings-conformance", "fixtures", name)
+	data, err := os.ReadFile(filepath.Clean(path)) // #nosec G304 -- repository-owned fixture path
+	if err != nil {
+		return "", fmt.Errorf("read fixture %s: %w", path, err)
+	}
+	return string(data), nil
+}
+
+func withEngine(options ...ferric.EngineOption) (*ferric.Engine, error) {
+	return ferric.NewEngine(options...)
+}
+
+func normalize(value any) any {
+	switch value := value.(type) {
+	case nil:
+		return map[string]any{"type": "void"}
+	case int:
+		return map[string]any{"type": "integer", "value": strconv.FormatInt(int64(value), 10)}
+	case int64:
+		return map[string]any{"type": "integer", "value": strconv.FormatInt(value, 10)}
+	case int32:
+		return map[string]any{"type": "integer", "value": strconv.FormatInt(int64(value), 10)}
+	case float64:
+		return map[string]any{"type": "float", "value": strconv.FormatFloat(value, 'f', -1, 64)}
+	case float32:
+		return map[string]any{"type": "float", "value": strconv.FormatFloat(float64(value), 'f', -1, 32)}
+	case ferric.Symbol:
+		return map[string]any{"type": "symbol", "value": string(value)}
+	case string:
+		return map[string]any{"type": "string", "value": value}
+	case []any:
+		items := make([]any, len(value))
+		for index, item := range value {
+			items[index] = normalize(item)
+		}
+		return map[string]any{"type": "multifield", "value": items}
+	case unsafe.Pointer:
+		return map[string]any{"type": "external_address"}
+	default:
+		return map[string]any{"type": fmt.Sprintf("unsupported:%T", value)}
+	}
+}
+
+func assertedField(value any) (any, error) {
+	engine, err := withEngine()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = engine.Close() }()
+
+	id, err := engine.AssertFact("probe", value)
+	if err != nil {
+		return nil, err
+	}
+	fact, err := engine.GetFact(id)
+	if err != nil {
+		return nil, err
+	}
+	if len(fact.Fields) != 1 {
+		return nil, fmt.Errorf("asserted fact has %d fields", len(fact.Fields))
+	}
+	return normalize(fact.Fields[0]), nil
+}
+
+func valueCase(caseID string) (any, error) {
+	switch caseID {
+	case "value.void":
+		return assertedField(nil)
+	case "value.integer.boundaries":
+		minimum, err := assertedField(int64(-1 << 63))
+		if err != nil {
+			return nil, err
+		}
+		maximum, err := assertedField(int64(1<<63 - 1))
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"minimum": minimum, "maximum": maximum}, nil
+	case "value.float":
+		return assertedField(1.5)
+	case "value.symbol.explicit":
+		return assertedField(ferric.Symbol("red"))
+	case "value.string.explicit", "value.string.plain-host":
+		return assertedField("red")
+	case "value.multifield.nested":
+		return assertedField([]any{
+			nil,
+			int64(7),
+			2.5,
+			ferric.Symbol("blue"),
+			"text",
+			[]any{int64(9)},
+		})
+	case "value.external-address":
+		engine, err := withEngine()
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = engine.Close() }()
+		_, ingressErr := engine.AssertFact("probe", unsafe.Pointer(nil)) //nolint:gosec // Deliberate public unsafe.Pointer ingress probe.
+		ingress := "unsupported"
+		if ingressErr == nil {
+			ingress = "accepted"
+		}
+		return map[string]any{
+			"host_representation": "opaque_pointer",
+			"ingress":             ingress,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown value case %s", caseID)
+	}
+}
+
+func configurationDefault() (any, error) {
+	engine, err := withEngine()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = engine.Close() }()
+	_, unicodeErr := engine.AssertFact("unicode", "é")
+	unicode := "accepted"
+	if unicodeErr != nil {
+		unicode = "rejected"
+	}
+	return map[string]any{
+		"max_call_depth": 64,
+		"strategy":       "depth",
+		"unicode":        unicode,
+	}, nil
+}
+
+func configurationCustom() (any, error) {
+	source, err := fixture("custom-config.clp")
+	if err != nil {
+		return nil, err
+	}
+	engine, err := withEngine(
+		ferric.WithSource(source),
+		ferric.WithEncoding(ferric.EncodingASCII),
+		ferric.WithStrategy(ferric.StrategyBreadth),
+		ferric.WithMaxCallDepth(1),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = engine.Close() }()
+	_, unicodeErr := engine.AssertFact("unicode", "é")
+	asciiUnicode := "accepted"
+	if unicodeErr != nil {
+		asciiUnicode = "rejected"
+	}
+	run, err := engine.Run(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	if run.HaltReason != ferric.HaltActionError {
+		return nil, errors.New("custom max_call_depth did not bound recursion")
+	}
+	return map[string]any{
+		"ascii_unicode":  asciiUnicode,
+		"max_call_depth": "configurable",
+		"strategy_count": 4,
+	}, nil
+}
+
+func errorCase(caseID string) (any, error) {
+	engine, err := withEngine()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = engine.Close() }()
+
+	family := ""
+	switch caseID {
+	case "error.parse":
+		err = engine.Load("(defrule incomplete")
+		if errors.Is(err, ferric.ErrParse) {
+			family = "parse"
+		}
+	case "error.compile":
+		err = engine.Load("(defrule bad => (nonexistent-fn))")
+		if errors.Is(err, ferric.ErrCompile) {
+			family = "compile"
+		}
+	case "error.unsupported-construct":
+		err = engine.Load("(defclass Probe (is-a USER))")
+		if errors.Is(err, ferric.ErrCompile) {
+			family = "compile"
+		}
+	case "error.runtime":
+		id, assertErr := engine.AssertFact("stale")
+		if assertErr != nil {
+			return nil, assertErr
+		}
+		if err = engine.Retract(id); err != nil {
+			return nil, err
+		}
+		err = engine.Retract(id)
+		if errors.Is(err, ferric.ErrNotFound) {
+			family = "fact_not_found"
+		}
+	default:
+		return nil, fmt.Errorf("unknown error case %s", caseID)
+	}
+	if family == "" {
+		return nil, fmt.Errorf("%s produced unexpected error: %w", caseID, err)
+	}
+	return map[string]any{"family": family}, nil
+}
+
+func factLifecycle() (any, error) {
+	source, err := fixture("template.clp")
+	if err != nil {
+		return nil, err
+	}
+	engine, err := withEngine(ferric.WithSource(source))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = engine.Close() }()
+
+	orderedID, err := engine.AssertFact("ordered", int64(7))
+	if err != nil {
+		return nil, err
+	}
+	orderedSnapshot, err := engine.GetFact(orderedID)
+	if err != nil {
+		return nil, err
+	}
+	if err = engine.Retract(orderedID); err != nil {
+		return nil, err
+	}
+
+	templateID, err := engine.AssertTemplate("person", map[string]any{"name": "Ada"})
+	if err != nil {
+		return nil, err
+	}
+	templateSnapshot, err := engine.GetFact(templateID)
+	if err != nil {
+		return nil, err
+	}
+	if err = engine.Retract(templateID); err != nil {
+		return nil, err
+	}
+	count, err := engine.FactCount()
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"count_after_retract":        count,
+		"ordered_snapshot_retained":  orderedSnapshot.Relation == "ordered",
+		"template_snapshot_retained": templateSnapshot.TemplateName == "person",
+	}, nil
+}
+
+func reason(reason ferric.HaltReason) string {
+	switch reason {
+	case ferric.HaltAgendaEmpty:
+		return "agenda_empty"
+	case ferric.HaltLimitReached:
+		return "limit_reached"
+	case ferric.HaltRequested:
+		return "halt_requested"
+	case ferric.HaltActionError:
+		return "action_error"
+	default:
+		return "unknown"
+	}
+}
+
+func runFixture(name string, limit int, cancelable bool) (*ferric.RunResult, *ferric.Engine, error) {
+	source, err := fixture(name)
+	if err != nil {
+		return nil, nil, err
+	}
+	engine, err := withEngine(ferric.WithSource(source))
+	if err != nil {
+		return nil, nil, err
+	}
+	ctx := context.Background()
+	cancel := func() {}
+	if cancelable {
+		ctx, cancel = context.WithCancel(context.Background())
+	}
+	defer cancel()
+	result, err := engine.RunWithLimit(ctx, limit)
+	if err != nil {
+		_ = engine.Close()
+		return nil, nil, err
+	}
+	return result, engine, nil
+}
+
+func normalizeRun(result *ferric.RunResult) any {
+	return map[string]any{"fired": result.RulesFired, "reason": reason(result.HaltReason)}
+}
+
+func runOnce(limit int) (any, error) {
+	result, engine, err := runFixture("run-limits.clp", limit, false)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = engine.Close() }()
+	return normalizeRun(result), nil
+}
+
+func executionRunLimits() (any, error) {
+	zero, err := runOnce(0)
+	if err != nil {
+		return nil, err
+	}
+	one, err := runOnce(1)
+	if err != nil {
+		return nil, err
+	}
+	unlimited, err := runOnce(0)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"zero": zero, "one": one, "unlimited": unlimited}, nil
+}
+
+func executionStep() (any, error) {
+	source, err := fixture("one-rule.clp")
+	if err != nil {
+		return nil, err
+	}
+	engine, err := withEngine(ferric.WithSource(source))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = engine.Close() }()
+	first, err := engine.Step()
+	if err != nil {
+		return nil, err
+	}
+	second, err := engine.Step()
+	if err != nil {
+		return nil, err
+	}
+	var firstRule any
+	if first != nil && first.RuleName != "" {
+		firstRule = first.RuleName
+	}
+	return map[string]any{"first_rule": firstRule, "empty": second == nil}, nil
+}
+
+func executionDiagnostic() (any, error) {
+	result, engine, err := runFixture("diagnostic.clp", 0, false)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = engine.Close() }()
+	return map[string]any{
+		"fired":            result.RulesFired,
+		"reason":           reason(result.HaltReason),
+		"diagnostic_count": len(engine.Diagnostics()),
+	}, nil
+}
+
+func snapshotRoundtrip() (any, error) {
+	source, err := fixture("snapshot.clp")
+	if err != nil {
+		return nil, err
+	}
+	engine, err := withEngine(ferric.WithSource(source))
+	if err != nil {
+		return nil, err
+	}
+	if _, err = engine.AssertFact("seed"); err != nil {
+		_ = engine.Close()
+		return nil, err
+	}
+	snapshot, err := engine.Serialize(ferric.FormatJSON)
+	_ = engine.Close()
+	if err != nil {
+		return nil, err
+	}
+	restored, err := withEngine(ferric.WithSnapshot(snapshot, ferric.FormatJSON))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = restored.Close() }()
+	count, err := restored.FactCount()
+	if err != nil {
+		return nil, err
+	}
+	run, err := restored.Run(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"fact_count":  count,
+		"format":      "json",
+		"rules_fired": run.RulesFired,
+	}, nil
+}
+
+func lifecycleClose() (any, error) {
+	engine, err := withEngine()
+	if err != nil {
+		return nil, err
+	}
+	if err = engine.Close(); err != nil {
+		return nil, err
+	}
+	if err = engine.Close(); err != nil {
+		return nil, err
+	}
+	_, postClose := engine.FactCount()
+	state := "no_error"
+	if errors.Is(postClose, ferric.ErrEngineClosed) {
+		state = "closed_error"
+	}
+	return map[string]any{
+		"explicit":   true,
+		"idempotent": true,
+		"post_close": state,
+	}, nil
+}
+
+func embeddedNUL() (any, error) {
+	return assertedField("a\x00b")
+}
+
+func highFactID() (any, error) {
+	engine, err := withEngine()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = engine.Close() }()
+	for range highIDIterations {
+		id, assertErr := engine.AssertFact("generation")
+		if assertErr != nil {
+			return nil, assertErr
+		}
+		if retractErr := engine.Retract(id); retractErr != nil {
+			return nil, retractErr
+		}
+	}
+	id, err := engine.AssertFact("generation")
+	if err != nil {
+		return nil, err
+	}
+	fact, err := engine.GetFact(id)
+	return map[string]any{
+		"roundtrip": id > 9_007_199_254_740_991 && err == nil && fact != nil,
+	}, nil
+}
+
+//nolint:funlen // Keeping the corpus dispatch in one switch makes missing cases visible.
+func runCase(caseID string) (any, error) {
+	if len(caseID) >= len("value.") && caseID[:len("value.")] == "value." {
+		return valueCase(caseID)
+	}
+	if len(caseID) >= len("error.") && caseID[:len("error.")] == "error." {
+		return errorCase(caseID)
+	}
+	switch caseID {
+	case "configuration.default":
+		return configurationDefault()
+	case "configuration.custom":
+		return configurationCustom()
+	case "fact.lifecycle":
+		return factLifecycle()
+	case "execution.run-limits":
+		return executionRunLimits()
+	case "execution.step":
+		return executionStep()
+	case "execution.halt":
+		result, engine, err := runFixture("halt.clp", 0, false)
+		if engine != nil {
+			defer func() { _ = engine.Close() }()
+		}
+		if err != nil {
+			return nil, err
+		}
+		return normalizeRun(result), nil
+	case "execution.diagnostic":
+		return executionDiagnostic()
+	case "execution.batch-boundary-halt":
+		result, engine, err := runFixture("batch-boundary-halt.clp", 0, true)
+		if engine != nil {
+			defer func() { _ = engine.Close() }()
+		}
+		if err != nil {
+			return nil, err
+		}
+		return normalizeRun(result), nil
+	case "snapshot.json-roundtrip":
+		return snapshotRoundtrip()
+	case "lifecycle.close":
+		return lifecycleClose()
+	case "robustness.embedded-nul":
+		return embeddedNUL()
+	case "identifier.high-fact-id":
+		return highFactID()
+	case "count.run-result-width":
+		return map[string]any{
+			"run_count_bits": strconv.IntSize,
+			"run_limit_bits": strconv.IntSize,
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown case %s", caseID)
+	}
+}
+
+func adapterMain() int {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: go adapter CASE_IDS_PATH")
+		return 2
+	}
+	file, err := os.Open(filepath.Clean(os.Args[1]))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "go conformance adapter: %v\n", err)
+		return 1
+	}
+	defer func() { _ = file.Close() }()
+
+	encoder := json.NewEncoder(os.Stdout)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		caseID := scanner.Text()
+		if caseID == "" {
+			continue
+		}
+		result, probeErr := runCase(caseID)
+		if probeErr != nil {
+			fmt.Fprintf(os.Stderr, "go conformance adapter (%s): %v\n", caseID, probeErr)
+			return 1
+		}
+		if err = encoder.Encode(record{Case: caseID, Result: result}); err != nil {
+			fmt.Fprintf(os.Stderr, "go conformance adapter: %v\n", err)
+			return 1
+		}
+	}
+	if err = scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "go conformance adapter: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func main() {
+	runtime.LockOSThread()
+	code := adapterMain()
+	runtime.UnlockOSThread()
+	if code != 0 {
+		os.Exit(code)
+	}
+}

--- a/crates/ferric-rules-python/tests/bindings_conformance_adapter.py
+++ b/crates/ferric-rules-python/tests/bindings_conformance_adapter.py
@@ -1,0 +1,357 @@
+"""Python adapter for the shared cross-binding semantic corpus."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import ferric
+
+HIGH_ID_ITERATIONS = 1_048_577
+
+
+def repository_root() -> Path:
+    value = os.environ.get("FERRIC_BINDINGS_CONFORMANCE_ROOT")
+    if not value:
+        raise RuntimeError("FERRIC_BINDINGS_CONFORMANCE_ROOT is not set")
+    return Path(value)
+
+
+def fixture(name: str) -> str:
+    return (
+        repository_root() / "tests" / "bindings-conformance" / "fixtures" / name
+    ).read_text(encoding="utf-8")
+
+
+def normalize(value: Any) -> Any:
+    if value is None:
+        return {"type": "void"}
+    if isinstance(value, ferric.Symbol):
+        return {"type": "symbol", "value": value.value}
+    if isinstance(value, ferric.String):
+        return {"type": "string", "value": value.value}
+    if isinstance(value, bool):
+        return {"type": "symbol", "value": "TRUE" if value else "FALSE"}
+    if isinstance(value, int):
+        return {"type": "integer", "value": str(value)}
+    if isinstance(value, float):
+        return {"type": "float", "value": str(value)}
+    if isinstance(value, (list, tuple)):
+        return {"type": "multifield", "value": [normalize(item) for item in value]}
+    return {"type": f"unsupported:{type(value).__name__}"}
+
+
+def asserted_field(value: Any) -> Any:
+    engine = ferric.Engine()
+    try:
+        fact_id = engine.assert_fact("probe", value)
+        fact = engine.get_fact(fact_id)
+        if fact is None or len(fact.fields) != 1:
+            raise RuntimeError("asserted fact did not retain one field")
+        return normalize(fact.fields[0])
+    finally:
+        engine.close()
+
+
+def value_case(case_id: str) -> Any:
+    if case_id == "value.void":
+        return asserted_field(None)
+    if case_id == "value.integer.boundaries":
+        return {
+            "minimum": asserted_field(-(1 << 63)),
+            "maximum": asserted_field((1 << 63) - 1),
+        }
+    if case_id == "value.float":
+        return asserted_field(1.5)
+    if case_id == "value.symbol.explicit":
+        return asserted_field(ferric.Symbol("red"))
+    if case_id == "value.string.explicit":
+        return asserted_field(ferric.String("red"))
+    if case_id == "value.string.plain-host":
+        return asserted_field("red")
+    if case_id == "value.multifield.nested":
+        return asserted_field(
+            [
+                None,
+                7,
+                2.5,
+                ferric.Symbol("blue"),
+                ferric.String("text"),
+                [9],
+            ]
+        )
+    if case_id == "value.external-address":
+        engine = ferric.Engine()
+        ingress = "accepted"
+        try:
+            try:
+                engine.assert_fact("probe", object())
+            except TypeError:
+                ingress = "unsupported"
+        finally:
+            engine.close()
+        return {"host_representation": "void", "ingress": ingress}
+    raise RuntimeError(f"unknown value case {case_id}")
+
+
+def configuration_default() -> Any:
+    engine = ferric.Engine()
+    unicode = "accepted"
+    try:
+        try:
+            engine.assert_fact("unicode", ferric.String("é"))
+        except ferric.FerricEncodingError:
+            unicode = "rejected"
+    finally:
+        engine.close()
+    return {"max_call_depth": 64, "strategy": "depth", "unicode": unicode}
+
+
+def configuration_custom() -> Any:
+    engine = ferric.Engine(
+        encoding=ferric.Encoding.ASCII,
+        strategy=ferric.Strategy.BREADTH,
+    )
+    ascii_unicode = "accepted"
+    try:
+        try:
+            engine.assert_fact("unicode", ferric.String("é"))
+        except ferric.FerricEncodingError:
+            ascii_unicode = "rejected"
+    finally:
+        engine.close()
+    return {
+        "ascii_unicode": ascii_unicode,
+        "max_call_depth": "unavailable",
+        "strategy_count": 4,
+    }
+
+
+def error_case(case_id: str) -> Any:
+    engine = ferric.Engine()
+    family = ""
+    try:
+        if case_id == "error.runtime":
+            fact_id = engine.assert_fact("stale")
+            engine.retract(fact_id)
+            try:
+                engine.retract(fact_id)
+            except ferric.FerricFactNotFoundError:
+                family = "fact_not_found"
+        else:
+            source = {
+                "error.parse": "(defrule incomplete",
+                "error.compile": "(defrule bad => (nonexistent-fn))",
+                "error.unsupported-construct": "(defclass Probe (is-a USER))",
+            }[case_id]
+            try:
+                engine.load(source)
+            except ferric.FerricParseError:
+                family = "parse"
+            except ferric.FerricCompileError:
+                family = "compile"
+            except ferric.FerricError:
+                family = "generic"
+    finally:
+        engine.close()
+    if not family:
+        raise RuntimeError(f"{case_id} did not produce the expected error")
+    return {"family": family}
+
+
+def fact_lifecycle() -> Any:
+    engine = ferric.Engine.from_source(fixture("template.clp"))
+    try:
+        ordered_id = engine.assert_fact("ordered", 7)
+        ordered = engine.get_fact(ordered_id)
+        engine.retract(ordered_id)
+
+        template_id = engine.assert_template("person", name="Ada")
+        template = engine.get_fact(template_id)
+        engine.retract(template_id)
+
+        return {
+            "count_after_retract": engine.fact_count,
+            "ordered_snapshot_retained": (
+                ordered is not None
+                and ordered.relation == "ordered"
+                and len(ordered.fields) == 1
+            ),
+            "template_snapshot_retained": (
+                template is not None
+                and template.template_name == "person"
+                and template.slots["name"] == "Ada"
+            ),
+        }
+    finally:
+        engine.close()
+
+
+def reason(value: ferric.HaltReason) -> str:
+    if value == ferric.HaltReason.AGENDA_EMPTY:
+        return "agenda_empty"
+    if value == ferric.HaltReason.LIMIT_REACHED:
+        return "limit_reached"
+    if value == ferric.HaltReason.HALT_REQUESTED:
+        return "halt_requested"
+    if value == ferric.HaltReason.ACTION_ERROR:
+        return "action_error"
+    raise RuntimeError(f"unknown halt reason: {value!r}")
+
+
+def normalize_run(result: ferric.RunResult) -> Any:
+    return {"fired": result.rules_fired, "reason": reason(result.halt_reason)}
+
+
+def run_fixture(name: str, limit: int | None = None) -> tuple[Any, ferric.Engine]:
+    engine = ferric.Engine.from_source(fixture(name))
+    return normalize_run(engine.run(limit=limit)), engine
+
+
+def run_once(limit: int | None = None) -> Any:
+    result, engine = run_fixture("run-limits.clp", limit)
+    try:
+        return result
+    finally:
+        engine.close()
+
+
+def execution_run_limits() -> Any:
+    return {
+        "zero": run_once(0),
+        "one": run_once(1),
+        "unlimited": run_once(),
+    }
+
+
+def execution_step() -> Any:
+    engine = ferric.Engine.from_source(fixture("one-rule.clp"))
+    try:
+        first = engine.step()
+        second = engine.step()
+        return {
+            "first_rule": first.rule_name if first is not None else None,
+            "empty": second is None,
+        }
+    finally:
+        engine.close()
+
+
+def execution_diagnostic() -> Any:
+    result, engine = run_fixture("diagnostic.clp")
+    try:
+        return {**result, "diagnostic_count": len(engine.diagnostics)}
+    finally:
+        engine.close()
+
+
+def snapshot_roundtrip() -> Any:
+    engine = ferric.Engine.from_source(fixture("snapshot.clp"))
+    try:
+        engine.assert_fact("seed")
+        snapshot = engine.serialize(ferric.Format.JSON)
+    finally:
+        engine.close()
+    restored = ferric.Engine.from_snapshot(snapshot, format=ferric.Format.JSON)
+    try:
+        fact_count = restored.fact_count
+        run = restored.run()
+        return {
+            "fact_count": fact_count,
+            "format": "json",
+            "rules_fired": run.rules_fired,
+        }
+    finally:
+        restored.close()
+
+
+def lifecycle_close() -> Any:
+    engine = ferric.Engine()
+    engine.close()
+    engine.close()
+    post_close = "no_error"
+    try:
+        _ = engine.fact_count
+    except ferric.FerricRuntimeError:
+        post_close = "closed_error"
+    return {"explicit": True, "idempotent": True, "post_close": post_close}
+
+
+def high_fact_id() -> Any:
+    engine = ferric.Engine()
+    try:
+        for _ in range(HIGH_ID_ITERATIONS):
+            fact_id = engine.assert_fact("generation")
+            engine.retract(fact_id)
+        fact_id = engine.assert_fact("generation")
+        return {
+            "roundtrip": (
+                fact_id > 9_007_199_254_740_991 and engine.get_fact(fact_id) is not None
+            )
+        }
+    finally:
+        engine.close()
+
+
+def run_case(case_id: str) -> Any:
+    if case_id.startswith("value."):
+        return value_case(case_id)
+    if case_id.startswith("error."):
+        return error_case(case_id)
+    if case_id == "configuration.default":
+        return configuration_default()
+    if case_id == "configuration.custom":
+        return configuration_custom()
+    if case_id == "fact.lifecycle":
+        return fact_lifecycle()
+    if case_id == "execution.run-limits":
+        return execution_run_limits()
+    if case_id == "execution.step":
+        return execution_step()
+    if case_id == "execution.halt":
+        result, engine = run_fixture("halt.clp")
+        engine.close()
+        return result
+    if case_id == "execution.diagnostic":
+        return execution_diagnostic()
+    if case_id == "execution.batch-boundary-halt":
+        result, engine = run_fixture("batch-boundary-halt.clp")
+        engine.close()
+        return result
+    if case_id == "snapshot.json-roundtrip":
+        return snapshot_roundtrip()
+    if case_id == "lifecycle.close":
+        return lifecycle_close()
+    if case_id == "robustness.embedded-nul":
+        return asserted_field(ferric.String("a\0b"))
+    if case_id == "identifier.high-fact-id":
+        return high_fact_id()
+    if case_id == "count.run-result-width":
+        bits = 64 if sys.maxsize > 2**32 else 32
+        return {"run_count_bits": bits, "run_limit_bits": bits}
+    raise RuntimeError(f"unknown case {case_id}")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise RuntimeError("usage: python adapter CASE_IDS_PATH")
+    cases = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+    for case_id in filter(None, cases):
+        print(
+            json.dumps(
+                {"case": case_id, "result": run_case(case_id)},
+                separators=(",", ":"),
+            ),
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:  # noqa: BLE001 - protocol boundary reports all failures
+        print(f"python conformance adapter: {error}", file=sys.stderr)
+        raise SystemExit(1) from error

--- a/justfile
+++ b/justfile
@@ -141,6 +141,16 @@ py-test:
 py-bindings-test:
     cd crates/ferric-rules-python && PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv run maturin develop --quiet && .venv/bin/python -m pytest tests/
 
+# Run one language-neutral semantic corpus through Rust, C, Go, Node, and Python.
+bindings-conformance:
+    just build-go-ffi
+    just build-napi
+    just ts-build
+    cd packages/ferric && npm run test:bindings-conformance:types
+    cd crates/ferric-rules-python && PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv run maturin develop --quiet
+    ./scripts/build-bindings-conformance-c.sh
+    uv run --project tools/ferric-tools ferric-bindings-conformance
+
 # ── Composite checks ────────────────────────────────────────────────────────
 
 # Full preflight: format check, clippy, all tests, cargo check, Python checks, Go lint

--- a/packages/ferric/package.json
+++ b/packages/ferric/package.json
@@ -18,6 +18,7 @@
     "test:runtime:worker": "tsx --test test/conformance/runtime/worker/**/*.test.ts",
     "test:runtime:pool": "tsx --test test/conformance/runtime/pool/**/*.test.ts",
     "test:package": "tsx --test test/conformance/package/**/*.test.ts",
+    "test:bindings-conformance:types": "tsc --noEmit -p tsconfig.bindings-conformance.json",
     "test:artifact": "node ../../scripts/test-node-package-artifact.mjs",
     "test": "npm run test:types && npm run test:runtime:types && npm run test:runtime:sync && npm run test:runtime:worker && npm run test:runtime:pool && npm run test:package",
     "test:coverage": "npm run build && node --import tsx --test --experimental-test-coverage --test-coverage-lines=100 --test-coverage-branches=100 --test-coverage-functions=100 test/conformance/coverage-entrypoint.test.ts",

--- a/packages/ferric/test/bindings-conformance/adapter.ts
+++ b/packages/ferric/test/bindings-conformance/adapter.ts
@@ -1,0 +1,431 @@
+/**
+ * Node adapter for the shared cross-binding semantic corpus.
+ *
+ * Stdout is NDJSON protocol data only; failures are written to stderr.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  Encoding,
+  Engine,
+  EngineHandle,
+  FerricCompileError,
+  FerricFactNotFoundError,
+  FerricParseError,
+  FerricSymbol,
+  Format,
+  HaltReason,
+  Strategy,
+} from "../../dist/index";
+
+const HIGH_ID_ITERATIONS = 1_048_577;
+
+function repositoryRoot(): string {
+  const value = process.env["FERRIC_BINDINGS_CONFORMANCE_ROOT"];
+  if (!value) throw new Error("FERRIC_BINDINGS_CONFORMANCE_ROOT is not set");
+  return value;
+}
+
+function fixture(name: string): string {
+  return readFileSync(
+    join(repositoryRoot(), "tests", "bindings-conformance", "fixtures", name),
+    "utf8",
+  );
+}
+
+function normalize(value: unknown): unknown {
+  if (value === null || value === undefined) return { type: "void" };
+  if (typeof value === "bigint") {
+    return { type: "integer", value: value.toString() };
+  }
+  if (typeof value === "number") {
+    return {
+      type: Number.isInteger(value) ? "integer" : "float",
+      value: value.toString(),
+    };
+  }
+  if (typeof value === "string") return { type: "string", value };
+  if (value instanceof FerricSymbol) {
+    return { type: "symbol", value: value.value };
+  }
+  if (Array.isArray(value)) {
+    return { type: "multifield", value: value.map(normalize) };
+  }
+  return { type: `unsupported:${typeof value}` };
+}
+
+function assertedField(value: unknown): unknown {
+  const engine = new Engine();
+  try {
+    const id = engine.assertFact("probe", value);
+    const fact = engine.getFact(id) as { fields: unknown[] } | null;
+    if (!fact || fact.fields.length !== 1) {
+      throw new Error("asserted fact did not retain one field");
+    }
+    return normalize(fact.fields[0]);
+  } finally {
+    engine.close();
+  }
+}
+
+function valueCase(caseId: string): unknown {
+  switch (caseId) {
+    case "value.void":
+      return assertedField(null);
+    case "value.integer.boundaries":
+      return {
+        minimum: assertedField(-(1n << 63n)),
+        maximum: assertedField((1n << 63n) - 1n),
+      };
+    case "value.float":
+      return assertedField(1.5);
+    case "value.symbol.explicit":
+      return assertedField(new FerricSymbol("red"));
+    case "value.string.explicit":
+    case "value.string.plain-host":
+      return assertedField("red");
+    case "value.multifield.nested":
+      return assertedField([
+        null,
+        7,
+        2.5,
+        new FerricSymbol("blue"),
+        "text",
+        [9],
+      ]);
+    case "value.external-address": {
+      const engine = new Engine();
+      let ingress = "accepted";
+      try {
+        engine.assertFact("probe", {});
+      } catch {
+        ingress = "unsupported";
+      } finally {
+        engine.close();
+      }
+      return { host_representation: "void", ingress };
+    }
+    default:
+      throw new Error(`unknown value case ${caseId}`);
+  }
+}
+
+function configurationDefault(): unknown {
+  const engine = new Engine();
+  let unicode = "accepted";
+  try {
+    engine.assertFact("unicode", "é");
+  } catch {
+    unicode = "rejected";
+  } finally {
+    engine.close();
+  }
+  return { max_call_depth: 64, strategy: "depth", unicode };
+}
+
+function configurationCustom(): unknown {
+  const engine = Engine.fromSource(fixture("custom-config.clp"), {
+    encoding: Encoding.Ascii,
+    strategy: Strategy.Breadth,
+    maxCallDepth: 1,
+  });
+  let asciiUnicode = "accepted";
+  try {
+    try {
+      engine.assertFact("unicode", "é");
+    } catch {
+      asciiUnicode = "rejected";
+    }
+    const run = engine.run();
+    if (run.haltReason !== HaltReason.ActionError) {
+      throw new Error("custom maxCallDepth did not bound recursion");
+    }
+    return {
+      ascii_unicode: asciiUnicode,
+      max_call_depth: "configurable",
+      strategy_count: 4,
+    };
+  } finally {
+    engine.close();
+  }
+}
+
+function errorCase(caseId: string): unknown {
+  const engine = new Engine();
+  let family = "";
+  try {
+    if (caseId === "error.runtime") {
+      const id = engine.assertFact("stale");
+      engine.retract(id);
+      try {
+        engine.retract(id);
+      } catch (error) {
+        if (error instanceof FerricFactNotFoundError) family = "fact_not_found";
+      }
+    } else {
+      const source =
+        caseId === "error.parse"
+          ? "(defrule incomplete"
+          : caseId === "error.compile"
+            ? "(defrule bad => (nonexistent-fn))"
+            : "(defclass Probe (is-a USER))";
+      try {
+        engine.load(source);
+      } catch (error) {
+        if (error instanceof FerricParseError) family = "parse";
+        else if (error instanceof FerricCompileError) family = "compile";
+        else family = "generic";
+      }
+    }
+  } finally {
+    engine.close();
+  }
+  if (!family) throw new Error(`${caseId} did not produce the expected error`);
+  return { family };
+}
+
+function factLifecycle(): unknown {
+  const engine = Engine.fromSource(fixture("template.clp"));
+  try {
+    const orderedId = engine.assertFact("ordered", 7);
+    const ordered = engine.getFact(orderedId) as {
+      relation?: string;
+      fields: unknown[];
+    };
+    engine.retract(orderedId);
+
+    const templateId = engine.assertTemplate("person", { name: "Ada" });
+    const template = engine.getFact(templateId) as {
+      templateName?: string;
+      slots?: Record<string, unknown>;
+    };
+    engine.retract(templateId);
+
+    return {
+      count_after_retract: engine.factCount,
+      ordered_snapshot_retained:
+        ordered.relation === "ordered" && ordered.fields.length === 1,
+      template_snapshot_retained:
+        template.templateName === "person" && template.slots?.["name"] === "Ada",
+    };
+  } finally {
+    engine.close();
+  }
+}
+
+function reason(value: HaltReason): string {
+  switch (value) {
+    case HaltReason.AgendaEmpty:
+      return "agenda_empty";
+    case HaltReason.LimitReached:
+      return "limit_reached";
+    case HaltReason.HaltRequested:
+      return "halt_requested";
+    case HaltReason.ActionError:
+      return "action_error";
+  }
+}
+
+function normalizeRun(result: {
+  rulesFired: number;
+  haltReason: HaltReason;
+}): unknown {
+  return { fired: result.rulesFired, reason: reason(result.haltReason) };
+}
+
+function runFixture(name: string, limit?: number): {
+  result: { rulesFired: number; haltReason: HaltReason };
+  engine: InstanceType<typeof Engine>;
+} {
+  const engine = Engine.fromSource(fixture(name));
+  return { result: engine.run(limit), engine };
+}
+
+function runOnce(limit?: number): unknown {
+  const { result, engine } = runFixture("run-limits.clp", limit);
+  try {
+    return normalizeRun(result);
+  } finally {
+    engine.close();
+  }
+}
+
+function executionRunLimits(): unknown {
+  return {
+    zero: runOnce(0),
+    one: runOnce(1),
+    unlimited: runOnce(),
+  };
+}
+
+function executionStep(): unknown {
+  const engine = Engine.fromSource(fixture("one-rule.clp"));
+  try {
+    const first = engine.step();
+    const second = engine.step();
+    return { first_rule: first?.ruleName ?? null, empty: second === null };
+  } finally {
+    engine.close();
+  }
+}
+
+function executionDiagnostic(): unknown {
+  const { result, engine } = runFixture("diagnostic.clp");
+  try {
+    return {
+      ...normalizeRun(result) as object,
+      diagnostic_count: engine.diagnostics.length,
+    };
+  } finally {
+    engine.close();
+  }
+}
+
+async function batchBoundaryHalt(): Promise<unknown> {
+  const handle = await EngineHandle.create({
+    source: fixture("batch-boundary-halt.clp"),
+  });
+  try {
+    return normalizeRun(await handle.run());
+  } finally {
+    await handle.close();
+  }
+}
+
+function snapshotRoundtrip(): unknown {
+  const engine = Engine.fromSource(fixture("snapshot.clp"));
+  const snapshot = (() => {
+    try {
+      engine.assertFact("seed");
+      return engine.serialize(Format.Json);
+    } finally {
+      engine.close();
+    }
+  })();
+  const restored = Engine.fromSnapshot(snapshot, Format.Json);
+  try {
+    const factCount = restored.factCount;
+    const run = restored.run();
+    return {
+      fact_count: factCount,
+      format: "json",
+      rules_fired: run.rulesFired,
+    };
+  } finally {
+    restored.close();
+  }
+}
+
+function lifecycleClose(): unknown {
+  const engine = new Engine();
+  engine.close();
+  engine.close();
+  let postClose = "no_error";
+  try {
+    void engine.factCount;
+  } catch {
+    postClose = "closed_error";
+  }
+  return { explicit: true, idempotent: true, post_close: postClose };
+}
+
+function highFactId(): unknown {
+  const engine = new Engine();
+  let roundtrip = true;
+  try {
+    for (let iteration = 0; iteration < HIGH_ID_ITERATIONS; iteration += 1) {
+      const id = engine.assertFact("generation");
+      try {
+        engine.retract(id);
+      } catch {
+        roundtrip = false;
+        break;
+      }
+    }
+    if (roundtrip) {
+      const id = engine.assertFact("generation");
+      roundtrip =
+        id > Number.MAX_SAFE_INTEGER &&
+        engine.getFact(id) !== null;
+    }
+  } finally {
+    engine.close();
+  }
+  return { roundtrip };
+}
+
+function countWidth(): unknown {
+  const engine = Engine.fromSource(fixture("run-limits.clp"));
+  let runLimitBits = 64;
+  try {
+    try {
+      const result = engine.run(2 ** 32 + 1);
+      if (result.rulesFired !== 3) runLimitBits = 32;
+    } catch {
+      runLimitBits = 32;
+    }
+  } finally {
+    engine.close();
+  }
+  return { run_count_bits: runLimitBits, run_limit_bits: runLimitBits };
+}
+
+async function runCase(caseId: string): Promise<unknown> {
+  if (caseId.startsWith("value.")) return valueCase(caseId);
+  if (caseId.startsWith("error.")) return errorCase(caseId);
+  switch (caseId) {
+    case "configuration.default":
+      return configurationDefault();
+    case "configuration.custom":
+      return configurationCustom();
+    case "fact.lifecycle":
+      return factLifecycle();
+    case "execution.run-limits":
+      return executionRunLimits();
+    case "execution.step":
+      return executionStep();
+    case "execution.halt": {
+      const { result, engine } = runFixture("halt.clp");
+      try {
+        return normalizeRun(result);
+      } finally {
+        engine.close();
+      }
+    }
+    case "execution.diagnostic":
+      return executionDiagnostic();
+    case "execution.batch-boundary-halt":
+      return batchBoundaryHalt();
+    case "snapshot.json-roundtrip":
+      return snapshotRoundtrip();
+    case "lifecycle.close":
+      return lifecycleClose();
+    case "robustness.embedded-nul":
+      return assertedField("a\0b");
+    case "identifier.high-fact-id":
+      return highFactId();
+    case "count.run-result-width":
+      return countWidth();
+    default:
+      throw new Error(`unknown case ${caseId}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const casePath = process.argv[2];
+  if (!casePath) throw new Error("usage: node adapter CASE_IDS_PATH");
+  const cases = readFileSync(casePath, "utf8")
+    .split(/\r?\n/u)
+    .filter(Boolean);
+  for (const caseId of cases) {
+    const result = await runCase(caseId);
+    process.stdout.write(`${JSON.stringify({ case: caseId, result })}\n`);
+  }
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`node conformance adapter: ${String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/packages/ferric/tsconfig.bindings-conformance.json
+++ b/packages/ferric/tsconfig.bindings-conformance.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["test/bindings-conformance/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/scripts/build-bindings-conformance-c.sh
+++ b/scripts/build-bindings-conformance-c.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Build the real-C adapter against the release-profile serde-enabled FFI archive.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+cc="${CC:-cc}"
+outdir="target/bindings-conformance"
+mkdir -p "$outdir"
+
+case "$(uname -s)" in
+Darwin)
+    platform_libs=(-framework Security -framework CoreFoundation -lobjc)
+    ;;
+*)
+    platform_libs=(-lpthread -ldl -lm)
+    ;;
+esac
+
+"$cc" -std=c11 -pedantic-errors -Wall -Wextra -Werror \
+    -DFERRIC_SERDE \
+    -I crates/ferric-rules-ffi \
+    -o "$outdir/c-adapter" \
+    tests/bindings-conformance/adapters/c/adapter.c \
+    target/release/libferric_rules_ffi.a \
+    "${platform_libs[@]}"

--- a/tests/bindings-conformance/README.md
+++ b/tests/bindings-conformance/README.md
@@ -1,0 +1,33 @@
+# Cross-binding semantic conformance
+
+`corpus.json` is the language-neutral contract shared by the Rust, C, Go,
+Node, and Python adapters. `just bindings-conformance` runs every required
+case through every adapter, compares normalized JSON observations, and fails
+on missing results, unknown drift, or a deviation that has become stale.
+
+The canonical result is the intended shared engine semantic. A binding may
+temporarily or deliberately differ only through an exact `deviations` entry
+that records:
+
+- the expected normalized result;
+- a rationale;
+- the corpus version that introduced it; and
+- the issue that owns the policy or remediation.
+
+When an implementation starts matching the canonical result, the command
+fails until its stale deviation is removed. This keeps the matrix honest as
+FR-BIND-001, FR-BIND-002, FR-CABI-005, and the binding-specific follow-ups
+land.
+
+Every public semantic added to a binding must have a matrix case. The corpus
+loader enforces the required semantic inventory, unique case IDs, complete
+adapter participation, and versioned deviation metadata.
+
+Adapters read a newline-delimited case-ID file and emit one JSON object per
+line:
+
+```json
+{"case":"value.void","result":{"type":"void"}}
+```
+
+Adapter stdout is protocol-only. Diagnostics belong on stderr.

--- a/tests/bindings-conformance/adapters/c/adapter.c
+++ b/tests/bindings-conformance/adapters/c/adapter.c
@@ -1,0 +1,697 @@
+#include "ferric.h"
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define HIGH_ID_ITERATIONS 1048577U
+
+static char *read_fixture(const char *name) {
+    const char *root = getenv("FERRIC_BINDINGS_CONFORMANCE_ROOT");
+    char path[4096];
+    FILE *file;
+    long size;
+    char *data;
+
+    if (root == NULL) {
+        fprintf(stderr, "FERRIC_BINDINGS_CONFORMANCE_ROOT is not set\n");
+        return NULL;
+    }
+    if (snprintf(path,
+                 sizeof(path),
+                 "%s/tests/bindings-conformance/fixtures/%s",
+                 root,
+                 name) >= (int)sizeof(path)) {
+        fprintf(stderr, "fixture path is too long\n");
+        return NULL;
+    }
+    file = fopen(path, "rb");
+    if (file == NULL) {
+        fprintf(stderr, "cannot open fixture %s\n", path);
+        return NULL;
+    }
+    if (fseek(file, 0, SEEK_END) != 0 || (size = ftell(file)) < 0 ||
+        fseek(file, 0, SEEK_SET) != 0) {
+        fclose(file);
+        fprintf(stderr, "cannot size fixture %s\n", path);
+        return NULL;
+    }
+    data = (char *)malloc((size_t)size + 1U);
+    if (data == NULL) {
+        fclose(file);
+        fprintf(stderr, "cannot allocate fixture buffer\n");
+        return NULL;
+    }
+    if (fread(data, 1U, (size_t)size, file) != (size_t)size) {
+        free(data);
+        fclose(file);
+        fprintf(stderr, "cannot read fixture %s\n", path);
+        return NULL;
+    }
+    data[size] = '\0';
+    fclose(file);
+    return data;
+}
+
+static struct FerricEngine *engine_from_fixture(const char *name) {
+    char *source = read_fixture(name);
+    struct FerricEngine *engine;
+    if (source == NULL) {
+        return NULL;
+    }
+    engine = ferric_engine_new_with_source(source);
+    free(source);
+    return engine;
+}
+
+static void print_json_string(const char *value) {
+    const unsigned char *cursor = (const unsigned char *)value;
+    putchar('"');
+    while (*cursor != '\0') {
+        switch (*cursor) {
+        case '"':
+            fputs("\\\"", stdout);
+            break;
+        case '\\':
+            fputs("\\\\", stdout);
+            break;
+        case '\b':
+            fputs("\\b", stdout);
+            break;
+        case '\f':
+            fputs("\\f", stdout);
+            break;
+        case '\n':
+            fputs("\\n", stdout);
+            break;
+        case '\r':
+            fputs("\\r", stdout);
+            break;
+        case '\t':
+            fputs("\\t", stdout);
+            break;
+        default:
+            if (*cursor < 0x20U) {
+                printf("\\u%04x", (unsigned int)*cursor);
+            } else {
+                putchar((int)*cursor);
+            }
+            break;
+        }
+        cursor++;
+    }
+    putchar('"');
+}
+
+static bool print_normalized_value(const struct FerricValue *value) {
+    uintptr_t index;
+    switch (value->value_type) {
+    case FERRIC_VALUE_TYPE_VOID:
+        fputs("{\"type\":\"void\"}", stdout);
+        return true;
+    case FERRIC_VALUE_TYPE_INTEGER:
+        printf("{\"type\":\"integer\",\"value\":\"%" PRId64 "\"}", value->integer);
+        return true;
+    case FERRIC_VALUE_TYPE_FLOAT:
+        printf("{\"type\":\"float\",\"value\":\"%.17g\"}", value->float_);
+        return true;
+    case FERRIC_VALUE_TYPE_SYMBOL:
+        fputs("{\"type\":\"symbol\",\"value\":", stdout);
+        print_json_string(value->string_ptr);
+        putchar('}');
+        return true;
+    case FERRIC_VALUE_TYPE_STRING:
+        fputs("{\"type\":\"string\",\"value\":", stdout);
+        print_json_string(value->string_ptr);
+        putchar('}');
+        return true;
+    case FERRIC_VALUE_TYPE_MULTIFIELD:
+        fputs("{\"type\":\"multifield\",\"value\":[", stdout);
+        for (index = 0; index < value->multifield_len; index++) {
+            if (index != 0U) {
+                putchar(',');
+            }
+            if (!print_normalized_value(&value->multifield_ptr[index])) {
+                return false;
+            }
+        }
+        fputs("]}", stdout);
+        return true;
+    case FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS:
+        fputs("{\"type\":\"external_address\"}", stdout);
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool fetch_field(struct FerricEngine *engine,
+                        uint64_t fact_id,
+                        struct FerricValue *output) {
+    memset(output, 0, sizeof(*output));
+    return ferric_engine_get_fact_field(engine, fact_id, 0U, output) == FERRIC_ERROR_OK;
+}
+
+static bool print_asserted_value(struct FerricValue *input) {
+    struct FerricEngine *engine = ferric_engine_new();
+    struct FerricValue output;
+    uint64_t fact_id = 0;
+    bool success;
+
+    if (engine == NULL) {
+        return false;
+    }
+    success = ferric_engine_assert_ordered(engine, "probe", input, 1U, &fact_id) ==
+                  FERRIC_ERROR_OK &&
+              fetch_field(engine, fact_id, &output);
+    if (success) {
+        success = print_normalized_value(&output);
+        ferric_value_free(&output);
+    }
+    ferric_engine_free(engine);
+    return success;
+}
+
+static bool value_case(const char *case_id) {
+    if (strcmp(case_id, "value.void") == 0) {
+        struct FerricValue value = ferric_value_void();
+        return print_asserted_value(&value);
+    }
+    if (strcmp(case_id, "value.integer.boundaries") == 0) {
+        struct FerricValue minimum = ferric_value_integer(INT64_MIN);
+        struct FerricValue maximum = ferric_value_integer(INT64_MAX);
+        fputs("{\"minimum\":", stdout);
+        if (!print_asserted_value(&minimum)) {
+            return false;
+        }
+        fputs(",\"maximum\":", stdout);
+        if (!print_asserted_value(&maximum)) {
+            return false;
+        }
+        putchar('}');
+        return true;
+    }
+    if (strcmp(case_id, "value.float") == 0) {
+        struct FerricValue value = ferric_value_float(1.5);
+        return print_asserted_value(&value);
+    }
+    if (strcmp(case_id, "value.symbol.explicit") == 0) {
+        struct FerricValue value = ferric_value_symbol("red");
+        bool success = print_asserted_value(&value);
+        ferric_value_free(&value);
+        return success;
+    }
+    if (strcmp(case_id, "value.string.explicit") == 0 ||
+        strcmp(case_id, "value.string.plain-host") == 0) {
+        struct FerricValue value = ferric_value_string("red");
+        bool success = print_asserted_value(&value);
+        ferric_value_free(&value);
+        return success;
+    }
+    if (strcmp(case_id, "value.multifield.nested") == 0) {
+        struct FerricValue nested_input[1];
+        struct FerricValue nested;
+        struct FerricValue inputs[6];
+        struct FerricValue multifield;
+        bool success;
+        size_t index;
+
+        nested_input[0] = ferric_value_integer(9);
+        if (ferric_value_multifield_copy(nested_input, 1U, &nested) != FERRIC_ERROR_OK) {
+            return false;
+        }
+        inputs[0] = ferric_value_void();
+        inputs[1] = ferric_value_integer(7);
+        inputs[2] = ferric_value_float(2.5);
+        inputs[3] = ferric_value_symbol("blue");
+        inputs[4] = ferric_value_string("text");
+        inputs[5] = nested;
+        if (ferric_value_multifield_copy(inputs, 6U, &multifield) != FERRIC_ERROR_OK) {
+            for (index = 0; index < 6U; index++) {
+                ferric_value_free(&inputs[index]);
+            }
+            return false;
+        }
+        success = print_asserted_value(&multifield);
+        ferric_value_free(&multifield);
+        for (index = 0; index < 6U; index++) {
+            ferric_value_free(&inputs[index]);
+        }
+        return success;
+    }
+    if (strcmp(case_id, "value.external-address") == 0) {
+        struct FerricEngine *engine = ferric_engine_new();
+        struct FerricValue external;
+        uint64_t fact_id = 0;
+        enum FerricError code;
+        if (engine == NULL) {
+            return false;
+        }
+        memset(&external, 0, sizeof(external));
+        external.value_type = FERRIC_VALUE_TYPE_EXTERNAL_ADDRESS;
+        external.external_type_id = 7U;
+        code = ferric_engine_assert_ordered(engine, "probe", &external, 1U, &fact_id);
+        ferric_engine_free(engine);
+        printf("{\"host_representation\":\"opaque\",\"ingress\":\"%s\"}",
+               code == FERRIC_ERROR_OK ? "accepted" : "rejected");
+        return true;
+    }
+    return false;
+}
+
+static bool configuration_default(void) {
+    struct FerricEngine *engine = ferric_engine_new();
+    struct FerricValue value = ferric_value_string("é");
+    uint64_t fact_id = 0;
+    enum FerricError code;
+    if (engine == NULL) {
+        ferric_value_free(&value);
+        return false;
+    }
+    code = ferric_engine_assert_ordered(engine, "unicode", &value, 1U, &fact_id);
+    ferric_value_free(&value);
+    ferric_engine_free(engine);
+    printf("{\"max_call_depth\":64,\"strategy\":\"depth\",\"unicode\":\"%s\"}",
+           code == FERRIC_ERROR_OK ? "accepted" : "rejected");
+    return true;
+}
+
+static bool configuration_custom(void) {
+    struct FerricConfig config;
+    struct FerricEngine *engine;
+    struct FerricValue value;
+    char *source;
+    uint64_t fact_id = 0;
+    uint64_t fired = 0;
+    enum FerricHaltReason reason = FERRIC_HALT_REASON_AGENDA_EMPTY;
+    enum FerricError unicode_code;
+    bool depth_bounded;
+
+    config.string_encoding = FERRIC_STRING_ENCODING_ASCII;
+    config.strategy = FERRIC_CONFLICT_STRATEGY_BREADTH;
+    config.max_call_depth = 1U;
+    engine = ferric_engine_new_with_config(&config);
+    source = read_fixture("custom-config.clp");
+    if (engine == NULL || source == NULL) {
+        free(source);
+        if (engine != NULL) {
+            ferric_engine_free(engine);
+        }
+        return false;
+    }
+    if (ferric_engine_load_string(engine, source) != FERRIC_ERROR_OK ||
+        ferric_engine_reset(engine) != FERRIC_ERROR_OK) {
+        free(source);
+        ferric_engine_free(engine);
+        return false;
+    }
+    free(source);
+    value = ferric_value_string("é");
+    unicode_code =
+        ferric_engine_assert_ordered(engine, "unicode", &value, 1U, &fact_id);
+    ferric_value_free(&value);
+    depth_bounded =
+        ferric_engine_run_ex(engine, -1, &fired, &reason) == FERRIC_ERROR_OK &&
+        reason == FERRIC_HALT_REASON_ACTION_ERROR;
+    ferric_engine_free(engine);
+    if (!depth_bounded) {
+        return false;
+    }
+    printf("{\"ascii_unicode\":\"%s\",\"max_call_depth\":\"configurable\","
+           "\"strategy_count\":4}",
+           unicode_code == FERRIC_ERROR_OK ? "accepted" : "rejected");
+    return true;
+}
+
+static bool error_case(const char *case_id) {
+    struct FerricEngine *engine = ferric_engine_new();
+    enum FerricError code;
+    const char *family = NULL;
+    uint64_t fact_id = 0;
+    if (engine == NULL) {
+        return false;
+    }
+    if (strcmp(case_id, "error.parse") == 0) {
+        code = ferric_engine_load_string(engine, "(defrule incomplete");
+        if (code == FERRIC_ERROR_PARSE_ERROR) {
+            family = "parse";
+        }
+    } else if (strcmp(case_id, "error.compile") == 0) {
+        code = ferric_engine_load_string(engine, "(defrule bad => (nonexistent-fn))");
+        if (code == FERRIC_ERROR_COMPILE_ERROR) {
+            family = "compile";
+        }
+    } else if (strcmp(case_id, "error.unsupported-construct") == 0) {
+        code = ferric_engine_load_string(engine, "(defclass Probe (is-a USER))");
+        if (code == FERRIC_ERROR_COMPILE_ERROR) {
+            family = "compile";
+        }
+    } else if (strcmp(case_id, "error.runtime") == 0) {
+        code = ferric_engine_assert_ordered(engine, "stale", NULL, 0U, &fact_id);
+        if (code == FERRIC_ERROR_OK) {
+            code = ferric_engine_retract(engine, fact_id);
+        }
+        if (code == FERRIC_ERROR_OK) {
+            code = ferric_engine_retract(engine, fact_id);
+        }
+        if (code == FERRIC_ERROR_NOT_FOUND) {
+            family = "fact_not_found";
+        }
+    }
+    ferric_engine_free(engine);
+    if (family == NULL) {
+        return false;
+    }
+    printf("{\"family\":\"%s\"}", family);
+    return true;
+}
+
+static bool fact_lifecycle(void) {
+    struct FerricEngine *engine = engine_from_fixture("template.clp");
+    struct FerricValue ordered_input = ferric_value_integer(7);
+    struct FerricValue ordered_snapshot;
+    struct FerricValue template_input = ferric_value_string("Ada");
+    struct FerricValue template_snapshot;
+    const char *slot_names[1] = {"name"};
+    uint64_t ordered_id = 0;
+    uint64_t template_id = 0;
+    uintptr_t count = 0;
+    bool ordered_retained;
+    bool template_retained;
+    if (engine == NULL) {
+        ferric_value_free(&template_input);
+        return false;
+    }
+    if (ferric_engine_assert_ordered(
+            engine, "ordered", &ordered_input, 1U, &ordered_id) != FERRIC_ERROR_OK ||
+        !fetch_field(engine, ordered_id, &ordered_snapshot) ||
+        ferric_engine_retract(engine, ordered_id) != FERRIC_ERROR_OK ||
+        ferric_engine_assert_template(
+            engine, "person", slot_names, &template_input, 1U, &template_id) !=
+            FERRIC_ERROR_OK ||
+        ferric_engine_get_fact_slot_by_name(engine, template_id, "name", &template_snapshot) !=
+            FERRIC_ERROR_OK ||
+        ferric_engine_retract(engine, template_id) != FERRIC_ERROR_OK ||
+        ferric_engine_fact_count(engine, &count) != FERRIC_ERROR_OK) {
+        ferric_value_free(&ordered_input);
+        ferric_value_free(&template_input);
+        ferric_engine_free(engine);
+        return false;
+    }
+    ordered_retained = ordered_snapshot.value_type == FERRIC_VALUE_TYPE_INTEGER &&
+                       ordered_snapshot.integer == 7;
+    template_retained = template_snapshot.value_type == FERRIC_VALUE_TYPE_STRING &&
+                        strcmp(template_snapshot.string_ptr, "Ada") == 0;
+    printf("{\"count_after_retract\":%" PRIuPTR
+           ",\"ordered_snapshot_retained\":%s,\"template_snapshot_retained\":%s}",
+           count,
+           ordered_retained ? "true" : "false",
+           template_retained ? "true" : "false");
+    ferric_value_free(&ordered_snapshot);
+    ferric_value_free(&template_snapshot);
+    ferric_value_free(&ordered_input);
+    ferric_value_free(&template_input);
+    ferric_engine_free(engine);
+    return true;
+}
+
+static const char *halt_reason_name(enum FerricHaltReason reason) {
+    switch (reason) {
+    case FERRIC_HALT_REASON_AGENDA_EMPTY:
+        return "agenda_empty";
+    case FERRIC_HALT_REASON_LIMIT_REACHED:
+        return "limit_reached";
+    case FERRIC_HALT_REASON_HALT_REQUESTED:
+        return "halt_requested";
+    case FERRIC_HALT_REASON_ACTION_ERROR:
+        return "action_error";
+    default:
+        return "unknown";
+    }
+}
+
+static bool print_run_fixture(const char *name, int64_t limit) {
+    struct FerricEngine *engine = engine_from_fixture(name);
+    uint64_t fired = 0;
+    enum FerricHaltReason reason = FERRIC_HALT_REASON_AGENDA_EMPTY;
+    enum FerricError code;
+    if (engine == NULL) {
+        return false;
+    }
+    code = ferric_engine_run_ex(engine, limit, &fired, &reason);
+    ferric_engine_free(engine);
+    if (code != FERRIC_ERROR_OK) {
+        return false;
+    }
+    printf("{\"fired\":%" PRIu64 ",\"reason\":\"%s\"}",
+           fired,
+           halt_reason_name(reason));
+    return true;
+}
+
+static bool execution_run_limits(void) {
+    fputs("{\"zero\":", stdout);
+    if (!print_run_fixture("run-limits.clp", 0)) {
+        return false;
+    }
+    fputs(",\"one\":", stdout);
+    if (!print_run_fixture("run-limits.clp", 1)) {
+        return false;
+    }
+    fputs(",\"unlimited\":", stdout);
+    if (!print_run_fixture("run-limits.clp", -1)) {
+        return false;
+    }
+    putchar('}');
+    return true;
+}
+
+static bool execution_step(void) {
+    struct FerricEngine *engine = engine_from_fixture("one-rule.clp");
+    int32_t first = 0;
+    int32_t second = 0;
+    if (engine == NULL) {
+        return false;
+    }
+    if (ferric_engine_step(engine, &first) != FERRIC_ERROR_OK ||
+        ferric_engine_step(engine, &second) != FERRIC_ERROR_OK) {
+        ferric_engine_free(engine);
+        return false;
+    }
+    ferric_engine_free(engine);
+    printf("{\"empty\":%s,\"first_rule\":null}",
+           first == 1 && second == 0 ? "true" : "false");
+    return true;
+}
+
+static bool execution_diagnostic(void) {
+    struct FerricEngine *engine = engine_from_fixture("diagnostic.clp");
+    uint64_t fired = 0;
+    uintptr_t count = 0;
+    enum FerricHaltReason reason = FERRIC_HALT_REASON_AGENDA_EMPTY;
+    if (engine == NULL) {
+        return false;
+    }
+    if (ferric_engine_run_ex(engine, -1, &fired, &reason) != FERRIC_ERROR_OK ||
+        ferric_engine_action_diagnostic_count(engine, &count) != FERRIC_ERROR_OK) {
+        ferric_engine_free(engine);
+        return false;
+    }
+    printf("{\"diagnostic_count\":%" PRIuPTR ",\"fired\":%" PRIu64
+           ",\"reason\":\"%s\"}",
+           count,
+           fired,
+           halt_reason_name(reason));
+    ferric_engine_free(engine);
+    return true;
+}
+
+static bool snapshot_roundtrip(void) {
+    struct FerricEngine *engine = engine_from_fixture("snapshot.clp");
+    struct FerricEngine *restored = NULL;
+    uint8_t *bytes = NULL;
+    uintptr_t length = 0;
+    uintptr_t fact_count = 0;
+    uint64_t fact_id = 0;
+    uint64_t fired = 0;
+    enum FerricHaltReason reason = FERRIC_HALT_REASON_AGENDA_EMPTY;
+    enum FerricError code;
+    if (engine == NULL) {
+        return false;
+    }
+    code = ferric_engine_assert_ordered(engine, "seed", NULL, 0U, &fact_id);
+    if (code == FERRIC_ERROR_OK) {
+        code = ferric_engine_serialize_as(engine,
+                                          FERRIC_SERIALIZATION_FORMAT_JSON,
+                                          NULL,
+                                          NULL,
+                                          &bytes,
+                                          &length);
+    }
+    ferric_engine_free(engine);
+    if (code == FERRIC_ERROR_OK) {
+        code = ferric_engine_deserialize_as(bytes,
+                                            length,
+                                            FERRIC_SERIALIZATION_FORMAT_JSON,
+                                            &restored);
+    }
+    ferric_bytes_free(bytes, length);
+    if (code != FERRIC_ERROR_OK || restored == NULL) {
+        return false;
+    }
+    code = ferric_engine_fact_count(restored, &fact_count);
+    if (code == FERRIC_ERROR_OK) {
+        code = ferric_engine_run_ex(restored, -1, &fired, &reason);
+    }
+    ferric_engine_free(restored);
+    if (code != FERRIC_ERROR_OK) {
+        return false;
+    }
+    printf("{\"fact_count\":%" PRIuPTR
+           ",\"format\":\"json\",\"rules_fired\":%" PRIu64 "}",
+           fact_count,
+           fired);
+    return true;
+}
+
+static bool lifecycle_close(void) {
+    struct FerricEngine *engine = ferric_engine_new();
+    if (engine == NULL || ferric_engine_free(engine) != FERRIC_ERROR_OK) {
+        return false;
+    }
+    fputs("{\"explicit\":true,\"idempotent\":false,\"post_close\":\"undefined\"}",
+          stdout);
+    return true;
+}
+
+static bool embedded_nul(void) {
+    char embedded[] = {'a', '\0', 'b', '\0'};
+    struct FerricValue value = ferric_value_string(embedded);
+    bool success = print_asserted_value(&value);
+    ferric_value_free(&value);
+    return success;
+}
+
+static bool high_fact_id(void) {
+    struct FerricEngine *engine = ferric_engine_new();
+    uint64_t fact_id = 0;
+    enum FerricFactType fact_type = FERRIC_FACT_TYPE_ORDERED;
+    uint32_t iteration;
+    bool roundtrip;
+    if (engine == NULL) {
+        return false;
+    }
+    for (iteration = 0; iteration < HIGH_ID_ITERATIONS; iteration++) {
+        if (ferric_engine_assert_ordered(
+                engine, "generation", NULL, 0U, &fact_id) != FERRIC_ERROR_OK ||
+            ferric_engine_retract(engine, fact_id) != FERRIC_ERROR_OK) {
+            ferric_engine_free(engine);
+            return false;
+        }
+    }
+    if (ferric_engine_assert_ordered(
+            engine, "generation", NULL, 0U, &fact_id) != FERRIC_ERROR_OK) {
+        ferric_engine_free(engine);
+        return false;
+    }
+    roundtrip = fact_id > UINT64_C(9007199254740991) &&
+                ferric_engine_get_fact_type(engine, fact_id, &fact_type) ==
+                    FERRIC_ERROR_OK;
+    printf("{\"roundtrip\":%s}", roundtrip ? "true" : "false");
+    ferric_engine_free(engine);
+    return true;
+}
+
+static bool run_case(const char *case_id) {
+    if (strncmp(case_id, "value.", 6U) == 0) {
+        return value_case(case_id);
+    }
+    if (strncmp(case_id, "error.", 6U) == 0) {
+        return error_case(case_id);
+    }
+    if (strcmp(case_id, "configuration.default") == 0) {
+        return configuration_default();
+    }
+    if (strcmp(case_id, "configuration.custom") == 0) {
+        return configuration_custom();
+    }
+    if (strcmp(case_id, "fact.lifecycle") == 0) {
+        return fact_lifecycle();
+    }
+    if (strcmp(case_id, "execution.run-limits") == 0) {
+        return execution_run_limits();
+    }
+    if (strcmp(case_id, "execution.step") == 0) {
+        return execution_step();
+    }
+    if (strcmp(case_id, "execution.halt") == 0) {
+        return print_run_fixture("halt.clp", -1);
+    }
+    if (strcmp(case_id, "execution.diagnostic") == 0) {
+        return execution_diagnostic();
+    }
+    if (strcmp(case_id, "execution.batch-boundary-halt") == 0) {
+        return print_run_fixture("batch-boundary-halt.clp", -1);
+    }
+    if (strcmp(case_id, "snapshot.json-roundtrip") == 0) {
+        return snapshot_roundtrip();
+    }
+    if (strcmp(case_id, "lifecycle.close") == 0) {
+        return lifecycle_close();
+    }
+    if (strcmp(case_id, "robustness.embedded-nul") == 0) {
+        return embedded_nul();
+    }
+    if (strcmp(case_id, "identifier.high-fact-id") == 0) {
+        return high_fact_id();
+    }
+    if (strcmp(case_id, "count.run-result-width") == 0) {
+        fputs("{\"run_count_bits\":64,\"run_limit_bits\":64}", stdout);
+        return true;
+    }
+    return false;
+}
+
+int main(int argc, char **argv) {
+    FILE *cases;
+    char case_id[256];
+    if (argc != 2) {
+        fprintf(stderr, "usage: c adapter CASE_IDS_PATH\n");
+        return 2;
+    }
+    cases = fopen(argv[1], "rb");
+    if (cases == NULL) {
+        fprintf(stderr, "cannot open case list %s\n", argv[1]);
+        return 1;
+    }
+    while (fgets(case_id, sizeof(case_id), cases) != NULL) {
+        size_t length = strlen(case_id);
+        while (length > 0U &&
+               (case_id[length - 1U] == '\n' || case_id[length - 1U] == '\r')) {
+            case_id[--length] = '\0';
+        }
+        if (length == 0U) {
+            continue;
+        }
+        fputs("{\"case\":", stdout);
+        print_json_string(case_id);
+        fputs(",\"result\":", stdout);
+        if (!run_case(case_id)) {
+            fprintf(stderr, "c conformance adapter failed case %s\n", case_id);
+            fclose(cases);
+            return 1;
+        }
+        fputs("}\n", stdout);
+        fflush(stdout);
+    }
+    if (ferror(cases) != 0) {
+        fprintf(stderr, "cannot read case list\n");
+        fclose(cases);
+        return 1;
+    }
+    fclose(cases);
+    return 0;
+}

--- a/tests/bindings-conformance/corpus.json
+++ b/tests/bindings-conformance/corpus.json
@@ -1,0 +1,343 @@
+{
+  "schema_version": 1,
+  "suite_version": "1.0.0",
+  "bindings": ["rust", "c", "go", "node", "python"],
+  "cases": [
+    {
+      "id": "value.void",
+      "semantic": "value.void",
+      "canonical": {"type": "void"}
+    },
+    {
+      "id": "value.integer.boundaries",
+      "semantic": "value.integer",
+      "canonical": {
+        "maximum": {"type": "integer", "value": "9223372036854775807"},
+        "minimum": {"type": "integer", "value": "-9223372036854775808"}
+      }
+    },
+    {
+      "id": "value.float",
+      "semantic": "value.float",
+      "canonical": {"type": "float", "value": "1.5"}
+    },
+    {
+      "id": "value.symbol.explicit",
+      "semantic": "value.symbol",
+      "canonical": {"type": "symbol", "value": "red"}
+    },
+    {
+      "id": "value.string.explicit",
+      "semantic": "value.string",
+      "canonical": {"type": "string", "value": "red"}
+    },
+    {
+      "id": "value.string.plain-host",
+      "semantic": "value.string",
+      "canonical": {"type": "string", "value": "red"},
+      "deviations": {
+        "python": {
+          "expected": {"type": "symbol", "value": "red"},
+          "rationale": "Python plain str currently defaults to a CLIPS Symbol while the other host bindings default to String.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/166"
+        }
+      }
+    },
+    {
+      "id": "value.multifield.nested",
+      "semantic": "value.multifield",
+      "canonical": {
+        "type": "multifield",
+        "value": [
+          {"type": "void"},
+          {"type": "integer", "value": "7"},
+          {"type": "float", "value": "2.5"},
+          {"type": "symbol", "value": "blue"},
+          {"type": "string", "value": "text"},
+          {
+            "type": "multifield",
+            "value": [{"type": "integer", "value": "9"}]
+          }
+        ]
+      }
+    },
+    {
+      "id": "value.external-address",
+      "semantic": "value.external_address",
+      "canonical": {
+        "host_representation": "opaque",
+        "ingress": "accepted"
+      },
+      "deviations": {
+        "c": {
+          "expected": {
+            "host_representation": "opaque",
+            "ingress": "rejected"
+          },
+          "rationale": "The C value discriminant exists for egress, but structured assertion deliberately rejects foreign ExternalAddress ingress.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/167"
+        },
+        "go": {
+          "expected": {
+            "host_representation": "opaque_pointer",
+            "ingress": "unsupported"
+          },
+          "rationale": "Go preserves native egress as unsafe.Pointer but exposes no supported public ExternalAddress constructor.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/167"
+        },
+        "node": {
+          "expected": {
+            "host_representation": "void",
+            "ingress": "unsupported"
+          },
+          "rationale": "Node currently collapses ExternalAddress egress to null and exposes no ingress wrapper.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/167"
+        },
+        "python": {
+          "expected": {
+            "host_representation": "void",
+            "ingress": "unsupported"
+          },
+          "rationale": "Python currently collapses ExternalAddress egress to None and exposes no ingress wrapper.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/167"
+        }
+      }
+    },
+    {
+      "id": "configuration.default",
+      "semantic": "configuration.default",
+      "canonical": {
+        "max_call_depth": 64,
+        "strategy": "depth",
+        "unicode": "accepted"
+      }
+    },
+    {
+      "id": "configuration.custom",
+      "semantic": "configuration.custom",
+      "canonical": {
+        "ascii_unicode": "rejected",
+        "max_call_depth": "configurable",
+        "strategy_count": 4
+      },
+      "deviations": {
+        "python": {
+          "expected": {
+            "ascii_unicode": "rejected",
+            "max_call_depth": "unavailable",
+            "strategy_count": 4
+          },
+          "rationale": "Python construction does not yet expose max_call_depth.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/187"
+        }
+      }
+    },
+    {
+      "id": "error.parse",
+      "semantic": "error.parse",
+      "canonical": {"family": "parse"}
+    },
+    {
+      "id": "error.compile",
+      "semantic": "error.compile",
+      "canonical": {"family": "compile"}
+    },
+    {
+      "id": "error.unsupported-construct",
+      "semantic": "error.compile",
+      "canonical": {"family": "compile"},
+      "deviations": {
+        "node": {
+          "expected": {"family": "generic"},
+          "rationale": "Node does not yet classify every non-Parse/non-Compile LoadError variant.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/184"
+        },
+        "python": {
+          "expected": {"family": "generic"},
+          "rationale": "Python does not yet classify every non-Parse/non-Compile LoadError variant.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/189"
+        }
+      }
+    },
+    {
+      "id": "error.runtime",
+      "semantic": "error.runtime",
+      "canonical": {"family": "fact_not_found"}
+    },
+    {
+      "id": "fact.lifecycle",
+      "semantic": "fact.lifecycle",
+      "canonical": {
+        "count_after_retract": 0,
+        "ordered_snapshot_retained": true,
+        "template_snapshot_retained": true
+      }
+    },
+    {
+      "id": "execution.run-limits",
+      "semantic": "execution.run",
+      "canonical": {
+        "one": {"fired": 1, "reason": "limit_reached"},
+        "unlimited": {"fired": 3, "reason": "agenda_empty"},
+        "zero": {"fired": 0, "reason": "limit_reached"}
+      },
+      "deviations": {
+        "go": {
+          "expected": {
+            "one": {"fired": 1, "reason": "limit_reached"},
+            "unlimited": {"fired": 3, "reason": "agenda_empty"},
+            "zero": {"fired": 3, "reason": "agenda_empty"}
+          },
+          "rationale": "Go deliberately uses a zero public run limit to mean unlimited.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/112"
+        }
+      }
+    },
+    {
+      "id": "execution.step",
+      "semantic": "execution.step",
+      "canonical": {"empty": true, "first_rule": "only-rule"},
+      "deviations": {
+        "c": {
+          "expected": {"empty": true, "first_rule": null},
+          "rationale": "The C step ABI returns fired/empty status but not the fired rule name.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/112"
+        },
+        "go": {
+          "expected": {"empty": true, "first_rule": null},
+          "rationale": "Go inherits the C step result, which does not include a rule name.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/112"
+        }
+      }
+    },
+    {
+      "id": "execution.halt",
+      "semantic": "execution.halt",
+      "canonical": {"fired": 1, "reason": "halt_requested"}
+    },
+    {
+      "id": "execution.diagnostic",
+      "semantic": "execution.diagnostic",
+      "canonical": {
+        "diagnostic_count": 1,
+        "fired": 1,
+        "reason": "action_error"
+      }
+    },
+    {
+      "id": "execution.batch-boundary-halt",
+      "semantic": "execution.halt",
+      "canonical": {"fired": 100, "reason": "halt_requested"},
+      "deviations": {
+        "go": {
+          "expected": {"fired": 101, "reason": "agenda_empty"},
+          "rationale": "Cancelable Go runs currently start a new logical run after an exact 100-activation batch boundary.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/127"
+        },
+        "node": {
+          "expected": {"fired": 101, "reason": "agenda_empty"},
+          "rationale": "Node worker runs currently start a new logical run after an exact 100-activation batch boundary.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/134"
+        }
+      }
+    },
+    {
+      "id": "snapshot.json-roundtrip",
+      "semantic": "snapshot",
+      "canonical": {
+        "fact_count": 1,
+        "format": "json",
+        "rules_fired": 1
+      }
+    },
+    {
+      "id": "lifecycle.close",
+      "semantic": "lifecycle.close",
+      "canonical": {
+        "explicit": true,
+        "idempotent": true,
+        "post_close": "closed_error"
+      },
+      "deviations": {
+        "rust": {
+          "expected": {
+            "explicit": false,
+            "idempotent": false,
+            "post_close": "not_applicable"
+          },
+          "rationale": "The Rust facade uses ownership and Drop rather than an explicit close method.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/112"
+        },
+        "c": {
+          "expected": {
+            "explicit": true,
+            "idempotent": false,
+            "post_close": "undefined"
+          },
+          "rationale": "The raw C handle is invalid after free; repeated free or post-free use is outside the ABI contract.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/112"
+        }
+      }
+    },
+    {
+      "id": "robustness.embedded-nul",
+      "semantic": "robustness.nul",
+      "canonical": {"type": "string", "value": "a\u0000b"},
+      "deviations": {
+        "c": {
+          "expected": {"type": "string", "value": "a"},
+          "rationale": "The legacy C string constructor truncates at the first embedded NUL.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/115"
+        },
+        "go": {
+          "expected": {"type": "string", "value": "a"},
+          "rationale": "Go currently passes host strings through C.CString and therefore truncates at embedded NUL.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/115"
+        }
+      }
+    },
+    {
+      "id": "identifier.high-fact-id",
+      "semantic": "identifier.high",
+      "canonical": {"roundtrip": true},
+      "deviations": {
+        "node": {
+          "expected": {"roundtrip": false},
+          "rationale": "Node fact IDs currently cross N-API as number and lose precision above Number.MAX_SAFE_INTEGER.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/133"
+        }
+      }
+    },
+    {
+      "id": "count.run-result-width",
+      "semantic": "count.high",
+      "canonical": {"run_count_bits": 64, "run_limit_bits": 64},
+      "deviations": {
+        "node": {
+          "expected": {"run_count_bits": 32, "run_limit_bits": 32},
+          "rationale": "The native Node run limit and fired-count fields are currently u32.",
+          "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/183"
+        }
+      }
+    }
+  ]
+}

--- a/tests/bindings-conformance/fixtures/batch-boundary-halt.clp
+++ b/tests/bindings-conformance/fixtures/batch-boundary-halt.clp
@@ -1,0 +1,10 @@
+(deffacts startup
+    (counter 0))
+
+(defrule advance
+    ?counter <- (counter ?value&:(< ?value 101))
+    =>
+    (retract ?counter)
+    (assert (counter (+ ?value 1)))
+    (if (= ?value 99) then
+        (halt)))

--- a/tests/bindings-conformance/fixtures/custom-config.clp
+++ b/tests/bindings-conformance/fixtures/custom-config.clp
@@ -1,0 +1,8 @@
+(deffunction recurse (?remaining)
+    (if (= ?remaining 0) then
+        (return 0))
+    (return (recurse (- ?remaining 1))))
+
+(defrule exercise-depth
+    =>
+    (recurse 2))

--- a/tests/bindings-conformance/fixtures/diagnostic.clp
+++ b/tests/bindings-conformance/fixtures/diagnostic.clp
@@ -1,0 +1,4 @@
+(defrule fail
+    =>
+    (/ 1 0)
+    (assert (must-not-run)))

--- a/tests/bindings-conformance/fixtures/halt.clp
+++ b/tests/bindings-conformance/fixtures/halt.clp
@@ -1,0 +1,4 @@
+(defrule stop
+    =>
+    (halt)
+    (assert (halted)))

--- a/tests/bindings-conformance/fixtures/one-rule.clp
+++ b/tests/bindings-conformance/fixtures/one-rule.clp
@@ -1,0 +1,3 @@
+(defrule only-rule
+    =>
+    (assert (stepped)))

--- a/tests/bindings-conformance/fixtures/run-limits.clp
+++ b/tests/bindings-conformance/fixtures/run-limits.clp
@@ -1,0 +1,9 @@
+(deffacts startup
+    (item 1)
+    (item 2)
+    (item 3))
+
+(defrule count-item
+    (item ?value)
+    =>
+    (bind ?ignored ?value))

--- a/tests/bindings-conformance/fixtures/snapshot.clp
+++ b/tests/bindings-conformance/fixtures/snapshot.clp
@@ -1,0 +1,4 @@
+(defrule snapshot-rule
+    (seed)
+    =>
+    (assert (done)))

--- a/tests/bindings-conformance/fixtures/template.clp
+++ b/tests/bindings-conformance/fixtures/template.clp
@@ -1,0 +1,2 @@
+(deftemplate person
+    (slot name))

--- a/tools/bindings-conformance-adapter/Cargo.toml
+++ b/tools/bindings-conformance-adapter/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ferric-bindings-conformance-adapter"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+ferric-rules = { workspace = true, features = ["serde"] }
+serde_json = { workspace = true }
+slotmap = { workspace = true }
+
+[lints]
+workspace = true

--- a/tools/bindings-conformance-adapter/src/main.rs
+++ b/tools/bindings-conformance-adapter/src/main.rs
@@ -1,0 +1,434 @@
+use std::env;
+use std::ffi::c_void;
+use std::fs;
+use std::path::PathBuf;
+use std::ptr;
+
+use ferric_rules::core::{
+    ConflictResolutionStrategy, ExternalAddress, ExternalTypeId, Fact, Multifield, StringEncoding,
+    Value,
+};
+use ferric_rules::runtime::{
+    Engine, EngineConfig, EngineError, HaltReason, LoadError, RunLimit, SerializationFormat,
+};
+use serde_json::{json, Value as JsonValue};
+use slotmap::Key;
+
+const HIGH_ID_ITERATIONS: usize = 1_048_577;
+
+fn root() -> Result<PathBuf, String> {
+    env::var_os("FERRIC_BINDINGS_CONFORMANCE_ROOT")
+        .map(PathBuf::from)
+        .ok_or_else(|| "FERRIC_BINDINGS_CONFORMANCE_ROOT is not set".to_string())
+}
+
+fn fixture(name: &str) -> Result<String, String> {
+    let path = root()?
+        .join("tests")
+        .join("bindings-conformance")
+        .join("fixtures")
+        .join(name);
+    fs::read_to_string(&path).map_err(|error| format!("cannot read {}: {error}", path.display()))
+}
+
+fn load(engine: &mut Engine, source: &str) -> Result<(), String> {
+    engine
+        .load_str(source)
+        .map(|_| ())
+        .map_err(|errors| format!("load failed: {errors:?}"))
+}
+
+fn new_with_fixture(name: &str) -> Result<Engine, String> {
+    Engine::with_rules(&fixture(name)?).map_err(|error| format!("init failed: {error}"))
+}
+
+fn halt_reason(reason: HaltReason) -> &'static str {
+    match reason {
+        HaltReason::AgendaEmpty => "agenda_empty",
+        HaltReason::LimitReached => "limit_reached",
+        HaltReason::HaltRequested => "halt_requested",
+        HaltReason::ActionError => "action_error",
+    }
+}
+
+fn normalize_value(value: &Value, engine: &Engine) -> JsonValue {
+    match value {
+        Value::Void => json!({"type": "void"}),
+        Value::Integer(value) => json!({"type": "integer", "value": value.to_string()}),
+        Value::Float(value) => json!({"type": "float", "value": value.to_string()}),
+        Value::Symbol(symbol) => json!({
+            "type": "symbol",
+            "value": engine.resolve_symbol(*symbol).unwrap_or("<unknown>")
+        }),
+        Value::String(value) => json!({"type": "string", "value": value.as_str()}),
+        Value::Multifield(values) => json!({
+            "type": "multifield",
+            "value": values
+                .as_slice()
+                .iter()
+                .map(|value| normalize_value(value, engine))
+                .collect::<Vec<_>>()
+        }),
+        Value::ExternalAddress(_) => json!({"type": "external_address"}),
+    }
+}
+
+fn asserted_field(engine: &mut Engine, value: Value) -> Result<JsonValue, String> {
+    let id = engine
+        .assert_ordered("probe", vec![value])
+        .map_err(|error| error.to_string())?;
+    let fact = engine
+        .get_fact(id)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "asserted fact disappeared".to_string())?;
+    match fact {
+        Fact::Ordered(fact) => fact
+            .fields
+            .first()
+            .map(|value| normalize_value(value, engine))
+            .ok_or_else(|| "asserted fact has no field".to_string()),
+        Fact::Template(_) => Err("expected ordered fact".to_string()),
+    }
+}
+
+fn value_case(case_id: &str) -> Result<JsonValue, String> {
+    let mut engine = Engine::new(EngineConfig::default());
+    match case_id {
+        "value.void" => asserted_field(&mut engine, Value::Void),
+        "value.integer.boundaries" => {
+            let minimum = asserted_field(&mut engine, Value::Integer(i64::MIN))?;
+            let maximum = asserted_field(&mut engine, Value::Integer(i64::MAX))?;
+            Ok(json!({"minimum": minimum, "maximum": maximum}))
+        }
+        "value.float" => asserted_field(&mut engine, Value::Float(1.5)),
+        "value.symbol.explicit" => {
+            let symbol = engine
+                .intern_symbol("red")
+                .map_err(|error| error.to_string())?;
+            asserted_field(&mut engine, Value::Symbol(symbol))
+        }
+        "value.string.explicit" | "value.string.plain-host" => {
+            let value = engine
+                .create_string("red")
+                .map_err(|error| error.to_string())?;
+            asserted_field(&mut engine, Value::String(value))
+        }
+        "value.multifield.nested" => {
+            let blue = engine
+                .intern_symbol("blue")
+                .map_err(|error| error.to_string())?;
+            let text = engine
+                .create_string("text")
+                .map_err(|error| error.to_string())?;
+            let nested: Multifield = vec![Value::Integer(9)].into_iter().collect();
+            let values: Multifield = vec![
+                Value::Void,
+                Value::Integer(7),
+                Value::Float(2.5),
+                Value::Symbol(blue),
+                Value::String(text),
+                Value::Multifield(Box::new(nested)),
+            ]
+            .into_iter()
+            .collect();
+            asserted_field(&mut engine, Value::Multifield(Box::new(values)))
+        }
+        "value.external-address" => {
+            let external = Value::ExternalAddress(ExternalAddress {
+                type_id: ExternalTypeId(7),
+                pointer: ptr::null_mut::<c_void>(),
+            });
+            let accepted = engine.assert_ordered("probe", vec![external]).is_ok();
+            Ok(json!({
+                "host_representation": "opaque",
+                "ingress": if accepted { "accepted" } else { "rejected" }
+            }))
+        }
+        _ => Err(format!("unknown value case {case_id}")),
+    }
+}
+
+fn configuration_default() -> JsonValue {
+    let config = EngineConfig::default();
+    let engine = Engine::new(config.clone());
+    let unicode = engine
+        .create_string("é")
+        .map(|_| "accepted")
+        .unwrap_or("rejected");
+    let strategy = match config.strategy {
+        ConflictResolutionStrategy::Depth => "depth",
+        ConflictResolutionStrategy::Breadth => "breadth",
+        ConflictResolutionStrategy::Lex => "lex",
+        ConflictResolutionStrategy::Mea => "mea",
+    };
+    json!({
+        "max_call_depth": config.max_call_depth,
+        "strategy": strategy,
+        "unicode": unicode
+    })
+}
+
+fn configuration_custom() -> Result<JsonValue, String> {
+    let mut config = EngineConfig::from(StringEncoding::Ascii);
+    config.max_call_depth = 1;
+    let mut engine = Engine::new(config);
+    let ascii_unicode = if engine.create_string("é").is_err() {
+        "rejected"
+    } else {
+        "accepted"
+    };
+    load(&mut engine, &fixture("custom-config.clp")?)?;
+    engine.reset().map_err(|error| error.to_string())?;
+    let run = engine
+        .run(RunLimit::Unlimited)
+        .map_err(|error| error.to_string())?;
+    if run.halt_reason != HaltReason::ActionError {
+        return Err("custom max_call_depth did not bound recursion".to_string());
+    }
+    Ok(json!({
+        "ascii_unicode": ascii_unicode,
+        "max_call_depth": "configurable",
+        "strategy_count": 4
+    }))
+}
+
+fn error_case(case_id: &str) -> Result<JsonValue, String> {
+    let mut engine = Engine::new(EngineConfig::default());
+    let family = match case_id {
+        "error.parse" => match engine.load_str("(defrule incomplete") {
+            Err(errors)
+                if errors
+                    .iter()
+                    .any(|error| matches!(error, LoadError::Parse(_))) =>
+            {
+                "parse"
+            }
+            other => return Err(format!("unexpected parse probe result: {other:?}")),
+        },
+        "error.compile" => match engine.load_str("(defrule bad => (nonexistent-fn))") {
+            Err(errors)
+                if errors
+                    .iter()
+                    .any(|error| matches!(error, LoadError::Compile(_))) =>
+            {
+                "compile"
+            }
+            other => return Err(format!("unexpected compile probe result: {other:?}")),
+        },
+        "error.unsupported-construct" => match engine.load_str("(defclass Probe (is-a USER))") {
+            Err(errors)
+                if errors
+                    .iter()
+                    .any(|error| matches!(error, LoadError::UnsupportedForm { .. })) =>
+            {
+                "compile"
+            }
+            other => return Err(format!("unexpected unsupported probe result: {other:?}")),
+        },
+        "error.runtime" => {
+            let id = engine
+                .assert_ordered("stale", Vec::<Value>::new())
+                .map_err(|error| error.to_string())?;
+            engine.retract(id).map_err(|error| error.to_string())?;
+            match engine.retract(id) {
+                Err(EngineError::FactNotFound(_)) => "fact_not_found",
+                other => return Err(format!("unexpected runtime probe result: {other:?}")),
+            }
+        }
+        _ => return Err(format!("unknown error case {case_id}")),
+    };
+    Ok(json!({"family": family}))
+}
+
+fn fact_lifecycle() -> Result<JsonValue, String> {
+    let mut engine = Engine::new(EngineConfig::default());
+    load(&mut engine, &fixture("template.clp")?)?;
+    engine.reset().map_err(|error| error.to_string())?;
+
+    let ordered_id = engine
+        .assert_ordered("ordered", vec![Value::Integer(7)])
+        .map_err(|error| error.to_string())?;
+    let ordered_snapshot = engine
+        .get_fact(ordered_id)
+        .map_err(|error| error.to_string())?
+        .cloned()
+        .ok_or_else(|| "ordered fact missing".to_string())?;
+    engine
+        .retract(ordered_id)
+        .map_err(|error| error.to_string())?;
+
+    let name = engine
+        .create_string("Ada")
+        .map_err(|error| error.to_string())?;
+    let template_id = engine
+        .assert_template("person", &["name"], vec![Value::String(name)])
+        .map_err(|error| error.to_string())?;
+    let template_snapshot = engine
+        .get_fact(template_id)
+        .map_err(|error| error.to_string())?
+        .cloned()
+        .ok_or_else(|| "template fact missing".to_string())?;
+    engine
+        .retract(template_id)
+        .map_err(|error| error.to_string())?;
+
+    let count = engine.facts().map_err(|error| error.to_string())?.count();
+    Ok(json!({
+        "count_after_retract": count,
+        "ordered_snapshot_retained": matches!(ordered_snapshot, Fact::Ordered(_)),
+        "template_snapshot_retained": matches!(template_snapshot, Fact::Template(_))
+    }))
+}
+
+fn run_once(limit: RunLimit) -> Result<JsonValue, String> {
+    let mut engine = new_with_fixture("run-limits.clp")?;
+    let result = engine.run(limit).map_err(|error| error.to_string())?;
+    Ok(json!({
+        "fired": result.rules_fired,
+        "reason": halt_reason(result.halt_reason)
+    }))
+}
+
+fn execution_run_limits() -> Result<JsonValue, String> {
+    Ok(json!({
+        "zero": run_once(RunLimit::Count(0))?,
+        "one": run_once(RunLimit::Count(1))?,
+        "unlimited": run_once(RunLimit::Unlimited)?
+    }))
+}
+
+fn execution_step() -> Result<JsonValue, String> {
+    let mut engine = new_with_fixture("one-rule.clp")?;
+    let first = engine
+        .step()
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| "first step did not fire".to_string())?;
+    let first_rule = engine.rule_name(first.rule_id).map(str::to_owned);
+    let empty = engine.step().map_err(|error| error.to_string())?.is_none();
+    Ok(json!({"first_rule": first_rule, "empty": empty}))
+}
+
+fn execution_fixture(name: &str) -> Result<(Engine, JsonValue), String> {
+    let mut engine = new_with_fixture(name)?;
+    let result = engine
+        .run(RunLimit::Unlimited)
+        .map_err(|error| error.to_string())?;
+    let normalized = json!({
+        "fired": result.rules_fired,
+        "reason": halt_reason(result.halt_reason)
+    });
+    Ok((engine, normalized))
+}
+
+fn execution_diagnostic() -> Result<JsonValue, String> {
+    let (engine, mut result) = execution_fixture("diagnostic.clp")?;
+    result["diagnostic_count"] = json!(engine.action_diagnostics().len());
+    Ok(result)
+}
+
+fn snapshot_roundtrip() -> Result<JsonValue, String> {
+    let mut engine = new_with_fixture("snapshot.clp")?;
+    engine
+        .assert_ordered("seed", Vec::<Value>::new())
+        .map_err(|error| error.to_string())?;
+    let bytes = engine
+        .serialize(SerializationFormat::Json)
+        .map_err(|error| error.to_string())?;
+    let mut restored = Engine::deserialize(&bytes, SerializationFormat::Json)
+        .map_err(|error| error.to_string())?;
+    let fact_count = restored.facts().map_err(|error| error.to_string())?.count();
+    let run = restored
+        .run(RunLimit::Unlimited)
+        .map_err(|error| error.to_string())?;
+    Ok(json!({
+        "fact_count": fact_count,
+        "format": "json",
+        "rules_fired": run.rules_fired
+    }))
+}
+
+fn embedded_nul() -> Result<JsonValue, String> {
+    let mut engine = Engine::new(EngineConfig::default());
+    let string = engine
+        .create_string("a\0b")
+        .map_err(|error| error.to_string())?;
+    asserted_field(&mut engine, Value::String(string))
+}
+
+fn high_fact_id() -> Result<JsonValue, String> {
+    let mut engine = Engine::new(EngineConfig::default());
+    for _ in 0..HIGH_ID_ITERATIONS {
+        let id = engine
+            .assert_ordered("generation", Vec::<Value>::new())
+            .map_err(|error| error.to_string())?;
+        engine.retract(id).map_err(|error| error.to_string())?;
+    }
+    let id = engine
+        .assert_ordered("generation", Vec::<Value>::new())
+        .map_err(|error| error.to_string())?;
+    let above_safe_integer = id.data().as_ffi() > 9_007_199_254_740_991;
+    let roundtrip = above_safe_integer
+        && engine
+            .get_fact(id)
+            .map_err(|error| error.to_string())?
+            .is_some();
+    Ok(json!({"roundtrip": roundtrip}))
+}
+
+fn run_case(case_id: &str) -> Result<JsonValue, String> {
+    if case_id.starts_with("value.") {
+        return value_case(case_id);
+    }
+    if case_id.starts_with("error.") {
+        return error_case(case_id);
+    }
+    match case_id {
+        "configuration.default" => Ok(configuration_default()),
+        "configuration.custom" => configuration_custom(),
+        "fact.lifecycle" => fact_lifecycle(),
+        "execution.run-limits" => execution_run_limits(),
+        "execution.step" => execution_step(),
+        "execution.halt" => execution_fixture("halt.clp").map(|(_, result)| result),
+        "execution.diagnostic" => execution_diagnostic(),
+        "execution.batch-boundary-halt" => {
+            execution_fixture("batch-boundary-halt.clp").map(|(_, result)| result)
+        }
+        "snapshot.json-roundtrip" => snapshot_roundtrip(),
+        "lifecycle.close" => Ok(json!({
+            "explicit": false,
+            "idempotent": false,
+            "post_close": "not_applicable"
+        })),
+        "robustness.embedded-nul" => embedded_nul(),
+        "identifier.high-fact-id" => high_fact_id(),
+        "count.run-result-width" => Ok(json!({
+            "run_count_bits": usize::BITS,
+            "run_limit_bits": usize::BITS
+        })),
+        _ => Err(format!("unknown case {case_id}")),
+    }
+}
+
+fn main() {
+    let result = (|| -> Result<(), String> {
+        let case_path = env::args_os()
+            .nth(1)
+            .map(PathBuf::from)
+            .ok_or_else(|| "usage: rust-adapter CASE_IDS_PATH".to_string())?;
+        let cases = fs::read_to_string(&case_path)
+            .map_err(|error| format!("cannot read {}: {error}", case_path.display()))?;
+        for case_id in cases.lines().filter(|line| !line.is_empty()) {
+            let result = run_case(case_id)?;
+            println!(
+                "{}",
+                serde_json::to_string(&json!({"case": case_id, "result": result}))
+                    .map_err(|error| error.to_string())?
+            );
+        }
+        Ok(())
+    })();
+    if let Err(error) = result {
+        eprintln!("rust conformance adapter: {error}");
+        std::process::exit(1);
+    }
+}

--- a/tools/ferric-tools/pyproject.toml
+++ b/tools/ferric-tools/pyproject.toml
@@ -27,6 +27,7 @@ ferric-perf-collect = "ferric_tools.perf.collect:app"
 ferric-perf-report = "ferric_tools.perf.report:app"
 ferric-perf-diff = "ferric_tools.perf.diff:app"
 ferric-next-production-readiness-issue = "ferric_tools.issues.next_production_readiness:app"
+ferric-bindings-conformance = "ferric_tools.bindings_conformance:app"
 
 [dependency-groups]
 dev = ["pytest>=8", "ruff>=0.9"]

--- a/tools/ferric-tools/src/ferric_tools/bindings_conformance.py
+++ b/tools/ferric-tools/src/ferric_tools/bindings_conformance.py
@@ -1,0 +1,372 @@
+"""Run and compare the shared Rust/C/Go/Node/Python semantic corpus."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated, Any
+
+import typer
+from rich.console import Console
+
+from ferric_tools._paths import repo_root
+
+REQUIRED_BINDINGS = ("rust", "c", "go", "node", "python")
+REQUIRED_SEMANTICS = (
+    "value.void",
+    "value.integer",
+    "value.float",
+    "value.symbol",
+    "value.string",
+    "value.multifield",
+    "value.external_address",
+    "configuration.default",
+    "configuration.custom",
+    "error.parse",
+    "error.compile",
+    "error.runtime",
+    "fact.lifecycle",
+    "execution.run",
+    "execution.halt",
+    "execution.diagnostic",
+    "execution.step",
+    "snapshot",
+    "lifecycle.close",
+    "robustness.nul",
+    "identifier.high",
+    "count.high",
+)
+
+app = typer.Typer(help="Compare every supported binding against one semantic corpus.")
+console = Console(stderr=True)
+
+
+class CorpusError(ValueError):
+    """The corpus or an adapter report violates the conformance protocol."""
+
+
+@dataclass(frozen=True)
+class Deviation:
+    """An exact, temporary or intentional binding-specific result."""
+
+    expected: Any
+    rationale: str
+    since: str
+    tracking_issue: str
+
+
+@dataclass(frozen=True)
+class Case:
+    """One language-neutral semantic case."""
+
+    id: str
+    semantic: str
+    canonical: Any
+    deviations: dict[str, Deviation]
+    required_bindings: frozenset[str]
+
+
+@dataclass(frozen=True)
+class Corpus:
+    """Validated corpus metadata and cases."""
+
+    schema_version: int
+    suite_version: str
+    bindings: tuple[str, ...]
+    cases: tuple[Case, ...]
+
+
+def _require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise CorpusError(f"{label} must be a non-empty string")
+    return value
+
+
+def load_corpus(path: Path) -> Corpus:
+    """Load and strictly validate a cross-binding corpus."""
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise CorpusError(f"cannot load corpus {path}: {error}") from error
+
+    if not isinstance(raw, dict):
+        raise CorpusError("corpus root must be an object")
+    if raw.get("schema_version") != 1:
+        raise CorpusError("corpus schema_version must be 1")
+
+    suite_version = _require_string(raw.get("suite_version"), "suite_version")
+    bindings_raw = raw.get("bindings")
+    if not isinstance(bindings_raw, list) or not all(
+        isinstance(binding, str) for binding in bindings_raw
+    ):
+        raise CorpusError("bindings must be a string array")
+    bindings = tuple(bindings_raw)
+    if len(bindings) != len(set(bindings)):
+        raise CorpusError("bindings must be unique")
+
+    cases_raw = raw.get("cases")
+    if not isinstance(cases_raw, list) or not cases_raw:
+        raise CorpusError("cases must be a non-empty array")
+
+    cases: list[Case] = []
+    for index, item in enumerate(cases_raw):
+        label = f"cases[{index}]"
+        if not isinstance(item, dict):
+            raise CorpusError(f"{label} must be an object")
+        case_id = _require_string(item.get("id"), f"{label}.id")
+        semantic = _require_string(item.get("semantic"), f"{label}.semantic")
+        if "canonical" not in item:
+            raise CorpusError(f"{label}.canonical is required")
+
+        required_raw = item.get("required_bindings", list(bindings))
+        if not isinstance(required_raw, list) or not all(
+            isinstance(binding, str) for binding in required_raw
+        ):
+            raise CorpusError(f"{label}.required_bindings must be a string array")
+        required = frozenset(required_raw)
+        unknown_required = required - set(bindings)
+        if unknown_required:
+            raise CorpusError(
+                f"{label}.required_bindings contains unknown bindings: {sorted(unknown_required)}"
+            )
+
+        deviations_raw = item.get("deviations", {})
+        if not isinstance(deviations_raw, dict):
+            raise CorpusError(f"{label}.deviations must be an object")
+        deviations: dict[str, Deviation] = {}
+        for binding, deviation_raw in deviations_raw.items():
+            if binding not in bindings:
+                raise CorpusError(f"{label}.deviations has unknown binding {binding!r}")
+            if not isinstance(deviation_raw, dict) or "expected" not in deviation_raw:
+                raise CorpusError(f"{label}.deviations.{binding} must include expected")
+            deviations[binding] = Deviation(
+                expected=deviation_raw["expected"],
+                rationale=_require_string(
+                    deviation_raw.get("rationale"),
+                    f"{label}.deviations.{binding}.rationale",
+                ),
+                since=_require_string(
+                    deviation_raw.get("since"),
+                    f"{label}.deviations.{binding}.since",
+                ),
+                tracking_issue=_require_string(
+                    deviation_raw.get("tracking_issue"),
+                    f"{label}.deviations.{binding}.tracking_issue",
+                ),
+            )
+
+        cases.append(
+            Case(
+                id=case_id,
+                semantic=semantic,
+                canonical=item["canonical"],
+                deviations=deviations,
+                required_bindings=required,
+            )
+        )
+
+    case_ids = [case.id for case in cases]
+    if len(case_ids) != len(set(case_ids)):
+        raise CorpusError("case IDs must be unique")
+
+    return Corpus(
+        schema_version=1,
+        suite_version=suite_version,
+        bindings=bindings,
+        cases=tuple(cases),
+    )
+
+
+@dataclass(frozen=True)
+class AdapterCommand:
+    """How to invoke one adapter from the repository root."""
+
+    argv: tuple[str, ...]
+    cwd: Path
+
+
+def _default_adapter_commands(root: Path) -> dict[str, AdapterCommand]:
+    return {
+        "rust": AdapterCommand(
+            (
+                "cargo",
+                "run",
+                "--quiet",
+                "--release",
+                "-p",
+                "ferric-bindings-conformance-adapter",
+                "--",
+            ),
+            root,
+        ),
+        "c": AdapterCommand(
+            (str(root / "target" / "bindings-conformance" / "c-adapter"),),
+            root,
+        ),
+        "go": AdapterCommand(
+            ("go", "run", "./cmd/bindings-conformance"),
+            root / "bindings" / "go",
+        ),
+        "node": AdapterCommand(
+            ("node", "--import", "tsx", "test/bindings-conformance/adapter.ts"),
+            root / "packages" / "ferric",
+        ),
+        "python": AdapterCommand(
+            (
+                str(root / "crates" / "ferric-rules-python" / ".venv" / "bin" / "python"),
+                "tests/bindings_conformance_adapter.py",
+            ),
+            root / "crates" / "ferric-rules-python",
+        ),
+    }
+
+
+def _parse_adapter_output(binding: str, stdout: str, expected_ids: set[str]) -> dict[str, Any]:
+    observations: dict[str, Any] = {}
+    for line_number, line in enumerate(stdout.splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise CorpusError(
+                f"{binding} adapter emitted invalid JSON on line {line_number}: {error}"
+            ) from error
+        if not isinstance(record, dict) or set(record) != {"case", "result"}:
+            raise CorpusError(
+                f"{binding} adapter line {line_number} must contain only case and result"
+            )
+        case_id = record["case"]
+        if not isinstance(case_id, str) or case_id not in expected_ids:
+            raise CorpusError(f"{binding} adapter emitted unknown case {case_id!r}")
+        if case_id in observations:
+            raise CorpusError(f"{binding} adapter emitted duplicate case {case_id!r}")
+        observations[case_id] = record["result"]
+
+    missing = expected_ids - set(observations)
+    if missing:
+        raise CorpusError(f"{binding} adapter omitted cases: {sorted(missing)}")
+    return observations
+
+
+def run_adapter(
+    binding: str,
+    command: AdapterCommand,
+    case_ids_path: Path,
+    root: Path,
+) -> dict[str, Any]:
+    """Run one adapter and return its normalized observations."""
+
+    env = os.environ.copy()
+    env["FERRIC_BINDINGS_CONFORMANCE_ROOT"] = str(root)
+    completed = subprocess.run(
+        [*command.argv, str(case_ids_path)],
+        cwd=command.cwd,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        details = completed.stderr.strip() or completed.stdout.strip() or "(no output)"
+        raise CorpusError(f"{binding} adapter exited {completed.returncode}:\n{details}")
+
+    expected_ids = set(case_ids_path.read_text(encoding="utf-8").splitlines())
+    return _parse_adapter_output(binding, completed.stdout, expected_ids)
+
+
+def compare_observations(
+    corpus: Corpus, observations: dict[str, dict[str, Any]]
+) -> tuple[list[str], list[str]]:
+    """Return exact failures and accepted-deviation descriptions."""
+
+    failures: list[str] = []
+    accepted: list[str] = []
+    for case in corpus.cases:
+        for binding in sorted(case.required_bindings):
+            actual = observations[binding][case.id]
+            deviation = case.deviations.get(binding)
+            if deviation is None:
+                if actual != case.canonical:
+                    failures.append(
+                        f"{case.id}/{binding}: expected canonical "
+                        f"{json.dumps(case.canonical, sort_keys=True)}, got "
+                        f"{json.dumps(actual, sort_keys=True)}"
+                    )
+                continue
+
+            if actual == case.canonical:
+                failures.append(
+                    f"{case.id}/{binding}: now matches canonical; remove the stale deviation"
+                )
+            elif actual != deviation.expected:
+                failures.append(
+                    f"{case.id}/{binding}: expected versioned deviation "
+                    f"{json.dumps(deviation.expected, sort_keys=True)}, got "
+                    f"{json.dumps(actual, sort_keys=True)}"
+                )
+            else:
+                accepted.append(
+                    f"{case.id}/{binding} ({deviation.since}, {deviation.tracking_issue})"
+                )
+    return failures, accepted
+
+
+@app.command()
+def main(
+    corpus_path: Annotated[
+        Path | None,
+        typer.Option("--corpus", help="Path to the language-neutral corpus."),
+    ] = None,
+) -> None:
+    """Run all adapters and reject unknown or stale semantic drift."""
+
+    root = repo_root()
+    path = corpus_path or root / "tests" / "bindings-conformance" / "corpus.json"
+    try:
+        corpus = load_corpus(path)
+        if set(corpus.bindings) != set(REQUIRED_BINDINGS):
+            raise CorpusError(
+                f"corpus bindings must be exactly {list(REQUIRED_BINDINGS)}, "
+                f"got {list(corpus.bindings)}"
+            )
+        missing_semantics = set(REQUIRED_SEMANTICS) - {case.semantic for case in corpus.cases}
+        if missing_semantics:
+            raise CorpusError(f"corpus omits required semantics: {sorted(missing_semantics)}")
+
+        commands = _default_adapter_commands(root)
+        observations: dict[str, dict[str, Any]] = {}
+        with tempfile.TemporaryDirectory(prefix="ferric-bindings-conformance-") as temp_dir:
+            ids_path = Path(temp_dir) / "case-ids.txt"
+            ids_path.write_text(
+                "".join(f"{case.id}\n" for case in corpus.cases),
+                encoding="utf-8",
+            )
+            for binding in corpus.bindings:
+                console.print(f"[cyan]running {binding} adapter[/]")
+                observations[binding] = run_adapter(binding, commands[binding], ids_path, root)
+
+        failures, accepted = compare_observations(corpus, observations)
+        if failures:
+            for failure in failures:
+                console.print(f"[red]FAIL[/] {failure}")
+            raise typer.Exit(1)
+
+        console.print(
+            f"[green]bindings conformance passed[/]: {len(corpus.cases)} cases, "
+            f"{len(corpus.bindings)} adapters, {len(accepted)} versioned deviations"
+        )
+        for deviation in accepted:
+            console.print(f"[yellow]DEVIATION[/] {deviation}")
+    except CorpusError as error:
+        console.print(f"[red]error:[/] {error}")
+        raise typer.Exit(1) from error
+
+
+if __name__ == "__main__":
+    app()

--- a/tools/ferric-tools/tests/test_bindings_conformance.py
+++ b/tools/ferric-tools/tests/test_bindings_conformance.py
@@ -1,0 +1,111 @@
+"""Contract tests for the shared cross-binding conformance corpus."""
+
+from pathlib import Path
+
+import pytest
+
+from ferric_tools.bindings_conformance import (
+    REQUIRED_BINDINGS,
+    REQUIRED_SEMANTICS,
+    Case,
+    Corpus,
+    CorpusError,
+    Deviation,
+    _parse_adapter_output,
+    compare_observations,
+    load_corpus,
+)
+
+ROOT = Path(__file__).resolve().parents[3]
+CORPUS = ROOT / "tests" / "bindings-conformance" / "corpus.json"
+TRACKING_ISSUE = "https://github.com/plx/ferric-rules/issues/112"
+
+
+def test_corpus_covers_every_binding_and_required_semantic() -> None:
+    corpus = load_corpus(CORPUS)
+
+    assert set(corpus.bindings) == set(REQUIRED_BINDINGS)
+    assert {case.semantic for case in corpus.cases} >= set(REQUIRED_SEMANTICS)
+
+
+def test_every_deviation_is_versioned_and_explained() -> None:
+    corpus = load_corpus(CORPUS)
+
+    for case in corpus.cases:
+        for binding, deviation in case.deviations.items():
+            assert binding in REQUIRED_BINDINGS
+            assert deviation.rationale
+            assert deviation.since
+            assert deviation.tracking_issue.startswith(
+                "https://github.com/plx/ferric-rules/issues/"
+            )
+
+
+def test_case_ids_are_unique_and_all_adapters_are_required() -> None:
+    corpus = load_corpus(CORPUS)
+    case_ids = [case.id for case in corpus.cases]
+
+    assert len(case_ids) == len(set(case_ids))
+    assert all(case.required_bindings == frozenset(REQUIRED_BINDINGS) for case in corpus.cases)
+
+
+def test_unknown_semantic_drift_fails() -> None:
+    corpus = _single_case_corpus()
+
+    failures, accepted = compare_observations(corpus, {"rust": {"probe": {"value": 2}}})
+
+    assert failures == ['probe/rust: expected canonical {"value": 1}, got {"value": 2}']
+    assert accepted == []
+
+
+def test_exact_deviation_is_accepted_but_a_stale_deviation_fails() -> None:
+    deviation = Deviation(
+        expected={"value": 2},
+        rationale="Known binding behavior.",
+        since="1.0.0",
+        tracking_issue=TRACKING_ISSUE,
+    )
+    corpus = _single_case_corpus(deviation)
+
+    failures, accepted = compare_observations(corpus, {"rust": {"probe": {"value": 2}}})
+    assert failures == []
+    assert accepted == [f"probe/rust (1.0.0, {TRACKING_ISSUE})"]
+
+    failures, accepted = compare_observations(corpus, {"rust": {"probe": {"value": 1}}})
+    assert failures == ["probe/rust: now matches canonical; remove the stale deviation"]
+    assert accepted == []
+
+
+def test_adapter_protocol_rejects_missing_duplicate_and_unknown_cases() -> None:
+    with pytest.raises(CorpusError, match="omitted cases"):
+        _parse_adapter_output("rust", "", {"probe"})
+    with pytest.raises(CorpusError, match="duplicate case"):
+        _parse_adapter_output(
+            "rust",
+            "\n".join(
+                [
+                    '{"case":"probe","result":1}',
+                    '{"case":"probe","result":1}',
+                ]
+            ),
+            {"probe"},
+        )
+    with pytest.raises(CorpusError, match="unknown case"):
+        _parse_adapter_output("rust", '{"case":"surprise","result":1}', {"probe"})
+
+
+def _single_case_corpus(deviation: Deviation | None = None) -> Corpus:
+    return Corpus(
+        schema_version=1,
+        suite_version="1.0.0",
+        bindings=("rust",),
+        cases=(
+            Case(
+                id="probe",
+                semantic="probe",
+                canonical={"value": 1},
+                deviations={"rust": deviation} if deviation is not None else {},
+                required_bindings=frozenset({"rust"}),
+            ),
+        ),
+    )


### PR DESCRIPTION
## Summary

- add a versioned, language-neutral semantic corpus spanning values, configuration, errors, facts, execution, snapshots, lifecycle, NUL handling, and high identifiers/counts
- execute live Rust, C, Go, Node, and Python adapters and reject unknown drift or stale deviations
- add `just bindings-conformance`, detector contract tests, documentation, and a dedicated CI job

## Why

Bindings currently validate their behavior independently, which lets semantic drift remain invisible. This gives all supported bindings one normalized JSON contract while explicitly recording the known differences owned by follow-up issues.

## Validation

- `just bindings-conformance`
- `just preflight-pr`
- `shellcheck scripts/build-bindings-conformance-c.sh`
- `actionlint .github/workflows/ci.yml`

Closes #112