### PR TITLE
[FR-CABI-007] Guarantee exactly-once pinned async completion on request panic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,21 @@ jobs:
           CC: clang
           FERRIC_TSAN_TOOLCHAIN: nightly-2025-11-04
 
+  pinned-async-tsan:
+    name: Pinned Async Completion (ThreadSanitizer)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@just
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2025-11-04
+          components: rust-src
+      - run: just pinned-async-tsan
+        env:
+          FERRIC_TSAN_TOOLCHAIN: nightly-2025-11-04
+
   ffi-go-asan:
     name: Go/C Lifecycle (AddressSanitizer)
     runs-on: ubuntu-latest

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -144,6 +144,12 @@
  *   submission and later invoke the supplied
  *   FerricPinnedCompletionFn with an owned FerricPinnedResult
  *   carrying the echoed request_id.
+ *   Every accepted operation removes its registry entry and
+ *   invokes completion exactly once across success, error,
+ *   cancellation, close, and contained operation panic. A
+ *   contained operation panic reports
+ *   FERRIC_ERROR_INTERNAL_ERROR. Cleanup happens before callback
+ *   invocation, so the request_id is reusable from the callback.
  *
  * The async completion callback runs ON THE WORKER THREAD.
  * It must be transport-only: resume a continuation, signal an

--- a/crates/ferric-rules-ffi/build.rs
+++ b/crates/ferric-rules-ffi/build.rs
@@ -147,6 +147,12 @@ pub const HEADER_PREAMBLE: &str = r"/*
  *   submission and later invoke the supplied
  *   FerricPinnedCompletionFn with an owned FerricPinnedResult
  *   carrying the echoed request_id.
+ *   Every accepted operation removes its registry entry and
+ *   invokes completion exactly once across success, error,
+ *   cancellation, close, and contained operation panic. A
+ *   contained operation panic reports
+ *   FERRIC_ERROR_INTERNAL_ERROR. Cleanup happens before callback
+ *   invocation, so the request_id is reusable from the callback.
  *
  * The async completion callback runs ON THE WORKER THREAD.
  * It must be transport-only: resume a continuation, signal an

--- a/crates/ferric-rules-ffi/ferric.h
+++ b/crates/ferric-rules-ffi/ferric.h
@@ -144,6 +144,12 @@
  *   submission and later invoke the supplied
  *   FerricPinnedCompletionFn with an owned FerricPinnedResult
  *   carrying the echoed request_id.
+ *   Every accepted operation removes its registry entry and
+ *   invokes completion exactly once across success, error,
+ *   cancellation, close, and contained operation panic. A
+ *   contained operation panic reports
+ *   FERRIC_ERROR_INTERNAL_ERROR. Cleanup happens before callback
+ *   invocation, so the request_id is reusable from the callback.
  *
  * The async completion callback runs ON THE WORKER THREAD.
  * It must be transport-only: resume a continuation, signal an

