### PR TITLE
[FR-CABI-006] Contain Rust panics at C exports

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,5 +4,7 @@
 # versions.
 [patch.crates-io]
 ferric-rules-core = { path = "crates/ferric-rules-core" }
+ferric-rules-ffi-macros = { path = "crates/ferric-rules-ffi-macros" }
 ferric-rules-parser = { path = "crates/ferric-rules-parser" }
+ferric-rules-pinned = { path = "crates/ferric-rules-pinned" }
 ferric-rules-runtime = { path = "crates/ferric-rules-runtime" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,18 @@ jobs:
         env:
           FERRIC_REQUIRE_SANITIZERS: "1"
 
+  ffi-panic-harness:
+    name: FFI Panic Containment
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@just
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - run: just ffi-panic-harness
+
   ffi-diagnostics-tsan:
     name: FFI Diagnostics (ThreadSanitizer)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,12 +525,22 @@ version = "0.1.0"
 dependencies = [
  "cbindgen",
  "ferric-rules-core",
+ "ferric-rules-ffi-macros",
  "ferric-rules-parser",
  "ferric-rules-pinned",
  "ferric-rules-runtime",
  "proptest",
  "slotmap",
  "tracing",
+]
+
+[[package]]
+name = "ferric-rules-ffi-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/ferric-rules-cli",
     "crates/ferric-rules-core",
     "crates/ferric-rules-ffi",
+    "crates/ferric-rules-ffi-macros",
     "crates/ferric-rules-napi",
     "crates/ferric-rules-parser",
     "crates/ferric-rules-pinned",
@@ -93,6 +94,7 @@ objc2 = { version = "0.6" }
 ferric-rules = { version = "=0.1.0", path = "crates/ferric-rules" }
 ferric-rules-core = { version = "=0.1.0", path = "crates/ferric-rules-core" }
 ferric-rules-ffi = { version = "=0.1.0", path = "crates/ferric-rules-ffi" }
+ferric-rules-ffi-macros = { version = "=0.1.0", path = "crates/ferric-rules-ffi-macros" }
 ferric-rules-cli = { version = "=0.1.0", path = "crates/ferric-rules-cli" }
 ferric-rules-parser = { version = "=0.1.0", path = "crates/ferric-rules-parser" }
 ferric-rules-pinned = { version = "=0.1.0", path = "crates/ferric-rules-pinned" }
@@ -115,12 +117,13 @@ lto = true
 codegen-units = 1
 strip = "symbols"
 
-# FFI profile: development builds with panic=abort for C ABI safety
+# FFI profile: development builds retain unwind so exported wrappers can
+# contain ordinary Rust panics before they reach the C ABI boundary.
 [profile.ffi-dev]
 inherits = "dev"
-panic = "abort"
+panic = "unwind"
 
-# FFI profile: release builds with panic=abort for C ABI safety
+# FFI profile: release builds use the same containment-capable panic strategy.
 [profile.ffi-release]
 inherits = "release"
-panic = "abort"
+panic = "unwind"

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -16,7 +16,7 @@ acceptable license is selected for notice generation.
 
 ## License Overview
 
-- MIT License: 210
+- MIT License: 211
 - Apache License 2.0: 4
 - Boost Software License 1.0: 2
 - ISC License: 1
@@ -2275,6 +2275,7 @@ Used by:
 - ferric-rules-cli 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
 - ferric-rules-core 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
 - ferric-rules-ffi 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
+- ferric-rules-ffi-macros 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
 - ferric-rules-napi 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
 - ferric-rules-parser 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
 - ferric-rules-pinned 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -36,6 +36,35 @@
  * only the global channel.
  *
  * ============================================================
+ * PANIC CONTAINMENT
+ * ============================================================
+ *
+ * Every exported function is a generated wrapper around a non-extern
+ * Rust implementation. The shipped ffi-dev and ffi-release profiles
+ * retain unwind support so an ordinary Rust panic can be caught before
+ * it reaches the C ABI.
+ *
+ * A contained panic records a stable, payload-independent message in
+ * the calling thread's global error channel and, when a still-live
+ * engine handle was supplied, that engine's error channel. Ownership-
+ * consuming free functions report globally because handle lifetime may
+ * be indeterminate after a panic.
+ *
+ * Defined panic sentinels by return category:
+ * - FerricError: FERRIC_ERROR_INTERNAL_ERROR
+ * - pointers: NULL
+ * - FerricValue: Void
+ * - bool: false
+ * - integer/count: 0
+ * - void: return after recording the diagnostic
+ *
+ * A panic in an async submission wrapper is a synchronous rejection:
+ * it returns FERRIC_ERROR_INTERNAL_ERROR and does not fire completion.
+ * The guarantee cannot contain non-unwinding termination such as an
+ * allocator abort/OOM or an explicit process abort. Host callbacks must
+ * still obey their documented no-unwind contract.
+ *
+ * ============================================================
  * OWNERSHIP AND LIFETIME
  * ============================================================
  *

--- a/crates/ferric-rules-ffi-macros/Cargo.toml
+++ b/crates/ferric-rules-ffi-macros/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ferric-rules-ffi-macros"
+description = "Internal export-wrapper macros for ferric-rules-ffi"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
+
+[lints]
+workspace = true

--- a/crates/ferric-rules-ffi-macros/src/lib.rs
+++ b/crates/ferric-rules-ffi-macros/src/lib.rs
@@ -1,0 +1,185 @@
+//! Procedural macros used to generate Ferric's panic-containing C exports.
+
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse_macro_input, FnArg, ItemFn, Pat, ReturnType, Type, TypePtr, Visibility};
+
+/// Generate a C export wrapper around a non-extern Rust implementation.
+///
+/// The wrapper routes every call through `crate::boundary::invoke`, whose
+/// return-type trait defines the panic sentinel. An `engine` pointer parameter
+/// is detected mechanically so a contained panic can also update that
+/// handle's diagnostic channel. Ownership-consuming free functions use
+/// `#[ffi_export(global_only)]` because a panic may leave the handle lifetime
+/// indeterminate.
+#[proc_macro_attribute]
+pub fn ffi_export(args: TokenStream, item: TokenStream) -> TokenStream {
+    let global_only = match args.to_string().as_str() {
+        "" => false,
+        "global_only" => true,
+        _ => {
+            return syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "expected #[ffi_export] or #[ffi_export(global_only)]",
+            )
+            .into_compile_error()
+            .into();
+        }
+    };
+
+    let function = parse_macro_input!(item as ItemFn);
+    expand_ffi_export(function, global_only)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}
+
+fn expand_ffi_export(
+    mut function: ItemFn,
+    global_only: bool,
+) -> syn::Result<proc_macro2::TokenStream> {
+    if !matches!(function.vis, Visibility::Public(_)) {
+        return Err(syn::Error::new_spanned(
+            &function.vis,
+            "FFI export must be public",
+        ));
+    }
+    let Some(abi) = function.sig.abi.as_ref() else {
+        return Err(syn::Error::new_spanned(
+            &function.sig,
+            "FFI export must use extern \"C\"",
+        ));
+    };
+    let Some(abi_name) = abi.name.as_ref() else {
+        return Err(syn::Error::new_spanned(abi, "FFI export ABI must be C"));
+    };
+    if abi_name.value() != "C" {
+        return Err(syn::Error::new_spanned(
+            abi_name,
+            "FFI export ABI must be C",
+        ));
+    }
+
+    let mut wrapper_attrs = std::mem::take(&mut function.attrs);
+    wrapper_attrs.retain(|attribute| !attribute.path().is_ident("no_mangle"));
+    let implementation_attrs: Vec<_> = wrapper_attrs
+        .iter()
+        .filter(|attribute| !attribute.path().is_ident("doc"))
+        .collect();
+    let visibility = function.vis;
+    let wrapper_signature = function.sig;
+    let implementation_body = function.block;
+    let export_name = wrapper_signature.ident.clone();
+    let implementation_name = format_ident!("__ferric_ffi_impl_{export_name}");
+
+    let argument_names = argument_names(&wrapper_signature.inputs)?;
+    let target = if global_only {
+        quote!(crate::boundary::PanicTarget::Global)
+    } else {
+        infer_panic_target(&wrapper_signature.inputs)?
+    };
+
+    let mut implementation_signature = wrapper_signature.clone();
+    implementation_signature.ident = implementation_name.clone();
+    implementation_signature.abi = None;
+
+    let call = if implementation_signature.unsafety.is_some() {
+        quote!(unsafe { #implementation_name(#(#argument_names),*) })
+    } else {
+        quote!(#implementation_name(#(#argument_names),*))
+    };
+
+    let return_type = match &wrapper_signature.output {
+        ReturnType::Default => quote!(()),
+        ReturnType::Type(_, ty) => quote!(#ty),
+    };
+
+    Ok(quote! {
+        #(#wrapper_attrs)*
+        #[no_mangle]
+        #visibility #wrapper_signature {
+            crate::boundary::invoke::<#return_type, _>(
+                stringify!(#export_name),
+                #target,
+                move || #call,
+            )
+        }
+
+        #(#implementation_attrs)*
+        #implementation_signature #implementation_body
+    })
+}
+
+fn argument_names(
+    inputs: &syn::punctuated::Punctuated<FnArg, syn::token::Comma>,
+) -> syn::Result<Vec<syn::Ident>> {
+    inputs
+        .iter()
+        .map(|argument| match argument {
+            FnArg::Typed(argument) => match argument.pat.as_ref() {
+                Pat::Ident(ident) if ident.subpat.is_none() => Ok(ident.ident.clone()),
+                pattern => Err(syn::Error::new_spanned(
+                    pattern,
+                    "FFI export arguments must use simple identifier patterns",
+                )),
+            },
+            FnArg::Receiver(receiver) => Err(syn::Error::new_spanned(
+                receiver,
+                "FFI exports cannot have a receiver",
+            )),
+        })
+        .collect()
+}
+
+fn infer_panic_target(
+    inputs: &syn::punctuated::Punctuated<FnArg, syn::token::Comma>,
+) -> syn::Result<proc_macro2::TokenStream> {
+    let Some(engine_argument) = inputs.iter().find_map(|argument| match argument {
+        FnArg::Typed(argument)
+            if matches!(argument.pat.as_ref(), Pat::Ident(ident) if ident.ident == "engine") =>
+        {
+            Some(argument)
+        }
+        _ => None,
+    }) else {
+        return Ok(quote!(crate::boundary::PanicTarget::Global));
+    };
+
+    let Type::Ptr(TypePtr { elem, .. }) = engine_argument.ty.as_ref() else {
+        return Err(syn::Error::new_spanned(
+            &engine_argument.ty,
+            "engine must be a raw pointer",
+        ));
+    };
+    let Type::Path(engine_type) = elem.as_ref() else {
+        return Err(syn::Error::new_spanned(
+            elem,
+            "engine pointer must target a named handle type",
+        ));
+    };
+    let Some(type_name) = engine_type
+        .path
+        .segments
+        .last()
+        .map(|segment| &segment.ident)
+    else {
+        return Err(syn::Error::new_spanned(
+            engine_type,
+            "engine pointer type is empty",
+        ));
+    };
+
+    if type_name == "FerricEngine" {
+        Ok(quote!(crate::boundary::PanicTarget::RawEngine(
+            engine as *const crate::engine::FerricEngine,
+        )))
+    } else if type_name == "FerricPinnedEngine" {
+        Ok(quote!(crate::boundary::PanicTarget::PinnedEngine(
+            engine as *const crate::pinned::FerricPinnedEngine,
+        )))
+    } else {
+        Err(syn::Error::new_spanned(
+            type_name,
+            "unsupported engine handle type; use #[ffi_export(global_only)] if appropriate",
+        ))
+    }
+}

--- a/crates/ferric-rules-ffi/Cargo.toml
+++ b/crates/ferric-rules-ffi/Cargo.toml
@@ -17,6 +17,7 @@ tracing = ["dep:tracing", "ferric-rules-runtime/tracing", "ferric-rules-pinned/t
 
 [dependencies]
 ferric-rules-core = { workspace = true }
+ferric-rules-ffi-macros = { workspace = true }
 ferric-rules-parser = { workspace = true }
 ferric-rules-pinned = { workspace = true }
 ferric-rules-runtime = { workspace = true }

--- a/crates/ferric-rules-ffi/build.rs
+++ b/crates/ferric-rules-ffi/build.rs
@@ -39,6 +39,35 @@ pub const HEADER_PREAMBLE: &str = r"/*
  * only the global channel.
  *
  * ============================================================
+ * PANIC CONTAINMENT
+ * ============================================================
+ *
+ * Every exported function is a generated wrapper around a non-extern
+ * Rust implementation. The shipped ffi-dev and ffi-release profiles
+ * retain unwind support so an ordinary Rust panic can be caught before
+ * it reaches the C ABI.
+ *
+ * A contained panic records a stable, payload-independent message in
+ * the calling thread's global error channel and, when a still-live
+ * engine handle was supplied, that engine's error channel. Ownership-
+ * consuming free functions report globally because handle lifetime may
+ * be indeterminate after a panic.
+ *
+ * Defined panic sentinels by return category:
+ * - FerricError: FERRIC_ERROR_INTERNAL_ERROR
+ * - pointers: NULL
+ * - FerricValue: Void
+ * - bool: false
+ * - integer/count: 0
+ * - void: return after recording the diagnostic
+ *
+ * A panic in an async submission wrapper is a synchronous rejection:
+ * it returns FERRIC_ERROR_INTERNAL_ERROR and does not fire completion.
+ * The guarantee cannot contain non-unwinding termination such as an
+ * allocator abort/OOM or an explicit process abort. Host callbacks must
+ * still obey their documented no-unwind contract.
+ *
+ * ============================================================
  * OWNERSHIP AND LIFETIME
  * ============================================================
  *
@@ -581,6 +610,19 @@ const BOUNDS_ANNOTATIONS: &[(&str, &str)] = &[
 ];
 
 fn main() {
+    // Keep cbindgen's source parser on the authored `extern "C"` signatures
+    // while Rust compilation expands those same items into generated panic
+    // wrappers plus non-extern implementations.
+    println!("cargo:rustc-check-cfg=cfg(ferric_ffi_compile)");
+    println!("cargo:rustc-cfg=ferric_ffi_compile");
+    println!("cargo:rustc-check-cfg=cfg(ferric_ffi_test_panic_injection)");
+    println!("cargo:rerun-if-env-changed=FERRIC_FFI_TEST_PANIC_INJECTION_BUILD");
+    if std::env::var_os("FERRIC_FFI_TEST_PANIC_INJECTION_BUILD").as_deref()
+        == Some(std::ffi::OsStr::new("1"))
+    {
+        println!("cargo:rustc-cfg=ferric_ffi_test_panic_injection");
+    }
+
     let crate_dir =
         std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by Cargo");
 

--- a/crates/ferric-rules-ffi/ferric.h
+++ b/crates/ferric-rules-ffi/ferric.h
@@ -36,6 +36,35 @@
  * only the global channel.
  *
  * ============================================================
+ * PANIC CONTAINMENT
+ * ============================================================
+ *
+ * Every exported function is a generated wrapper around a non-extern
+ * Rust implementation. The shipped ffi-dev and ffi-release profiles
+ * retain unwind support so an ordinary Rust panic can be caught before
+ * it reaches the C ABI.
+ *
+ * A contained panic records a stable, payload-independent message in
+ * the calling thread's global error channel and, when a still-live
+ * engine handle was supplied, that engine's error channel. Ownership-
+ * consuming free functions report globally because handle lifetime may
+ * be indeterminate after a panic.
+ *
+ * Defined panic sentinels by return category:
+ * - FerricError: FERRIC_ERROR_INTERNAL_ERROR
+ * - pointers: NULL
+ * - FerricValue: Void
+ * - bool: false
+ * - integer/count: 0
+ * - void: return after recording the diagnostic
+ *
+ * A panic in an async submission wrapper is a synchronous rejection:
+ * it returns FERRIC_ERROR_INTERNAL_ERROR and does not fire completion.
+ * The guarantee cannot contain non-unwinding termination such as an
+ * allocator abort/OOM or an explicit process abort. Host callbacks must
+ * still obey their documented no-unwind contract.
+ *
+ * ============================================================
  * OWNERSHIP AND LIFETIME
  * ============================================================
  *

--- a/crates/ferric-rules-ffi/src/boundary.rs
+++ b/crates/ferric-rules-ffi/src/boundary.rs
@@ -1,0 +1,166 @@
+//! Panic containment shared by every exported C ABI wrapper.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use crate::engine::FerricEngine;
+use crate::error::{try_set_global_error, FerricError};
+use crate::pinned::FerricPinnedEngine;
+use crate::types::FerricValue;
+
+/// Diagnostic target associated with one exported call.
+#[derive(Clone, Copy)]
+pub(crate) enum PanicTarget {
+    /// Only the thread-local global channel is available.
+    Global,
+    /// A live raw-engine handle was supplied.
+    RawEngine(*const FerricEngine),
+    /// A live pinned-engine handle was supplied.
+    PinnedEngine(*const FerricPinnedEngine),
+}
+
+/// Defined sentinel returned after a panic is contained.
+pub(crate) trait PanicSentinel {
+    fn panic_sentinel() -> Self;
+}
+
+impl PanicSentinel for FerricError {
+    fn panic_sentinel() -> Self {
+        Self::InternalError
+    }
+}
+
+impl<T> PanicSentinel for *const T {
+    fn panic_sentinel() -> Self {
+        std::ptr::null()
+    }
+}
+
+impl<T> PanicSentinel for *mut T {
+    fn panic_sentinel() -> Self {
+        std::ptr::null_mut()
+    }
+}
+
+impl PanicSentinel for FerricValue {
+    fn panic_sentinel() -> Self {
+        Self::void()
+    }
+}
+
+impl PanicSentinel for bool {
+    fn panic_sentinel() -> Self {
+        false
+    }
+}
+
+impl PanicSentinel for u64 {
+    fn panic_sentinel() -> Self {
+        0
+    }
+}
+
+impl PanicSentinel for () {
+    fn panic_sentinel() {}
+}
+
+/// Invoke one non-extern implementation while containing ordinary Rust
+/// panics inside the generated C wrapper.
+///
+/// Panic payloads are deliberately neither formatted nor downcast. They may
+/// contain arbitrary application data or non-string types; the stable
+/// diagnostic identifies only the export where containment occurred.
+pub(crate) fn invoke<R, F>(name: &'static str, target: PanicTarget, operation: F) -> R
+where
+    R: PanicSentinel,
+    F: FnOnce() -> R,
+{
+    match catch_unwind(AssertUnwindSafe(|| {
+        maybe_inject_test_panic(name);
+        operation()
+    })) {
+        Ok(result) => result,
+        Err(payload) => {
+            discard_panic_payload(payload);
+
+            let message = format!("internal Rust panic contained in C ABI export `{name}`");
+            try_set_global_error(message.clone());
+
+            // A valid supplied engine receives the same diagnostic. This is
+            // best-effort because the containment path itself must not permit
+            // a secondary diagnostic-state panic to escape the wrapper.
+            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| unsafe {
+                match target {
+                    PanicTarget::Global => {}
+                    PanicTarget::RawEngine(engine) => {
+                        crate::engine::record_boundary_panic(engine, message);
+                    }
+                    PanicTarget::PinnedEngine(engine) => {
+                        crate::pinned::record_boundary_panic(engine, message);
+                    }
+                }
+            })) {
+                discard_panic_payload(payload);
+            }
+
+            R::panic_sentinel()
+        }
+    }
+}
+
+/// Dispose of a caught payload without trusting its destructor to return
+/// normally. If that destructor panics, contain the secondary panic and leak
+/// only its payload rather than allowing another unwind to reach C.
+fn discard_panic_payload(payload: Box<dyn std::any::Any + Send>) {
+    if let Err(secondary_payload) = catch_unwind(AssertUnwindSafe(|| drop(payload))) {
+        std::mem::forget(secondary_payload);
+    }
+}
+
+#[cfg(ferric_ffi_test_panic_injection)]
+fn maybe_inject_test_panic(name: &str) {
+    if std::env::var_os("FERRIC_FFI_TEST_PANIC")
+        .is_some_and(|selected| selected == std::ffi::OsStr::new(name))
+    {
+        panic!("test-only injected FFI boundary panic");
+    }
+}
+
+#[cfg(not(ferric_ffi_test_panic_injection))]
+fn maybe_inject_test_panic(_name: &str) {}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    use super::{invoke, PanicTarget};
+    use crate::error::{with_global_error, FerricError};
+
+    struct PanicsOnDrop(Arc<AtomicBool>);
+
+    impl Drop for PanicsOnDrop {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::Relaxed);
+            panic!("panic payload destructor");
+        }
+    }
+
+    #[test]
+    fn panicking_payload_destructor_is_also_contained() {
+        let payload_was_dropped = Arc::new(AtomicBool::new(false));
+        let payload_flag = Arc::clone(&payload_was_dropped);
+
+        let result: FerricError = invoke("payload_test", PanicTarget::Global, || {
+            std::panic::panic_any(PanicsOnDrop(payload_flag));
+        });
+
+        assert_eq!(result, FerricError::InternalError);
+        assert!(payload_was_dropped.load(Ordering::Relaxed));
+        with_global_error(|message| {
+            assert_eq!(
+                message,
+                Some("internal Rust panic contained in C ABI export `payload_test`")
+            );
+        });
+    }
+}

--- a/crates/ferric-rules-ffi/src/engine.rs
+++ b/crates/ferric-rules-ffi/src/engine.rs
@@ -37,6 +37,7 @@ use crate::error::{
     copy_error_to_buffer, map_engine_error, map_load_error, set_engine_and_global_error,
     set_global_error, EngineErrorState, FerricError,
 };
+use ferric_rules_ffi_macros::ffi_export;
 use ferric_rules_runtime::engine::EngineError;
 use ferric_rules_runtime::loader::LoadError;
 use ferric_rules_runtime::{Engine, EngineConfig, InitError, RunLimit};
@@ -328,6 +329,22 @@ fn set_engine_error_message(
     code
 }
 
+/// Best-effort per-engine diagnostic update after a generated C wrapper
+/// contains a panic.
+///
+/// # Safety
+///
+/// `engine` must be null or a live raw-engine handle whose lifetime covers
+/// this call.
+pub(crate) unsafe fn record_boundary_panic(engine: *const FerricEngine, message: String) {
+    let Some(handle) = NonNull::new(engine.cast_mut()) else {
+        return;
+    };
+    lock_unpoisoned(diagnostics(handle))
+        .error_state
+        .set(message);
+}
+
 unsafe fn set_engine_error_for_handle(
     handle: NonNull<FerricEngine>,
     code: FerricError,
@@ -460,6 +477,7 @@ unsafe fn write_value_to_ffi(
 ///
 /// The returned pointer must be freed with `ferric_engine_free`.
 /// The engine is bound to the creating thread.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_new() -> *mut FerricEngine {
     ferric_engine_new_with_config(ptr::null())
@@ -473,6 +491,7 @@ pub unsafe extern "C" fn ferric_engine_new() -> *mut FerricEngine {
 ///
 /// - `config` may be null.
 /// - Returned pointer must be freed with `ferric_engine_free`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_new_with_config(
     config: *const FerricConfig,
@@ -503,6 +522,7 @@ pub unsafe extern "C" fn ferric_engine_new_with_config(
 /// - `engine` must be a pointer returned by `ferric_engine_new` or null.
 /// - The engine must not be in use by another call when freed.
 /// - The engine must be freed from the same thread that created it.
+#[cfg_attr(ferric_ffi_compile, ffi_export(global_only))]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_free(engine: *mut FerricEngine) -> FerricError {
     if engine.is_null() {
@@ -532,6 +552,7 @@ pub unsafe extern "C" fn ferric_engine_free(engine: *mut FerricEngine) -> Ferric
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `source` must be a valid NUL-terminated UTF-8 string.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_load_string(
     engine: *mut FerricEngine,
@@ -577,6 +598,7 @@ pub unsafe extern "C" fn ferric_engine_load_string(
 /// # Safety
 ///
 /// - `engine` must be a valid engine pointer or null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_last_error(engine: *const FerricEngine) -> *const c_char {
     // Deliberately skip thread-affinity and active-call checks. Error snapshots
@@ -626,6 +648,7 @@ pub unsafe extern "C" fn ferric_engine_last_error(engine: *const FerricEngine) -
 /// - `engine` must be a valid engine pointer or null (null → `NullPointer`).
 /// - `buf` must point to `buf_len` writable bytes, or be null for size query.
 /// - `out_len` must be a valid pointer (non-null).
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_last_error_copy(
     engine: *const FerricEngine,
@@ -658,6 +681,7 @@ pub unsafe extern "C" fn ferric_engine_last_error_copy(
 /// # Safety
 ///
 /// - `engine` must be a valid engine pointer or null (null returns `NullPointer`).
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_clear_error(engine: *mut FerricEngine) -> FerricError {
     let handle = match validate_engine_ptr(engine) {
@@ -676,6 +700,7 @@ pub unsafe extern "C" fn ferric_engine_clear_error(engine: *mut FerricEngine) ->
 /// # Safety
 ///
 /// - `engine` must be a valid engine pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_reset(engine: *mut FerricEngine) -> FerricError {
     let handle = match borrow_engine_mut(engine) {
@@ -708,6 +733,7 @@ pub unsafe extern "C" fn ferric_engine_reset(engine: *mut FerricEngine) -> Ferri
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_fired` may be null (output is simply not written).
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_run(
     engine: *mut FerricEngine,
@@ -749,6 +775,7 @@ pub unsafe extern "C" fn ferric_engine_run(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_status` may be null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_step(
     engine: *mut FerricEngine,
@@ -796,6 +823,7 @@ pub unsafe extern "C" fn ferric_engine_step(
 /// - `engine` must be a valid engine pointer.
 /// - `source` must be a valid NUL-terminated UTF-8 string.
 /// - `out_fact_id` may be null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_assert_string(
     engine: *mut FerricEngine,
@@ -843,6 +871,7 @@ pub unsafe extern "C" fn ferric_engine_assert_string(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `fact_id` must be a valid fact ID obtained from a previous assert.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_retract(
     engine: *mut FerricEngine,
@@ -884,6 +913,7 @@ pub unsafe extern "C" fn ferric_engine_retract(
 ///
 /// - `engine` must be a valid engine pointer or null.
 /// - `channel` must be a valid NUL-terminated UTF-8 string or null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_get_output(
     engine: *const FerricEngine,
@@ -975,6 +1005,7 @@ pub unsafe extern "C" fn ferric_engine_get_output(
 /// - `channel` must be a valid NUL-terminated UTF-8 string or null.
 /// - `buf` must point to `buf_len` writable bytes, or be null for a size query.
 /// - `out_len` must be a valid non-null pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_get_output_copy(
     engine: *const FerricEngine,
@@ -1026,6 +1057,7 @@ pub unsafe extern "C" fn ferric_engine_get_output_copy(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_count` must be a valid pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_action_diagnostic_count(
     engine: *const FerricEngine,
@@ -1056,6 +1088,7 @@ pub unsafe extern "C" fn ferric_engine_action_diagnostic_count(
 /// - `engine` must be a valid engine pointer.
 /// - `buf` must point to `buf_len` writable bytes, or be null for size query.
 /// - `out_len` must be a valid pointer (non-null).
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_action_diagnostic_copy(
     engine: *const FerricEngine,
@@ -1116,6 +1149,7 @@ pub unsafe extern "C" fn ferric_engine_action_diagnostic_copy(
 /// # Safety
 ///
 /// - `engine` must be a valid engine pointer or null (null returns `NullPointer`).
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_clear_action_diagnostics(
     engine: *mut FerricEngine,
@@ -1140,6 +1174,7 @@ pub unsafe extern "C" fn ferric_engine_clear_action_diagnostics(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_count` must be a valid pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_fact_count(
     engine: *const FerricEngine,
@@ -1175,6 +1210,7 @@ pub unsafe extern "C" fn ferric_engine_fact_count(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_count` must be a valid pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_get_fact_field_count(
     engine: *const FerricEngine,
@@ -1230,6 +1266,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_field_count(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_value` must be a valid pointer to a `FerricValue`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_get_fact_field(
     engine: *const FerricEngine,
@@ -1293,6 +1330,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_field(
 /// - `engine` must be a valid engine pointer.
 /// - `name` must be a valid NUL-terminated UTF-8 string.
 /// - `out_value` must be a valid pointer to a `FerricValue`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_get_global(
     engine: *const FerricEngine,
@@ -1340,6 +1378,7 @@ pub unsafe extern "C" fn ferric_engine_get_global(
 /// - `engine` must be a valid engine pointer.
 /// - `out_count` must be a valid pointer.
 /// - If `out_ids` is non-null, it must point to space for at least `max_ids` `u64`s.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_fact_ids(
     engine: *const FerricEngine,
@@ -1387,6 +1426,7 @@ pub unsafe extern "C" fn ferric_engine_fact_ids(
 /// - `relation` must be a valid NUL-terminated string.
 /// - `out_count` must be a valid pointer.
 /// - If `out_ids` is non-null, it must point to space for at least `max_ids` `u64`s.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_find_fact_ids(
     engine: *const FerricEngine,
@@ -1439,6 +1479,7 @@ pub unsafe extern "C" fn ferric_engine_find_fact_ids(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_type` must be a valid pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_get_fact_type(
     engine: *const FerricEngine,
@@ -1487,6 +1528,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_type(
 /// - `engine` must be a valid engine pointer.
 /// - `out_len` must be a valid pointer.
 /// - If `buf` is non-null, it must point to at least `buf_len` writable bytes.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_get_fact_relation(
     engine: *const FerricEngine,
@@ -1546,6 +1588,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_relation(
 /// - `engine` must be a valid engine pointer.
 /// - `out_len` must be a valid pointer.
 /// - If `buf` is non-null, it must point to at least `buf_len` writable bytes.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_get_fact_template_name(
     engine: *const FerricEngine,
@@ -1614,6 +1657,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_template_name(
 /// - `relation` must be a valid NUL-terminated string.
 /// - If `fields` is non-null, it must point to `field_count` valid `FerricValue`s.
 /// - `out_fact_id` may be null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_assert_ordered(
     engine: *mut FerricEngine,
@@ -1677,6 +1721,7 @@ pub unsafe extern "C" fn ferric_engine_assert_ordered(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_count` must be a valid pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_template_count(
     engine: *const FerricEngine,
@@ -1706,6 +1751,7 @@ pub unsafe extern "C" fn ferric_engine_template_count(
 /// - `engine` must be a valid engine pointer.
 /// - `out_len` must be a valid pointer.
 /// - If `buf` is non-null, it must point to at least `buf_len` writable bytes.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_template_name(
     engine: *const FerricEngine,
@@ -1747,6 +1793,7 @@ pub unsafe extern "C" fn ferric_engine_template_name(
 /// - `engine` must be a valid engine pointer.
 /// - `template_name` must be a valid NUL-terminated string.
 /// - `out_count` must be a valid pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_template_slot_count(
     engine: *const FerricEngine,
@@ -1791,6 +1838,7 @@ pub unsafe extern "C" fn ferric_engine_template_slot_count(
 /// - `template_name` must be a valid NUL-terminated string.
 /// - `out_len` must be a valid pointer.
 /// - If `buf` is non-null, it must point to at least `buf_len` writable bytes.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_template_slot_name(
     engine: *const FerricEngine,
@@ -1847,6 +1895,7 @@ pub unsafe extern "C" fn ferric_engine_template_slot_name(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_count` must be a valid pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_rule_count(
     engine: *const FerricEngine,
@@ -1878,6 +1927,7 @@ pub unsafe extern "C" fn ferric_engine_rule_count(
 /// - `out_len` must be a valid pointer.
 /// - If `buf` is non-null, it must point to at least `buf_len` writable bytes.
 /// - `out_salience` may be null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_rule_info(
     engine: *const FerricEngine,
@@ -1927,6 +1977,7 @@ pub unsafe extern "C" fn ferric_engine_rule_info(
 /// - `engine` must be a valid engine pointer.
 /// - `out_len` must be a valid pointer.
 /// - If `buf` is non-null, it must point to at least `buf_len` writable bytes.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_current_module(
     engine: *const FerricEngine,
@@ -1958,6 +2009,7 @@ pub unsafe extern "C" fn ferric_engine_current_module(
 /// - `engine` must be a valid engine pointer.
 /// - `out_len` must be a valid pointer.
 /// - If `buf` is non-null, it must point to at least `buf_len` writable bytes.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_get_focus(
     engine: *const FerricEngine,
@@ -1995,6 +2047,7 @@ pub unsafe extern "C" fn ferric_engine_get_focus(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_depth` must be a valid pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_focus_stack_depth(
     engine: *const FerricEngine,
@@ -2025,6 +2078,7 @@ pub unsafe extern "C" fn ferric_engine_focus_stack_depth(
 /// - `engine` must be a valid engine pointer.
 /// - `out_len` must be a valid pointer.
 /// - If `buf` is non-null, it must point to at least `buf_len` writable bytes.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_focus_stack_entry(
     engine: *const FerricEngine,
@@ -2065,6 +2119,7 @@ pub unsafe extern "C" fn ferric_engine_focus_stack_entry(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_count` must be a valid pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_module_count(
     engine: *const FerricEngine,
@@ -2094,6 +2149,7 @@ pub unsafe extern "C" fn ferric_engine_module_count(
 /// - `engine` must be a valid engine pointer.
 /// - `out_len` must be a valid pointer.
 /// - If `buf` is non-null, it must point to at least `buf_len` writable bytes.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_module_name(
     engine: *const FerricEngine,
@@ -2138,6 +2194,7 @@ pub unsafe extern "C" fn ferric_engine_module_name(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_count` must be a valid pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_agenda_count(
     engine: *const FerricEngine,
@@ -2166,6 +2223,7 @@ pub unsafe extern "C" fn ferric_engine_agenda_count(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `out_halted` must be a valid pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_is_halted(
     engine: *const FerricEngine,
@@ -2193,6 +2251,7 @@ pub unsafe extern "C" fn ferric_engine_is_halted(
 /// # Safety
 ///
 /// - `engine` must be a valid engine pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_halt(engine: *mut FerricEngine) -> FerricError {
     let handle = match borrow_engine_mut(engine) {
@@ -2209,6 +2268,7 @@ pub unsafe extern "C" fn ferric_engine_halt(engine: *mut FerricEngine) -> Ferric
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `line` must be a valid NUL-terminated string.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_push_input(
     engine: *mut FerricEngine,
@@ -2234,6 +2294,7 @@ pub unsafe extern "C" fn ferric_engine_push_input(
 /// # Safety
 ///
 /// - `engine` must be a valid engine pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_clear(engine: *mut FerricEngine) -> FerricError {
     let handle = match borrow_engine_mut(engine) {
@@ -2258,6 +2319,7 @@ pub unsafe extern "C" fn ferric_engine_clear(engine: *mut FerricEngine) -> Ferri
 ///
 /// - `source` must be a valid NUL-terminated UTF-8 string, or null.
 /// - Returned pointer must be freed with `ferric_engine_free`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_new_with_source(source: *const c_char) -> *mut FerricEngine {
     ferric_engine_new_with_source_config(source, ptr::null())
@@ -2273,6 +2335,7 @@ pub unsafe extern "C" fn ferric_engine_new_with_source(source: *const c_char) ->
 /// - `source` must be a valid NUL-terminated UTF-8 string, or null.
 /// - `config` may be null.
 /// - Returned pointer must be freed with `ferric_engine_free`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_new_with_source_config(
     source: *const c_char,
@@ -2325,6 +2388,7 @@ pub unsafe extern "C" fn ferric_engine_new_with_source_config(
 ///
 /// - `engine` must be a valid engine pointer.
 /// - `channel` must be a valid NUL-terminated string.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_clear_output(
     engine: *mut FerricEngine,
@@ -2353,6 +2417,7 @@ pub unsafe extern "C" fn ferric_engine_clear_output(
 /// - `engine` must be a valid engine pointer.
 /// - `out_fired` may be null.
 /// - `out_reason` may be null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_run_ex(
     engine: *mut FerricEngine,
@@ -2411,6 +2476,7 @@ pub unsafe extern "C" fn ferric_engine_run_ex(
 /// - If `count > 0`, `slot_names` must point to `count` valid NUL-terminated string pointers.
 /// - If `count > 0`, `slot_values` must point to `count` valid `FerricValue`s.
 /// - `out_fact_id` may be null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_assert_template(
     engine: *mut FerricEngine,
@@ -2507,6 +2573,7 @@ pub unsafe extern "C" fn ferric_engine_assert_template(
 /// - `engine` must be a valid engine pointer.
 /// - `slot_name` must be a valid NUL-terminated string.
 /// - `out_value` must be a valid pointer to a `FerricValue`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_get_fact_slot_by_name(
     engine: *const FerricEngine,
@@ -2557,6 +2624,7 @@ pub unsafe extern "C" fn ferric_engine_get_fact_slot_by_name(
 /// - `engine` must be a pointer returned by `ferric_engine_new` or null.
 /// - The engine must not be in use by another call when freed.
 /// - The caller must guarantee that no other thread is concurrently using this engine.
+#[cfg_attr(ferric_ffi_compile, ffi_export(global_only))]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_engine_free_unchecked(engine: *mut FerricEngine) -> FerricError {
     if engine.is_null() {
@@ -2753,6 +2821,7 @@ unsafe fn deserialize_engine_impl(
 /// - `out_data` and `out_len` must be valid, non-null pointers.
 /// - If `alloc_fn` is non-null, it must return a valid pointer to `size` bytes
 ///   (or null to signal failure).
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_serialize_as(
@@ -2796,6 +2865,7 @@ pub unsafe extern "C" fn ferric_engine_serialize_as(
 /// - `data` must point to `len` valid, readable bytes.
 /// - `out_engine` must be a valid, non-null pointer.
 /// - The returned engine must be freed with `ferric_engine_free`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_deserialize_as(
@@ -2833,6 +2903,7 @@ pub unsafe extern "C" fn ferric_engine_deserialize_as(
 /// - `out_data` and `out_len` must be valid, non-null pointers.
 /// - If `alloc_fn` is non-null, it must return a valid pointer to `size` bytes
 ///   (or null to signal failure).
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_serialize_bincode(
@@ -2862,6 +2933,7 @@ pub unsafe extern "C" fn ferric_engine_serialize_bincode(
 /// - `data` must point to `len` valid, readable bytes.
 /// - `out_engine` must be a valid, non-null pointer.
 /// - The returned engine must be freed with `ferric_engine_free`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_deserialize_bincode(
@@ -2884,6 +2956,7 @@ pub unsafe extern "C" fn ferric_engine_deserialize_bincode(
 /// # Safety
 ///
 /// Same safety requirements as `ferric_engine_serialize_bincode`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_serialize_json(
@@ -2908,6 +2981,7 @@ pub unsafe extern "C" fn ferric_engine_serialize_json(
 /// # Safety
 ///
 /// Same safety requirements as `ferric_engine_deserialize_bincode`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_deserialize_json(
@@ -2930,6 +3004,7 @@ pub unsafe extern "C" fn ferric_engine_deserialize_json(
 /// # Safety
 ///
 /// Same safety requirements as `ferric_engine_serialize_bincode`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_serialize_cbor(
@@ -2954,6 +3029,7 @@ pub unsafe extern "C" fn ferric_engine_serialize_cbor(
 /// # Safety
 ///
 /// Same safety requirements as `ferric_engine_deserialize_bincode`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_deserialize_cbor(
@@ -2976,6 +3052,7 @@ pub unsafe extern "C" fn ferric_engine_deserialize_cbor(
 /// # Safety
 ///
 /// Same safety requirements as `ferric_engine_serialize_bincode`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_serialize_msgpack(
@@ -3000,6 +3077,7 @@ pub unsafe extern "C" fn ferric_engine_serialize_msgpack(
 /// # Safety
 ///
 /// Same safety requirements as `ferric_engine_deserialize_bincode`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_deserialize_msgpack(
@@ -3022,6 +3100,7 @@ pub unsafe extern "C" fn ferric_engine_deserialize_msgpack(
 /// # Safety
 ///
 /// Same safety requirements as `ferric_engine_serialize_bincode`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_serialize_postcard(
@@ -3046,6 +3125,7 @@ pub unsafe extern "C" fn ferric_engine_serialize_postcard(
 /// # Safety
 ///
 /// Same safety requirements as `ferric_engine_deserialize_bincode`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_engine_deserialize_postcard(
@@ -3072,6 +3152,7 @@ pub unsafe extern "C" fn ferric_engine_deserialize_postcard(
 ///   null `alloc_fn`), or null.
 /// - `len` must be the length reported by the corresponding serialize call.
 /// - The buffer must not have been previously freed.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_bytes_free(data: *mut u8, len: usize) {

--- a/crates/ferric-rules-ffi/src/error.rs
+++ b/crates/ferric-rules-ffi/src/error.rs
@@ -4,6 +4,8 @@ use std::cell::RefCell;
 use std::ffi::CString;
 use std::os::raw::c_char;
 
+use ferric_rules_ffi_macros::ffi_export;
+
 /// C-facing error codes returned by all fallible FFI entry points.
 ///
 /// Stable numeric values — new codes may be added but existing values
@@ -67,6 +69,19 @@ thread_local! {
 /// Store a global (thread-local) error message.
 pub(crate) fn set_global_error(msg: String) {
     LAST_ERROR_GLOBAL.with(|e| *e.borrow_mut() = Some(msg));
+}
+
+/// Best-effort global diagnostic update for panic-containment paths.
+///
+/// Unlike [`set_global_error`], this never panics if containment interrupted a
+/// previous borrow of the thread-local slot or thread-local teardown is in
+/// progress.
+pub(crate) fn try_set_global_error(msg: String) {
+    let _ = LAST_ERROR_GLOBAL.try_with(|error| {
+        if let Ok(mut slot) = error.try_borrow_mut() {
+            *slot = Some(msg);
+        }
+    });
 }
 
 /// Store one current failure in both an engine-local snapshot and the
@@ -175,6 +190,7 @@ pub(crate) fn map_load_error(err: &LoadError) -> FerricError {
 ///
 /// The returned pointer must not be freed by the caller and must not be
 /// used after any subsequent FFI call that may modify the error channel.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_last_error_global() -> *const c_char {
     with_global_error(|msg| match msg {
@@ -192,6 +208,7 @@ pub unsafe extern "C" fn ferric_last_error_global() -> *const c_char {
 }
 
 /// Clear the global error channel.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub extern "C" fn ferric_clear_error_global() {
     clear_global_error();
@@ -218,6 +235,7 @@ pub extern "C" fn ferric_clear_error_global() {
 ///
 /// - `buf` must point to `buf_len` writable bytes, or be null for size query.
 /// - `out_len` must be a valid pointer (non-null).
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_last_error_global_copy(
     buf: *mut c_char,

--- a/crates/ferric-rules-ffi/src/lib.rs
+++ b/crates/ferric-rules-ffi/src/lib.rs
@@ -41,19 +41,24 @@
 //!   unrepresentable content instead of returning empty/truncated strings.
 //!   Length-reporting copy and serialization APIs preserve exact bytes.
 //!
-//! - **Panic policy**: FFI builds use `panic = "abort"` profiles (`ffi-dev`,
-//!   `ffi-release`) so that Rust panics never unwind across the C ABI boundary.
+//! - **Panic containment**: Every C export is generated around a non-extern
+//!   implementation and catches ordinary Rust panics before they reach the ABI.
+//!   `ffi-dev` and `ffi-release` retain unwind support for that purpose. A
+//!   contained panic records a payload-independent internal-error diagnostic
+//!   and returns the documented sentinel for its return category. Allocator
+//!   abort/OOM and other non-unwinding process termination remain outside the
+//!   guarantee.
 //!
 //! ## Build Instructions
 //!
 //! Ferric FFI ships with two dedicated profiles for C-ABI-safe builds:
 //!
-//! - **ffi-dev**: Development builds with `panic = "abort"` and debug info.
+//! - **ffi-dev**: Development builds with unwind-capable containment and debug info.
 //!   ```sh
 //!   cargo build -p ferric-rules-ffi --profile ffi-dev
 //!   ```
 //!
-//! - **ffi-release**: Release builds with `panic = "abort"` and optimizations.
+//! - **ffi-release**: Optimized builds with unwind-capable containment.
 //!   ```sh
 //!   cargo build -p ferric-rules-ffi --profile ffi-release
 //!   ```
@@ -70,9 +75,10 @@
 //!
 //! ### Panic Policy
 //!
-//! Both FFI profiles use `panic = "abort"` to prevent Rust panics from
-//! unwinding across the C ABI boundary. The default `dev`/`release` profiles
-//! retain normal unwind semantics for ergonomic development and testing.
+//! Both FFI profiles use `panic = "unwind"` so generated export wrappers can
+//! catch ordinary Rust panics before they reach the C ABI boundary. Panics are
+//! converted to stable sentinels and internal-error diagnostics. Non-unwinding
+//! termination such as allocator abort/OOM remains outside the guarantee.
 //!
 //! ## Module Organization
 //!
@@ -86,6 +92,8 @@ pub mod error;
 pub mod header;
 pub mod pinned;
 pub mod types;
+
+mod boundary;
 
 #[cfg(test)]
 mod tests;

--- a/crates/ferric-rules-ffi/src/pinned.rs
+++ b/crates/ferric-rules-ffi/src/pinned.rs
@@ -26,6 +26,7 @@ use std::ptr;
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::Duration;
 
+use ferric_rules_ffi_macros::ffi_export;
 use ferric_rules_pinned::{
     AutoreleasePolicy, HaltReason, PinnedEngine, PinnedEngineOptions, PinnedError,
     PreDispatchCancelToken, QueueWait, RunLimit, RunResult,
@@ -286,6 +287,19 @@ fn record_pinned_error(handle: &FerricPinnedEngine, err: &PinnedError) -> Ferric
     code
 }
 
+/// Best-effort per-engine diagnostic update after a generated C wrapper
+/// contains a panic.
+///
+/// # Safety
+///
+/// `engine` must be null or a live pinned-engine handle whose lifetime covers
+/// this call.
+pub(crate) unsafe fn record_boundary_panic(engine: *const FerricPinnedEngine, message: String) {
+    if let Some(handle) = engine.as_ref() {
+        lock_unpoisoned(&handle.error_state).set(message);
+    }
+}
+
 fn build_options_from_ffi(
     options: &FerricPinnedEngineOptions,
 ) -> Result<PinnedEngineOptions, FerricError> {
@@ -345,6 +359,7 @@ fn run_limit_from_i64(limit: i64) -> RunLimit {
 ///
 /// - `options` must point to a valid [`FerricPinnedEngineOptions`] or be NULL.
 /// - The returned handle must be freed with [`ferric_pinned_engine_free`].
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_new(
     options: *const FerricPinnedEngineOptions,
@@ -378,6 +393,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_new(
 /// # Safety
 ///
 /// - `engine` must be a valid handle or NULL.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_close(
     engine: *mut FerricPinnedEngine,
@@ -397,6 +413,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_close(
 ///
 /// - `engine` must be a pointer returned by [`ferric_pinned_engine_new`], or NULL.
 /// - The pointer must not be used after this call.
+#[cfg_attr(ferric_ffi_compile, ffi_export(global_only))]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_free(engine: *mut FerricPinnedEngine) -> FerricError {
     if engine.is_null() {
@@ -413,6 +430,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_free(engine: *mut FerricPinnedEngi
 /// # Safety
 ///
 /// - `engine` must be a valid handle (NULL ⇒ `false`).
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_is_closed(engine: *const FerricPinnedEngine) -> bool {
     match validate_engine_ptr(engine) {
@@ -428,6 +446,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_is_closed(engine: *const FerricPin
 /// # Safety
 ///
 /// - `engine` must be a valid handle.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_halt(engine: *mut FerricPinnedEngine) -> FerricError {
     let Ok(handle) = validate_engine_ptr(engine) else {
@@ -456,6 +475,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_halt(engine: *mut FerricPinnedEngi
 /// # Safety
 ///
 /// - `engine` must be a valid handle.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_cancel_request(
     engine: *mut FerricPinnedEngine,
@@ -497,6 +517,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_cancel_request(
 /// # Safety
 ///
 /// - `engine` must be a valid handle (NULL ⇒ NULL return).
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_last_error(
     engine: *const FerricPinnedEngine,
@@ -540,6 +561,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_last_error(
 /// - `engine` must be a valid pinned engine pointer or null.
 /// - `buf` must point to `buf_len` writable bytes, or be null for a size query.
 /// - `out_len` must be a valid, non-null pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_last_error_copy(
     engine: *const FerricPinnedEngine,
@@ -571,6 +593,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_last_error_copy(
 ///
 /// - `engine` must be a valid handle.
 /// - `source` must be a valid NUL-terminated UTF-8 string.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_load_string(
     engine: *mut FerricPinnedEngine,
@@ -594,6 +617,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_load_string(
 /// # Safety
 ///
 /// - `engine` must be a valid handle.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_reset(
     engine: *mut FerricPinnedEngine,
@@ -612,6 +636,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_reset(
 /// # Safety
 ///
 /// - `engine` must be a valid handle.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_clear(
     engine: *mut FerricPinnedEngine,
@@ -636,6 +661,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_clear(
 ///
 /// - `engine` must be a valid handle.
 /// - `out_fired` and `out_reason` may be NULL.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_run(
     engine: *mut FerricPinnedEngine,
@@ -668,6 +694,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_run(
 /// - `engine` must be a valid handle.
 /// - `out_data` and `out_len` must be valid, non-null pointers.
 /// - If `alloc_fn` is non-null, see [`crate::engine::FerricAllocFn`].
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 #[cfg(feature = "serde")]
 pub unsafe extern "C" fn ferric_pinned_engine_serialize_as(
@@ -729,6 +756,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_serialize_as(
 /// - `completion` must be a callable function pointer.
 /// - `context` may be any pointer; the caller is responsible for ensuring it
 ///   is safe to access from the worker thread.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_run_async(
     engine: *mut FerricPinnedEngine,
@@ -760,6 +788,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_run_async(
 ///
 /// The safety requirements are the same as
 /// [`ferric_pinned_engine_run_async`].
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_run_async_wait_for_capacity(
     engine: *mut FerricPinnedEngine,
@@ -833,6 +862,7 @@ fn pinned_engine_run_async_impl(
 /// - `source` must be a valid NUL-terminated UTF-8 string. The string is
 ///   copied; the caller may free it immediately after this call returns.
 /// - `completion` must be a callable function pointer.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_load_string_async(
     engine: *mut FerricPinnedEngine,
@@ -864,6 +894,7 @@ pub unsafe extern "C" fn ferric_pinned_engine_load_string_async(
 ///
 /// The safety requirements are the same as
 /// [`ferric_pinned_engine_load_string_async`].
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_engine_load_string_async_wait_for_capacity(
     engine: *mut FerricPinnedEngine,
@@ -976,6 +1007,7 @@ fn build_run_result(
 /// # Safety
 ///
 /// - `result` must be a valid handle returned via a completion callback.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_result_code(
     result: *const FerricPinnedResult,
@@ -991,6 +1023,7 @@ pub unsafe extern "C" fn ferric_pinned_result_code(
 /// # Safety
 ///
 /// - `result` must be a valid handle returned via a completion callback.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_result_request_id(result: *const FerricPinnedResult) -> u64 {
     if result.is_null() {
@@ -1008,6 +1041,7 @@ pub unsafe extern "C" fn ferric_pinned_result_request_id(result: *const FerricPi
 ///
 /// - `result` must be a valid handle.
 /// - `out_fired` and `out_reason` may be NULL.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_result_get_run(
     result: *const FerricPinnedResult,
@@ -1041,6 +1075,7 @@ pub unsafe extern "C" fn ferric_pinned_result_get_run(
 /// # Safety
 ///
 /// - `result` must be a valid handle.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_result_error_message(
     result: *const FerricPinnedResult,
@@ -1060,6 +1095,7 @@ pub unsafe extern "C" fn ferric_pinned_result_error_message(
 ///
 /// - `result` must be a handle obtained from a completion callback, or NULL.
 /// - The handle must not be used after this call.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_pinned_result_free(result: *mut FerricPinnedResult) {
     if result.is_null() {

--- a/crates/ferric-rules-ffi/src/tests/build_matrix.rs
+++ b/crates/ferric-rules-ffi/src/tests/build_matrix.rs
@@ -1,7 +1,7 @@
 //! Build matrix verification tests (Pass 009).
 //!
 //! These tests validate that FFI artifacts build correctly under all profiles
-//! and that the default test profile retains normal unwind semantics.
+//! and that every profile needed for containment retains unwind semantics.
 //!
 //! The `#[ignore]`d tests invoke `cargo build` as subprocesses and are slow;
 //! they are intended for CI validation rather than routine `cargo test` runs.
@@ -26,6 +26,11 @@ fn workspace_root() -> String {
         .to_str()
         .expect("workspace root is valid UTF-8")
         .to_string()
+}
+
+fn workspace_manifest() -> String {
+    std::fs::read_to_string(Path::new(&workspace_root()).join("Cargo.toml"))
+        .expect("workspace Cargo.toml must be readable")
 }
 
 /// Runs `cargo build -p ferric-rules-ffi --profile <profile>` from the workspace root
@@ -160,4 +165,21 @@ fn default_test_profile_uses_unwind() {
         result.is_err(),
         "catch_unwind should have caught the panic — test profile must use unwind, not abort"
     );
+}
+
+#[test]
+fn ffi_profiles_use_unwind_for_containment() {
+    let manifest = workspace_manifest();
+    for profile in ["ffi-dev", "ffi-release"] {
+        let marker = format!("[profile.{profile}]");
+        let start = manifest
+            .find(&marker)
+            .unwrap_or_else(|| panic!("missing {marker}"));
+        let rest = &manifest[start + marker.len()..];
+        let end = rest.find("\n[").unwrap_or(rest.len());
+        assert!(
+            rest[..end].contains("panic = \"unwind\""),
+            "{profile} must retain unwind support for generated C wrappers"
+        );
+    }
 }

--- a/crates/ferric-rules-ffi/src/tests/header.rs
+++ b/crates/ferric-rules-ffi/src/tests/header.rs
@@ -42,6 +42,13 @@ fn read_tsan_harness() -> String {
         .unwrap_or_else(|_| panic!("TSan harness not found at {}", script_path.display()))
 }
 
+fn read_panic_harness() -> String {
+    let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let script_path = crate_dir.join("../../scripts/ffi-panic-harness.sh");
+    std::fs::read_to_string(&script_path)
+        .unwrap_or_else(|_| panic!("panic harness not found at {}", script_path.display()))
+}
+
 #[test]
 fn header_has_include_guard() {
     let header = read_committed_header();
@@ -206,12 +213,26 @@ fn ci_runs_mixed_language_thread_sanitizer_harness() {
 }
 
 #[test]
+fn ci_runs_debug_and_release_panic_containment_harness() {
+    let workflow = read_ci_workflow();
+    assert!(workflow.contains("FFI Panic Containment"));
+    assert!(workflow.contains("just ffi-panic-harness"));
+
+    let script = read_panic_harness();
+    assert!(script.contains("for profile in ffi-dev ffi-release"));
+    assert!(script.contains("FERRIC_FFI_TEST_PANIC_INJECTION_BUILD=1"));
+    assert!(script.contains("--features serde"));
+    assert!(script.contains("panic_containment.c"));
+    assert!(script.contains("expected 100 header exports"));
+}
+
+#[test]
 fn tsan_harness_instruments_rust_std_and_c() {
     let script = read_tsan_harness();
     for required in [
         "-Zsanitizer=thread",
         "-Zexternal-clangrt",
-        "-Zbuild-std=std,panic_abort",
+        "-Zbuild-std=std,panic_unwind",
         "--crate-type staticlib",
         "-fsanitize=thread",
         "nm -u",
@@ -219,6 +240,67 @@ fn tsan_harness_instruments_rust_std_and_c() {
         assert!(
             script.contains(required),
             "TSan harness is missing required mixed-language instrumentation: {required}"
+        );
+    }
+}
+
+#[test]
+fn every_authored_c_export_uses_the_generated_boundary_wrapper() {
+    let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let source_dir = crate_dir.join("src");
+    let mut exports = Vec::new();
+
+    for file in ["engine.rs", "error.rs", "pinned.rs", "types.rs"] {
+        let source = std::fs::read_to_string(source_dir.join(file))
+            .unwrap_or_else(|_| panic!("could not read FFI source file {file}"));
+        let lines: Vec<_> = source.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            let Some(function_suffix) = line.split("extern \"C\" fn ferric_").nth(1) else {
+                continue;
+            };
+            let function_name = format!(
+                "ferric_{}",
+                function_suffix
+                    .split('(')
+                    .next()
+                    .expect("export name must end before arguments")
+            );
+            let attributes = lines[index.saturating_sub(6)..index].join("\n");
+            assert!(
+                attributes.contains("cfg_attr(ferric_ffi_compile, ffi_export"),
+                "{function_name} bypasses the generated panic wrapper"
+            );
+            assert!(
+                attributes.contains("#[no_mangle]"),
+                "{function_name} is missing its authored export marker"
+            );
+            exports.push(function_name);
+        }
+    }
+
+    exports.sort();
+    exports.dedup();
+    assert_eq!(
+        exports.len(),
+        100,
+        "the export audit count changed; verify every new return category has a panic sentinel"
+    );
+}
+
+#[test]
+fn header_documents_panic_containment_and_sentinels() {
+    let header = read_committed_header();
+    for required in [
+        "PANIC CONTAINMENT",
+        "generated wrapper around a non-extern",
+        "FERRIC_ERROR_INTERNAL_ERROR",
+        "FerricValue: Void",
+        "integer/count: 0",
+        "allocator abort/OOM",
+    ] {
+        assert!(
+            header.contains(required),
+            "panic contract is missing from ferric.h: {required}"
         );
     }
 }

--- a/crates/ferric-rules-ffi/src/types.rs
+++ b/crates/ferric-rules-ffi/src/types.rs
@@ -7,6 +7,7 @@ use std::ptr;
 use std::ffi::CStr;
 
 use ferric_rules_core::{ConflictResolutionStrategy, StringEncoding};
+use ferric_rules_ffi_macros::ffi_export;
 use ferric_rules_runtime::{Engine, EngineConfig, HaltReason};
 
 use crate::error::{set_global_error, FerricError};
@@ -497,6 +498,7 @@ pub(crate) unsafe fn ferric_to_value(
 // ---------------------------------------------------------------------------
 
 /// Create an integer `FerricValue`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub extern "C" fn ferric_value_integer(value: i64) -> FerricValue {
     FerricValue {
@@ -507,6 +509,7 @@ pub extern "C" fn ferric_value_integer(value: i64) -> FerricValue {
 }
 
 /// Create a float `FerricValue`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub extern "C" fn ferric_value_float(value: f64) -> FerricValue {
     FerricValue {
@@ -529,6 +532,7 @@ pub extern "C" fn ferric_value_float(value: f64) -> FerricValue {
 /// # Safety
 ///
 /// - `name` must be a valid NUL-terminated string, or null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_value_symbol(name: *const c_char) -> FerricValue {
     if name.is_null() {
@@ -555,6 +559,7 @@ pub unsafe extern "C" fn ferric_value_symbol(name: *const c_char) -> FerricValue
 /// # Safety
 ///
 /// - `s` must be a valid NUL-terminated string, or null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_value_string(s: *const c_char) -> FerricValue {
     if s.is_null() {
@@ -586,6 +591,7 @@ pub unsafe extern "C" fn ferric_value_string(s: *const c_char) -> FerricValue {
 /// - `out_value` must not currently contain live Ferric-owned resources.
 /// - If `len > 0`, `data` must point to `len` readable bytes.
 /// - The `data` span must not overlap `out_value`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_value_symbol_bytes(
     data: *const u8,
@@ -620,6 +626,7 @@ pub unsafe extern "C" fn ferric_value_symbol_bytes(
 /// - `out_value` must not currently contain live Ferric-owned resources.
 /// - If `len > 0`, `data` must point to `len` readable bytes.
 /// - The `data` span must not overlap `out_value`.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_value_string_bytes(
     data: *const u8,
@@ -690,6 +697,7 @@ unsafe fn ferric_value_from_bytes(
 }
 
 /// Create a void `FerricValue` with all fields zeroed/null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub extern "C" fn ferric_value_void() -> FerricValue {
     FerricValue::void()
@@ -726,6 +734,7 @@ pub extern "C" fn ferric_value_void() -> FerricValue {
 ///   declared number of initialized `FerricValue`s.
 /// - The complete input tree must remain readable and unchanged until this
 ///   function returns.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_value_multifield_copy(
     elements: *const FerricValue,
@@ -895,6 +904,7 @@ unsafe fn copy_borrowed_ferric_values(
 ///
 /// - `ptr` must be a pointer returned by an FFI function or null.
 /// - The pointer must not have been freed already.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_string_free(ptr: *mut c_char) {
     if !ptr.is_null() {
@@ -920,6 +930,7 @@ pub unsafe extern "C" fn ferric_string_free(ptr: *mut c_char) {
 /// - Every recursively owned allocation must have Ferric provenance; borrowed
 ///   or foreign-allocated value trees must not be passed to this function.
 /// - Any owned resources (`string_ptr`, `multifield_ptr`) must not have been freed already.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_value_free(value: *mut FerricValue) -> FerricError {
     if value.is_null() {
@@ -946,6 +957,7 @@ pub unsafe extern "C" fn ferric_value_free(value: *mut FerricValue) -> FerricErr
 /// - `arr` must point to a contiguous array of `len` `FerricValue`s, or be null.
 /// - The array and every recursively owned allocation must have been allocated
 ///   by Ferric; borrowed or foreign-allocated arrays must not be passed here.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
 #[no_mangle]
 pub unsafe extern "C" fn ferric_value_array_free(arr: *mut FerricValue, len: usize) -> FerricError {
     if arr.is_null() || len == 0 {

--- a/crates/ferric-rules-ffi/tests/c/panic_containment.c
+++ b/crates/ferric-rules-ffi/tests/c/panic_containment.c
@@ -1,0 +1,144 @@
+/*
+ * Native C subprocess regression harness for generated panic-containment
+ * wrappers. The linked Rust artifact must be built with the internal
+ * test-only panic-injection build cfg.
+ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include "ferric.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int failures = 0;
+static int callback_count = 0;
+
+#define CHECK(condition, message)                                              \
+    do {                                                                       \
+        if (!(condition)) {                                                    \
+            fprintf(stderr, "panic_containment: %s\n", (message));             \
+            failures++;                                                        \
+        }                                                                      \
+    } while (0)
+
+static void select_panic(const char *function_name) {
+    CHECK(setenv("FERRIC_FFI_TEST_PANIC", function_name, 1) == 0,
+          "failed to select test-only panic injection");
+}
+
+static void clear_panic(void) {
+    CHECK(unsetenv("FERRIC_FFI_TEST_PANIC") == 0,
+          "failed to clear test-only panic injection");
+}
+
+static void check_message(const char *message, const char *function_name,
+                          const char *channel) {
+    char expected[256];
+    int written = snprintf(
+        expected, sizeof(expected),
+        "internal Rust panic contained in C ABI export `%s`", function_name);
+    CHECK(written > 0 && (size_t)written < sizeof(expected),
+          "expected diagnostic did not fit");
+    if (written > 0 && (size_t)written < sizeof(expected)) {
+        CHECK(message != NULL && strcmp(message, expected) == 0, channel);
+    }
+}
+
+static void check_global_message(const char *function_name) {
+    check_message(ferric_last_error_global(), function_name,
+                  "global channel must contain exactly one stable panic report");
+}
+
+static void completion(void *context, enum FerricError code,
+                       struct FerricPinnedResult *result) {
+    (void)context;
+    (void)code;
+    callback_count++;
+    ferric_pinned_result_free(result);
+}
+
+int main(void) {
+    struct FerricEngine *raw = ferric_engine_new();
+    CHECK(raw != NULL, "raw engine construction must succeed");
+    if (raw == NULL) {
+        return 1;
+    }
+
+    select_panic("ferric_engine_reset");
+    enum FerricError status = ferric_engine_reset(raw);
+    clear_panic();
+    CHECK(status == FERRIC_ERROR_INTERNAL_ERROR,
+          "status-returning export must use INTERNAL_ERROR sentinel");
+    check_global_message("ferric_engine_reset");
+    check_message(ferric_engine_last_error(raw), "ferric_engine_reset",
+                  "raw-engine channel must mirror the panic report");
+    CHECK(ferric_engine_reset(raw) == FERRIC_ERROR_OK,
+          "raw engine must remain usable after a contained panic");
+
+    select_panic("ferric_engine_new");
+    struct FerricEngine *failed_engine = ferric_engine_new();
+    clear_panic();
+    CHECK(failed_engine == NULL,
+          "pointer-returning export must use a NULL sentinel");
+    check_global_message("ferric_engine_new");
+
+    select_panic("ferric_value_integer");
+    struct FerricValue value = ferric_value_integer(41);
+    clear_panic();
+    CHECK(value.value_type == FERRIC_VALUE_TYPE_VOID &&
+              value.string_ptr == NULL && value.multifield_ptr == NULL,
+          "FerricValue-returning export must use a Void sentinel");
+    check_global_message("ferric_value_integer");
+
+    select_panic("ferric_pinned_result_request_id");
+    uint64_t request_id = ferric_pinned_result_request_id(NULL);
+    clear_panic();
+    CHECK(request_id == 0, "integer-returning export must use a zero sentinel");
+    check_global_message("ferric_pinned_result_request_id");
+
+    select_panic("ferric_string_free");
+    ferric_string_free(NULL);
+    clear_panic();
+    check_global_message("ferric_string_free");
+
+    struct FerricPinnedEngine *pinned = ferric_pinned_engine_new(NULL);
+    CHECK(pinned != NULL, "pinned engine construction must succeed");
+    if (pinned != NULL) {
+        select_panic("ferric_pinned_engine_is_closed");
+        bool closed = ferric_pinned_engine_is_closed(pinned);
+        clear_panic();
+        CHECK(!closed, "bool-returning export must use a false sentinel");
+        check_global_message("ferric_pinned_engine_is_closed");
+        check_message(ferric_pinned_engine_last_error(pinned),
+                      "ferric_pinned_engine_is_closed",
+                      "pinned-engine channel must mirror the panic report");
+
+        select_panic("ferric_pinned_engine_run_async");
+        status = ferric_pinned_engine_run_async(pinned, -1, 77, NULL,
+                                                completion);
+        clear_panic();
+        CHECK(status == FERRIC_ERROR_INTERNAL_ERROR,
+              "callback-based submission must report synchronous panic");
+        CHECK(callback_count == 0,
+              "a synchronously rejected callback submission must not fire");
+        check_global_message("ferric_pinned_engine_run_async");
+        check_message(ferric_pinned_engine_last_error(pinned),
+                      "ferric_pinned_engine_run_async",
+                      "callback panic must update the pinned-engine channel");
+        CHECK(ferric_pinned_engine_reset(pinned) == FERRIC_ERROR_OK,
+              "pinned engine must remain usable after contained panics");
+        CHECK(ferric_pinned_engine_free(pinned) == FERRIC_ERROR_OK,
+              "pinned engine cleanup must succeed");
+    }
+
+    CHECK(ferric_engine_free(raw) == FERRIC_ERROR_OK,
+          "raw engine cleanup must succeed");
+
+    if (failures == 0) {
+        puts("panic-containment harness: all return categories survived");
+    }
+    return failures == 0 ? 0 : 1;
+}

--- a/crates/ferric-rules/tests/msrv_metadata.rs
+++ b/crates/ferric-rules/tests/msrv_metadata.rs
@@ -8,11 +8,12 @@ const EXPECTED_MSRV: &str = "1.75";
 const EXPECTED_VERSION: &str = "0.1.0";
 const EXPECTED_LICENSE: &str = "MIT OR Apache-2.0";
 const EXPECTED_REPOSITORY: &str = "https://github.com/plx/ferric-rules";
-const PUBLISHABLE_PACKAGES: [&str; 7] = [
+const PUBLISHABLE_PACKAGES: [&str; 8] = [
     "ferric-rules",
     "ferric-rules-cli",
     "ferric-rules-core",
     "ferric-rules-ffi",
+    "ferric-rules-ffi-macros",
     "ferric-rules-parser",
     "ferric-rules-pinned",
     "ferric-rules-runtime",

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -978,8 +978,34 @@ bytes.
 
 ### Panic Policy
 
-FFI builds use `panic = "abort"` profiles. No Rust panic unwind crosses the
-FFI boundary.
+Every public C function is generated as a small `extern "C"` wrapper around a
+non-extern Rust implementation. The `ffi-dev` and `ffi-release` profiles retain
+unwind support, and each wrapper catches ordinary Rust panics before they can
+reach the C ABI.
+
+A contained panic records a stable message naming the export, without
+formatting or downcasting the panic payload. The calling thread's global error
+channel is always updated; a supplied live raw or pinned engine also receives
+the same per-engine message. Ownership-consuming free functions update only
+the global channel because a panic can make the handle's remaining lifetime
+indeterminate.
+
+Return sentinels are fixed by category:
+
+| Return category | Panic sentinel |
+|-----------------|----------------|
+| `FerricError` | `FERRIC_ERROR_INTERNAL_ERROR` |
+| Any pointer | NULL |
+| `FerricValue` | Void |
+| `bool` | false |
+| Integer/count | 0 |
+| `void` | Return after recording the diagnostic |
+
+An async submission-wrapper panic is a synchronous rejection: it returns
+`FERRIC_ERROR_INTERNAL_ERROR` and does not invoke the completion callback.
+Containment does not cover non-unwinding termination such as allocator
+abort/OOM or an explicit process abort. Foreign callbacks must still return
+normally and obey their own no-unwind contract.
 
 ---
 

--- a/docs/phase6-baseline.md
+++ b/docs/phase6-baseline.md
@@ -162,8 +162,12 @@ caller-owned.
   last-error access remains callback-safe.
 
 **FFI Panic Policy:**
-- Shipped FFI artifacts use `ffi-dev` / `ffi-release` profiles with `panic = "abort"`.
-- No Rust unwind crosses the FFI boundary.
+- Shipped FFI artifacts use unwind-capable `ffi-dev` / `ffi-release` profiles.
+- Every C export is a generated panic-containing wrapper around a non-extern
+  implementation; ordinary panics become a documented sentinel plus an
+  internal-error diagnostic before reaching the ABI.
+- Allocator abort/OOM and other non-unwinding termination remain outside the
+  containment guarantee.
 
 **Copy-to-Buffer Semantics (stable contract):**
 - `out_len` is required.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -91,8 +91,9 @@ Thin re-export crate: `ferric_rules::core`, `ferric_rules::parser`, `ferric_rule
 
 C-ABI wrapper over the runtime. Produces `libferric_rules_ffi.{a,dylib,so}` plus
 auto-generated `ferric.h` via `cbindgen`. Dedicated `ffi-dev`/`ffi-release`
-profiles with `panic = abort`.
+profiles retain unwind support for generated panic-containing export wrappers.
 
+- `boundary.rs` — shared panic containment, error recording, and return sentinels.
 - `engine.rs` — `ferric_engine_*` surface (new/free, asserts, run, serialize,
   query).
 - `types.rs` — `FerricValue`, allocator-owned multifield copying, arrays,
@@ -107,6 +108,13 @@ profiles with `panic = abort`.
   last-error copies are synchronized across threads; borrowed last-error
   pointer use must not overlap other borrowed reads or destruction. The
   destruction-only unchecked free skips affinity but must not overlap access.
+
+### `ferric-rules-ffi-macros`
+
+Internal proc-macro dependency that separates each authored C signature into a
+generated `extern "C"` containment wrapper and a private non-extern
+implementation. It is published only so registry builds of
+`ferric-rules-ffi` retain the same boundary architecture.
 
 ### `ferric-rules-cli`
 

--- a/docs/rust-package-release.md
+++ b/docs/rust-package-release.md
@@ -14,6 +14,7 @@ Rust converts package hyphens to import underscores:
 | `ferric-rules-pinned` | `ferric_rules_pinned` | yes |
 | `ferric-rules-cli` | binary remains `ferric` | yes |
 | `ferric-rules-ffi` | `ferric_rules_ffi` | yes |
+| `ferric-rules-ffi-macros` | internal proc-macro dependency | yes |
 | `ferric-rules-napi` | `ferric_rules_napi` | no; shipped through npm |
 | `ferric-rules-python` | extension remains `ferric` | no; shipped through PyPI |
 | `ferric-rules-bench-gen` | n/a | no; repository tool |
@@ -21,9 +22,9 @@ Rust converts package hyphens to import underscores:
 All internal path dependencies also carry the exact synchronized registry
 version. Cargo removes their `path` keys when producing an archive, leaving a
 complete registry dependency graph. The workspace Cargo configuration patches
-the facade's unpublished dependency chain back to the local sources so its
-first-release package and dry-run checks work before crates.io contains them;
-Cargo configuration is not included in the package archives.
+unpublished internal dependencies back to the local sources so first-release
+package and dry-run checks work before crates.io contains them; Cargo
+configuration is not included in the package archives.
 
 ## Local artifact verification
 
@@ -52,6 +53,7 @@ crates.io index before publishing the next:
 # Tier 1: independent packages
 cargo publish -p ferric-rules-parser --locked
 cargo publish -p ferric-rules-core --locked
+cargo publish -p ferric-rules-ffi-macros --locked
 
 # Tier 2: depends on parser and core
 cargo publish -p ferric-rules-runtime --locked

--- a/justfile
+++ b/justfile
@@ -24,11 +24,11 @@ build-release:
 build-crate crate:
     cargo build -p {{crate}}
 
-# Build the FFI crate with panic=abort (dev)
+# Build the FFI crate with unwind-capable C-boundary containment (dev)
 build-ffi:
     cargo build -p ferric-rules-ffi --profile ffi-dev
 
-# Build the FFI crate with panic=abort (release)
+# Build the FFI crate with unwind-capable C-boundary containment (release)
 build-ffi-release:
     cargo build -p ferric-rules-ffi --profile ffi-release
 
@@ -74,6 +74,10 @@ test-ffi:
 # subprocesses under ASan/UBSan (when the compiler supports them)
 ffi-c-harness:
     ./scripts/ffi-c-harness.sh
+
+# Exercise generated panic wrappers in debug and release FFI subprocesses
+ffi-panic-harness:
+    ./scripts/ffi-panic-harness.sh
 
 # Run the mixed Rust/C pthread diagnostic harness under ThreadSanitizer
 # (x86_64 Linux; uses a pinned nightly to instrument Rust and std)

--- a/scripts/ffi-go-asan-harness.sh
+++ b/scripts/ffi-go-asan-harness.sh
@@ -58,7 +58,7 @@ CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}" \
 RUSTFLAGS="-Zsanitizer=address -Zexternal-clangrt -Cforce-frame-pointers=yes" \
     cargo +"$asan_toolchain" rustc \
         --locked \
-        -Zbuild-std=std,panic_abort \
+        -Zbuild-std=std,panic_unwind \
         --target "$asan_target" \
         -p ferric-rules-ffi \
         --profile ffi-dev \

--- a/scripts/ffi-panic-harness.sh
+++ b/scripts/ffi-panic-harness.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Build unwind-capable FFI artifacts with internal panic injection, exercise
+# every C return category in real subprocesses, and audit generated exports.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$root"
+
+CC="${CC:-cc}"
+outroot="$root/target/ffi-panic-harness"
+mkdir -p "$outroot"
+
+case "$(uname -s)" in
+Darwin)
+    platform_libs=(-framework Security -framework CoreFoundation -lobjc)
+    ;;
+*)
+    platform_libs=(-lpthread -ldl -lm)
+    ;;
+esac
+
+audit_symbols() {
+    local staticlib="$1"
+    local table="$outroot/symbols.txt"
+    local expected="$outroot/expected-symbols.txt"
+
+    case "$(uname -s)" in
+    Darwin)
+        nm -gU "$staticlib" | awk '{print $NF}' | sed 's/^_//' | sort -u >"$table"
+        ;;
+    *)
+        nm -g --defined-only "$staticlib" |
+            awk '{print $NF}' | sed 's/^_//' | sort -u >"$table"
+        ;;
+    esac
+
+    sed -nE 's/.*[ *](ferric_[a-z0-9_]+)\(.*/\1/p' \
+        crates/ferric-rules-ffi/ferric.h | sort -u >"$expected"
+    if [[ $(wc -l <"$expected") -ne 100 ]]; then
+        echo "ffi-panic-harness: expected 100 header exports" >&2
+        exit 1
+    fi
+    while IFS= read -r symbol; do
+        if ! grep -Fxq "$symbol" "$table"; then
+            echo "ffi-panic-harness: missing exported symbol: $symbol" >&2
+            exit 1
+        fi
+    done <"$expected"
+}
+
+for profile in ffi-dev ffi-release; do
+    target_dir="$outroot/$profile"
+    FERRIC_FFI_TEST_PANIC_INJECTION_BUILD=1 \
+        CARGO_TARGET_DIR="$target_dir" cargo build --locked \
+        -p ferric-rules-ffi \
+        --profile "$profile" \
+        --features serde
+
+    staticlib="$target_dir/$profile/libferric_rules_ffi.a"
+    binary="$target_dir/panic_containment"
+    "$CC" -std=c11 -Wall -Wextra -Werror \
+        -I crates/ferric-rules-ffi \
+        -o "$binary" \
+        crates/ferric-rules-ffi/tests/c/panic_containment.c \
+        "$staticlib" \
+        "${platform_libs[@]}"
+    "$binary"
+    audit_symbols "$staticlib"
+done

--- a/scripts/ffi-tsan-harness.sh
+++ b/scripts/ffi-tsan-harness.sh
@@ -31,7 +31,7 @@ CARGO_TARGET_DIR="$outdir" \
 RUSTFLAGS="-Zsanitizer=thread -Zexternal-clangrt -Cforce-frame-pointers=yes" \
     cargo +"$tsan_toolchain" rustc \
         --locked \
-        -Zbuild-std=std,panic_abort \
+        -Zbuild-std=std,panic_unwind \
         --target "$tsan_target" \
         -p ferric-rules-ffi \
         --profile ffi-dev \


### PR DESCRIPTION
## Summary

- generate every public C export as a small panic-containing wrapper around a private non-extern Rust implementation
- keep unwind support in the shipped FFI profiles, map contained panics to fixed sentinels, and update global/per-engine diagnostics without inspecting panic payloads
- add a test-only native subprocess harness for status, pointer, value, integer, bool, callback, and void return categories in both FFI profiles
- audit the 100-symbol export surface and document the containment, packaging, and non-unwinding termination contracts

## Root cause and impact

The dedicated FFI profiles used `panic = "abort"`, and the authored `extern "C"` functions had no common containment layer. Any reachable Rust panic therefore terminated an embedding host instead of producing a recoverable C result. The generated wrappers now catch ordinary unwinding panics before the ABI boundary, publish a payload-independent diagnostic, and return a documented sentinel. Allocator abort/OOM, explicit aborts, and foreign callbacks that violate their no-unwind contract remain outside the guarantee.

A panic in an async submission wrapper is treated as a synchronous rejection and does not invoke completion. Accepted async-request panic cleanup remains intentionally separate in #117.

## Validation

- `just preflight-pr`
- `cargo test --locked -p ferric-rules-ffi --all-features` (307 passed, 4 ignored build-matrix tests)
- strict Clippy for `ferric-rules-ffi` and `ferric-rules-ffi-macros`
- `just test-go`
- `just bindings-conformance` (25 cases across 5 adapters)
- packaged and verified normalized manifests for both `ferric-rules-ffi-macros` and `ferric-rules-ffi`
- compiled and linked the injected-panic C harness with warnings as errors without executing it locally
- audited all 100 header exports against the generated static library and verified committed headers are identical

The debug/release panic subprocesses and sanitizer jobs are left to hosted CI.

Closes #116