### PR TITLE
[FR-CABI-005] Reject embedded NUL at legacy C boundaries

### DIFF
--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -81,7 +81,17 @@
  *    never invalidate it. Do NOT free. Prefer
  *    ferric_engine_get_output_copy() for caller-owned storage.
  *
- * 9. Bounds annotations: Pointer parameters and struct fields
+ * 9. Embedded NUL policy: Legacy NUL-terminated inputs end at
+ *    the first NUL. Hosts starting from length-bearing strings
+ *    must reject embedded NUL before calling those entry points;
+ *    ferric_value_symbol_bytes() and ferric_value_string_bytes()
+ *    provide checked value construction. Legacy FerricValue
+ *    egress rejects unrepresentable Symbol/String data with
+ *    FERRIC_ERROR_INVALID_ARGUMENT. Borrowed output returns NULL
+ *    and records that error; ferric_engine_get_output_copy()
+ *    preserves all bytes and reports an authoritative length.
+ *
+ * 10. Bounds annotations: Pointer parameters and struct fields
  *    carry FERRIC_COUNTED_BY, FERRIC_SIZED_BY, and
  *    FERRIC_NULL_TERMINATED annotations when compiled with
  *    Clang -fbounds-safety. Define FERRIC_NO_BOUNDS_ANNOTATIONS
