### PR TITLE
[FR-CABI-004] Scope output snapshots to engines

### DIFF
--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -73,9 +73,13 @@
  * 7. External address pointers: FerricValue.external_pointer
  *    is NOT owned by the FFI. Lifetime is caller-managed.
  *
- * 8. Output string pointers: ferric_engine_get_output() returns
- *    a borrowed pointer valid until the next call that writes
- *    to that channel. Do NOT free.
+ * 8. Output snapshots: ferric_engine_get_output() returns a
+ *    per-engine, per-channel borrowed snapshot. It remains valid
+ *    until a later borrowed read for that same engine and channel
+ *    replaces it; that channel is cleared; the engine is reset or
+ *    cleared; or until engine destruction. Reads on other engines
+ *    never invalidate it. Do NOT free. Prefer
+ *    ferric_engine_get_output_copy() for caller-owned storage.
  *
  * 9. Bounds annotations: Pointer parameters and struct fields
  *    carry FERRIC_COUNTED_BY, FERRIC_SIZED_BY, and
@@ -574,13 +578,54 @@ enum FerricError ferric_engine_retract(struct FerricEngine *engine, uint64_t fac
 //
 // Returns a pointer to a NUL-terminated string, or null if the channel has
 // no output, the engine pointer is null, or the channel pointer is null.
-// The returned pointer is valid until the next call that writes to that channel.
+// The returned pointer is an engine-owned snapshot. It remains valid until a
+// later `ferric_engine_get_output` call for the same engine and channel
+// replaces that channel's snapshot; that channel is cleared; the engine is
+// reset or cleared; or the engine is destroyed. Calls involving another
+// engine never invalidate it. Output written after this call is not reflected
+// in the snapshot.
+//
+// Prefer `ferric_engine_get_output_copy` when retaining a borrowed pointer
+// would be inconvenient or when pointer-use windows could overlap.
 //
 // # Safety
 //
 // - `engine` must be a valid engine pointer or null.
 // - `channel` must be a valid NUL-terminated UTF-8 string or null.
 const char * FERRIC_NULL_TERMINATED ferric_engine_get_output(const struct FerricEngine *engine, const char * FERRIC_NULL_TERMINATED channel);
+
+// Copy the engine's captured output for a named channel.
+//
+// This is the preferred output accessor for hosts that do not want to retain
+// an engine-owned pointer. `*out_len` always reports the full required byte
+// count including the trailing NUL when output exists.
+//
+// ## Contract
+//
+// | Condition | Return | `*out_len` |
+// |-----------|--------|------------|
+// | `engine` is null | `NullPointer` | 0 |
+// | `channel` is null or invalid UTF-8 | `NullPointer` / `InvalidArgument` | 0 |
+// | `out_len` is null | `InvalidArgument` | (not written) |
+// | Channel has no non-empty output | `NotFound` | 0 |
+// | `buf` is null AND `buf_len` is 0 (size query) | `Ok` | required size (incl. NUL) |
+// | `buf` non-null, `buf_len` >= needed | `Ok` | bytes written (incl. NUL) |
+// | `buf` non-null, `buf_len` < needed | `BufferTooSmall` | full needed size (incl. NUL) |
+//
+// An undersized non-empty buffer receives a NUL-terminated prefix and a
+// `BufferTooSmall` status; truncation is never reported as success.
+//
+// # Safety
+//
+// - `engine` must be a valid engine pointer or null.
+// - `channel` must be a valid NUL-terminated UTF-8 string or null.
+// - `buf` must point to `buf_len` writable bytes, or be null for a size query.
+// - `out_len` must be a valid non-null pointer.
+enum FerricError ferric_engine_get_output_copy(const struct FerricEngine *engine,
+                                               const char * FERRIC_NULL_TERMINATED channel,
+                                               char *buf FERRIC_SIZED_BY(buf_len),
+                                               uintptr_t buf_len,
+                                               uintptr_t *out_len);
 
 // Get the number of action diagnostics captured during recent execution.
 //

--- a/crates/ferric-rules-ffi/build.rs
+++ b/crates/ferric-rules-ffi/build.rs
@@ -76,9 +76,13 @@ pub const HEADER_PREAMBLE: &str = r"/*
  * 7. External address pointers: FerricValue.external_pointer
  *    is NOT owned by the FFI. Lifetime is caller-managed.
  *
- * 8. Output string pointers: ferric_engine_get_output() returns
- *    a borrowed pointer valid until the next call that writes
- *    to that channel. Do NOT free.
+ * 8. Output snapshots: ferric_engine_get_output() returns a
+ *    per-engine, per-channel borrowed snapshot. It remains valid
+ *    until a later borrowed read for that same engine and channel
+ *    replaces it; that channel is cleared; the engine is reset or
+ *    cleared; or until engine destruction. Reads on other engines
+ *    never invalidate it. Do NOT free. Prefer
+ *    ferric_engine_get_output_copy() for caller-owned storage.
  *
  * 9. Bounds annotations: Pointer parameters and struct fields
  *    carry FERRIC_COUNTED_BY, FERRIC_SIZED_BY, and
@@ -376,6 +380,11 @@ const BOUNDS_ANNOTATIONS: &[(&str, &str)] = &[
         "ferric_engine_get_output(const struct FerricEngine *engine, const char *channel);",
         "ferric_engine_get_output(const struct FerricEngine *engine, const char * FERRIC_NULL_TERMINATED channel);",
     ),
+    // ferric_engine_get_output_copy: channel is NUL-terminated.
+    (
+        "ferric_engine_get_output_copy(const struct FerricEngine *engine,\n                                               const char *channel,",
+        "ferric_engine_get_output_copy(const struct FerricEngine *engine,\n                                               const char * FERRIC_NULL_TERMINATED channel,",
+    ),
     // ferric_engine_clear_output: channel is NUL-terminated.
     (
         "ferric_engine_clear_output(struct FerricEngine *engine, const char *channel);",
@@ -443,6 +452,11 @@ const BOUNDS_ANNOTATIONS: &[(&str, &str)] = &[
     (
         "ferric_engine_last_error_copy(const struct FerricEngine *engine,\n                                               char *buf,",
         "ferric_engine_last_error_copy(const struct FerricEngine *engine,\n                                               char *buf FERRIC_SIZED_BY(buf_len),",
+    ),
+    // ferric_engine_get_output_copy: buf is a byte buffer of buf_len bytes.
+    (
+        "const char * FERRIC_NULL_TERMINATED channel,\n                                               char *buf,",
+        "const char * FERRIC_NULL_TERMINATED channel,\n                                               char *buf FERRIC_SIZED_BY(buf_len),",
     ),
     // ferric_pinned_engine_last_error_copy: buf is a byte buffer of buf_len bytes.
     // (multi-line signature — pattern spans the line break)

--- a/crates/ferric-rules-ffi/ferric.h
+++ b/crates/ferric-rules-ffi/ferric.h
@@ -73,9 +73,13 @@
  * 7. External address pointers: FerricValue.external_pointer
  *    is NOT owned by the FFI. Lifetime is caller-managed.
  *
- * 8. Output string pointers: ferric_engine_get_output() returns
- *    a borrowed pointer valid until the next call that writes
- *    to that channel. Do NOT free.
+ * 8. Output snapshots: ferric_engine_get_output() returns a
+ *    per-engine, per-channel borrowed snapshot. It remains valid
+ *    until a later borrowed read for that same engine and channel
+ *    replaces it; that channel is cleared; the engine is reset or
+ *    cleared; or until engine destruction. Reads on other engines
+ *    never invalidate it. Do NOT free. Prefer
+ *    ferric_engine_get_output_copy() for caller-owned storage.
  *
  * 9. Bounds annotations: Pointer parameters and struct fields
  *    carry FERRIC_COUNTED_BY, FERRIC_SIZED_BY, and
@@ -574,13 +578,54 @@ enum FerricError ferric_engine_retract(struct FerricEngine *engine, uint64_t fac
 //
 // Returns a pointer to a NUL-terminated string, or null if the channel has
 // no output, the engine pointer is null, or the channel pointer is null.
-// The returned pointer is valid until the next call that writes to that channel.
+// The returned pointer is an engine-owned snapshot. It remains valid until a
+// later `ferric_engine_get_output` call for the same engine and channel
+// replaces that channel's snapshot; that channel is cleared; the engine is
+// reset or cleared; or the engine is destroyed. Calls involving another
+// engine never invalidate it. Output written after this call is not reflected
+// in the snapshot.
+//
+// Prefer `ferric_engine_get_output_copy` when retaining a borrowed pointer
+// would be inconvenient or when pointer-use windows could overlap.
 //
 // # Safety
 //
 // - `engine` must be a valid engine pointer or null.
 // - `channel` must be a valid NUL-terminated UTF-8 string or null.
 const char * FERRIC_NULL_TERMINATED ferric_engine_get_output(const struct FerricEngine *engine, const char * FERRIC_NULL_TERMINATED channel);
+
+// Copy the engine's captured output for a named channel.
+//
+// This is the preferred output accessor for hosts that do not want to retain
+// an engine-owned pointer. `*out_len` always reports the full required byte
+// count including the trailing NUL when output exists.
+//
+// ## Contract
+//
+// | Condition | Return | `*out_len` |
+// |-----------|--------|------------|
+// | `engine` is null | `NullPointer` | 0 |
+// | `channel` is null or invalid UTF-8 | `NullPointer` / `InvalidArgument` | 0 |
+// | `out_len` is null | `InvalidArgument` | (not written) |
+// | Channel has no non-empty output | `NotFound` | 0 |
+// | `buf` is null AND `buf_len` is 0 (size query) | `Ok` | required size (incl. NUL) |
+// | `buf` non-null, `buf_len` >= needed | `Ok` | bytes written (incl. NUL) |
+// | `buf` non-null, `buf_len` < needed | `BufferTooSmall` | full needed size (incl. NUL) |
+//
+// An undersized non-empty buffer receives a NUL-terminated prefix and a
+// `BufferTooSmall` status; truncation is never reported as success.
+//
+// # Safety
+//
+// - `engine` must be a valid engine pointer or null.
+// - `channel` must be a valid NUL-terminated UTF-8 string or null.
+// - `buf` must point to `buf_len` writable bytes, or be null for a size query.
+// - `out_len` must be a valid non-null pointer.
+enum FerricError ferric_engine_get_output_copy(const struct FerricEngine *engine,
+                                               const char * FERRIC_NULL_TERMINATED channel,
+                                               char *buf FERRIC_SIZED_BY(buf_len),
+                                               uintptr_t buf_len,
+                                               uintptr_t *out_len);
 
 // Get the number of action diagnostics captured during recent execution.
 //

--- a/crates/ferric-rules-ffi/src/engine.rs
+++ b/crates/ferric-rules-ffi/src/engine.rs
@@ -111,6 +111,17 @@ impl CachedOutputCString {
     }
 }
 
+fn prune_cleared_output_snapshots(
+    engine: &Engine,
+    output_cstrings: &RefCell<HashMap<String, CachedOutputCString>>,
+) {
+    output_cstrings.borrow_mut().retain(|channel, _| {
+        engine
+            .get_output(channel)
+            .is_some_and(|output| !output.is_empty())
+    });
+}
+
 #[cfg(test)]
 pub(crate) unsafe fn output_cache_lifetime_for_test(
     engine: *const FerricEngine,
@@ -699,6 +710,7 @@ pub unsafe extern "C" fn ferric_engine_run(
 
     match handle.engine.run(run_limit) {
         Ok(result) => {
+            prune_cleared_output_snapshots(handle.engine, handle.output_cstrings);
             if !out_fired.is_null() {
                 *out_fired = result.rules_fired as u64;
             }
@@ -729,7 +741,12 @@ pub unsafe extern "C" fn ferric_engine_step(
         Err(code) => return code,
     };
 
-    match handle.engine.step() {
+    let result = handle.engine.step();
+    if result.is_ok() {
+        prune_cleared_output_snapshots(handle.engine, handle.output_cstrings);
+    }
+
+    match result {
         Ok(Some(_fired)) => {
             if !out_status.is_null() {
                 *out_status = 1;
@@ -2302,6 +2319,7 @@ pub unsafe extern "C" fn ferric_engine_run_ex(
 
     match handle.engine.run(run_limit) {
         Ok(result) => {
+            prune_cleared_output_snapshots(handle.engine, handle.output_cstrings);
             if !out_fired.is_null() {
                 *out_fired = result.rules_fired as u64;
             }

--- a/crates/ferric-rules-ffi/src/engine.rs
+++ b/crates/ferric-rules-ffi/src/engine.rs
@@ -58,6 +58,7 @@ pub struct FerricEngine {
     owner_thread: ThreadId,
     call_active: AtomicBool,
     diagnostics: Mutex<EngineDiagnostics>,
+    output_cstrings: RefCell<HashMap<String, CachedOutputCString>>,
 }
 
 #[derive(Debug, Default)]
@@ -82,6 +83,7 @@ impl FerricEngine {
             owner_thread: std::thread::current().id(),
             call_active: AtomicBool::new(false),
             diagnostics: Mutex::new(EngineDiagnostics::new()),
+            output_cstrings: RefCell::new(HashMap::new()),
         }
     }
 
@@ -91,14 +93,42 @@ impl FerricEngine {
     }
 }
 
-thread_local! {
-    static OUTPUT_CSTRINGS: RefCell<HashMap<String, CachedOutputCString>> =
-        RefCell::new(HashMap::new());
-}
-
 struct CachedOutputCString {
     snapshot: String,
     cstring: CString,
+    #[cfg(test)]
+    lifetime: std::sync::Arc<()>,
+}
+
+impl CachedOutputCString {
+    fn new(output: &str) -> Self {
+        Self {
+            snapshot: output.to_string(),
+            cstring: CString::new(output).unwrap_or_default(),
+            #[cfg(test)]
+            lifetime: std::sync::Arc::new(()),
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) unsafe fn output_cache_lifetime_for_test(
+    engine: *const FerricEngine,
+    channel: &str,
+) -> Option<std::sync::Weak<()>> {
+    let handle = NonNull::new(engine.cast_mut())?;
+    output_cstrings(handle)
+        .borrow()
+        .get(channel)
+        .map(|entry| std::sync::Arc::downgrade(&entry.lifetime))
+}
+
+#[cfg(test)]
+pub(crate) unsafe fn output_cache_entry_count_for_test(
+    engine: *const FerricEngine,
+) -> Option<usize> {
+    let handle = NonNull::new(engine.cast_mut())?;
+    Some(output_cstrings(handle).borrow().len())
 }
 
 // ---------------------------------------------------------------------------
@@ -150,6 +180,18 @@ unsafe fn diagnostics<'a>(handle: NonNull<FerricEngine>) -> &'a Mutex<EngineDiag
     &*std::ptr::addr_of!((*handle.as_ptr()).diagnostics)
 }
 
+/// Project the owner-thread borrowed-output cache from an opaque handle.
+///
+/// # Safety
+///
+/// `handle` must point to a live engine handle, and access must remain on the
+/// engine's owner thread without overlapping another runtime call.
+unsafe fn output_cstrings<'a>(
+    handle: NonNull<FerricEngine>,
+) -> &'a RefCell<HashMap<String, CachedOutputCString>> {
+    &*std::ptr::addr_of!((*handle.as_ptr()).output_cstrings)
+}
+
 /// Check thread affinity without touching the owner-thread-only runtime.
 ///
 /// # Safety
@@ -191,12 +233,14 @@ impl Drop for EngineCallGuard<'_> {
 struct EngineWriteAccess<'a> {
     engine: &'a mut Engine,
     diagnostics: &'a Mutex<EngineDiagnostics>,
+    output_cstrings: &'a RefCell<HashMap<String, CachedOutputCString>>,
     _guard: EngineCallGuard<'a>,
 }
 
 struct EngineReadAccess<'a> {
     engine: &'a Engine,
     diagnostics: &'a Mutex<EngineDiagnostics>,
+    output_cstrings: &'a RefCell<HashMap<String, CachedOutputCString>>,
     _guard: EngineCallGuard<'a>,
 }
 
@@ -238,9 +282,11 @@ unsafe fn borrow_engine_mut<'a>(
     let guard = enter_engine_call(handle)?;
     let runtime = &mut *std::ptr::addr_of_mut!((*handle.as_ptr()).engine);
     let diagnostic_state = diagnostics(handle);
+    let output_cache = output_cstrings(handle);
     Ok(EngineWriteAccess {
         engine: runtime,
         diagnostics: diagnostic_state,
+        output_cstrings: output_cache,
         _guard: guard,
     })
 }
@@ -253,9 +299,11 @@ unsafe fn borrow_engine_checked<'a>(
     let guard = enter_engine_call(handle)?;
     let runtime = &*std::ptr::addr_of!((*handle.as_ptr()).engine);
     let diagnostic_state = diagnostics(handle);
+    let output_cache = output_cstrings(handle);
     Ok(EngineReadAccess {
         engine: runtime,
         diagnostics: diagnostic_state,
+        output_cstrings: output_cache,
         _guard: guard,
     })
 }
@@ -607,7 +655,10 @@ pub unsafe extern "C" fn ferric_engine_reset(engine: *mut FerricEngine) -> Ferri
     };
 
     match handle.engine.reset() {
-        Ok(()) => FerricError::Ok,
+        Ok(()) => {
+            handle.output_cstrings.borrow_mut().clear();
+            FerricError::Ok
+        }
         Err(ref err) => set_engine_runtime_error(handle.diagnostics, err),
     }
 }
@@ -780,7 +831,15 @@ pub unsafe extern "C" fn ferric_engine_retract(
 ///
 /// Returns a pointer to a NUL-terminated string, or null if the channel has
 /// no output, the engine pointer is null, or the channel pointer is null.
-/// The returned pointer is valid until the next call that writes to that channel.
+/// The returned pointer is an engine-owned snapshot. It remains valid until a
+/// later `ferric_engine_get_output` call for the same engine and channel
+/// replaces that channel's snapshot; that channel is cleared; the engine is
+/// reset or cleared; or the engine is destroyed. Calls involving another
+/// engine never invalidate it. Output written after this call is not reflected
+/// in the snapshot.
+///
+/// Prefer `ferric_engine_get_output_copy` when retaining a borrowed pointer
+/// would be inconvenient or when pointer-use windows could overlap.
 ///
 /// # Safety
 ///
@@ -799,30 +858,93 @@ pub unsafe extern "C" fn ferric_engine_get_output(
     };
 
     match handle.engine.get_output(channel_str) {
-        Some(output) if !output.is_empty() => OUTPUT_CSTRINGS.with(|cache| {
+        Some(output) if !output.is_empty() => {
             use std::collections::hash_map::Entry;
 
-            let mut cache = cache.borrow_mut();
+            let mut cache = handle.output_cstrings.borrow_mut();
             match cache.entry(channel_str.to_string()) {
                 Entry::Occupied(mut entry) => {
                     if entry.get().snapshot != output {
-                        entry.insert(CachedOutputCString {
-                            snapshot: output.to_string(),
-                            cstring: CString::new(output).unwrap_or_default(),
-                        });
+                        entry.insert(CachedOutputCString::new(output));
                     }
                     entry.get().cstring.as_ptr()
                 }
                 Entry::Vacant(entry) => {
-                    let slot = entry.insert(CachedOutputCString {
-                        snapshot: output.to_string(),
-                        cstring: CString::new(output).unwrap_or_default(),
-                    });
+                    let slot = entry.insert(CachedOutputCString::new(output));
                     slot.cstring.as_ptr()
                 }
             }
-        }),
+        }
         _ => ptr::null(),
+    }
+}
+
+/// Copy the engine's captured output for a named channel.
+///
+/// This is the preferred output accessor for hosts that do not want to retain
+/// an engine-owned pointer. `*out_len` always reports the full required byte
+/// count including the trailing NUL when output exists.
+///
+/// ## Contract
+///
+/// | Condition | Return | `*out_len` |
+/// |-----------|--------|------------|
+/// | `engine` is null | `NullPointer` | 0 |
+/// | `channel` is null or invalid UTF-8 | `NullPointer` / `InvalidArgument` | 0 |
+/// | `out_len` is null | `InvalidArgument` | (not written) |
+/// | Channel has no non-empty output | `NotFound` | 0 |
+/// | `buf` is null AND `buf_len` is 0 (size query) | `Ok` | required size (incl. NUL) |
+/// | `buf` non-null, `buf_len` >= needed | `Ok` | bytes written (incl. NUL) |
+/// | `buf` non-null, `buf_len` < needed | `BufferTooSmall` | full needed size (incl. NUL) |
+///
+/// An undersized non-empty buffer receives a NUL-terminated prefix and a
+/// `BufferTooSmall` status; truncation is never reported as success.
+///
+/// # Safety
+///
+/// - `engine` must be a valid engine pointer or null.
+/// - `channel` must be a valid NUL-terminated UTF-8 string or null.
+/// - `buf` must point to `buf_len` writable bytes, or be null for a size query.
+/// - `out_len` must be a valid non-null pointer.
+#[no_mangle]
+pub unsafe extern "C" fn ferric_engine_get_output_copy(
+    engine: *const FerricEngine,
+    channel: *const c_char,
+    buf: *mut c_char,
+    buf_len: usize,
+    out_len: *mut usize,
+) -> FerricError {
+    let handle = match borrow_engine_checked(engine) {
+        Ok(handle) => handle,
+        Err(code) => {
+            if !out_len.is_null() {
+                *out_len = 0;
+            }
+            return code;
+        }
+    };
+    if out_len.is_null() {
+        return set_engine_error_message(
+            handle.diagnostics,
+            FerricError::InvalidArgument,
+            "out_len pointer is null".to_string(),
+        );
+    }
+    *out_len = 0;
+    let channel_str = match engine_c_str_to_str(channel, "channel", handle.diagnostics) {
+        Ok(channel) => channel,
+        Err(code) => return code,
+    };
+
+    match handle.engine.get_output(channel_str) {
+        Some(output) if !output.is_empty() => {
+            copy_str_to_buffer(output, buf, buf_len, out_len, handle.diagnostics)
+        }
+        _ => set_engine_error_message(
+            handle.diagnostics,
+            FerricError::NotFound,
+            format!("output channel has no captured output: {channel_str}"),
+        ),
     }
 }
 /// Get the number of action diagnostics captured during recent execution.
@@ -2047,6 +2169,7 @@ pub unsafe extern "C" fn ferric_engine_clear(engine: *mut FerricEngine) -> Ferri
         Err(code) => return code,
     };
     handle.engine.clear();
+    handle.output_cstrings.borrow_mut().clear();
     FerricError::Ok
 }
 
@@ -2144,6 +2267,7 @@ pub unsafe extern "C" fn ferric_engine_clear_output(
         Err(code) => return code,
     };
     handle.engine.clear_output_channel(channel_str);
+    handle.output_cstrings.borrow_mut().remove(channel_str);
     FerricError::Ok
 }
 

--- a/crates/ferric-rules-ffi/src/lib.rs
+++ b/crates/ferric-rules-ffi/src/lib.rs
@@ -29,7 +29,10 @@
 //! - **Ownership conventions**: Callers own handles returned by `_new` functions and
 //!   must free them with corresponding `_free` functions. The borrowed raw-engine
 //!   error pointer remains valid until the next borrowed read on that engine or
-//!   engine destruction; concurrent consumers should use the copy API.
+//!   engine destruction; concurrent consumers should use the copy API. Borrowed
+//!   output snapshots are stored per engine and channel, cannot be invalidated by
+//!   another engine, and are reclaimed at engine destruction. Hosts should prefer
+//!   `ferric_engine_get_output_copy` for caller-owned output storage.
 //!
 //! - **Panic policy**: FFI builds use `panic = "abort"` profiles (`ffi-dev`,
 //!   `ffi-release`) so that Rust panics never unwind across the C ABI boundary.

--- a/crates/ferric-rules-ffi/src/tests.rs
+++ b/crates/ferric-rules-ffi/src/tests.rs
@@ -28,6 +28,9 @@ mod lifecycle;
 mod execution;
 
 #[cfg(test)]
+mod output_lifetime;
+
+#[cfg(test)]
 mod action_diagnostics;
 
 #[cfg(test)]

--- a/crates/ferric-rules-ffi/src/tests/contract_lock.rs
+++ b/crates/ferric-rules-ffi/src/tests/contract_lock.rs
@@ -13,9 +13,10 @@ use crate::engine::{
     ferric_engine_assert_string, ferric_engine_clear_action_diagnostics, ferric_engine_clear_error,
     ferric_engine_fact_count, ferric_engine_free, ferric_engine_get_fact_field,
     ferric_engine_get_fact_field_count, ferric_engine_get_global, ferric_engine_get_output,
-    ferric_engine_last_error, ferric_engine_last_error_copy, ferric_engine_load_string,
-    ferric_engine_new, ferric_engine_new_with_config, ferric_engine_reset, ferric_engine_retract,
-    ferric_engine_run, ferric_engine_step, FerricEngine,
+    ferric_engine_get_output_copy, ferric_engine_last_error, ferric_engine_last_error_copy,
+    ferric_engine_load_string, ferric_engine_new, ferric_engine_new_with_config,
+    ferric_engine_reset, ferric_engine_retract, ferric_engine_run, ferric_engine_step,
+    FerricEngine,
 };
 use crate::error::{
     ferric_clear_error_global, ferric_last_error_global, ferric_last_error_global_copy, FerricError,
@@ -93,6 +94,13 @@ fn contract_lock_canonical_function_names_exist() {
     // output capture
     let _: unsafe extern "C" fn(*const FerricEngine, *const c_char) -> *const c_char =
         ferric_engine_get_output;
+    let _: unsafe extern "C" fn(
+        *const FerricEngine,
+        *const c_char,
+        *mut c_char,
+        usize,
+        *mut usize,
+    ) -> FerricError = ferric_engine_get_output_copy;
 
     // action diagnostics
     let _: unsafe extern "C" fn(*const FerricEngine, *mut usize) -> FerricError =

--- a/crates/ferric-rules-ffi/src/tests/header.rs
+++ b/crates/ferric-rules-ffi/src/tests/header.rs
@@ -534,6 +534,10 @@ fn header_contains_query_functions() {
         header.contains("ferric_engine_get_output"),
         "Missing ferric_engine_get_output"
     );
+    assert!(
+        header.contains("ferric_engine_get_output_copy"),
+        "Missing ferric_engine_get_output_copy"
+    );
 }
 
 #[test]
@@ -689,6 +693,10 @@ fn header_has_counted_by_and_sized_by_annotations() {
     assert!(
         header.contains("*buf FERRIC_SIZED_BY(buf_len),\n                                                      uintptr_t buf_len,\n                                                      uintptr_t *out_len);"),
         "Missing FERRIC_SIZED_BY on ferric_engine_action_diagnostic_copy buf parameter"
+    );
+    assert!(
+        header.contains("ferric_engine_get_output_copy(const struct FerricEngine *engine,\n                                               const char * FERRIC_NULL_TERMINATED channel,\n                                               char *buf FERRIC_SIZED_BY(buf_len),"),
+        "Missing bounds annotations on ferric_engine_get_output_copy"
     );
 }
 

--- a/crates/ferric-rules-ffi/src/tests/output_lifetime.rs
+++ b/crates/ferric-rules-ffi/src/tests/output_lifetime.rs
@@ -1,0 +1,234 @@
+//! Regression coverage for engine-scoped borrowed output storage.
+
+use crate::engine::{
+    ferric_engine_clear_output, ferric_engine_free, ferric_engine_get_output,
+    ferric_engine_get_output_copy, ferric_engine_last_error, ferric_engine_load_string,
+    ferric_engine_new, ferric_engine_reset, ferric_engine_run, output_cache_entry_count_for_test,
+    output_cache_lifetime_for_test, FerricEngine,
+};
+use crate::error::FerricError;
+use std::ffi::{CStr, CString};
+
+unsafe fn engine_with_output(text: &str) -> *mut FerricEngine {
+    let engine = ferric_engine_new();
+    assert!(!engine.is_null());
+    let source = CString::new(format!(r#"(defrule emit => (printout shared "{text}"))"#)).unwrap();
+    assert_eq!(
+        ferric_engine_load_string(engine, source.as_ptr()),
+        FerricError::Ok
+    );
+    assert_eq!(ferric_engine_reset(engine), FerricError::Ok);
+    let mut fired = 0;
+    assert_eq!(ferric_engine_run(engine, -1, &mut fired), FerricError::Ok);
+    assert_eq!(fired, 1);
+    engine
+}
+
+#[test]
+fn borrowed_output_cache_is_engine_scoped_and_freed_with_engine() {
+    unsafe {
+        let channel = CString::new("shared").unwrap();
+        let first = engine_with_output("engine-a");
+        let second = engine_with_output("engine-b");
+
+        assert!(!ferric_engine_get_output(first, channel.as_ptr()).is_null());
+        assert_eq!(output_cache_entry_count_for_test(first), Some(1));
+        let first_entry = output_cache_lifetime_for_test(first, "shared")
+            .expect("first engine should have a cached output entry");
+
+        assert!(!ferric_engine_get_output(second, channel.as_ptr()).is_null());
+        assert_eq!(output_cache_entry_count_for_test(first), Some(1));
+        assert_eq!(output_cache_entry_count_for_test(second), Some(1));
+        let first_entry_survived_second_read = first_entry.upgrade().is_some();
+        let second_entry = output_cache_lifetime_for_test(second, "shared")
+            .expect("second engine should have a cached output entry");
+
+        assert_eq!(ferric_engine_free(first), FerricError::Ok);
+        assert_eq!(ferric_engine_free(second), FerricError::Ok);
+        let first_entry_was_reclaimed = first_entry.upgrade().is_none();
+        let second_entry_was_reclaimed = second_entry.upgrade().is_none();
+
+        assert!(
+            first_entry_survived_second_read,
+            "reading engine B must not replace engine A's same-channel cache entry"
+        );
+        assert!(
+            first_entry_was_reclaimed && second_entry_was_reclaimed,
+            "freeing each engine must reclaim its cached output entries"
+        );
+    }
+}
+
+#[test]
+fn clearing_output_and_reset_reclaim_borrowed_snapshots() {
+    unsafe {
+        let engine = engine_with_output("engine-a");
+        let channel = CString::new("shared").unwrap();
+        assert!(!ferric_engine_get_output(engine, channel.as_ptr()).is_null());
+        assert_eq!(output_cache_entry_count_for_test(engine), Some(1));
+        let cleared_entry = output_cache_lifetime_for_test(engine, "shared").unwrap();
+
+        assert_eq!(
+            ferric_engine_clear_output(engine, channel.as_ptr()),
+            FerricError::Ok
+        );
+        assert_eq!(output_cache_entry_count_for_test(engine), Some(0));
+        assert!(cleared_entry.upgrade().is_none());
+
+        assert_eq!(ferric_engine_reset(engine), FerricError::Ok);
+        let mut fired = 0;
+        assert_eq!(ferric_engine_run(engine, -1, &mut fired), FerricError::Ok);
+        assert_eq!(fired, 1);
+        assert!(!ferric_engine_get_output(engine, channel.as_ptr()).is_null());
+        let reset_entry = output_cache_lifetime_for_test(engine, "shared").unwrap();
+
+        assert_eq!(ferric_engine_reset(engine), FerricError::Ok);
+        assert_eq!(output_cache_entry_count_for_test(engine), Some(0));
+        assert!(reset_entry.upgrade().is_none());
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}
+
+#[test]
+fn output_copy_reports_required_length_and_truncation() {
+    unsafe {
+        let engine = engine_with_output("engine-a");
+        let channel = CString::new("shared").unwrap();
+        let mut needed = 0;
+
+        assert_eq!(
+            ferric_engine_get_output_copy(
+                engine,
+                channel.as_ptr(),
+                std::ptr::null_mut(),
+                0,
+                &mut needed,
+            ),
+            FerricError::Ok
+        );
+        assert_eq!(needed, "engine-a".len() + 1);
+
+        let sentinel = std::os::raw::c_char::try_from(b'x')
+            .expect("ASCII sentinel must fit in the platform C char type");
+        let mut small = [sentinel; 5];
+        let mut reported = 0;
+        assert_eq!(
+            ferric_engine_get_output_copy(
+                engine,
+                channel.as_ptr(),
+                small.as_mut_ptr(),
+                small.len(),
+                &mut reported,
+            ),
+            FerricError::BufferTooSmall
+        );
+        assert_eq!(reported, needed);
+        assert_eq!(
+            CStr::from_ptr(small.as_ptr()).to_bytes(),
+            b"engi",
+            "undersized copies must be explicitly reported and NUL-terminated"
+        );
+
+        let mut exact = vec![0 as std::os::raw::c_char; needed];
+        assert_eq!(
+            ferric_engine_get_output_copy(
+                engine,
+                channel.as_ptr(),
+                exact.as_mut_ptr(),
+                exact.len(),
+                &mut reported,
+            ),
+            FerricError::Ok
+        );
+        assert_eq!(reported, needed);
+        assert_eq!(CStr::from_ptr(exact.as_ptr()).to_bytes(), b"engine-a");
+
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}
+
+#[test]
+fn output_copy_validates_missing_and_invalid_inputs() {
+    unsafe {
+        let engine = engine_with_output("engine-a");
+        let channel = CString::new("shared").unwrap();
+        let missing = CString::new("missing").unwrap();
+        let mut out_len = usize::MAX;
+        let mut byte = 0 as std::os::raw::c_char;
+
+        assert_eq!(
+            ferric_engine_get_output_copy(
+                engine,
+                missing.as_ptr(),
+                std::ptr::null_mut(),
+                0,
+                &mut out_len,
+            ),
+            FerricError::NotFound
+        );
+        assert_eq!(out_len, 0);
+        assert_eq!(
+            CStr::from_ptr(ferric_engine_last_error(engine))
+                .to_str()
+                .unwrap(),
+            "output channel has no captured output: missing"
+        );
+
+        out_len = usize::MAX;
+        assert_eq!(
+            ferric_engine_get_output_copy(
+                engine,
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                0,
+                &mut out_len,
+            ),
+            FerricError::NullPointer
+        );
+        assert_eq!(out_len, 0);
+
+        assert_eq!(
+            ferric_engine_get_output_copy(
+                engine,
+                channel.as_ptr(),
+                std::ptr::null_mut(),
+                1,
+                &mut out_len,
+            ),
+            FerricError::InvalidArgument
+        );
+        assert_eq!(out_len, "engine-a".len() + 1);
+
+        assert_eq!(
+            ferric_engine_get_output_copy(engine, channel.as_ptr(), &mut byte, 0, &mut out_len,),
+            FerricError::BufferTooSmall
+        );
+        assert_eq!(out_len, "engine-a".len() + 1);
+
+        assert_eq!(
+            ferric_engine_get_output_copy(
+                engine,
+                channel.as_ptr(),
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+            ),
+            FerricError::InvalidArgument
+        );
+
+        out_len = usize::MAX;
+        assert_eq!(
+            ferric_engine_get_output_copy(
+                std::ptr::null(),
+                channel.as_ptr(),
+                std::ptr::null_mut(),
+                0,
+                &mut out_len,
+            ),
+            FerricError::NullPointer
+        );
+        assert_eq!(out_len, 0);
+
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}

--- a/crates/ferric-rules-ffi/src/tests/output_lifetime.rs
+++ b/crates/ferric-rules-ffi/src/tests/output_lifetime.rs
@@ -3,10 +3,12 @@
 use crate::engine::{
     ferric_engine_clear_output, ferric_engine_free, ferric_engine_get_output,
     ferric_engine_get_output_copy, ferric_engine_last_error, ferric_engine_load_string,
-    ferric_engine_new, ferric_engine_reset, ferric_engine_run, output_cache_entry_count_for_test,
-    output_cache_lifetime_for_test, FerricEngine,
+    ferric_engine_new, ferric_engine_reset, ferric_engine_run, ferric_engine_run_ex,
+    ferric_engine_step, output_cache_entry_count_for_test, output_cache_lifetime_for_test,
+    FerricEngine,
 };
 use crate::error::FerricError;
+use crate::types::FerricHaltReason;
 use std::ffi::{CStr, CString};
 
 unsafe fn engine_with_output(text: &str) -> *mut FerricEngine {
@@ -22,6 +24,14 @@ unsafe fn engine_with_output(text: &str) -> *mut FerricEngine {
     assert_eq!(ferric_engine_run(engine, -1, &mut fired), FerricError::Ok);
     assert_eq!(fired, 1);
     engine
+}
+
+unsafe fn load_action_rule(engine: *mut FerricEngine, name: &str, action: &str) {
+    let source = CString::new(format!(r"(defrule {name} => ({action}))")).unwrap();
+    assert_eq!(
+        ferric_engine_load_string(engine, source.as_ptr()),
+        FerricError::Ok
+    );
 }
 
 #[test]
@@ -86,6 +96,55 @@ fn clearing_output_and_reset_reclaim_borrowed_snapshots() {
         assert_eq!(output_cache_entry_count_for_test(engine), Some(0));
         assert!(reset_entry.upgrade().is_none());
         assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}
+
+#[test]
+fn action_driven_reset_and_clear_reclaim_borrowed_snapshots() {
+    unsafe {
+        let channel = CString::new("shared").unwrap();
+
+        let run_engine = engine_with_output("run-reset");
+        assert!(!ferric_engine_get_output(run_engine, channel.as_ptr()).is_null());
+        let run_entry = output_cache_lifetime_for_test(run_engine, "shared").unwrap();
+        load_action_rule(run_engine, "reset-output-cache", "reset");
+        let mut fired = 0;
+        assert_eq!(
+            ferric_engine_run(run_engine, -1, &mut fired),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 1);
+        assert!(run_entry.upgrade().is_none());
+        assert_eq!(output_cache_entry_count_for_test(run_engine), Some(0));
+        assert_eq!(ferric_engine_free(run_engine), FerricError::Ok);
+
+        let run_ex_engine = engine_with_output("run-ex-reset");
+        assert!(!ferric_engine_get_output(run_ex_engine, channel.as_ptr()).is_null());
+        let run_ex_entry = output_cache_lifetime_for_test(run_ex_engine, "shared").unwrap();
+        load_action_rule(run_ex_engine, "reset-output-cache-ex", "reset");
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_run_ex(run_ex_engine, -1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 1);
+        assert!(run_ex_entry.upgrade().is_none());
+        assert_eq!(output_cache_entry_count_for_test(run_ex_engine), Some(0));
+        assert_eq!(ferric_engine_free(run_ex_engine), FerricError::Ok);
+
+        let step_engine = engine_with_output("step-clear");
+        assert!(!ferric_engine_get_output(step_engine, channel.as_ptr()).is_null());
+        let step_entry = output_cache_lifetime_for_test(step_engine, "shared").unwrap();
+        load_action_rule(step_engine, "clear-output-cache", "clear");
+        let mut status = 0;
+        assert_eq!(
+            ferric_engine_step(step_engine, &mut status),
+            FerricError::Ok
+        );
+        assert_eq!(status, 1);
+        assert!(step_entry.upgrade().is_none());
+        assert_eq!(output_cache_entry_count_for_test(step_engine), Some(0));
+        assert_eq!(ferric_engine_free(step_engine), FerricError::Ok);
     }
 }
 

--- a/crates/ferric-rules-ffi/tests/c/output_lifetime.c
+++ b/crates/ferric-rules-ffi/tests/c/output_lifetime.c
@@ -1,0 +1,152 @@
+/*
+ * output_lifetime.c — C-ABI regression harness for FR-CABI-004 (issue #114).
+ *
+ * A borrowed output pointer belongs to one engine. Reading the same channel
+ * from a second engine must not invalidate the first engine's pointer. The
+ * copy API must report its exact size and any truncation, and repeated engine
+ * destruction must release engine-scoped borrowed storage.
+ *
+ * Run through `just ffi-c-harness`; the pre-fix process-wide channel cache
+ * triggers an AddressSanitizer use-after-free when `first_output` is read
+ * after the second engine replaces the shared cache entry.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "ferric.h"
+
+static FerricEngine *engine_with_output(const char *channel, const char *text) {
+    char source[256] = {0};
+    uint64_t fired = 0;
+    FerricEngine *engine = ferric_engine_new();
+    if (engine == NULL) {
+        return NULL;
+    }
+
+    int written = snprintf(
+        source, sizeof(source),
+        "(defrule emit => (printout %s \"%s\"))", channel, text);
+    if (written < 0 || (size_t)written >= sizeof(source) ||
+        ferric_engine_load_string(engine, source) != FERRIC_ERROR_OK ||
+        ferric_engine_reset(engine) != FERRIC_ERROR_OK ||
+        ferric_engine_run(engine, -1, &fired) != FERRIC_ERROR_OK ||
+        fired != UINT64_C(1)) {
+        (void)ferric_engine_free(engine);
+        return NULL;
+    }
+
+    return engine;
+}
+
+static int check_copy_contract(FerricEngine *engine) {
+    char small[5] = {'x', 'x', 'x', 'x', 'x'};
+    char exact[32] = {0};
+    uintptr_t needed = 0;
+
+    if (ferric_engine_get_output_copy(engine, "shared", NULL, 0, &needed) !=
+            FERRIC_ERROR_OK ||
+        needed != sizeof("engine-a")) {
+        fprintf(stderr, "output copy size query returned the wrong result\n");
+        return 1;
+    }
+
+    uintptr_t reported = 0;
+    if (ferric_engine_get_output_copy(engine, "shared", small, sizeof(small),
+                                      &reported) !=
+            FERRIC_ERROR_BUFFER_TOO_SMALL ||
+        reported != needed || small[sizeof(small) - 1] != '\0' ||
+        strcmp(small, "engi") != 0) {
+        fprintf(stderr, "undersized output copy was not reported explicitly\n");
+        return 1;
+    }
+
+    if (ferric_engine_get_output_copy(engine, "shared", exact, needed,
+                                      &reported) != FERRIC_ERROR_OK ||
+        reported != needed || strcmp(exact, "engine-a") != 0) {
+        fprintf(stderr, "exact output copy returned the wrong result\n");
+        return 1;
+    }
+
+    reported = UINTPTR_MAX;
+    if (ferric_engine_get_output_copy(engine, "missing", NULL, 0, &reported) !=
+            FERRIC_ERROR_NOT_FOUND ||
+        reported != 0) {
+        fprintf(stderr, "missing output copy returned the wrong result\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+static int stress_engine_lifecycle(void) {
+    for (unsigned i = 0; i < 128; i++) {
+        char channel[32] = {0};
+        int written =
+            snprintf(channel, sizeof(channel), "lifecycle_%03u", i);
+        if (written < 0 || (size_t)written >= sizeof(channel)) {
+            return 1;
+        }
+
+        FerricEngine *engine = engine_with_output(channel, "payload");
+        if (engine == NULL) {
+            fprintf(stderr, "lifecycle engine %u failed to initialize\n", i);
+            return 1;
+        }
+        const char *output = ferric_engine_get_output(engine, channel);
+        if (output == NULL || strcmp(output, "payload") != 0 ||
+            ferric_engine_free(engine) != FERRIC_ERROR_OK) {
+            fprintf(stderr, "lifecycle engine %u failed\n", i);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int main(void) {
+    FerricEngine *first = engine_with_output("shared", "engine-a");
+    FerricEngine *second = engine_with_output("shared", "engine-b");
+    if (first == NULL || second == NULL) {
+        fprintf(stderr, "failed to create output-producing engines\n");
+        if (first != NULL) {
+            (void)ferric_engine_free(first);
+        }
+        if (second != NULL) {
+            (void)ferric_engine_free(second);
+        }
+        return 1;
+    }
+
+    const char *first_output = ferric_engine_get_output(first, "shared");
+    if (first_output == NULL || strcmp(first_output, "engine-a") != 0) {
+        fprintf(stderr, "first engine returned the wrong output\n");
+        return 1;
+    }
+
+    const char *second_output = ferric_engine_get_output(second, "shared");
+    if (second_output == NULL || strcmp(second_output, "engine-b") != 0) {
+        fprintf(stderr, "second engine returned the wrong output\n");
+        return 1;
+    }
+
+    if (strcmp(first_output, "engine-a") != 0) {
+        fprintf(stderr, "second engine invalidated first engine's pointer\n");
+        return 1;
+    }
+    if (check_copy_contract(first) != 0) {
+        return 1;
+    }
+
+    if (ferric_engine_free(first) != FERRIC_ERROR_OK ||
+        ferric_engine_free(second) != FERRIC_ERROR_OK) {
+        fprintf(stderr, "failed to free output-producing engines\n");
+        return 1;
+    }
+    if (stress_engine_lifecycle() != 0) {
+        return 1;
+    }
+
+    printf("output-lifetime harness: pointer isolation, copy, and cleanup passed\n");
+    return 0;
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -776,6 +776,7 @@ C, C++, Swift, Kotlin (NDK), and other languages with C FFI support.
 
 ```c
 #include "ferric.h"
+#include <stdlib.h>
 
 // Create engine with defaults
 FerricEngine* engine = ferric_engine_new();
@@ -795,8 +796,18 @@ ferric_engine_reset(engine);
 uint64_t fired;
 ferric_engine_run(engine, -1, &fired);
 
-// Read output
-const char* output = ferric_engine_get_output(engine, "stdout");
+// Read output into caller-owned storage
+size_t output_len = 0;
+if (ferric_engine_get_output_copy(engine, "t", NULL, 0, &output_len) ==
+    FERRIC_ERROR_OK) {
+    char* output = malloc(output_len);
+    if (output != NULL &&
+        ferric_engine_get_output_copy(engine, "t", output, output_len,
+                                      &output_len) == FERRIC_ERROR_OK) {
+        // use output
+    }
+    free(output);
+}
 
 // Clean up
 ferric_engine_free(engine);
@@ -849,14 +860,16 @@ The `*_copy` functions follow a uniform contract:
 
 | Condition | Return Code | `*out_len` |
 |-----------|-------------|------------|
-| No error stored | `FERRIC_ERROR_NOT_FOUND` | 0 |
+| No source value (for example, no error or no channel output) | `FERRIC_ERROR_NOT_FOUND` | 0 |
 | `out_len` is NULL | `FERRIC_ERROR_INVALID_ARGUMENT` | (not written) |
 | `buf` is NULL, `buf_len` is 0 (size query) | `FERRIC_ERROR_OK` | Required size (incl. NUL) |
 | `buf` non-null, `buf_len` >= needed | `FERRIC_ERROR_OK` | Bytes written (incl. NUL) |
 | `buf` non-null, `buf_len` < needed | `FERRIC_ERROR_BUFFER_TOO_SMALL` | Full needed size (incl. NUL) |
 
 On truncation, the buffer receives `buf_len - 1` bytes followed by a NUL
-terminator.
+terminator and the function returns `FERRIC_ERROR_BUFFER_TOO_SMALL`; truncation
+is never reported as success. `ferric_engine_get_output_copy` follows this
+contract and is the preferred output accessor for caller-owned storage.
 
 ### Fact Lifecycle
 
@@ -923,8 +936,13 @@ must be acyclic and no deeper than 128 nested multifield levels.
 Other borrowed pointers must **not** be freed by the caller.
 `ferric_engine_last_error` remains valid until the next borrowed last-error
 read on that engine or engine destruction; error writers and the copy API do
-not invalidate it. `ferric_engine_get_output` remains valid until the next
-call that writes to that output channel.
+not invalidate it. `ferric_engine_get_output` returns a per-engine,
+per-channel snapshot that remains valid until a later borrowed read for the
+same engine and channel replaces it; that channel is cleared; the engine is
+reset or cleared; or until engine destruction. Reads on other engines do not
+invalidate it, and later output writes are not reflected in an existing
+snapshot. Use `ferric_engine_get_output_copy` when the caller should own the
+bytes.
 
 ### Panic Policy
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -171,6 +171,11 @@ C FFI surface. Key differences:
   involving a validated raw-engine handle updates both its per-engine snapshot
   and the calling thread's global fallback; pre-handle failures update only
   global state.
+- Prefer `ferric_engine_get_output_copy` for captured output. The legacy
+  `ferric_engine_get_output` pointer is an engine-owned, per-channel snapshot:
+  another engine cannot invalidate it, but a later borrowed read for the same
+  engine/channel can replace it; output clear/reset operations and engine
+  destruction invalidate the relevant snapshot.
 - Include `ferric.h` and link against the Ferric shared library.
 
 See [compatibility.md](compatibility.md) Section 16.13 for the full FFI

--- a/docs/phase6-baseline.md
+++ b/docs/phase6-baseline.md
@@ -114,7 +114,10 @@ C-ABI functions with opaque `FerricEngine*` handle:
 - `ferric_engine_get_global` -- read a defglobal value as `FerricValue`
 
 **Output:**
-- `ferric_engine_get_output` -- retrieve captured channel output
+- `ferric_engine_get_output` -- retrieve an engine-scoped borrowed channel
+  snapshot; storage is reclaimed with the engine
+- `ferric_engine_get_output_copy` -- copy captured channel output into
+  caller-owned storage with required-length and truncation reporting
 
 **Error Handling:**
 - Failed calls involving a validated raw-engine handle mirror the same current

--- a/scripts/ffi-c-harness.sh
+++ b/scripts/ffi-c-harness.sh
@@ -19,6 +19,7 @@ harness_sources=(
     "crates/ferric-rules-ffi/tests/c/discriminant_abuse.c"
     "crates/ferric-rules-ffi/tests/c/error_channels.c"
     "crates/ferric-rules-ffi/tests/c/multifield_copy.c"
+    "crates/ferric-rules-ffi/tests/c/output_lifetime.c"
 )
 outdir="target/c-harness"
 mkdir -p "$outdir"


### PR DESCRIPTION
## Summary

- move borrowed output snapshots from a process/thread-local channel cache into each engine handle
- reclaim snapshots on channel clear, engine reset/clear, action-driven reset/clear, and engine destruction
- add `ferric_engine_get_output_copy` with size-query, exact-copy, and explicit `BUFFER_TOO_SMALL` behavior
- lock the C header/ABI contract and document the borrowed and copied-output lifetimes

## Why

The old cache was keyed only by channel. Reading the same channel from engine B replaced engine A's backing `CString`, invalidating A's returned pointer, and cache entries could survive for the process lifetime. Engine-owned per-channel storage gives the borrowed API the documented engine scope, while the additive copy API lets hosts use caller-owned bounded buffers.

Execution entry points also reconcile snapshots after `run`, `run_ex`, and `step`, so `(reset)` and `(clear)` actions invalidate cached channels just like the direct lifecycle APIs.

Embedded-NUL policy remains tracked separately by #115.

## Red regressions

Before the initial implementation, the focused deterministic lifetime test failed with:

```text
reading engine B must not replace engine A's same-channel cache entry
```

The regression uses test-only lifetime tokens and entry counts, so it proves isolation and cleanup without dereferencing an invalid pointer.

The review follow-up added an action-driven lifecycle regression. Before its fix, it failed because the cached snapshot remained live after a rule executed `(reset)`.

## Validation

- `just preflight-pr` (rerun after review fix)
- `cargo test -p ferric-rules-ffi --all-features` (297 passed, 4 ignored)
- `cargo test -p ferric-rules-ffi output_lifetime -- --nocapture` (5 passed)
- `cargo clippy -p ferric-rules-ffi --all-targets --all-features -- -D warnings`
- `just test-go`
- `just bindings-conformance` (25 cases, 5 adapters)
- ordinary native C build/run of `output_lifetime.c`

Local validation deliberately used deterministic lifetime accounting and a non-instrumented C harness. The required hosted FFI C harness job provides ASan/UBSan coverage.

Closes #114