--- a/crates/ferric-rules-ffi/src/error.rs
+++ b/crates/ferric-rules-ffi/src/error.rs
@@ -317,6 +317,7 @@ pub(crate) fn map_pinned_error(err: &PinnedError) -> FerricError {
         PinnedError::Canceled => FerricError::PinnedCanceled,
         PinnedError::QueueFull => FerricError::PinnedQueueFull,
         PinnedError::DispatchFailed => FerricError::PinnedDispatchFailed,
+        PinnedError::Internal => FerricError::InternalError,
         PinnedError::ReentrantCall => FerricError::PinnedReentrantCall,
         PinnedError::Init(_) => FerricError::InternalError,
         PinnedError::Load(errors) => errors

--- a/crates/ferric-rules-ffi/src/pinned.rs
+++ b/crates/ferric-rules-ffi/src/pinned.rs
@@ -18,6 +18,13 @@
 //! [`FerricPinnedResult`] handle. The completion is contractually
 //! transport-only — it must not perform long work or call back into
 //! the same pinned engine.
+//!
+//! Successful submission accepts the operation: every accepted operation
+//! removes its request ID from the registry and invokes its completion exactly
+//! once across success, error, cancellation, close, or a contained operation
+//! panic. A contained operation panic reports [`FerricError::InternalError`];
+//! cleanup occurs before foreign callback code runs, so the ID is reusable
+//! from the callback onward.
 
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
@@ -139,6 +146,27 @@ struct AsyncRequestRegistration {
     token: Arc<PreDispatchCancelToken>,
 }
 
+struct RegisteredAsyncRequest {
+    token: Arc<PreDispatchCancelToken>,
+    cleanup: AsyncRequestCleanup,
+}
+
+/// Sole owner of one registry removal.
+///
+/// It is captured by the accepted request's completion. If submission fails,
+/// dropping the unaccepted request drops this guard instead. Either path
+/// removes the ID once, without duplicating cleanup branches.
+struct AsyncRequestCleanup {
+    registry: Arc<Mutex<HashMap<u64, AsyncRequestRegistration>>>,
+    request_id: u64,
+}
+
+impl Drop for AsyncRequestCleanup {
+    fn drop(&mut self) {
+        lock_unpoisoned(&self.registry).remove(&self.request_id);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Async-callback plumbing
 // ---------------------------------------------------------------------------
@@ -215,7 +243,7 @@ fn register_async_request(
     handle: &FerricPinnedEngine,
     request_id: u64,
     kind: AsyncRequestKind,
-) -> Result<Arc<PreDispatchCancelToken>, FerricError> {
+) -> Result<RegisteredAsyncRequest, FerricError> {
     let mut requests = lock_unpoisoned(&handle.async_requests);
     if requests.contains_key(&request_id) {
         set_global_error(format!(
@@ -231,14 +259,13 @@ fn register_async_request(
             token: token.clone(),
         },
     );
-    Ok(token)
-}
-
-fn unregister_async_request(
-    registry: &Arc<Mutex<HashMap<u64, AsyncRequestRegistration>>>,
-    request_id: u64,
-) {
-    lock_unpoisoned(registry).remove(&request_id);
+    Ok(RegisteredAsyncRequest {
+        token,
+        cleanup: AsyncRequestCleanup {
+            registry: handle.async_requests.clone(),
+            request_id,
+        },
+    })
 }
 
 #[cfg(test)]
@@ -820,11 +847,12 @@ fn pinned_engine_run_async_impl(
         set_global_error("completion callback is null".to_string());
         return FerricError::InvalidArgument;
     };
-    let pre_dispatch = match register_async_request(handle, request_id, AsyncRequestKind::Run) {
-        Ok(token) => token,
+    let registered = match register_async_request(handle, request_id, AsyncRequestKind::Run) {
+        Ok(registered) => registered,
         Err(code) => return code,
     };
-    let registry = handle.async_requests.clone();
+    let pre_dispatch = registered.token;
+    let cleanup = registered.cleanup;
     let callback = CompletionCallback { context, func };
     let run_limit = run_limit_from_i64(limit);
 
@@ -833,7 +861,7 @@ fn pinned_engine_run_async_impl(
         pre_dispatch,
         queue_wait,
         move |result| {
-            unregister_async_request(&registry, request_id);
+            drop(cleanup);
             let pinned_result = build_run_result(request_id, &result);
             let code = pinned_result.code;
             callback.fire(code, Box::new(pinned_result));
@@ -842,10 +870,7 @@ fn pinned_engine_run_async_impl(
 
     match submission {
         Ok(()) => FerricError::Ok,
-        Err(e) => {
-            unregister_async_request(&handle.async_requests, request_id);
-            record_pinned_error(handle, &e)
-        }
+        Err(e) => record_pinned_error(handle, &e),
     }
 }
 
@@ -932,11 +957,12 @@ fn pinned_engine_load_string_async_impl(
         set_global_error("completion callback is null".to_string());
         return FerricError::InvalidArgument;
     };
-    let pre_dispatch = match register_async_request(handle, request_id, AsyncRequestKind::Load) {
-        Ok(token) => token,
+    let registered = match register_async_request(handle, request_id, AsyncRequestKind::Load) {
+        Ok(registered) => registered,
         Err(code) => return code,
     };
-    let registry = handle.async_requests.clone();
+    let pre_dispatch = registered.token;
+    let cleanup = registered.cleanup;
     let callback = CompletionCallback { context, func };
 
     let submission = handle.pinned.load_str_async_cancelable_with_queue_wait(
@@ -944,7 +970,7 @@ fn pinned_engine_load_string_async_impl(
         pre_dispatch,
         queue_wait,
         move |result| {
-            unregister_async_request(&registry, request_id);
+            drop(cleanup);
             let (code, message) = match result {
                 Ok(_) => (FerricError::Ok, None),
                 Err(ref e) => (map_pinned_error(e), Some(e.to_string())),
@@ -963,10 +989,7 @@ fn pinned_engine_load_string_async_impl(
 
     match submission {
         Ok(()) => FerricError::Ok,
-        Err(e) => {
-            unregister_async_request(&handle.async_requests, request_id);
-            record_pinned_error(handle, &e)
-        }
+        Err(e) => record_pinned_error(handle, &e),
     }
 }
 
@@ -1102,6 +1125,93 @@ pub unsafe extern "C" fn ferric_pinned_result_free(result: *mut FerricPinnedResu
         return;
     }
     drop(Box::from_raw(result));
+}
+
+#[cfg(test)]
+mod async_lifecycle_tests {
+    use std::collections::HashMap;
+    use std::sync::{mpsc, Arc, Mutex};
+    use std::time::Duration;
+
+    use super::*;
+
+    fn test_handle() -> FerricPinnedEngine {
+        FerricPinnedEngine {
+            pinned: PinnedEngine::new(PinnedEngineOptions::default()).unwrap(),
+            error_state: Mutex::new(EngineErrorState::default()),
+            error_cstring: Mutex::new(None),
+            async_requests: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    #[test]
+    fn panicking_request_removes_registry_entry_before_terminal_delivery() {
+        let handle = test_handle();
+        let registered = register_async_request(&handle, 117, AsyncRequestKind::Run).unwrap();
+        let cleanup = registered.cleanup;
+        let (result_tx, result_rx) = mpsc::channel();
+
+        handle
+            .pinned
+            .submit_with_completion(
+                |_| -> Result<(), PinnedError> {
+                    panic!("synthetic registered async request panic");
+                },
+                move |result| {
+                    drop(cleanup);
+                    result_tx.send(result).unwrap();
+                },
+            )
+            .unwrap();
+
+        let result = result_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert!(matches!(result, Err(PinnedError::Internal)));
+        assert!(!lock_unpoisoned(&handle.async_requests).contains_key(&117));
+
+        let reused = register_async_request(&handle, 117, AsyncRequestKind::Run)
+            .expect("terminal registry removal should permit request ID reuse");
+        drop(reused.cleanup);
+
+        handle
+            .pinned
+            .with_engine(|_| Ok(()))
+            .expect("worker should serve a later request");
+        handle.pinned.close().unwrap();
+    }
+
+    #[test]
+    fn internal_pinned_error_maps_to_internal_ffi_result() {
+        let result = build_run_result(117, &Err(PinnedError::Internal));
+        assert_eq!(result.code, FerricError::InternalError);
+        assert_eq!(result.request_id, 117);
+        assert!(matches!(result.payload, PinnedResultPayload::Empty));
+        assert_eq!(
+            result
+                .message
+                .as_ref()
+                .and_then(|message| message.to_str().ok()),
+            Some("pinned engine request failed internally")
+        );
+    }
+
+    #[test]
+    fn rejected_submission_drops_its_registry_cleanup_guard() {
+        let handle = test_handle();
+        handle.pinned.close().unwrap();
+        let registered = register_async_request(&handle, 118, AsyncRequestKind::Load).unwrap();
+        let cleanup = registered.cleanup;
+
+        let submission = handle.pinned.submit_with_completion(
+            |_| Ok(()),
+            move |_| {
+                drop(cleanup);
+                panic!("rejected request must not complete");
+            },
+        );
+
+        assert!(matches!(submission, Err(PinnedError::Closed)));
+        assert!(!lock_unpoisoned(&handle.async_requests).contains_key(&118));
+    }
 }
 
 #[cfg(test)]

--- a/crates/ferric-rules-ffi/src/tests/header.rs
+++ b/crates/ferric-rules-ffi/src/tests/header.rs
@@ -252,6 +252,7 @@ fn ci_runs_pinned_async_completion_race_under_thread_sanitizer() {
         "-Zbuild-std=std,panic_unwind",
         "cancellation_racing_operation_panic_finalizes_once",
         "--exact",
+        "test result: ok. 1 passed;",
     ] {
         assert!(
             script.contains(required),

--- a/crates/ferric-rules-ffi/src/tests/header.rs
+++ b/crates/ferric-rules-ffi/src/tests/header.rs
@@ -42,6 +42,17 @@ fn read_tsan_harness() -> String {
         .unwrap_or_else(|_| panic!("TSan harness not found at {}", script_path.display()))
 }
 
+fn read_pinned_async_tsan_harness() -> String {
+    let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let script_path = crate_dir.join("../../scripts/pinned-async-tsan.sh");
+    std::fs::read_to_string(&script_path).unwrap_or_else(|_| {
+        panic!(
+            "pinned async TSan harness not found at {}",
+            script_path.display()
+        )
+    })
+}
+
 fn read_panic_harness() -> String {
     let crate_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
     let script_path = crate_dir.join("../../scripts/ffi-panic-harness.sh");
@@ -173,6 +184,23 @@ fn header_documents_cancel_and_submission_race() {
 }
 
 #[test]
+fn header_documents_exactly_once_async_terminal_contract() {
+    let header = read_committed_header();
+    for required in [
+        "Every accepted operation removes its registry entry",
+        "invokes completion exactly once",
+        "contained operation panic reports",
+        "FERRIC_ERROR_INTERNAL_ERROR",
+        "request_id is reusable from the callback",
+    ] {
+        assert!(
+            header.contains(required),
+            "pinned async terminal contract is missing from ferric.h: {required}"
+        );
+    }
+}
+
+#[test]
 fn header_documents_completion_callback_unwind_contract() {
     let header = read_committed_header();
     assert!(
@@ -210,6 +238,26 @@ fn ci_runs_mixed_language_thread_sanitizer_harness() {
         workflow.contains("just ffi-tsan-harness"),
         "CI must run the mixed Rust/C TSan harness"
     );
+}
+
+#[test]
+fn ci_runs_pinned_async_completion_race_under_thread_sanitizer() {
+    let workflow = read_ci_workflow();
+    assert!(workflow.contains("Pinned Async Completion (ThreadSanitizer)"));
+    assert!(workflow.contains("just pinned-async-tsan"));
+
+    let script = read_pinned_async_tsan_harness();
+    for required in [
+        "-Zsanitizer=thread",
+        "-Zbuild-std=std,panic_unwind",
+        "cancellation_racing_operation_panic_finalizes_once",
+        "--exact",
+    ] {
+        assert!(
+            script.contains(required),
+            "pinned async TSan harness is missing required coverage: {required}"
+        );
+    }
 }
 
 #[test]

--- a/crates/ferric-rules-pinned/src/engine.rs
+++ b/crates/ferric-rules-pinned/src/engine.rs
@@ -172,7 +172,7 @@ impl PinnedEngine {
             return Err(PinnedError::ReentrantCall);
         }
         let (tx, rx) = mpsc::channel::<Result<R, PinnedError>>();
-        let req: Request = Box::new(move |engine: &mut Engine| {
+        let req = Request::new(move |engine: &mut Engine| {
             let result = f(engine);
             // Caller may have abandoned; send failure is fine.
             let _ = tx.send(result);
@@ -237,7 +237,7 @@ impl PinnedEngine {
     where
         F: FnOnce(&mut Engine) + Send + 'static,
     {
-        let req: Request = Box::new(f);
+        let req = Request::new(f);
         self.send_request(req, QueueWait::NoWait, None)
     }
 
@@ -246,8 +246,35 @@ impl PinnedEngine {
     where
         F: FnOnce(&mut Engine) + Send + 'static,
     {
-        let req: Request = Box::new(f);
+        let req = Request::new(f);
         self.send_request(req, wait, None)
+    }
+
+    /// Submit a typed asynchronous operation with an exactly-once completion.
+    ///
+    /// Once submission succeeds, `completion` is invoked once on the worker
+    /// thread with the operation result. A panic in `operation` is contained
+    /// and reported as [`PinnedError::Internal`]. A synchronous submission
+    /// error means the request was not accepted and `completion` will not run.
+    /// The completion is consumed before invocation; if it panics, the worker
+    /// contains that panic without retrying it. As with the typed async
+    /// helpers, completion work must be transport-only and must not block or
+    /// synchronously re-enter this engine.
+    pub fn submit_with_completion<T, F, C>(
+        &self,
+        operation: F,
+        completion: C,
+    ) -> Result<(), PinnedError>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Engine) -> Result<T, PinnedError> + Send + 'static,
+        C: FnOnce(Result<T, PinnedError>) + Send + 'static,
+    {
+        self.send_request(
+            Request::with_completion(operation, completion),
+            QueueWait::NoWait,
+            None,
+        )
     }
 
     /// Async variant of [`Self::run`].
@@ -315,23 +342,25 @@ impl PinnedEngine {
         let cancel_token = request_cancel.run_cancel_flag();
         let closed = self.inner.closed.clone();
         let admission_cancel = request_cancel.clone();
-        let req: Request = Box::new(move |engine| {
-            if let Err(err) = request_cancel.begin() {
-                let _ = request_cancel.finish();
-                completion(Err(err));
-                return;
-            }
-            let guard = cancel_state.activate(cancel_token.clone());
-            let mut result = crate::worker::run_with_cancel(engine, limit, &cancel_token, &closed)
-                .map_err(PinnedError::from);
-            drop(guard);
-            if request_cancel.finish() {
-                if let Ok(run_result) = &mut result {
-                    run_result.halt_reason = ferric_rules_runtime::HaltReason::HaltRequested;
+        let completion_cancel = request_cancel.clone();
+        let req = Request::with_completion(
+            move |engine| {
+                request_cancel.begin()?;
+                let guard = cancel_state.activate(cancel_token.clone());
+                let result = crate::worker::run_with_cancel(engine, limit, &cancel_token, &closed)
+                    .map_err(PinnedError::from);
+                drop(guard);
+                result
+            },
+            move |mut result| {
+                if completion_cancel.finish() {
+                    if let Ok(run_result) = &mut result {
+                        run_result.halt_reason = ferric_rules_runtime::HaltReason::HaltRequested;
+                    }
                 }
-            }
-            completion(result);
-        });
+                completion(result);
+            },
+        );
         self.send_request(req, queue_wait, Some(&admission_cancel))
     }
 
@@ -391,16 +420,17 @@ impl PinnedEngine {
         F: FnOnce(Result<ferric_rules_runtime::LoadResult, PinnedError>) + Send + 'static,
     {
         let admission_cancel = request_cancel.clone();
-        let req: Request = Box::new(move |engine| {
-            if let Err(err) = request_cancel.begin() {
-                let _ = request_cancel.finish();
-                completion(Err(err));
-                return;
-            }
-            let result = engine.load_str(&source).map_err(PinnedError::from);
-            let _ = request_cancel.finish();
-            completion(result);
-        });
+        let completion_cancel = request_cancel.clone();
+        let req = Request::with_completion(
+            move |engine| {
+                request_cancel.begin()?;
+                engine.load_str(&source).map_err(PinnedError::from)
+            },
+            move |result| {
+                let _ = completion_cancel.finish();
+                completion(result);
+            },
+        );
         self.send_request(req, queue_wait, Some(&admission_cancel))
     }
 
@@ -759,5 +789,65 @@ mod policy_tests {
             (1..=5).contains(&delta),
             "expected 1..=5 batches, got {delta}"
         );
+    }
+}
+
+#[cfg(test)]
+mod completion_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{mpsc, Arc};
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn cancellation_racing_operation_panic_finalizes_once() {
+        let engine = PinnedEngine::new(PinnedEngineOptions::default()).unwrap();
+        let completion_count = Arc::new(AtomicUsize::new(0));
+
+        for expected_count in 1..=128 {
+            let token = Arc::new(PreDispatchCancelToken::new());
+            let operation_token = token.clone();
+            let completion_token = token.clone();
+            let admission_token = token.clone();
+            let callback_count = completion_count.clone();
+            let (entered_tx, entered_rx) = mpsc::channel();
+            let (release_tx, release_rx) = mpsc::channel();
+            let (result_tx, result_rx) = mpsc::channel();
+
+            let request = Request::with_completion(
+                move |_| -> Result<(), PinnedError> {
+                    operation_token.begin()?;
+                    entered_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    panic!("synthetic cancellation/panic race");
+                },
+                move |result| {
+                    let cancellation_won = completion_token.finish();
+                    callback_count.fetch_add(1, Ordering::SeqCst);
+                    result_tx.send((result, cancellation_won)).unwrap();
+                },
+            );
+            engine
+                .send_request(request, QueueWait::NoWait, Some(&admission_token))
+                .unwrap();
+
+            entered_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+            assert!(token.cancel_run());
+            release_tx.send(()).unwrap();
+
+            let (result, cancellation_won) =
+                result_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+            assert!(matches!(result, Err(PinnedError::Internal)));
+            assert!(cancellation_won);
+            assert!(!token.is_started());
+            assert_eq!(completion_count.load(Ordering::SeqCst), expected_count);
+        }
+
+        engine
+            .with_engine(|_| Ok(()))
+            .expect("worker should remain usable after cancellation/panic race");
+        assert_eq!(completion_count.load(Ordering::SeqCst), 128);
+        engine.close().unwrap();
     }
 }

--- a/crates/ferric-rules-pinned/src/engine.rs
+++ b/crates/ferric-rules-pinned/src/engine.rs
@@ -795,7 +795,8 @@ mod policy_tests {
 #[cfg(test)]
 mod completion_tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::{mpsc, Arc};
+    use std::sync::{mpsc, Arc, Barrier};
+    use std::thread;
     use std::time::Duration;
 
     use super::*;
@@ -812,14 +813,15 @@ mod completion_tests {
             let admission_token = token.clone();
             let callback_count = completion_count.clone();
             let (entered_tx, entered_rx) = mpsc::channel();
-            let (release_tx, release_rx) = mpsc::channel();
             let (result_tx, result_rx) = mpsc::channel();
+            let race_start = Arc::new(Barrier::new(2));
+            let operation_start = race_start.clone();
 
             let request = Request::with_completion(
                 move |_| -> Result<(), PinnedError> {
                     operation_token.begin()?;
                     entered_tx.send(()).unwrap();
-                    release_rx.recv().unwrap();
+                    operation_start.wait();
                     panic!("synthetic cancellation/panic race");
                 },
                 move |result| {
@@ -833,13 +835,17 @@ mod completion_tests {
                 .unwrap();
 
             entered_rx.recv_timeout(Duration::from_secs(2)).unwrap();
-            assert!(token.cancel_run());
-            release_tx.send(()).unwrap();
+            let cancellation_token = token.clone();
+            let cancellation = thread::spawn(move || {
+                race_start.wait();
+                cancellation_token.cancel_run()
+            });
 
             let (result, cancellation_won) =
                 result_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+            let cancellation_requested = cancellation.join().unwrap();
             assert!(matches!(result, Err(PinnedError::Internal)));
-            assert!(cancellation_won);
+            assert_eq!(cancellation_won, cancellation_requested);
             assert!(!token.is_started());
             assert_eq!(completion_count.load(Ordering::SeqCst), expected_count);
         }

--- a/crates/ferric-rules-pinned/src/error.rs
+++ b/crates/ferric-rules-pinned/src/error.rs
@@ -12,8 +12,8 @@ use ferric_rules_runtime::SerializationError;
 
 /// Error returned by [`PinnedEngine`](crate::PinnedEngine) operations.
 ///
-/// The five `Pinned*`-style variants describe scheduling failures owned by
-/// this crate; the rest wrap errors from the underlying engine.
+/// The scheduling and internal variants describe failures owned by this
+/// crate; the rest wrap errors from the underlying engine.
 #[derive(Debug)]
 pub enum PinnedError {
     /// Handle has been closed and no longer accepts requests.
@@ -24,6 +24,8 @@ pub enum PinnedError {
     QueueFull,
     /// Worker thread is unreachable (panicked or terminated unexpectedly).
     DispatchFailed,
+    /// An accepted asynchronous request panicked while executing.
+    Internal,
     /// A synchronous pinned operation was called from its own worker thread.
     ReentrantCall,
     /// Engine construction failed.
@@ -44,6 +46,7 @@ impl fmt::Display for PinnedError {
             Self::Canceled => f.write_str("request canceled before completion"),
             Self::QueueFull => f.write_str("pinned engine request queue is full"),
             Self::DispatchFailed => f.write_str("pinned engine worker stopped unexpectedly"),
+            Self::Internal => f.write_str("pinned engine request failed internally"),
             Self::ReentrantCall => {
                 f.write_str("synchronous pinned engine call from its worker would deadlock")
             }
@@ -74,6 +77,7 @@ impl Error for PinnedError {
             | Self::Canceled
             | Self::QueueFull
             | Self::DispatchFailed
+            | Self::Internal
             | Self::ReentrantCall => None,
         }
     }

--- a/crates/ferric-rules-pinned/src/lib.rs
+++ b/crates/ferric-rules-pinned/src/lib.rs
@@ -11,10 +11,10 @@
 //!
 //! - The handle is `Send + Sync`. The underlying `Engine` never leaves the
 //!   worker thread, so its `!Send + !Sync` invariants are preserved.
-//! - Requests are erased into `Box<dyn FnOnce(&mut Engine) + Send + 'static>`.
-//!   Typed operations (`run`, `load_str`, …) are thin wrappers that construct
-//!   the closure and ship the typed `Result` back through a per-request
-//!   oneshot.
+//! - Requests are erased into worker-owned envelopes. Completion-aware
+//!   envelopes keep the operation separate from one terminal `FnOnce`, so an
+//!   operation panic becomes [`PinnedError::Internal`] and still consumes the
+//!   completion exactly once.
 //! - [`PinnedEngine::halt`] flips the active run's cancellation token; the
 //!   worker bounds [`Engine::run`] into 64-firing chunks and checks the token
 //!   between chunks. Idle calls are non-latching no-ops.

--- a/crates/ferric-rules-pinned/src/request.rs
+++ b/crates/ferric-rules-pinned/src/request.rs
@@ -1,10 +1,55 @@
-//! The opaque request type shipped from public-handle threads to the worker.
+//! Type-erased request envelopes shipped to the worker.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use ferric_rules_runtime::Engine;
 
 /// A unit of work submitted to the pinned worker.
 ///
-/// The closure captures its inputs and a per-request oneshot sender for the
-/// typed reply. The worker simply invokes it with `&mut Engine` — it does not
-/// need to know what typed operation lives inside.
-pub(crate) type Request = Box<dyn FnOnce(&mut Engine) + Send + 'static>;
+/// Completion-aware requests keep the fallible operation separate from their
+/// terminal callback. That separation lets the envelope convert an operation
+/// panic into a typed error before consuming the callback exactly once.
+pub(crate) struct Request {
+    dispatch: Box<dyn FnOnce(&mut Engine) + Send + 'static>,
+}
+
+impl Request {
+    pub(crate) fn new<F>(operation: F) -> Self
+    where
+        F: FnOnce(&mut Engine) + Send + 'static,
+    {
+        Self {
+            dispatch: Box::new(operation),
+        }
+    }
+
+    pub(crate) fn with_completion<T, F, C>(operation: F, completion: C) -> Self
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Engine) -> Result<T, crate::PinnedError> + Send + 'static,
+        C: FnOnce(Result<T, crate::PinnedError>) + Send + 'static,
+    {
+        Self::new(move |engine| {
+            let result = match catch_unwind(AssertUnwindSafe(|| operation(engine))) {
+                Ok(result) => result,
+                Err(payload) => {
+                    discard_panic_payload(payload);
+                    Err(crate::PinnedError::Internal)
+                }
+            };
+            completion(result);
+        })
+    }
+
+    pub(crate) fn dispatch(self, engine: &mut Engine) {
+        (self.dispatch)(engine);
+    }
+}
+
+/// Dispose of a caught payload without allowing an untrusted destructor to
+/// terminate the worker with a secondary panic.
+pub(crate) fn discard_panic_payload(payload: Box<dyn std::any::Any + Send>) {
+    if let Err(secondary_payload) = catch_unwind(AssertUnwindSafe(|| drop(payload))) {
+        std::mem::forget(secondary_payload);
+    }
+}

--- a/crates/ferric-rules-pinned/src/worker.rs
+++ b/crates/ferric-rules-pinned/src/worker.rs
@@ -18,7 +18,7 @@ use ferric_rules_runtime::{Engine, HaltReason, RunLimit, RunResult};
 use crate::autorelease;
 use crate::error::PinnedError;
 use crate::options::ResolvedOptions;
-use crate::request::Request;
+use crate::request::{discard_panic_payload, Request};
 
 /// Maximum number of rule firings between cancellation checks inside
 /// [`run_with_cancel`].
@@ -93,7 +93,9 @@ fn dispatch_request(engine: &mut Engine, request: Request) {
     // One misbehaving request must not terminate the worker and drop every
     // queued completion. Sync requests observe their dropped response sender
     // as DispatchFailed; later requests remain available for dispatch.
-    drop(catch_unwind(AssertUnwindSafe(|| request(engine))));
+    if let Err(payload) = catch_unwind(AssertUnwindSafe(|| request.dispatch(engine))) {
+        discard_panic_payload(payload);
+    }
 }
 
 fn drain_more(rx: &Receiver<Request>, engine: &mut Engine, max: usize) {

--- a/crates/ferric-rules-pinned/tests/panic_propagation.rs
+++ b/crates/ferric-rules-pinned/tests/panic_propagation.rs
@@ -1,7 +1,5 @@
-//! Request panics surface as `DispatchFailed` without killing the worker.
-//!
-//! Note: in release builds with the `ffi-abort` profile, panics abort the
-//! process. These tests run under the default `dev` profile which unwinds.
+//! Synchronous request panics surface as `DispatchFailed`; completion-aware
+//! asynchronous panics surface as `Internal`. The worker survives both.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};

--- a/crates/ferric-rules-pinned/tests/panic_propagation.rs
+++ b/crates/ferric-rules-pinned/tests/panic_propagation.rs
@@ -3,6 +3,7 @@
 //! Note: in release builds with the `ffi-abort` profile, panics abort the
 //! process. These tests run under the default `dev` profile which unwinds.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
@@ -64,5 +65,66 @@ fn panic_does_not_drop_queued_async_completion() {
     engine
         .with_engine(|_| Ok(()))
         .expect("worker should remain usable");
+    engine.close().unwrap();
+}
+
+#[test]
+fn panicking_async_operation_completes_once_with_internal_error() {
+    let engine = PinnedEngine::new(PinnedEngineOptions::default()).unwrap();
+    let completion_count = Arc::new(AtomicUsize::new(0));
+    let callback_count = completion_count.clone();
+    let (completion_tx, completion_rx) = mpsc::channel();
+
+    engine
+        .submit_with_completion(
+            |_| -> Result<(), PinnedError> {
+                panic!("synthetic async request panic");
+            },
+            move |result| {
+                callback_count.fetch_add(1, Ordering::SeqCst);
+                completion_tx.send(result).unwrap();
+            },
+        )
+        .unwrap();
+
+    let result = completion_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("accepted panicking request did not complete");
+    assert!(matches!(result, Err(PinnedError::Internal)));
+    assert_eq!(completion_count.load(Ordering::SeqCst), 1);
+
+    engine
+        .with_engine(|_| Ok(()))
+        .expect("worker should remain usable after contained async panic");
+    thread::sleep(Duration::from_millis(20));
+    assert_eq!(completion_count.load(Ordering::SeqCst), 1);
+    engine.close().unwrap();
+}
+
+#[test]
+fn panicking_completion_is_consumed_before_worker_containment() {
+    let engine = PinnedEngine::new(PinnedEngineOptions::default()).unwrap();
+    let completion_count = Arc::new(AtomicUsize::new(0));
+    let callback_count = completion_count.clone();
+    let (entered_tx, entered_rx) = mpsc::channel();
+
+    engine
+        .submit_with_completion(
+            |_| Ok(()),
+            move |_| {
+                callback_count.fetch_add(1, Ordering::SeqCst);
+                entered_tx.send(()).unwrap();
+                panic!("synthetic completion panic");
+            },
+        )
+        .unwrap();
+
+    entered_rx
+        .recv_timeout(Duration::from_secs(2))
+        .expect("completion did not run");
+    engine
+        .with_engine(|_| Ok(()))
+        .expect("worker should remain usable after callback panic");
+    assert_eq!(completion_count.load(Ordering::SeqCst), 1);
     engine.close().unwrap();
 }

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1009,6 +1009,11 @@ result: the registry entry is removed, the callback fires exactly once with
 `FERRIC_ERROR_INTERNAL_ERROR`, and later work continues on the same worker.
 Registry cleanup happens before callback invocation, so the completed
 `request_id` is reusable at that point.
+The terminal diagnostic is carried by the result handle rather than written to
+the global or per-engine last-error channel. Although the worker remains
+available, the panic may have left logical engine state partially updated;
+consumers that require a known state should reset or recreate the engine before
+relying on later results.
 Containment does not cover non-unwinding termination such as allocator
 abort/OOM or an explicit process abort. Foreign callbacks must still return
 normally and obey their own no-unwind contract.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1003,6 +1003,12 @@ Return sentinels are fixed by category:
 
 An async submission-wrapper panic is a synchronous rejection: it returns
 `FERRIC_ERROR_INTERNAL_ERROR` and does not invoke the completion callback.
+After a pinned async submission returns `FERRIC_ERROR_OK`, an ordinary Rust
+panic while executing that accepted request is instead a terminal asynchronous
+result: the registry entry is removed, the callback fires exactly once with
+`FERRIC_ERROR_INTERNAL_ERROR`, and later work continues on the same worker.
+Registry cleanup happens before callback invocation, so the completed
+`request_id` is reusable at that point.
 Containment does not cover non-unwinding termination such as allocator
 abort/OOM or an explicit process abort. Foreign callbacks must still return
 normally and obey their own no-unwind contract.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -87,6 +87,16 @@ Thin re-export crate: `ferric_rules::core`, `ferric_rules::parser`, `ferric_rule
   run via `just scaling-check`.
 - `benches/` — Criterion suite (see §5).
 
+### `ferric-rules-pinned`
+
+Rust-owned worker-thread execution for embedding contexts that cannot preserve
+the runtime engine's thread affinity. Requests use a bounded FIFO queue with
+cooperative cancellation and optional Apple autorelease-pool policies.
+Completion-aware request envelopes keep the operation separate from one
+terminal callback: an ordinary operation panic becomes `PinnedError::Internal`,
+the callback still runs exactly once, and the worker continues serving later
+requests.
+
 ### `ferric-rules-ffi`
 
 C-ABI wrapper over the runtime. Produces `libferric_rules_ffi.{a,dylib,so}` plus

--- a/justfile
+++ b/justfile
@@ -84,6 +84,11 @@ ffi-panic-harness:
 ffi-tsan-harness:
     ./scripts/ffi-tsan-harness.sh
 
+# Repeat the cancellation/panic completion race under Rust ThreadSanitizer
+# (x86_64 Linux; pure Rust, with a pinned nightly and instrumented std)
+pinned-async-tsan:
+    bash ./scripts/pinned-async-tsan.sh
+
 # Build the Rust static library and Go cgo binding with AddressSanitizer, then
 # run the real-handle post-Close lifecycle regression (Linux amd64/arm64)
 ffi-go-asan-harness:

--- a/scripts/pinned-async-tsan.sh
+++ b/scripts/pinned-async-tsan.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Repeat the accepted-request cancellation/panic race with the pinned worker,
+# completion envelope, and Rust standard library instrumented by TSan.
+set -euo pipefail
+
+task_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$task_root"
+
+if [[ $(uname -s) != Linux || $(uname -m) != x86_64 ]]; then
+    echo "pinned-async-tsan: requires x86_64 Linux" >&2
+    exit 1
+fi
+
+tsan_toolchain="${FERRIC_TSAN_TOOLCHAIN:-nightly-2025-11-04}"
+tsan_target="x86_64-unknown-linux-gnu"
+outdir="$task_root/target/pinned-async-tsan"
+
+if ! command -v "cargo" >/dev/null 2>&1; then
+    echo "pinned-async-tsan: cargo is required" >&2
+    exit 1
+fi
+
+CARGO_TARGET_DIR="$outdir" \
+RUSTFLAGS="-Zsanitizer=thread -Cforce-frame-pointers=yes" \
+TSAN_OPTIONS="halt_on_error=1:exitcode=66:detect_deadlocks=1" \
+    cargo +"$tsan_toolchain" test \
+        --locked \
+        -Zbuild-std=std,panic_unwind \
+        --target "$tsan_target" \
+        -p ferric-rules-pinned \
+        --lib \
+        engine::completion_tests::cancellation_racing_operation_panic_finalizes_once \
+        -- \
+        --exact

--- a/scripts/pinned-async-tsan.sh
+++ b/scripts/pinned-async-tsan.sh
@@ -20,6 +20,9 @@ if ! command -v "cargo" >/dev/null 2>&1; then
     exit 1
 fi
 
+tsan_output="$(mktemp "${TMPDIR:-/tmp}/ferric-pinned-async-tsan.XXXXXX")"
+trap 'rm -f "$tsan_output"' EXIT
+
 CARGO_TARGET_DIR="$outdir" \
 RUSTFLAGS="-Zsanitizer=thread -Cforce-frame-pointers=yes" \
 TSAN_OPTIONS="halt_on_error=1:exitcode=66:detect_deadlocks=1" \
@@ -31,4 +34,10 @@ TSAN_OPTIONS="halt_on_error=1:exitcode=66:detect_deadlocks=1" \
         --lib \
         engine::completion_tests::cancellation_racing_operation_panic_finalizes_once \
         -- \
-        --exact
+        --exact \
+        2>&1 | tee "$tsan_output"
+
+if ! grep -Fq "test result: ok. 1 passed;" "$tsan_output"; then
+    echo "pinned-async-tsan: exact filter did not run one passing test" >&2
+    exit 1
+fi


### PR DESCRIPTION
Closes #117

## Scope

FR-CABI-007 moves typed asynchronous execution into worker-owned completion-aware request envelopes. The envelope catches an ordinary operation panic, converts it to `PinnedError::Internal`, finalizes cancellation state, and consumes one terminal `FnOnce` completion. The C ABI now maps that terminal error to `FERRIC_ERROR_INTERNAL_ERROR` and gives each registration one cleanup guard that removes the request ID before callback invocation, including rejected submissions.

## Stack

- Immediate predecessor: https://github.com/plx/ferric-rules/pull/264
- Earlier included PRs: none
- Required merge order: https://github.com/plx/ferric-rules/pull/264 → this PR
- Tests require predecessor code: yes
- Branch point: `1f2004b6de8ca59335687444ace6682ef89ddba2`

## Red-before-fix evidence

`cargo test -p ferric-rules-pinned --test panic_propagation panicking_async_operation_completes_once_with_internal_error -- --exact --nocapture` failed: the worker contained the synthetic operation panic, but the accepted request dropped its completion sender and the receiver reported `Disconnected` instead of receiving a terminal error.

## Validation

- `just preflight-pr` — passed after the final review follow-ups (formatting, clippy, workspace tests/checks, examples, Python tools/bindings, Go lint, TypeScript lint, and license generation)
- `cargo test -p ferric-rules-pinned` — passed, including exactly-once operation-panic and callback-panic coverage plus 128 genuine cancellation-versus-panic races
- `cargo test -p ferric-rules-ffi async_lifecycle_tests` — passed; internal mapping, registry cleanup, rejected-submission cleanup, ID reuse, and later worker service verified without a native pointer harness
- `cargo clippy -p ferric-rules-pinned -p ferric-rules-ffi --all-targets -- -D warnings` — passed
- `cargo build -p ferric-rules-ffi --profile ffi-dev` — passed; generated C and Go headers are identical
- `bash -n scripts/pinned-async-tsan.sh` — passed; hosted `Pinned Async Completion (ThreadSanitizer)` also passed on x86_64 Linux and now fails if its exact filter does not run one test
- All 32 hosted checks passed on `d2e9816`, including FFI panic containment, both TSan jobs, all bindings/packages, and performance assessment
- Independent final reviews — Claude Opus 5 reported no blocking findings; the hosted Claude review passed on the final head
- `RUSTDOCFLAGS='-D warnings' cargo doc -p ferric-rules-pinned --no-deps` — optional strict probe remains red on seven pre-existing private/broken intra-doc links; standard doc tests pass in `just preflight-pr`, and this PR introduces no failing link

## Acceptance criteria

- Every accepted typed async operation has one worker-owned terminal completion path. Existing success, load-error, cancellation, and close-drain tests remain green; the new synthetic panic regression completes once with `PinnedError::Internal`.
- Run and load cancellation state is finalized after either an ordinary result or a contained panic. The repeated cancellation/panic race observes one completion per accepted request and leaves every token finished.
- FFI registrations have one cleanup owner. It is dropped before terminal delivery, or when an unaccepted request is dropped, eliminating duplicated cleanup branches and permitting request-ID reuse after completion.
- `PinnedError::Internal` maps to a result carrying `FERRIC_ERROR_INTERNAL_ERROR`; later work on the same worker succeeds after both operation and completion panics.
- Duplicate terminal delivery is structurally unavailable: the fallible operation never owns the completion, and the envelope consumes one `FnOnce` only after panic conversion.
- Hosted `Pinned Async Completion (ThreadSanitizer)` repeats the cancellation/panic callback-count race 128 times with Rust and `std` instrumented.

## Residual risks

- Containment applies to unwinding Rust panics, not allocator abort/OOM, explicit abort, or other non-unwinding termination. The public C contract documents that boundary.
- A contained panic may leave logical engine state partially updated even though the worker survives. The compatibility contract advises consumers that need a known state to reset or recreate the engine before relying on later results.