@@ -585,6 +595,10 @@ enum FerricError ferric_engine_retract(struct FerricEngine *engine, uint64_t fac
 // engine never invalidate it. Output written after this call is not reflected
 // in the snapshot.
 //
+// If the captured output contains embedded NUL, this legacy C-string accessor
+// returns null and records `InvalidArgument`. Use
+// `ferric_engine_get_output_copy` to preserve every byte.
+//
 // Prefer `ferric_engine_get_output_copy` when retaining a borrowed pointer
 // would be inconvenient or when pointer-use windows could overlap.
 //
@@ -598,7 +612,8 @@ const char * FERRIC_NULL_TERMINATED ferric_engine_get_output(const struct Ferric
 //
 // This is the preferred output accessor for hosts that do not want to retain
 // an engine-owned pointer. `*out_len` always reports the full required byte
-// count including the trailing NUL when output exists.
+// count including the trailing NUL when output exists. The copied payload
+// preserves embedded NUL; `*out_len`, not C-string scanning, is authoritative.
 //
 // ## Contract
 //
@@ -694,6 +709,9 @@ enum FerricError ferric_engine_get_fact_field_count(const struct FerricEngine *e
 // The returned `FerricValue` is written to `*out_value`. The caller owns
 // any heap-allocated resources (`string_ptr`, `multifield_ptr`) and must free
 // them with `ferric_value_free` or the type-specific free functions.
+// A Symbol/String containing embedded NUL (including inside a multifield)
+// cannot be represented by this legacy C-string value and returns
+// `InvalidArgument`; `*out_value` is left as Void.
 //
 // # Safety
 //
@@ -711,6 +729,8 @@ enum FerricError ferric_engine_get_fact_field(const struct FerricEngine *engine,
 //
 // Module/global visibility resolution follows the runtime's standard rules.
 // Ambiguity and not-found conditions produce runtime-authored diagnostics.
+// A Symbol/String containing embedded NUL (including inside a multifield)
+// returns `InvalidArgument`, and `*out_value` is left as Void.
 //
 // # Safety
 //
@@ -1097,6 +1117,8 @@ enum FerricError ferric_engine_assert_template(struct FerricEngine *engine,
 //
 // The returned `FerricValue` is written to `*out_value`. The caller owns
 // any heap-allocated resources and must free them with `ferric_value_free`.
+// A Symbol/String containing embedded NUL (including inside a multifield)
+// returns `InvalidArgument`, and `*out_value` is left as Void.
 //
 // # Safety
 //
@@ -1656,25 +1678,79 @@ struct FerricValue ferric_value_integer(int64_t value);
 // Create a float `FerricValue`.
 struct FerricValue ferric_value_float(double value);
 
-// Create a symbol `FerricValue` with a heap-copied string.
+// Create a symbol `FerricValue` with a heap-copied legacy C string.
 //
 // Returns a void value if `name` is null. The caller owns the
 // `string_ptr` and must free it with `ferric_value_free`.
+//
+// This legacy entry point reads through the first NUL terminator; bytes after
+// that terminator are not part of the input and cannot be diagnosed. Hosts
+// starting from a pointer-plus-length string should use
+// `ferric_value_symbol_bytes`, which rejects embedded NUL explicitly.
 //
 // # Safety
 //
 // - `name` must be a valid NUL-terminated string, or null.
 struct FerricValue ferric_value_symbol(const char * FERRIC_NULL_TERMINATED name);
 
-// Create a string `FerricValue` with a heap-copied string.
+// Create a string `FerricValue` with a heap-copied legacy C string.
 //
 // Returns a void value if `s` is null. The caller owns the
 // `string_ptr` and must free it with `ferric_value_free`.
+//
+// This legacy entry point reads through the first NUL terminator; bytes after
+// that terminator are not part of the input and cannot be diagnosed. Hosts
+// starting from a pointer-plus-length string should use
+// `ferric_value_string_bytes`, which rejects embedded NUL explicitly.
 //
 // # Safety
 //
 // - `s` must be a valid NUL-terminated string, or null.
 struct FerricValue ferric_value_string(const char * FERRIC_NULL_TERMINATED s);
+
+// Create a symbol from a pointer-plus-length UTF-8 span.
+//
+// This is the checked constructor for hosts whose native strings carry an
+// explicit byte length. Embedded NUL is rejected with
+// `FERRIC_ERROR_INVALID_ARGUMENT` rather than silently truncating the value.
+// The resulting legacy `FerricValue` remains NUL-terminated and is owned by
+// the caller.
+//
+// On every failure, `*out_value` is left as Void. A null `data` pointer with
+// zero length creates an empty symbol; null with non-zero length returns
+// `FERRIC_ERROR_NULL_POINTER`.
+//
+// # Safety
+//
+// - `out_value` must point to writable storage for one `FerricValue`.
+// - `out_value` must not currently contain live Ferric-owned resources.
+// - If `len > 0`, `data` must point to `len` readable bytes.
+// - The `data` span must not overlap `out_value`.
+enum FerricError ferric_value_symbol_bytes(const uint8_t *data FERRIC_SIZED_BY(len),
+                                           uintptr_t len,
+                                           struct FerricValue *out_value);
+
+// Create a string from a pointer-plus-length UTF-8 span.
+//
+// This is the checked constructor for hosts whose native strings carry an
+// explicit byte length. Embedded NUL is rejected with
+// `FERRIC_ERROR_INVALID_ARGUMENT` rather than silently truncating the value.
+// The resulting legacy `FerricValue` remains NUL-terminated and is owned by
+// the caller.
+//
+// On every failure, `*out_value` is left as Void. A null `data` pointer with
+// zero length creates an empty string; null with non-zero length returns
+// `FERRIC_ERROR_NULL_POINTER`.
+//
+// # Safety
+//
+// - `out_value` must point to writable storage for one `FerricValue`.
+// - `out_value` must not currently contain live Ferric-owned resources.
+// - If `len > 0`, `data` must point to `len` readable bytes.
+// - The `data` span must not overlap `out_value`.
+enum FerricError ferric_value_string_bytes(const uint8_t *data FERRIC_SIZED_BY(len),
+                                           uintptr_t len,
+                                           struct FerricValue *out_value);
 
 // Create a void `FerricValue` with all fields zeroed/null.
 struct FerricValue ferric_value_void(void);

--- a/crates/ferric-rules-ffi/build.rs
+++ b/crates/ferric-rules-ffi/build.rs
@@ -84,7 +84,17 @@ pub const HEADER_PREAMBLE: &str = r"/*
  *    never invalidate it. Do NOT free. Prefer
  *    ferric_engine_get_output_copy() for caller-owned storage.
  *
- * 9. Bounds annotations: Pointer parameters and struct fields
+ * 9. Embedded NUL policy: Legacy NUL-terminated inputs end at
+ *    the first NUL. Hosts starting from length-bearing strings
+ *    must reject embedded NUL before calling those entry points;
+ *    ferric_value_symbol_bytes() and ferric_value_string_bytes()
+ *    provide checked value construction. Legacy FerricValue
+ *    egress rejects unrepresentable Symbol/String data with
+ *    FERRIC_ERROR_INVALID_ARGUMENT. Borrowed output returns NULL
+ *    and records that error; ferric_engine_get_output_copy()
+ *    preserves all bytes and reports an authoritative length.
+ *
+ * 10. Bounds annotations: Pointer parameters and struct fields
  *    carry FERRIC_COUNTED_BY, FERRIC_SIZED_BY, and
  *    FERRIC_NULL_TERMINATED annotations when compiled with
  *    Clang -fbounds-safety. Define FERRIC_NO_BOUNDS_ANNOTATIONS
@@ -441,6 +451,16 @@ const BOUNDS_ANNOTATIONS: &[(&str, &str)] = &[
     (
         "ferric_value_multifield_copy(const struct FerricValue *elements,\n                                              uintptr_t len,",
         "ferric_value_multifield_copy(const struct FerricValue *elements FERRIC_COUNTED_BY(len),\n                                              uintptr_t len,",
+    ),
+    // ferric_value_symbol_bytes: data is a byte span of len bytes.
+    (
+        "ferric_value_symbol_bytes(const uint8_t *data,\n                                           uintptr_t len,",
+        "ferric_value_symbol_bytes(const uint8_t *data FERRIC_SIZED_BY(len),\n                                           uintptr_t len,",
+    ),
+    // ferric_value_string_bytes: data is a byte span of len bytes.
+    (
+        "ferric_value_string_bytes(const uint8_t *data,\n                                           uintptr_t len,",
+        "ferric_value_string_bytes(const uint8_t *data FERRIC_SIZED_BY(len),\n                                           uintptr_t len,",
     ),
     // ferric_last_error_global_copy: buf is a byte buffer of buf_len bytes.
     (

--- a/crates/ferric-rules-ffi/ferric.h
+++ b/crates/ferric-rules-ffi/ferric.h
@@ -81,7 +81,17 @@
  *    never invalidate it. Do NOT free. Prefer
  *    ferric_engine_get_output_copy() for caller-owned storage.
  *
- * 9. Bounds annotations: Pointer parameters and struct fields
+ * 9. Embedded NUL policy: Legacy NUL-terminated inputs end at
+ *    the first NUL. Hosts starting from length-bearing strings
+ *    must reject embedded NUL before calling those entry points;
+ *    ferric_value_symbol_bytes() and ferric_value_string_bytes()
+ *    provide checked value construction. Legacy FerricValue
+ *    egress rejects unrepresentable Symbol/String data with
+ *    FERRIC_ERROR_INVALID_ARGUMENT. Borrowed output returns NULL
+ *    and records that error; ferric_engine_get_output_copy()
+ *    preserves all bytes and reports an authoritative length.
+ *
+ * 10. Bounds annotations: Pointer parameters and struct fields
  *    carry FERRIC_COUNTED_BY, FERRIC_SIZED_BY, and
  *    FERRIC_NULL_TERMINATED annotations when compiled with
  *    Clang -fbounds-safety. Define FERRIC_NO_BOUNDS_ANNOTATIONS
@@ -585,6 +595,10 @@ enum FerricError ferric_engine_retract(struct FerricEngine *engine, uint64_t fac
 // engine never invalidate it. Output written after this call is not reflected
 // in the snapshot.
 //
+// If the captured output contains embedded NUL, this legacy C-string accessor
+// returns null and records `InvalidArgument`. Use
+// `ferric_engine_get_output_copy` to preserve every byte.
+//
 // Prefer `ferric_engine_get_output_copy` when retaining a borrowed pointer
 // would be inconvenient or when pointer-use windows could overlap.
 //
@@ -598,7 +612,8 @@ const char * FERRIC_NULL_TERMINATED ferric_engine_get_output(const struct Ferric
 //
 // This is the preferred output accessor for hosts that do not want to retain
 // an engine-owned pointer. `*out_len` always reports the full required byte
-// count including the trailing NUL when output exists.
+// count including the trailing NUL when output exists. The copied payload
+// preserves embedded NUL; `*out_len`, not C-string scanning, is authoritative.
 //
 // ## Contract
 //
@@ -694,6 +709,9 @@ enum FerricError ferric_engine_get_fact_field_count(const struct FerricEngine *e
 // The returned `FerricValue` is written to `*out_value`. The caller owns
 // any heap-allocated resources (`string_ptr`, `multifield_ptr`) and must free
 // them with `ferric_value_free` or the type-specific free functions.
+// A Symbol/String containing embedded NUL (including inside a multifield)
+// cannot be represented by this legacy C-string value and returns
+// `InvalidArgument`; `*out_value` is left as Void.
 //
 // # Safety
 //
@@ -711,6 +729,8 @@ enum FerricError ferric_engine_get_fact_field(const struct FerricEngine *engine,
 //
 // Module/global visibility resolution follows the runtime's standard rules.
 // Ambiguity and not-found conditions produce runtime-authored diagnostics.
+// A Symbol/String containing embedded NUL (including inside a multifield)
+// returns `InvalidArgument`, and `*out_value` is left as Void.
 //
 // # Safety
 //
@@ -1097,6 +1117,8 @@ enum FerricError ferric_engine_assert_template(struct FerricEngine *engine,
 //
 // The returned `FerricValue` is written to `*out_value`. The caller owns
 // any heap-allocated resources and must free them with `ferric_value_free`.
+// A Symbol/String containing embedded NUL (including inside a multifield)
+// returns `InvalidArgument`, and `*out_value` is left as Void.
 //
 // # Safety
 //
@@ -1656,25 +1678,79 @@ struct FerricValue ferric_value_integer(int64_t value);
 // Create a float `FerricValue`.
 struct FerricValue ferric_value_float(double value);
 
-// Create a symbol `FerricValue` with a heap-copied string.
+// Create a symbol `FerricValue` with a heap-copied legacy C string.
 //
 // Returns a void value if `name` is null. The caller owns the
 // `string_ptr` and must free it with `ferric_value_free`.
+//
+// This legacy entry point reads through the first NUL terminator; bytes after
+// that terminator are not part of the input and cannot be diagnosed. Hosts
+// starting from a pointer-plus-length string should use
+// `ferric_value_symbol_bytes`, which rejects embedded NUL explicitly.
 //
 // # Safety
 //
 // - `name` must be a valid NUL-terminated string, or null.
 struct FerricValue ferric_value_symbol(const char * FERRIC_NULL_TERMINATED name);
 
-// Create a string `FerricValue` with a heap-copied string.
+// Create a string `FerricValue` with a heap-copied legacy C string.
 //
 // Returns a void value if `s` is null. The caller owns the
 // `string_ptr` and must free it with `ferric_value_free`.
+//
+// This legacy entry point reads through the first NUL terminator; bytes after
+// that terminator are not part of the input and cannot be diagnosed. Hosts
+// starting from a pointer-plus-length string should use
+// `ferric_value_string_bytes`, which rejects embedded NUL explicitly.
 //
 // # Safety
 //
 // - `s` must be a valid NUL-terminated string, or null.
 struct FerricValue ferric_value_string(const char * FERRIC_NULL_TERMINATED s);
+
+// Create a symbol from a pointer-plus-length UTF-8 span.
+//
+// This is the checked constructor for hosts whose native strings carry an
+// explicit byte length. Embedded NUL is rejected with
+// `FERRIC_ERROR_INVALID_ARGUMENT` rather than silently truncating the value.
+// The resulting legacy `FerricValue` remains NUL-terminated and is owned by
+// the caller.
+//
+// On every failure, `*out_value` is left as Void. A null `data` pointer with
+// zero length creates an empty symbol; null with non-zero length returns
+// `FERRIC_ERROR_NULL_POINTER`.
+//
+// # Safety
+//
+// - `out_value` must point to writable storage for one `FerricValue`.
+// - `out_value` must not currently contain live Ferric-owned resources.
+// - If `len > 0`, `data` must point to `len` readable bytes.
+// - The `data` span must not overlap `out_value`.
+enum FerricError ferric_value_symbol_bytes(const uint8_t *data FERRIC_SIZED_BY(len),
+                                           uintptr_t len,
+                                           struct FerricValue *out_value);
+
+// Create a string from a pointer-plus-length UTF-8 span.
+//
+// This is the checked constructor for hosts whose native strings carry an
+// explicit byte length. Embedded NUL is rejected with
+// `FERRIC_ERROR_INVALID_ARGUMENT` rather than silently truncating the value.
+// The resulting legacy `FerricValue` remains NUL-terminated and is owned by
+// the caller.
+//
+// On every failure, `*out_value` is left as Void. A null `data` pointer with
+// zero length creates an empty string; null with non-zero length returns
+// `FERRIC_ERROR_NULL_POINTER`.
+//
+// # Safety
+//
+// - `out_value` must point to writable storage for one `FerricValue`.
+// - `out_value` must not currently contain live Ferric-owned resources.
+// - If `len > 0`, `data` must point to `len` readable bytes.
+// - The `data` span must not overlap `out_value`.
+enum FerricError ferric_value_string_bytes(const uint8_t *data FERRIC_SIZED_BY(len),
+                                           uintptr_t len,
+                                           struct FerricValue *out_value);
 
 // Create a void `FerricValue` with all fields zeroed/null.
 struct FerricValue ferric_value_void(void);

--- a/crates/ferric-rules-ffi/src/engine.rs
+++ b/crates/ferric-rules-ffi/src/engine.rs
@@ -101,13 +101,13 @@ struct CachedOutputCString {
 }
 
 impl CachedOutputCString {
-    fn new(output: &str) -> Self {
-        Self {
+    fn new(output: &str) -> Result<Self, std::ffi::NulError> {
+        Ok(Self {
             snapshot: output.to_string(),
-            cstring: CString::new(output).unwrap_or_default(),
+            cstring: CString::new(output)?,
             #[cfg(test)]
             lifetime: std::sync::Arc::new(()),
-        }
+        })
     }
 }
 
@@ -425,6 +425,24 @@ unsafe fn copy_str_to_buffer(
             FerricError::BufferTooSmall,
             format!("output buffer is too small: need {needed} bytes, got {buf_len}"),
         )
+    }
+}
+
+unsafe fn write_value_to_ffi(
+    value: &ferric_rules_core::Value,
+    engine: &Engine,
+    out_value: *mut FerricValue,
+    diagnostics: &Mutex<EngineDiagnostics>,
+) -> FerricError {
+    ptr::write(out_value, FerricValue::void());
+    match value_to_ferric(value, engine) {
+        Ok(converted) => {
+            ptr::write(out_value, converted);
+            FerricError::Ok
+        }
+        Err(message) => {
+            set_engine_error_message(diagnostics, FerricError::InvalidArgument, message)
+        }
     }
 }
 
@@ -855,6 +873,10 @@ pub unsafe extern "C" fn ferric_engine_retract(
 /// engine never invalidate it. Output written after this call is not reflected
 /// in the snapshot.
 ///
+/// If the captured output contains embedded NUL, this legacy C-string accessor
+/// returns null and records `InvalidArgument`. Use
+/// `ferric_engine_get_output_copy` to preserve every byte.
+///
 /// Prefer `ferric_engine_get_output_copy` when retaining a borrowed pointer
 /// would be inconvenient or when pointer-use windows could overlap.
 ///
@@ -878,16 +900,45 @@ pub unsafe extern "C" fn ferric_engine_get_output(
         Some(output) if !output.is_empty() => {
             use std::collections::hash_map::Entry;
 
+            if let Some(position) = output.as_bytes().iter().position(|byte| *byte == 0) {
+                handle.output_cstrings.borrow_mut().remove(channel_str);
+                set_engine_error_message(
+                    handle.diagnostics,
+                    FerricError::InvalidArgument,
+                    format!(
+                        "output channel {channel_str:?} contains embedded NUL at byte {position}; \
+                         use ferric_engine_get_output_copy for length-aware access"
+                    ),
+                );
+                return ptr::null();
+            }
+
             let mut cache = handle.output_cstrings.borrow_mut();
             match cache.entry(channel_str.to_string()) {
                 Entry::Occupied(mut entry) => {
                     if entry.get().snapshot != output {
-                        entry.insert(CachedOutputCString::new(output));
+                        let Ok(snapshot) = CachedOutputCString::new(output) else {
+                            set_engine_error_message(
+                                handle.diagnostics,
+                                FerricError::InvalidArgument,
+                                "captured output cannot be represented as a C string".to_string(),
+                            );
+                            return ptr::null();
+                        };
+                        entry.insert(snapshot);
                     }
                     entry.get().cstring.as_ptr()
                 }
                 Entry::Vacant(entry) => {
-                    let slot = entry.insert(CachedOutputCString::new(output));
+                    let Ok(snapshot) = CachedOutputCString::new(output) else {
+                        set_engine_error_message(
+                            handle.diagnostics,
+                            FerricError::InvalidArgument,
+                            "captured output cannot be represented as a C string".to_string(),
+                        );
+                        return ptr::null();
+                    };
+                    let slot = entry.insert(snapshot);
                     slot.cstring.as_ptr()
                 }
             }
@@ -900,7 +951,8 @@ pub unsafe extern "C" fn ferric_engine_get_output(
 ///
 /// This is the preferred output accessor for hosts that do not want to retain
 /// an engine-owned pointer. `*out_len` always reports the full required byte
-/// count including the trailing NUL when output exists.
+/// count including the trailing NUL when output exists. The copied payload
+/// preserves embedded NUL; `*out_len`, not C-string scanning, is authoritative.
 ///
 /// ## Contract
 ///
@@ -1170,6 +1222,9 @@ pub unsafe extern "C" fn ferric_engine_get_fact_field_count(
 /// The returned `FerricValue` is written to `*out_value`. The caller owns
 /// any heap-allocated resources (`string_ptr`, `multifield_ptr`) and must free
 /// them with `ferric_value_free` or the type-specific free functions.
+/// A Symbol/String containing embedded NUL (including inside a multifield)
+/// cannot be represented by this legacy C-string value and returns
+/// `InvalidArgument`; `*out_value` is left as Void.
 ///
 /// # Safety
 ///
@@ -1205,8 +1260,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_field(
                 Fact::Template(t) => t.slots.get(index),
             };
             if let Some(val) = field_value {
-                *out_value = value_to_ferric(val, handle.engine);
-                FerricError::Ok
+                write_value_to_ffi(val, handle.engine, out_value, handle.diagnostics)
             } else {
                 set_engine_error_message(
                     handle.diagnostics,
@@ -1231,6 +1285,8 @@ pub unsafe extern "C" fn ferric_engine_get_fact_field(
 ///
 /// Module/global visibility resolution follows the runtime's standard rules.
 /// Ambiguity and not-found conditions produce runtime-authored diagnostics.
+/// A Symbol/String containing embedded NUL (including inside a multifield)
+/// returns `InvalidArgument`, and `*out_value` is left as Void.
 ///
 /// # Safety
 ///
@@ -1260,8 +1316,7 @@ pub unsafe extern "C" fn ferric_engine_get_global(
     }
 
     if let Some(val) = handle.engine.get_global(name_str) {
-        *out_value = value_to_ferric(val, handle.engine);
-        FerricError::Ok
+        write_value_to_ffi(val, handle.engine, out_value, handle.diagnostics)
     } else {
         set_engine_error_message(
             handle.diagnostics,
@@ -2444,6 +2499,8 @@ pub unsafe extern "C" fn ferric_engine_assert_template(
 ///
 /// The returned `FerricValue` is written to `*out_value`. The caller owns
 /// any heap-allocated resources and must free them with `ferric_value_free`.
+/// A Symbol/String containing embedded NUL (including inside a multifield)
+/// returns `InvalidArgument`, and `*out_value` is left as Void.
 ///
 /// # Safety
 ///
@@ -2478,10 +2535,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_slot_by_name(
     let fid = ferric_rules_core::FactId::from(key_data);
 
     match handle.engine.get_fact_slot_by_name(fid, name_str) {
-        Ok(value) => {
-            *out_value = value_to_ferric(value, handle.engine);
-            FerricError::Ok
-        }
+        Ok(value) => write_value_to_ffi(value, handle.engine, out_value, handle.diagnostics),
         Err(ref err) => set_engine_runtime_error(handle.diagnostics, err),
     }
 }

--- a/crates/ferric-rules-ffi/src/lib.rs
+++ b/crates/ferric-rules-ffi/src/lib.rs
@@ -34,6 +34,13 @@
 //!   another engine, and are reclaimed at engine destruction. Hosts should prefer
 //!   `ferric_engine_get_output_copy` for caller-owned output storage.
 //!
+//! - **Embedded-NUL policy**: Legacy NUL-terminated inputs end at their first
+//!   NUL. Hosts converting length-bearing strings must reject embedded NUL
+//!   before calling those entry points; the checked value constructors do this
+//!   explicitly. Legacy `FerricValue` and borrowed-output egress reject
+//!   unrepresentable content instead of returning empty/truncated strings.
+//!   Length-reporting copy and serialization APIs preserve exact bytes.
+//!
 //! - **Panic policy**: FFI builds use `panic = "abort"` profiles (`ffi-dev`,
 //!   `ffi-release`) so that Rust panics never unwind across the C ABI boundary.
 //!

--- a/crates/ferric-rules-ffi/src/tests.rs
+++ b/crates/ferric-rules-ffi/src/tests.rs
@@ -31,6 +31,9 @@ mod execution;
 mod output_lifetime;
 
 #[cfg(test)]
+mod embedded_nul;
+
+#[cfg(test)]
 mod action_diagnostics;
 
 #[cfg(test)]

--- a/crates/ferric-rules-ffi/src/tests/contract_lock.rs
+++ b/crates/ferric-rules-ffi/src/tests/contract_lock.rs
@@ -23,7 +23,8 @@ use crate::error::{
 };
 use crate::types::{
     ferric_string_free, ferric_value_array_free, ferric_value_free, ferric_value_multifield_copy,
-    FerricConfig, FerricConflictStrategy, FerricStringEncoding, FerricValue,
+    ferric_value_string_bytes, ferric_value_symbol_bytes, FerricConfig, FerricConflictStrategy,
+    FerricStringEncoding, FerricValue,
 };
 use std::os::raw::c_char;
 
@@ -119,6 +120,10 @@ fn contract_lock_canonical_function_names_exist() {
     let _: unsafe extern "C" fn(*mut c_char) = ferric_string_free;
     let _: unsafe extern "C" fn(*const FerricValue, usize, *mut FerricValue) -> FerricError =
         ferric_value_multifield_copy;
+    let _: unsafe extern "C" fn(*const u8, usize, *mut FerricValue) -> FerricError =
+        ferric_value_symbol_bytes;
+    let _: unsafe extern "C" fn(*const u8, usize, *mut FerricValue) -> FerricError =
+        ferric_value_string_bytes;
     let _: unsafe extern "C" fn(*mut FerricValue) -> FerricError = ferric_value_free;
     let _: unsafe extern "C" fn(*mut FerricValue, usize) -> FerricError = ferric_value_array_free;
 }

--- a/crates/ferric-rules-ffi/src/tests/embedded_nul.rs
+++ b/crates/ferric-rules-ffi/src/tests/embedded_nul.rs
@@ -1,0 +1,306 @@
+//! Regression coverage for embedded-NUL handling at the C ABI boundary.
+
+#[cfg(feature = "serde")]
+use crate::engine::{
+    ferric_bytes_free, ferric_engine_deserialize_bincode, ferric_engine_serialize_bincode,
+};
+use crate::engine::{
+    ferric_engine_free, ferric_engine_get_fact_field, ferric_engine_get_fact_slot_by_name,
+    ferric_engine_get_output, ferric_engine_get_output_copy, ferric_engine_last_error,
+    ferric_engine_load_string, ferric_engine_new, ferric_engine_reset, ferric_engine_run,
+    FerricEngine,
+};
+use crate::error::{ferric_last_error_global, FerricError};
+use crate::types::{
+    ferric_value_free, ferric_value_string_bytes, ferric_value_symbol_bytes, FerricValue,
+    FerricValueType,
+};
+use ferric_rules_core::{Multifield, Value};
+use slotmap::Key as _;
+use std::ffi::{CStr, CString};
+
+unsafe fn assert_internal_value(engine: *mut FerricEngine, relation: &str, value: Value) -> u64 {
+    (&mut *engine)
+        .engine
+        .assert_ordered(relation, value)
+        .expect("test value should be accepted by the Rust runtime")
+        .data()
+        .as_ffi()
+}
+
+unsafe fn nul_string_value(engine: *mut FerricEngine) -> Value {
+    Value::String(
+        (&*engine)
+            .engine
+            .create_string("a\0b")
+            .expect("the Rust runtime supports embedded NUL"),
+    )
+}
+
+#[test]
+fn length_aware_value_constructors_reject_nul_and_preserve_valid_bytes() {
+    unsafe {
+        for constructor in [ferric_value_symbol_bytes, ferric_value_string_bytes] {
+            let mut out = FerricValue {
+                value_type: FerricValueType::Integer.as_raw(),
+                integer: 91,
+                ..FerricValue::void()
+            };
+            assert_eq!(
+                constructor(b"a\0b".as_ptr(), 3, &mut out),
+                FerricError::InvalidArgument
+            );
+            assert_eq!(out.value_type, FerricValueType::Void.as_raw());
+            assert!(out.string_ptr.is_null());
+            let diagnostic = ferric_last_error_global();
+            assert!(!diagnostic.is_null());
+            assert!(CStr::from_ptr(diagnostic)
+                .to_string_lossy()
+                .contains("embedded NUL at byte 1"));
+
+            let valid = "héllo".as_bytes();
+            assert_eq!(
+                constructor(valid.as_ptr(), valid.len(), &mut out),
+                FerricError::Ok
+            );
+            assert_eq!(
+                CStr::from_ptr(out.string_ptr).to_bytes(),
+                valid,
+                "valid UTF-8 must be copied exactly"
+            );
+            assert_eq!(ferric_value_free(&mut out), FerricError::Ok);
+
+            assert_eq!(constructor(std::ptr::null(), 0, &mut out), FerricError::Ok);
+            assert_eq!(CStr::from_ptr(out.string_ptr).to_bytes(), b"");
+            assert_eq!(ferric_value_free(&mut out), FerricError::Ok);
+
+            assert_eq!(
+                constructor(std::ptr::null(), 1, &mut out),
+                FerricError::NullPointer
+            );
+            assert_eq!(out.value_type, FerricValueType::Void.as_raw());
+
+            assert_eq!(
+                constructor([0xff].as_ptr(), 1, &mut out),
+                FerricError::InvalidArgument
+            );
+            assert_eq!(out.value_type, FerricValueType::Void.as_raw());
+            let diagnostic = ferric_last_error_global();
+            assert!(!diagnostic.is_null());
+            assert!(CStr::from_ptr(diagnostic)
+                .to_string_lossy()
+                .contains("not valid UTF-8"));
+        }
+    }
+}
+
+#[test]
+fn legacy_value_egress_rejects_embedded_nul_strings_and_symbols() {
+    unsafe {
+        let engine = ferric_engine_new();
+        assert!(!engine.is_null());
+
+        let string_id = assert_internal_value(engine, "string-payload", nul_string_value(engine));
+        let symbol = (&mut *engine)
+            .engine
+            .intern_symbol("a\0b")
+            .expect("the Rust runtime supports embedded NUL");
+        let symbol_id = assert_internal_value(engine, "symbol-payload", Value::Symbol(symbol));
+
+        for fact_id in [string_id, symbol_id] {
+            let mut out = FerricValue {
+                value_type: FerricValueType::Integer.as_raw(),
+                integer: 91,
+                ..FerricValue::void()
+            };
+            assert_eq!(
+                ferric_engine_get_fact_field(engine, fact_id, 0, &mut out),
+                FerricError::InvalidArgument,
+                "legacy FerricValue egress must reject content it cannot represent"
+            );
+            assert_eq!(out.value_type, FerricValueType::Void.as_raw());
+            assert!(out.string_ptr.is_null());
+
+            let diagnostic = ferric_engine_last_error(engine);
+            assert!(!diagnostic.is_null());
+            assert!(
+                CStr::from_ptr(diagnostic)
+                    .to_string_lossy()
+                    .contains("embedded NUL"),
+                "the rejection must explain the offending content"
+            );
+        }
+
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}
+
+#[test]
+fn nested_and_template_slot_value_egress_rejects_embedded_nul() {
+    unsafe {
+        let engine = ferric_engine_new();
+        assert!(!engine.is_null());
+        let source = CString::new("(deftemplate item (slot value))").unwrap();
+        assert_eq!(
+            ferric_engine_load_string(engine, source.as_ptr()),
+            FerricError::Ok
+        );
+        assert_eq!(ferric_engine_reset(engine), FerricError::Ok);
+
+        let template_value = nul_string_value(engine);
+        let template_id = (&mut *engine)
+            .engine
+            .assert_template("item", &["value"], vec![template_value])
+            .unwrap()
+            .data()
+            .as_ffi();
+        let mut out = FerricValue {
+            value_type: FerricValueType::Integer.as_raw(),
+            integer: 91,
+            ..FerricValue::void()
+        };
+        let slot_name = CString::new("value").unwrap();
+        assert_eq!(
+            ferric_engine_get_fact_slot_by_name(engine, template_id, slot_name.as_ptr(), &mut out,),
+            FerricError::InvalidArgument
+        );
+        assert_eq!(out.value_type, FerricValueType::Void.as_raw());
+
+        let mut multifield = Multifield::new();
+        multifield.push(Value::Integer(7));
+        multifield.push(nul_string_value(engine));
+        let multifield_id = assert_internal_value(
+            engine,
+            "nested-payload",
+            Value::Multifield(Box::new(multifield)),
+        );
+        out = FerricValue {
+            value_type: FerricValueType::Integer.as_raw(),
+            integer: 92,
+            ..FerricValue::void()
+        };
+        assert_eq!(
+            ferric_engine_get_fact_field(engine, multifield_id, 0, &mut out),
+            FerricError::InvalidArgument
+        );
+        assert_eq!(out.value_type, FerricValueType::Void.as_raw());
+
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn snapshot_round_trip_preserves_nul_before_legacy_egress_rejects_it() {
+    unsafe {
+        let engine = ferric_engine_new();
+        assert!(!engine.is_null());
+        assert_internal_value(engine, "snapshot-payload", nul_string_value(engine));
+
+        let mut data = std::ptr::null_mut();
+        let mut len = 0;
+        assert_eq!(
+            ferric_engine_serialize_bincode(
+                engine,
+                None,
+                std::ptr::null_mut(),
+                &mut data,
+                &mut len,
+            ),
+            FerricError::Ok
+        );
+        assert!(!data.is_null());
+        assert!(len > 0);
+
+        let mut restored = std::ptr::null_mut();
+        assert_eq!(
+            ferric_engine_deserialize_bincode(data, len, &mut restored),
+            FerricError::Ok
+        );
+        ferric_bytes_free(data, len);
+        assert!(!restored.is_null());
+
+        let fact_id = (&*restored)
+            .engine
+            .facts()
+            .unwrap()
+            .next()
+            .expect("restored engine should contain the test fact")
+            .0
+            .data()
+            .as_ffi();
+        let mut out = FerricValue::void();
+        assert_eq!(
+            ferric_engine_get_fact_field(restored, fact_id, 0, &mut out),
+            FerricError::InvalidArgument
+        );
+        assert_eq!(out.value_type, FerricValueType::Void.as_raw());
+
+        assert_eq!(ferric_engine_free(restored), FerricError::Ok);
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}
+
+#[test]
+fn borrowed_output_rejects_embedded_nul_while_copy_is_lossless() {
+    unsafe {
+        let engine = ferric_engine_new();
+        assert!(!engine.is_null());
+        let source =
+            CString::new("(defrule emit (payload ?value) => (printout shared ?value))").unwrap();
+        assert_eq!(
+            ferric_engine_load_string(engine, source.as_ptr()),
+            FerricError::Ok
+        );
+        assert_eq!(ferric_engine_reset(engine), FerricError::Ok);
+        assert_internal_value(engine, "payload", nul_string_value(engine));
+
+        let mut fired = 0;
+        assert_eq!(ferric_engine_run(engine, -1, &mut fired), FerricError::Ok);
+        assert_eq!(fired, 1);
+        assert_eq!((&*engine).engine.get_output("shared"), Some("a\0b"));
+
+        let channel = CString::new("shared").unwrap();
+        assert!(
+            ferric_engine_get_output(engine, channel.as_ptr()).is_null(),
+            "the legacy borrowed C-string API must reject embedded NUL"
+        );
+        let diagnostic = ferric_engine_last_error(engine);
+        assert!(!diagnostic.is_null());
+        assert!(CStr::from_ptr(diagnostic)
+            .to_string_lossy()
+            .contains("embedded NUL"));
+
+        let mut needed = 0;
+        assert_eq!(
+            ferric_engine_get_output_copy(
+                engine,
+                channel.as_ptr(),
+                std::ptr::null_mut(),
+                0,
+                &mut needed,
+            ),
+            FerricError::Ok
+        );
+        assert_eq!(
+            needed, 4,
+            "required size includes all bytes and the final NUL"
+        );
+
+        let mut copied = [0_u8; 4];
+        assert_eq!(
+            ferric_engine_get_output_copy(
+                engine,
+                channel.as_ptr(),
+                copied.as_mut_ptr().cast(),
+                copied.len(),
+                &mut needed,
+            ),
+            FerricError::Ok
+        );
+        assert_eq!(needed, copied.len());
+        assert_eq!(copied, [b'a', 0, b'b', 0]);
+
+        assert_eq!(ferric_engine_free(engine), FerricError::Ok);
+    }
+}

--- a/crates/ferric-rules-ffi/src/tests/header.rs
+++ b/crates/ferric-rules-ffi/src/tests/header.rs
@@ -670,6 +670,14 @@ fn header_has_counted_by_and_sized_by_annotations() {
         header.contains("*elements FERRIC_COUNTED_BY(len)"),
         "Missing FERRIC_COUNTED_BY on ferric_value_multifield_copy elements"
     );
+    assert!(
+        header.contains("ferric_value_symbol_bytes(const uint8_t *data FERRIC_SIZED_BY(len),"),
+        "Missing FERRIC_SIZED_BY on ferric_value_symbol_bytes data"
+    );
+    assert!(
+        header.contains("ferric_value_string_bytes(const uint8_t *data FERRIC_SIZED_BY(len),"),
+        "Missing FERRIC_SIZED_BY on ferric_value_string_bytes data"
+    );
 
     // ferric_last_error_global_copy: buf sized_by buf_len
     assert!(
@@ -698,6 +706,16 @@ fn header_has_counted_by_and_sized_by_annotations() {
         header.contains("ferric_engine_get_output_copy(const struct FerricEngine *engine,\n                                               const char * FERRIC_NULL_TERMINATED channel,\n                                               char *buf FERRIC_SIZED_BY(buf_len),"),
         "Missing bounds annotations on ferric_engine_get_output_copy"
     );
+}
+
+#[test]
+fn header_documents_embedded_nul_policy() {
+    let header = read_committed_header();
+    assert!(header.contains("Embedded NUL policy:"));
+    assert!(header.contains("ferric_value_symbol_bytes()"));
+    assert!(header.contains("ferric_value_string_bytes()"));
+    assert!(header.contains("Legacy FerricValue"));
+    assert!(header.contains("ferric_engine_get_output_copy()"));
 }
 
 #[test]

--- a/crates/ferric-rules-ffi/src/types.rs
+++ b/crates/ferric-rules-ffi/src/types.rs
@@ -362,46 +362,65 @@ use ferric_rules_core::Value;
 /// Heap-allocates strings (for Symbol/String variants) and arrays (for Multifield).
 /// The caller owns the resulting `FerricValue` and must free it with
 /// `ferric_value_free` or the type-specific free functions.
-pub(crate) fn value_to_ferric(value: &Value, engine: &Engine) -> FerricValue {
+///
+/// Legacy `FerricValue` string payloads are NUL-terminated and therefore
+/// cannot represent embedded NUL. Such values return an error instead of
+/// silently becoming an empty or truncated C string.
+pub(crate) fn value_to_ferric(value: &Value, engine: &Engine) -> Result<FerricValue, String> {
     match value {
-        Value::Integer(i) => FerricValue {
+        Value::Integer(i) => Ok(FerricValue {
             value_type: FerricValueType::Integer.as_raw(),
             integer: *i,
             ..FerricValue::void()
-        },
-        Value::Float(f) => FerricValue {
+        }),
+        Value::Float(f) => Ok(FerricValue {
             value_type: FerricValueType::Float.as_raw(),
             float: *f,
             ..FerricValue::void()
-        },
+        }),
         Value::Symbol(sym) => {
             let name = engine.resolve_symbol(*sym).unwrap_or("<unknown>");
-            let cstring = CString::new(name).unwrap_or_default();
-            FerricValue {
+            let cstring = CString::new(name).map_err(|error| {
+                format!(
+                    "symbol contains embedded NUL at byte {}; legacy FerricValue \
+                     C-string egress cannot represent it",
+                    error.nul_position()
+                )
+            })?;
+            Ok(FerricValue {
                 value_type: FerricValueType::Symbol.as_raw(),
                 string_ptr: cstring.into_raw(),
                 ..FerricValue::void()
-            }
+            })
         }
         Value::String(s) => {
-            let cstring = CString::new(s.as_str()).unwrap_or_default();
-            FerricValue {
+            let cstring = CString::new(s.as_str()).map_err(|error| {
+                format!(
+                    "string contains embedded NUL at byte {}; legacy FerricValue \
+                     C-string egress cannot represent it",
+                    error.nul_position()
+                )
+            })?;
+            Ok(FerricValue {
                 value_type: FerricValueType::String.as_raw(),
                 string_ptr: cstring.into_raw(),
                 ..FerricValue::void()
-            }
+            })
         }
         Value::Multifield(mf) => {
-            let values: Vec<FerricValue> = mf.iter().map(|v| value_to_ferric(v, engine)).collect();
-            OwnedFerricValues(values).into_multifield()
+            let mut values = OwnedFerricValues::with_capacity(mf.len());
+            for element in mf.iter() {
+                values.push(value_to_ferric(element, engine)?);
+            }
+            Ok(values.into_multifield())
         }
-        Value::ExternalAddress(ea) => FerricValue {
+        Value::ExternalAddress(ea) => Ok(FerricValue {
             value_type: FerricValueType::ExternalAddress.as_raw(),
             external_type_id: ea.type_id.0,
             external_pointer: ea.pointer,
             ..FerricValue::void()
-        },
-        Value::Void => FerricValue::void(),
+        }),
+        Value::Void => Ok(FerricValue::void()),
     }
 }
 
@@ -497,10 +516,15 @@ pub extern "C" fn ferric_value_float(value: f64) -> FerricValue {
     }
 }
 
-/// Create a symbol `FerricValue` with a heap-copied string.
+/// Create a symbol `FerricValue` with a heap-copied legacy C string.
 ///
 /// Returns a void value if `name` is null. The caller owns the
 /// `string_ptr` and must free it with `ferric_value_free`.
+///
+/// This legacy entry point reads through the first NUL terminator; bytes after
+/// that terminator are not part of the input and cannot be diagnosed. Hosts
+/// starting from a pointer-plus-length string should use
+/// `ferric_value_symbol_bytes`, which rejects embedded NUL explicitly.
 ///
 /// # Safety
 ///
@@ -510,8 +534,7 @@ pub unsafe extern "C" fn ferric_value_symbol(name: *const c_char) -> FerricValue
     if name.is_null() {
         return FerricValue::void();
     }
-    let cstr = CStr::from_ptr(name);
-    let cstring = CString::new(cstr.to_bytes()).unwrap_or_default();
+    let cstring = CStr::from_ptr(name).to_owned();
     FerricValue {
         value_type: FerricValueType::Symbol.as_raw(),
         string_ptr: cstring.into_raw(),
@@ -519,10 +542,15 @@ pub unsafe extern "C" fn ferric_value_symbol(name: *const c_char) -> FerricValue
     }
 }
 
-/// Create a string `FerricValue` with a heap-copied string.
+/// Create a string `FerricValue` with a heap-copied legacy C string.
 ///
 /// Returns a void value if `s` is null. The caller owns the
 /// `string_ptr` and must free it with `ferric_value_free`.
+///
+/// This legacy entry point reads through the first NUL terminator; bytes after
+/// that terminator are not part of the input and cannot be diagnosed. Hosts
+/// starting from a pointer-plus-length string should use
+/// `ferric_value_string_bytes`, which rejects embedded NUL explicitly.
 ///
 /// # Safety
 ///
@@ -532,13 +560,133 @@ pub unsafe extern "C" fn ferric_value_string(s: *const c_char) -> FerricValue {
     if s.is_null() {
         return FerricValue::void();
     }
-    let cstr = CStr::from_ptr(s);
-    let cstring = CString::new(cstr.to_bytes()).unwrap_or_default();
+    let cstring = CStr::from_ptr(s).to_owned();
     FerricValue {
         value_type: FerricValueType::String.as_raw(),
         string_ptr: cstring.into_raw(),
         ..FerricValue::void()
     }
+}
+
+/// Create a symbol from a pointer-plus-length UTF-8 span.
+///
+/// This is the checked constructor for hosts whose native strings carry an
+/// explicit byte length. Embedded NUL is rejected with
+/// `FERRIC_ERROR_INVALID_ARGUMENT` rather than silently truncating the value.
+/// The resulting legacy `FerricValue` remains NUL-terminated and is owned by
+/// the caller.
+///
+/// On every failure, `*out_value` is left as Void. A null `data` pointer with
+/// zero length creates an empty symbol; null with non-zero length returns
+/// `FERRIC_ERROR_NULL_POINTER`.
+///
+/// # Safety
+///
+/// - `out_value` must point to writable storage for one `FerricValue`.
+/// - `out_value` must not currently contain live Ferric-owned resources.
+/// - If `len > 0`, `data` must point to `len` readable bytes.
+/// - The `data` span must not overlap `out_value`.
+#[no_mangle]
+pub unsafe extern "C" fn ferric_value_symbol_bytes(
+    data: *const u8,
+    len: usize,
+    out_value: *mut FerricValue,
+) -> FerricError {
+    ferric_value_from_bytes(
+        data,
+        len,
+        out_value,
+        FerricValueType::Symbol,
+        "ferric_value_symbol_bytes",
+        "symbol",
+    )
+}
+
+/// Create a string from a pointer-plus-length UTF-8 span.
+///
+/// This is the checked constructor for hosts whose native strings carry an
+/// explicit byte length. Embedded NUL is rejected with
+/// `FERRIC_ERROR_INVALID_ARGUMENT` rather than silently truncating the value.
+/// The resulting legacy `FerricValue` remains NUL-terminated and is owned by
+/// the caller.
+///
+/// On every failure, `*out_value` is left as Void. A null `data` pointer with
+/// zero length creates an empty string; null with non-zero length returns
+/// `FERRIC_ERROR_NULL_POINTER`.
+///
+/// # Safety
+///
+/// - `out_value` must point to writable storage for one `FerricValue`.
+/// - `out_value` must not currently contain live Ferric-owned resources.
+/// - If `len > 0`, `data` must point to `len` readable bytes.
+/// - The `data` span must not overlap `out_value`.
+#[no_mangle]
+pub unsafe extern "C" fn ferric_value_string_bytes(
+    data: *const u8,
+    len: usize,
+    out_value: *mut FerricValue,
+) -> FerricError {
+    ferric_value_from_bytes(
+        data,
+        len,
+        out_value,
+        FerricValueType::String,
+        "ferric_value_string_bytes",
+        "string",
+    )
+}
+
+unsafe fn ferric_value_from_bytes(
+    data: *const u8,
+    len: usize,
+    out_value: *mut FerricValue,
+    value_type: FerricValueType,
+    function: &str,
+    value_label: &str,
+) -> FerricError {
+    if out_value.is_null() {
+        set_global_error(format!("{function}: out_value is null"));
+        return FerricError::NullPointer;
+    }
+    ptr::write(out_value, FerricValue::void());
+
+    let bytes = if data.is_null() {
+        if len == 0 {
+            &[][..]
+        } else {
+            set_global_error(format!("{function}: data is null with non-zero length"));
+            return FerricError::NullPointer;
+        }
+    } else {
+        std::slice::from_raw_parts(data, len)
+    };
+
+    if let Err(error) = std::str::from_utf8(bytes) {
+        set_global_error(format!(
+            "{function}: {value_label} is not valid UTF-8: {error}"
+        ));
+        return FerricError::InvalidArgument;
+    }
+    if let Some(position) = bytes.iter().position(|byte| *byte == 0) {
+        set_global_error(format!(
+            "{function}: {value_label} contains embedded NUL at byte {position}"
+        ));
+        return FerricError::InvalidArgument;
+    }
+
+    let Some(cstring) = CString::new(bytes).ok() else {
+        set_global_error(format!("{function}: {value_label} contains embedded NUL"));
+        return FerricError::InvalidArgument;
+    };
+    ptr::write(
+        out_value,
+        FerricValue {
+            value_type: value_type.as_raw(),
+            string_ptr: cstring.into_raw(),
+            ..FerricValue::void()
+        },
+    );
+    FerricError::Ok
 }
 
 /// Create a void `FerricValue` with all fields zeroed/null.

--- a/crates/ferric-rules-ffi/tests/c/embedded_nul.c
+++ b/crates/ferric-rules-ffi/tests/c/embedded_nul.c
@@ -1,0 +1,81 @@
+/*
+ * Native C regression harness for the embedded-NUL boundary policy.
+ */
+
+#include "ferric.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define CHECK(condition, message)                                              \
+    do {                                                                       \
+        if (!(condition)) {                                                    \
+            fprintf(stderr, "embedded_nul: %s\n", (message));                  \
+            failures++;                                                        \
+        }                                                                      \
+    } while (0)
+
+typedef enum FerricError (*BytesConstructor)(const uint8_t *, uintptr_t,
+                                             struct FerricValue *);
+
+static void check_constructor(BytesConstructor constructor,
+                              uint32_t expected_type) {
+    const uint8_t embedded[] = {'a', 0, 'b'};
+    struct FerricValue value = ferric_value_integer(91);
+
+    CHECK(constructor(embedded, sizeof(embedded), &value) ==
+              FERRIC_ERROR_INVALID_ARGUMENT,
+          "embedded NUL must return INVALID_ARGUMENT");
+    CHECK(value.value_type == FERRIC_VALUE_TYPE_VOID &&
+              value.string_ptr == NULL,
+          "failed construction must leave a Void output");
+    CHECK(ferric_last_error_global() != NULL &&
+              strstr(ferric_last_error_global(), "embedded NUL at byte 1") !=
+                  NULL,
+          "rejection must identify the embedded-NUL byte");
+
+    const uint8_t valid[] = {'h', 0xc3, 0xa9};
+    CHECK(constructor(valid, sizeof(valid), &value) == FERRIC_ERROR_OK,
+          "valid UTF-8 byte spans must succeed");
+    CHECK(value.value_type == expected_type && value.string_ptr != NULL,
+          "successful construction must set the requested value type");
+    CHECK(value.string_ptr != NULL &&
+              memcmp(value.string_ptr, valid, sizeof(valid)) == 0 &&
+              value.string_ptr[sizeof(valid)] == '\0',
+          "valid UTF-8 bytes must be copied exactly");
+    CHECK(ferric_value_free(&value) == FERRIC_ERROR_OK,
+          "constructed value must be releasable");
+
+    CHECK(constructor(NULL, 0, &value) == FERRIC_ERROR_OK,
+          "NULL with zero length must construct an empty value");
+    CHECK(value.string_ptr != NULL && value.string_ptr[0] == '\0',
+          "empty value must have a valid terminator");
+    CHECK(ferric_value_free(&value) == FERRIC_ERROR_OK,
+          "empty value must be releasable");
+
+    CHECK(constructor(NULL, 1, &value) == FERRIC_ERROR_NULL_POINTER,
+          "NULL with non-zero length must return NULL_POINTER");
+    CHECK(value.value_type == FERRIC_VALUE_TYPE_VOID,
+          "null-data failure must leave a Void output");
+}
+
+int main(void) {
+    char legacy[] = {'a', '\0', 'b', '\0'};
+    struct FerricValue value = ferric_value_string(legacy);
+    CHECK(value.value_type == FERRIC_VALUE_TYPE_STRING &&
+              strcmp(value.string_ptr, "a") == 0,
+          "legacy C-string constructor must stop at its first terminator");
+    CHECK(ferric_value_free(&value) == FERRIC_ERROR_OK,
+          "legacy value must be releasable");
+
+    check_constructor(ferric_value_symbol_bytes, FERRIC_VALUE_TYPE_SYMBOL);
+    check_constructor(ferric_value_string_bytes, FERRIC_VALUE_TYPE_STRING);
+
+    if (failures == 0) {
+        puts("embedded-NUL harness: checked rejection and legacy behavior passed");
+    }
+    return failures == 0 ? 0 : 1;
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -854,6 +854,36 @@ message.
 Bindings should prefer the per-engine channel for engine operations and use the
 global channel as a fallback or for pre-engine failures.
 
+### Embedded-NUL String Policy
+
+Ferric's Rust strings can contain `\0`, but the legacy C ABI represents input
+strings and `FerricValue` Symbol/String payloads as NUL-terminated C strings.
+The C ABI therefore uses an explicit-rejection policy at that legacy boundary:
+
+- A legacy `const char *` input ends at its first NUL by definition; bytes
+  after it are not part of the C string. Bindings starting from a
+  pointer-plus-length string must reject embedded NUL before calling any such
+  entry point.
+- `ferric_value_symbol_bytes` and `ferric_value_string_bytes` accept an
+  explicit UTF-8 byte span and return `FERRIC_ERROR_INVALID_ARGUMENT` if it
+  contains embedded NUL. Their output remains Void on failure.
+- Fact-field, global, and named-slot queries return
+  `FERRIC_ERROR_INVALID_ARGUMENT` (with a diagnostic) instead of converting a
+  stored NUL-bearing Symbol/String to empty or truncated `FerricValue` data.
+  This rule applies recursively to multifields.
+- `ferric_engine_get_output` returns NULL and records
+  `FERRIC_ERROR_INVALID_ARGUMENT` when captured output contains embedded NUL.
+  Use `ferric_engine_get_output_copy` for exact access.
+- Length-reporting copy APIs preserve every source byte, including embedded
+  NUL. Their reported length includes one additional trailing terminator, so
+  callers must use `out_len` rather than `strlen`.
+- Snapshot serialization/deserialization APIs are byte-oriented and preserve
+  their serialized bytes exactly. If a restored engine contains NUL-bearing
+  values, the same legacy-egress rejection rules apply.
+
+The dependent Go boundary audit tracks applying this policy before every
+`C.CString` conversion.
+
 ### Copy-to-Buffer Contract
 
 The `*_copy` functions follow a uniform contract:
@@ -869,7 +899,9 @@ The `*_copy` functions follow a uniform contract:
 On truncation, the buffer receives `buf_len - 1` bytes followed by a NUL
 terminator and the function returns `FERRIC_ERROR_BUFFER_TOO_SMALL`; truncation
 is never reported as success. `ferric_engine_get_output_copy` follows this
-contract and is the preferred output accessor for caller-owned storage.
+contract and is the preferred output accessor for caller-owned storage. The
+reported length is authoritative even when the copied payload contains an
+embedded NUL.
 
 ### Fact Lifecycle
 

--- a/scripts/ffi-c-harness.sh
+++ b/scripts/ffi-c-harness.sh
@@ -17,6 +17,7 @@ CC="${CC:-cc}"
 CXX="${CXX:-c++}"
 harness_sources=(
     "crates/ferric-rules-ffi/tests/c/discriminant_abuse.c"
+    "crates/ferric-rules-ffi/tests/c/embedded_nul.c"
     "crates/ferric-rules-ffi/tests/c/error_channels.c"
     "crates/ferric-rules-ffi/tests/c/multifield_copy.c"
     "crates/ferric-rules-ffi/tests/c/output_lifetime.c"

--- a/tests/bindings-conformance/adapters/c/adapter.c
+++ b/tests/bindings-conformance/adapters/c/adapter.c
@@ -568,11 +568,17 @@ static bool lifecycle_close(void) {
 }
 
 static bool embedded_nul(void) {
-    char embedded[] = {'a', '\0', 'b', '\0'};
-    struct FerricValue value = ferric_value_string(embedded);
-    bool success = print_asserted_value(&value);
-    ferric_value_free(&value);
-    return success;
+    const uint8_t embedded[] = {'a', '\0', 'b'};
+    struct FerricValue value = ferric_value_void();
+    enum FerricError code =
+        ferric_value_string_bytes(embedded, sizeof(embedded), &value);
+    if (code != FERRIC_ERROR_INVALID_ARGUMENT ||
+        value.value_type != FERRIC_VALUE_TYPE_VOID) {
+        ferric_value_free(&value);
+        return false;
+    }
+    fputs("{\"error\":\"invalid_argument\"}", stdout);
+    return true;
 }
 
 static bool high_fact_id(void) {

--- a/tests/bindings-conformance/corpus.json
+++ b/tests/bindings-conformance/corpus.json
@@ -300,16 +300,16 @@
       "canonical": {"type": "string", "value": "a\u0000b"},
       "deviations": {
         "c": {
-          "expected": {"type": "string", "value": "a"},
-          "rationale": "The legacy C string constructor truncates at the first embedded NUL.",
+          "expected": {"error": "invalid_argument"},
+          "rationale": "The checked C byte-span constructor rejects embedded NUL explicitly because legacy FerricValue strings are NUL-terminated.",
           "since": "1.0.0",
           "tracking_issue": "https://github.com/plx/ferric-rules/issues/115"
         },
         "go": {
           "expected": {"type": "string", "value": "a"},
-          "rationale": "Go currently passes host strings through C.CString and therefore truncates at embedded NUL.",
+          "rationale": "Go currently passes host strings through C.CString; rejecting embedded NUL across the binding remains tracked by FR-GO-012.",
           "since": "1.0.0",
-          "tracking_issue": "https://github.com/plx/ferric-rules/issues/115"
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/131"
         }
       }
     },


### PR DESCRIPTION
## Summary

- define an explicit embedded-NUL policy for the legacy C ABI
- add checked pointer-plus-length Symbol/String constructors that validate UTF-8 and reject embedded NUL with `FERRIC_ERROR_INVALID_ARGUMENT`
- reject unrepresentable NUL-bearing values at legacy `FerricValue` egress, including nested multifields
- reject NUL-bearing borrowed output while preserving exact bytes through `ferric_engine_get_output_copy`
- document the policy, regenerate both committed headers, and extend Rust, native C, snapshot, and cross-binding regressions

## Root cause and impact

Rust runtime strings can contain NUL, but legacy `FerricValue` and borrowed-output APIs expose NUL-terminated C strings. Conversion previously used a fallback that silently replaced unrepresentable content with an empty string. The new policy makes that boundary explicit: legacy C strings still end at their first terminator, checked value ingress rejects embedded NUL, legacy value egress fails diagnostically, and length-aware output copy remains lossless.

The repository-wide Go `C.CString` ingress audit remains tracked separately by FR-GO-012 (#131); the conformance deviation now points there.

## Validation

- `cargo test -p ferric-rules-ffi --all-features` (303 passed, 4 ignored)
- `cargo clippy -p ferric-rules-ffi --all-targets --all-features -- -D warnings`
- plain native C embedded-NUL harness (no sanitizer instrumentation)
- `just bindings-conformance`
- `just test-go`
- `just preflight-pr`
- committed C headers are byte-identical

Local fuzz/sanitizer harnesses were intentionally not invoked; the hosted sanitizer checks provide that coverage.

Closes #115