### PR TITLE
[FR-CABI-009] Expose logical-run continuation for batched and cancelable hosts

### DIFF
--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -156,7 +156,14 @@
  *   owner thread.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and
- *   starts any later logical run with ferric_engine_run_ex().
+ *   starts any later logical run with ferric_engine_run_ex(). The
+ *   agenda is left intact.
+ * - Canceling does not guarantee an un-halted engine. A chunk that
+ *   lands exactly on an activation calling (halt) still reports
+ *   LIMIT_REACHED; the pending halt surfaces as HALT_REQUESTED only on
+ *   the next chunk that can run. Query ferric_engine_is_halted() if
+ *   that distinction matters. ferric_engine_run_ex() clears the flag
+ *   either way when it starts the next logical run.
  *
  * ============================================================
  * PINNED EXECUTION (ferric_pinned_*)
@@ -1179,7 +1186,11 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
 //
 // Host cancellation is distinct from an engine halt: stop calling this
 // function, report cancellation in the host API, and use
-// `ferric_engine_run_ex` to start the next logical run.
+// `ferric_engine_run_ex` to start the next logical run. This leaves the agenda
+// intact, but does not guarantee an un-halted engine — a chunk that lands
+// exactly on an activation calling `(halt)` still reports `LimitReached`, and
+// the pending halt surfaces only on the next chunk that can run. Query
+// `ferric_engine_is_halted` if that distinction matters.
 //
 // # Safety
 //

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -127,6 +127,32 @@
  *    before including this header to suppress.
  *
  * ============================================================
+ * LOGICAL RUN CONTINUATION
+ * ============================================================
+ *
+ * ferric_engine_run_ex() always starts a fresh logical run. It
+ * clears any prior halt request and action diagnostics, but does
+ * not reset working memory, the agenda, globals, or output.
+ *
+ * When it returns FERRIC_HALT_REASON_LIMIT_REACHED, a host may call
+ * ferric_engine_continue_run_ex() to execute another bounded chunk
+ * of that same logical run. Continuation preserves the pending halt
+ * flag and action diagnostics, so exact-boundary halt requests and
+ * early-chunk diagnostics remain visible.
+ *
+ * - Each call reports only that chunk's fired count. Hosts must sum
+ *   chunk counts for a logical-run total.
+ * - LIMIT_REACHED keeps continuation eligibility. AGENDA_EMPTY,
+ *   HALT_REQUESTED, and ACTION_ERROR are terminal and close it.
+ * - Read-only raw-engine queries are allowed between chunks. A fresh
+ *   run or another runtime-mutating raw-engine call closes the
+ *   continuation; later continuation returns INVALID_ARGUMENT and
+ *   leaves output parameters unchanged.
+ * - Host cancellation is not HALT_REQUESTED. A cancelable binding
+ *   stops submitting chunks, reports its own canceled outcome, and
+ *   starts any later logical run with ferric_engine_run_ex().
+ *
+ * ============================================================
  * PINNED EXECUTION (ferric_pinned_*)
  * ============================================================
  *
@@ -279,7 +305,8 @@ typedef enum FerricFactType {
     FERRIC_FACT_TYPE_TEMPLATE = 1
 } FerricFactType;
 
-// C-facing halt reason returned by `ferric_engine_run_ex`.
+// C-facing halt reason returned by `ferric_engine_run_ex` and
+// `ferric_engine_continue_run_ex`.
 typedef enum FerricHaltReason {
     FERRIC_HALT_REASON_AGENDA_EMPTY = 0,
     FERRIC_HALT_REASON_LIMIT_REACHED = 1,
@@ -1104,8 +1131,14 @@ enum FerricError ferric_engine_clear_output(struct FerricEngine *engine, const c
 
 // Extended run with halt reason output.
 //
-// Same limit semantics as `ferric_engine_run` (negative = unlimited).
-// Additionally writes the halt reason to `*out_reason` if non-null.
+// Always starts a fresh logical run, clearing any prior halt request and
+// action diagnostics without resetting working memory, the agenda, globals,
+// or output. Same limit semantics as `ferric_engine_run` (negative =
+// unlimited). Additionally writes the halt reason to `*out_reason` if
+// non-null.
+//
+// A successful `LimitReached` result may be continued with
+// `ferric_engine_continue_run_ex`. Other halt reasons are terminal.
 //
 // # Safety
 //
@@ -1116,6 +1149,36 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
                                       int64_t limit,
                                       uint64_t *out_fired,
                                       enum FerricHaltReason *out_reason);
+
+// Continue a logical run previously started by `ferric_engine_run_ex`.
+//
+// Call this only after `ferric_engine_run_ex` or a previous continuation
+// returned `FerricHaltReason::LimitReached`. Unlike a fresh run, continuation
+// preserves a pending halt request and action diagnostics from earlier chunks.
+//
+// Each successful call writes the number of rules fired by that chunk, not a
+// cumulative total. Hosts should accumulate `out_fired` across chunks. A
+// result other than `LimitReached` is terminal for the logical run.
+//
+// Read-only raw-engine queries may be called between chunks. Starting a fresh
+// run or calling another mutable raw-engine function ends the current logical
+// run; a later continuation attempt then returns
+// `FerricError::InvalidArgument`. On any error, output parameters are left
+// unchanged.
+//
+// Host cancellation is distinct from an engine halt: stop calling this
+// function, report cancellation in the host API, and use
+// `ferric_engine_run_ex` to start the next logical run.
+//
+// # Safety
+//
+// - `engine` must be a valid engine pointer.
+// - `out_fired` may be null.
+// - `out_reason` may be null.
+enum FerricError ferric_engine_continue_run_ex(struct FerricEngine *engine,
+                                               int64_t limit,
+                                               uint64_t *out_fired,
+                                               enum FerricHaltReason *out_reason);
 
 // Assert a template fact with named slots.
 //

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -144,9 +144,10 @@
  *   chunk counts for a logical-run total.
  * - LIMIT_REACHED keeps continuation eligibility. AGENDA_EMPTY,
  *   HALT_REQUESTED, and ACTION_ERROR are terminal and close it.
- * - Read-only raw-engine queries are allowed between chunks. A fresh
- *   run or another runtime-mutating raw-engine call closes the
- *   continuation; later continuation returns INVALID_ARGUMENT and
+ * - Read-only raw-engine queries and ferric_engine_clear_error() are
+ *   allowed between chunks. A fresh run or any other runtime-mutating
+ *   raw-engine call closes the continuation, even if that call fails.
+ *   A later continuation then returns INVALID_ARGUMENT and
  *   leaves output parameters unchanged.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and
@@ -1160,9 +1161,10 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
 // cumulative total. Hosts should accumulate `out_fired` across chunks. A
 // result other than `LimitReached` is terminal for the logical run.
 //
-// Read-only raw-engine queries may be called between chunks. Starting a fresh
-// run or calling another mutable raw-engine function ends the current logical
-// run; a later continuation attempt then returns
+// Read-only raw-engine queries and `ferric_engine_clear_error` may be called
+// between chunks. Starting a fresh run or calling any other
+// runtime-mutating raw-engine function ends the current logical run — even if
+// that call itself fails — and a later continuation attempt then returns
 // `FerricError::InvalidArgument`. On any error, output parameters are left
 // unchanged.
 //

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -149,10 +149,11 @@
  *   engine state closes the continuation, whether or not it then
  *   succeeds; a later continuation returns INVALID_ARGUMENT and
  *   leaves output parameters unchanged.
- * - A call rejected before it reaches engine state changes nothing,
- *   including continuation eligibility. A null handle, a thread
- *   affinity violation, and a reentrant call from a host callback all
- *   leave the logical run intact for the owner thread.
+ * - A call rejected before it reaches engine state changes no runtime
+ *   or continuation state, though it still publishes its documented
+ *   error. A null handle, a thread affinity violation, and a reentrant
+ *   call from a host callback all leave the logical run intact for the
+ *   owner thread.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and
  *   starts any later logical run with ferric_engine_run_ex().
@@ -1170,11 +1171,11 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
 // current logical run — whether or not it then succeeds — and a later
 // continuation attempt returns `FerricError::InvalidArgument`.
 //
-// A call rejected before it reaches engine state changes nothing, including
-// continuation eligibility: a null handle, a thread-affinity violation, and a
-// reentrant call from a host callback all leave the logical run intact for the
-// owner thread to continue. On any error, output parameters are left
-// unchanged.
+// A call rejected before it reaches engine state changes no runtime or
+// continuation state, though it still publishes its documented error: a null
+// handle, a thread-affinity violation, and a reentrant call from a host
+// callback all leave the logical run intact for the owner thread to continue.
+// On any error, output parameters are left unchanged.
 //
 // Host cancellation is distinct from an engine halt: stop calling this
 // function, report cancellation in the host API, and use

--- a/bindings/go/internal/ffi/lib/ferric.h
+++ b/bindings/go/internal/ffi/lib/ferric.h
@@ -145,10 +145,14 @@
  * - LIMIT_REACHED keeps continuation eligibility. AGENDA_EMPTY,
  *   HALT_REQUESTED, and ACTION_ERROR are terminal and close it.
  * - Read-only raw-engine queries and ferric_engine_clear_error() are
- *   allowed between chunks. A fresh run or any other runtime-mutating
- *   raw-engine call closes the continuation, even if that call fails.
- *   A later continuation then returns INVALID_ARGUMENT and
+ *   allowed between chunks. Any other raw-engine call that reaches
+ *   engine state closes the continuation, whether or not it then
+ *   succeeds; a later continuation returns INVALID_ARGUMENT and
  *   leaves output parameters unchanged.
+ * - A call rejected before it reaches engine state changes nothing,
+ *   including continuation eligibility. A null handle, a thread
+ *   affinity violation, and a reentrant call from a host callback all
+ *   leave the logical run intact for the owner thread.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and
  *   starts any later logical run with ferric_engine_run_ex().
@@ -1162,10 +1166,14 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
 // result other than `LimitReached` is terminal for the logical run.
 //
 // Read-only raw-engine queries and `ferric_engine_clear_error` may be called
-// between chunks. Starting a fresh run or calling any other
-// runtime-mutating raw-engine function ends the current logical run — even if
-// that call itself fails — and a later continuation attempt then returns
-// `FerricError::InvalidArgument`. On any error, output parameters are left
+// between chunks. Any other raw-engine call that reaches engine state ends the
+// current logical run — whether or not it then succeeds — and a later
+// continuation attempt returns `FerricError::InvalidArgument`.
+//
+// A call rejected before it reaches engine state changes nothing, including
+// continuation eligibility: a null handle, a thread-affinity violation, and a
+// reentrant call from a host callback all leave the logical run intact for the
+// owner thread to continue. On any error, output parameters are left
 // unchanged.
 //
 // Host cancellation is distinct from an engine halt: stop calling this

--- a/crates/ferric-rules-ffi/build.rs
+++ b/crates/ferric-rules-ffi/build.rs
@@ -159,7 +159,14 @@ pub const HEADER_PREAMBLE: &str = r"/*
  *   owner thread.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and
- *   starts any later logical run with ferric_engine_run_ex().
+ *   starts any later logical run with ferric_engine_run_ex(). The
+ *   agenda is left intact.
+ * - Canceling does not guarantee an un-halted engine. A chunk that
+ *   lands exactly on an activation calling (halt) still reports
+ *   LIMIT_REACHED; the pending halt surfaces as HALT_REQUESTED only on
+ *   the next chunk that can run. Query ferric_engine_is_halted() if
+ *   that distinction matters. ferric_engine_run_ex() clears the flag
+ *   either way when it starts the next logical run.
  *
  * ============================================================
  * PINNED EXECUTION (ferric_pinned_*)

--- a/crates/ferric-rules-ffi/build.rs
+++ b/crates/ferric-rules-ffi/build.rs
@@ -147,9 +147,10 @@ pub const HEADER_PREAMBLE: &str = r"/*
  *   chunk counts for a logical-run total.
  * - LIMIT_REACHED keeps continuation eligibility. AGENDA_EMPTY,
  *   HALT_REQUESTED, and ACTION_ERROR are terminal and close it.
- * - Read-only raw-engine queries are allowed between chunks. A fresh
- *   run or another runtime-mutating raw-engine call closes the
- *   continuation; later continuation returns INVALID_ARGUMENT and
+ * - Read-only raw-engine queries and ferric_engine_clear_error() are
+ *   allowed between chunks. A fresh run or any other runtime-mutating
+ *   raw-engine call closes the continuation, even if that call fails.
+ *   A later continuation then returns INVALID_ARGUMENT and
  *   leaves output parameters unchanged.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and

--- a/crates/ferric-rules-ffi/build.rs
+++ b/crates/ferric-rules-ffi/build.rs
@@ -152,10 +152,11 @@ pub const HEADER_PREAMBLE: &str = r"/*
  *   engine state closes the continuation, whether or not it then
  *   succeeds; a later continuation returns INVALID_ARGUMENT and
  *   leaves output parameters unchanged.
- * - A call rejected before it reaches engine state changes nothing,
- *   including continuation eligibility. A null handle, a thread
- *   affinity violation, and a reentrant call from a host callback all
- *   leave the logical run intact for the owner thread.
+ * - A call rejected before it reaches engine state changes no runtime
+ *   or continuation state, though it still publishes its documented
+ *   error. A null handle, a thread affinity violation, and a reentrant
+ *   call from a host callback all leave the logical run intact for the
+ *   owner thread.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and
  *   starts any later logical run with ferric_engine_run_ex().

--- a/crates/ferric-rules-ffi/build.rs
+++ b/crates/ferric-rules-ffi/build.rs
@@ -148,10 +148,14 @@ pub const HEADER_PREAMBLE: &str = r"/*
  * - LIMIT_REACHED keeps continuation eligibility. AGENDA_EMPTY,
  *   HALT_REQUESTED, and ACTION_ERROR are terminal and close it.
  * - Read-only raw-engine queries and ferric_engine_clear_error() are
- *   allowed between chunks. A fresh run or any other runtime-mutating
- *   raw-engine call closes the continuation, even if that call fails.
- *   A later continuation then returns INVALID_ARGUMENT and
+ *   allowed between chunks. Any other raw-engine call that reaches
+ *   engine state closes the continuation, whether or not it then
+ *   succeeds; a later continuation returns INVALID_ARGUMENT and
  *   leaves output parameters unchanged.
+ * - A call rejected before it reaches engine state changes nothing,
+ *   including continuation eligibility. A null handle, a thread
+ *   affinity violation, and a reentrant call from a host callback all
+ *   leave the logical run intact for the owner thread.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and
  *   starts any later logical run with ferric_engine_run_ex().

--- a/crates/ferric-rules-ffi/build.rs
+++ b/crates/ferric-rules-ffi/build.rs
@@ -130,6 +130,32 @@ pub const HEADER_PREAMBLE: &str = r"/*
  *    before including this header to suppress.
  *
  * ============================================================
+ * LOGICAL RUN CONTINUATION
+ * ============================================================
+ *
+ * ferric_engine_run_ex() always starts a fresh logical run. It
+ * clears any prior halt request and action diagnostics, but does
+ * not reset working memory, the agenda, globals, or output.
+ *
+ * When it returns FERRIC_HALT_REASON_LIMIT_REACHED, a host may call
+ * ferric_engine_continue_run_ex() to execute another bounded chunk
+ * of that same logical run. Continuation preserves the pending halt
+ * flag and action diagnostics, so exact-boundary halt requests and
+ * early-chunk diagnostics remain visible.
+ *
+ * - Each call reports only that chunk's fired count. Hosts must sum
+ *   chunk counts for a logical-run total.
+ * - LIMIT_REACHED keeps continuation eligibility. AGENDA_EMPTY,
+ *   HALT_REQUESTED, and ACTION_ERROR are terminal and close it.
+ * - Read-only raw-engine queries are allowed between chunks. A fresh
+ *   run or another runtime-mutating raw-engine call closes the
+ *   continuation; later continuation returns INVALID_ARGUMENT and
+ *   leaves output parameters unchanged.
+ * - Host cancellation is not HALT_REQUESTED. A cancelable binding
+ *   stops submitting chunks, reports its own canceled outcome, and
+ *   starts any later logical run with ferric_engine_run_ex().
+ *
+ * ============================================================
  * PINNED EXECUTION (ferric_pinned_*)
  * ============================================================
  *

--- a/crates/ferric-rules-ffi/ferric.h
+++ b/crates/ferric-rules-ffi/ferric.h
@@ -156,7 +156,14 @@
  *   owner thread.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and
- *   starts any later logical run with ferric_engine_run_ex().
+ *   starts any later logical run with ferric_engine_run_ex(). The
+ *   agenda is left intact.
+ * - Canceling does not guarantee an un-halted engine. A chunk that
+ *   lands exactly on an activation calling (halt) still reports
+ *   LIMIT_REACHED; the pending halt surfaces as HALT_REQUESTED only on
+ *   the next chunk that can run. Query ferric_engine_is_halted() if
+ *   that distinction matters. ferric_engine_run_ex() clears the flag
+ *   either way when it starts the next logical run.
  *
  * ============================================================
  * PINNED EXECUTION (ferric_pinned_*)
@@ -1179,7 +1186,11 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
 //
 // Host cancellation is distinct from an engine halt: stop calling this
 // function, report cancellation in the host API, and use
-// `ferric_engine_run_ex` to start the next logical run.
+// `ferric_engine_run_ex` to start the next logical run. This leaves the agenda
+// intact, but does not guarantee an un-halted engine — a chunk that lands
+// exactly on an activation calling `(halt)` still reports `LimitReached`, and
+// the pending halt surfaces only on the next chunk that can run. Query
+// `ferric_engine_is_halted` if that distinction matters.
 //
 // # Safety
 //

--- a/crates/ferric-rules-ffi/ferric.h
+++ b/crates/ferric-rules-ffi/ferric.h
@@ -127,6 +127,32 @@
  *    before including this header to suppress.
  *
  * ============================================================
+ * LOGICAL RUN CONTINUATION
+ * ============================================================
+ *
+ * ferric_engine_run_ex() always starts a fresh logical run. It
+ * clears any prior halt request and action diagnostics, but does
+ * not reset working memory, the agenda, globals, or output.
+ *
+ * When it returns FERRIC_HALT_REASON_LIMIT_REACHED, a host may call
+ * ferric_engine_continue_run_ex() to execute another bounded chunk
+ * of that same logical run. Continuation preserves the pending halt
+ * flag and action diagnostics, so exact-boundary halt requests and
+ * early-chunk diagnostics remain visible.
+ *
+ * - Each call reports only that chunk's fired count. Hosts must sum
+ *   chunk counts for a logical-run total.
+ * - LIMIT_REACHED keeps continuation eligibility. AGENDA_EMPTY,
+ *   HALT_REQUESTED, and ACTION_ERROR are terminal and close it.
+ * - Read-only raw-engine queries are allowed between chunks. A fresh
+ *   run or another runtime-mutating raw-engine call closes the
+ *   continuation; later continuation returns INVALID_ARGUMENT and
+ *   leaves output parameters unchanged.
+ * - Host cancellation is not HALT_REQUESTED. A cancelable binding
+ *   stops submitting chunks, reports its own canceled outcome, and
+ *   starts any later logical run with ferric_engine_run_ex().
+ *
+ * ============================================================
  * PINNED EXECUTION (ferric_pinned_*)
  * ============================================================
  *
@@ -279,7 +305,8 @@ typedef enum FerricFactType {
     FERRIC_FACT_TYPE_TEMPLATE = 1
 } FerricFactType;
 
-// C-facing halt reason returned by `ferric_engine_run_ex`.
+// C-facing halt reason returned by `ferric_engine_run_ex` and
+// `ferric_engine_continue_run_ex`.
 typedef enum FerricHaltReason {
     FERRIC_HALT_REASON_AGENDA_EMPTY = 0,
     FERRIC_HALT_REASON_LIMIT_REACHED = 1,
@@ -1104,8 +1131,14 @@ enum FerricError ferric_engine_clear_output(struct FerricEngine *engine, const c
 
 // Extended run with halt reason output.
 //
-// Same limit semantics as `ferric_engine_run` (negative = unlimited).
-// Additionally writes the halt reason to `*out_reason` if non-null.
+// Always starts a fresh logical run, clearing any prior halt request and
+// action diagnostics without resetting working memory, the agenda, globals,
+// or output. Same limit semantics as `ferric_engine_run` (negative =
+// unlimited). Additionally writes the halt reason to `*out_reason` if
+// non-null.
+//
+// A successful `LimitReached` result may be continued with
+// `ferric_engine_continue_run_ex`. Other halt reasons are terminal.
 //
 // # Safety
 //
@@ -1116,6 +1149,36 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
                                       int64_t limit,
                                       uint64_t *out_fired,
                                       enum FerricHaltReason *out_reason);
+
+// Continue a logical run previously started by `ferric_engine_run_ex`.
+//
+// Call this only after `ferric_engine_run_ex` or a previous continuation
+// returned `FerricHaltReason::LimitReached`. Unlike a fresh run, continuation
+// preserves a pending halt request and action diagnostics from earlier chunks.
+//
+// Each successful call writes the number of rules fired by that chunk, not a
+// cumulative total. Hosts should accumulate `out_fired` across chunks. A
+// result other than `LimitReached` is terminal for the logical run.
+//
+// Read-only raw-engine queries may be called between chunks. Starting a fresh
+// run or calling another mutable raw-engine function ends the current logical
+// run; a later continuation attempt then returns
+// `FerricError::InvalidArgument`. On any error, output parameters are left
+// unchanged.
+//
+// Host cancellation is distinct from an engine halt: stop calling this
+// function, report cancellation in the host API, and use
+// `ferric_engine_run_ex` to start the next logical run.
+//
+// # Safety
+//
+// - `engine` must be a valid engine pointer.
+// - `out_fired` may be null.
+// - `out_reason` may be null.
+enum FerricError ferric_engine_continue_run_ex(struct FerricEngine *engine,
+                                               int64_t limit,
+                                               uint64_t *out_fired,
+                                               enum FerricHaltReason *out_reason);
 
 // Assert a template fact with named slots.
 //

--- a/crates/ferric-rules-ffi/ferric.h
+++ b/crates/ferric-rules-ffi/ferric.h
@@ -144,9 +144,10 @@
  *   chunk counts for a logical-run total.
  * - LIMIT_REACHED keeps continuation eligibility. AGENDA_EMPTY,
  *   HALT_REQUESTED, and ACTION_ERROR are terminal and close it.
- * - Read-only raw-engine queries are allowed between chunks. A fresh
- *   run or another runtime-mutating raw-engine call closes the
- *   continuation; later continuation returns INVALID_ARGUMENT and
+ * - Read-only raw-engine queries and ferric_engine_clear_error() are
+ *   allowed between chunks. A fresh run or any other runtime-mutating
+ *   raw-engine call closes the continuation, even if that call fails.
+ *   A later continuation then returns INVALID_ARGUMENT and
  *   leaves output parameters unchanged.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and
@@ -1160,9 +1161,10 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
 // cumulative total. Hosts should accumulate `out_fired` across chunks. A
 // result other than `LimitReached` is terminal for the logical run.
 //
-// Read-only raw-engine queries may be called between chunks. Starting a fresh
-// run or calling another mutable raw-engine function ends the current logical
-// run; a later continuation attempt then returns
+// Read-only raw-engine queries and `ferric_engine_clear_error` may be called
+// between chunks. Starting a fresh run or calling any other
+// runtime-mutating raw-engine function ends the current logical run — even if
+// that call itself fails — and a later continuation attempt then returns
 // `FerricError::InvalidArgument`. On any error, output parameters are left
 // unchanged.
 //

--- a/crates/ferric-rules-ffi/ferric.h
+++ b/crates/ferric-rules-ffi/ferric.h
@@ -149,10 +149,11 @@
  *   engine state closes the continuation, whether or not it then
  *   succeeds; a later continuation returns INVALID_ARGUMENT and
  *   leaves output parameters unchanged.
- * - A call rejected before it reaches engine state changes nothing,
- *   including continuation eligibility. A null handle, a thread
- *   affinity violation, and a reentrant call from a host callback all
- *   leave the logical run intact for the owner thread.
+ * - A call rejected before it reaches engine state changes no runtime
+ *   or continuation state, though it still publishes its documented
+ *   error. A null handle, a thread affinity violation, and a reentrant
+ *   call from a host callback all leave the logical run intact for the
+ *   owner thread.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and
  *   starts any later logical run with ferric_engine_run_ex().
@@ -1170,11 +1171,11 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
 // current logical run — whether or not it then succeeds — and a later
 // continuation attempt returns `FerricError::InvalidArgument`.
 //
-// A call rejected before it reaches engine state changes nothing, including
-// continuation eligibility: a null handle, a thread-affinity violation, and a
-// reentrant call from a host callback all leave the logical run intact for the
-// owner thread to continue. On any error, output parameters are left
-// unchanged.
+// A call rejected before it reaches engine state changes no runtime or
+// continuation state, though it still publishes its documented error: a null
+// handle, a thread-affinity violation, and a reentrant call from a host
+// callback all leave the logical run intact for the owner thread to continue.
+// On any error, output parameters are left unchanged.
 //
 // Host cancellation is distinct from an engine halt: stop calling this
 // function, report cancellation in the host API, and use

--- a/crates/ferric-rules-ffi/ferric.h
+++ b/crates/ferric-rules-ffi/ferric.h
@@ -145,10 +145,14 @@
  * - LIMIT_REACHED keeps continuation eligibility. AGENDA_EMPTY,
  *   HALT_REQUESTED, and ACTION_ERROR are terminal and close it.
  * - Read-only raw-engine queries and ferric_engine_clear_error() are
- *   allowed between chunks. A fresh run or any other runtime-mutating
- *   raw-engine call closes the continuation, even if that call fails.
- *   A later continuation then returns INVALID_ARGUMENT and
+ *   allowed between chunks. Any other raw-engine call that reaches
+ *   engine state closes the continuation, whether or not it then
+ *   succeeds; a later continuation returns INVALID_ARGUMENT and
  *   leaves output parameters unchanged.
+ * - A call rejected before it reaches engine state changes nothing,
+ *   including continuation eligibility. A null handle, a thread
+ *   affinity violation, and a reentrant call from a host callback all
+ *   leave the logical run intact for the owner thread.
  * - Host cancellation is not HALT_REQUESTED. A cancelable binding
  *   stops submitting chunks, reports its own canceled outcome, and
  *   starts any later logical run with ferric_engine_run_ex().
@@ -1162,10 +1166,14 @@ enum FerricError ferric_engine_run_ex(struct FerricEngine *engine,
 // result other than `LimitReached` is terminal for the logical run.
 //
 // Read-only raw-engine queries and `ferric_engine_clear_error` may be called
-// between chunks. Starting a fresh run or calling any other
-// runtime-mutating raw-engine function ends the current logical run — even if
-// that call itself fails — and a later continuation attempt then returns
-// `FerricError::InvalidArgument`. On any error, output parameters are left
+// between chunks. Any other raw-engine call that reaches engine state ends the
+// current logical run — whether or not it then succeeds — and a later
+// continuation attempt returns `FerricError::InvalidArgument`.
+//
+// A call rejected before it reaches engine state changes nothing, including
+// continuation eligibility: a null handle, a thread-affinity violation, and a
+// reentrant call from a host callback all leave the logical run intact for the
+// owner thread to continue. On any error, output parameters are left
 // unchanged.
 //
 // Host cancellation is distinct from an engine halt: stop calling this

--- a/crates/ferric-rules-ffi/src/engine.rs
+++ b/crates/ferric-rules-ffi/src/engine.rs
@@ -2497,10 +2497,14 @@ pub unsafe extern "C" fn ferric_engine_run_ex(
 /// result other than `LimitReached` is terminal for the logical run.
 ///
 /// Read-only raw-engine queries and `ferric_engine_clear_error` may be called
-/// between chunks. Starting a fresh run or calling any other
-/// runtime-mutating raw-engine function ends the current logical run — even if
-/// that call itself fails — and a later continuation attempt then returns
-/// `FerricError::InvalidArgument`. On any error, output parameters are left
+/// between chunks. Any other raw-engine call that reaches engine state ends the
+/// current logical run — whether or not it then succeeds — and a later
+/// continuation attempt returns `FerricError::InvalidArgument`.
+///
+/// A call rejected before it reaches engine state changes nothing, including
+/// continuation eligibility: a null handle, a thread-affinity violation, and a
+/// reentrant call from a host callback all leave the logical run intact for the
+/// owner thread to continue. On any error, output parameters are left
 /// unchanged.
 ///
 /// Host cancellation is distinct from an engine halt: stop calling this

--- a/crates/ferric-rules-ffi/src/engine.rs
+++ b/crates/ferric-rules-ffi/src/engine.rs
@@ -2509,7 +2509,11 @@ pub unsafe extern "C" fn ferric_engine_run_ex(
 ///
 /// Host cancellation is distinct from an engine halt: stop calling this
 /// function, report cancellation in the host API, and use
-/// `ferric_engine_run_ex` to start the next logical run.
+/// `ferric_engine_run_ex` to start the next logical run. This leaves the agenda
+/// intact, but does not guarantee an un-halted engine — a chunk that lands
+/// exactly on an activation calling `(halt)` still reports `LimitReached`, and
+/// the pending halt surfaces only on the next chunk that can run. Query
+/// `ferric_engine_is_halted` if that distinction matters.
 ///
 /// # Safety
 ///

--- a/crates/ferric-rules-ffi/src/engine.rs
+++ b/crates/ferric-rules-ffi/src/engine.rs
@@ -19,7 +19,7 @@
 //! The internal `unsafe fn move_to_current_thread` is deliberately NOT
 //! exposed through the C API.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
@@ -58,6 +58,7 @@ pub struct FerricEngine {
     pub(crate) engine: Engine,
     owner_thread: ThreadId,
     call_active: AtomicBool,
+    logical_run_continuation_ready: Cell<bool>,
     diagnostics: Mutex<EngineDiagnostics>,
     output_cstrings: RefCell<HashMap<String, CachedOutputCString>>,
 }
@@ -83,6 +84,7 @@ impl FerricEngine {
             engine,
             owner_thread: std::thread::current().id(),
             call_active: AtomicBool::new(false),
+            logical_run_continuation_ready: Cell::new(false),
             diagnostics: Mutex::new(EngineDiagnostics::new()),
             output_cstrings: RefCell::new(HashMap::new()),
         }
@@ -183,6 +185,16 @@ unsafe fn call_active<'a>(handle: NonNull<FerricEngine>) -> &'a AtomicBool {
     &*std::ptr::addr_of!((*handle.as_ptr()).call_active)
 }
 
+/// Project the owner-thread logical-run continuation state.
+///
+/// # Safety
+///
+/// `handle` must point to a live engine handle, and access must remain on the
+/// engine's owner thread without overlapping another runtime call.
+unsafe fn logical_run_continuation_ready<'a>(handle: NonNull<FerricEngine>) -> &'a Cell<bool> {
+    &*std::ptr::addr_of!((*handle.as_ptr()).logical_run_continuation_ready)
+}
+
 /// Project the synchronized diagnostic state from an opaque handle.
 ///
 /// # Safety
@@ -244,6 +256,7 @@ impl Drop for EngineCallGuard<'_> {
 
 struct EngineWriteAccess<'a> {
     engine: &'a mut Engine,
+    logical_run_continuation_ready: &'a Cell<bool>,
     diagnostics: &'a Mutex<EngineDiagnostics>,
     output_cstrings: &'a RefCell<HashMap<String, CachedOutputCString>>,
     _guard: EngineCallGuard<'a>,
@@ -289,14 +302,24 @@ unsafe fn enter_engine_call<'a>(
 unsafe fn borrow_engine_mut<'a>(
     engine: *mut FerricEngine,
 ) -> Result<EngineWriteAccess<'a>, FerricError> {
+    let access = borrow_engine_mut_preserving_logical_run(engine)?;
+    access.logical_run_continuation_ready.set(false);
+    Ok(access)
+}
+
+unsafe fn borrow_engine_mut_preserving_logical_run<'a>(
+    engine: *mut FerricEngine,
+) -> Result<EngineWriteAccess<'a>, FerricError> {
     let handle = validate_engine_ptr(engine)?;
     check_thread_affinity(handle)?;
     let guard = enter_engine_call(handle)?;
     let runtime = &mut *std::ptr::addr_of_mut!((*handle.as_ptr()).engine);
+    let continuation_ready = logical_run_continuation_ready(handle);
     let diagnostic_state = diagnostics(handle);
     let output_cache = output_cstrings(handle);
     Ok(EngineWriteAccess {
         engine: runtime,
+        logical_run_continuation_ready: continuation_ready,
         diagnostics: diagnostic_state,
         output_cstrings: output_cache,
         _guard: guard,
@@ -2409,8 +2432,14 @@ pub unsafe extern "C" fn ferric_engine_clear_output(
 
 /// Extended run with halt reason output.
 ///
-/// Same limit semantics as `ferric_engine_run` (negative = unlimited).
-/// Additionally writes the halt reason to `*out_reason` if non-null.
+/// Always starts a fresh logical run, clearing any prior halt request and
+/// action diagnostics without resetting working memory, the agenda, globals,
+/// or output. Same limit semantics as `ferric_engine_run` (negative =
+/// unlimited). Additionally writes the halt reason to `*out_reason` if
+/// non-null.
+///
+/// A successful `LimitReached` result may be continued with
+/// `ferric_engine_continue_run_ex`. Other halt reasons are terminal.
 ///
 /// # Safety
 ///
@@ -2425,10 +2454,11 @@ pub unsafe extern "C" fn ferric_engine_run_ex(
     out_fired: *mut u64,
     out_reason: *mut FerricHaltReason,
 ) -> FerricError {
-    let handle = match borrow_engine_mut(engine) {
+    let handle = match borrow_engine_mut_preserving_logical_run(engine) {
         Ok(h) => h,
         Err(code) => return code,
     };
+    handle.logical_run_continuation_ready.set(false);
 
     let run_limit = if limit < 0 {
         RunLimit::Unlimited
@@ -2439,12 +2469,90 @@ pub unsafe extern "C" fn ferric_engine_run_ex(
 
     match handle.engine.run(run_limit) {
         Ok(result) => {
+            let reason = FerricHaltReason::from(result.halt_reason);
+            handle
+                .logical_run_continuation_ready
+                .set(reason == FerricHaltReason::LimitReached);
             prune_cleared_output_snapshots(handle.engine, handle.output_cstrings);
             if !out_fired.is_null() {
                 *out_fired = result.rules_fired as u64;
             }
             if !out_reason.is_null() {
-                *out_reason = FerricHaltReason::from(result.halt_reason);
+                *out_reason = reason;
+            }
+            FerricError::Ok
+        }
+        Err(ref err) => set_engine_runtime_error(handle.diagnostics, err),
+    }
+}
+
+/// Continue a logical run previously started by `ferric_engine_run_ex`.
+///
+/// Call this only after `ferric_engine_run_ex` or a previous continuation
+/// returned `FerricHaltReason::LimitReached`. Unlike a fresh run, continuation
+/// preserves a pending halt request and action diagnostics from earlier chunks.
+///
+/// Each successful call writes the number of rules fired by that chunk, not a
+/// cumulative total. Hosts should accumulate `out_fired` across chunks. A
+/// result other than `LimitReached` is terminal for the logical run.
+///
+/// Read-only raw-engine queries may be called between chunks. Starting a fresh
+/// run or calling another runtime-mutating raw-engine function ends the current
+/// logical run; a later continuation attempt then returns
+/// `FerricError::InvalidArgument`. On any error, output parameters are left
+/// unchanged.
+///
+/// Host cancellation is distinct from an engine halt: stop calling this
+/// function, report cancellation in the host API, and use
+/// `ferric_engine_run_ex` to start the next logical run.
+///
+/// # Safety
+///
+/// - `engine` must be a valid engine pointer.
+/// - `out_fired` may be null.
+/// - `out_reason` may be null.
+#[cfg_attr(ferric_ffi_compile, ffi_export)]
+#[no_mangle]
+pub unsafe extern "C" fn ferric_engine_continue_run_ex(
+    engine: *mut FerricEngine,
+    limit: i64,
+    out_fired: *mut u64,
+    out_reason: *mut FerricHaltReason,
+) -> FerricError {
+    let handle = match borrow_engine_mut_preserving_logical_run(engine) {
+        Ok(h) => h,
+        Err(code) => return code,
+    };
+
+    if !handle.logical_run_continuation_ready.get() {
+        return set_engine_error_message(
+            handle.diagnostics,
+            FerricError::InvalidArgument,
+            "ferric_engine_continue_run_ex requires a preceding logical-run chunk that returned LimitReached"
+                .to_string(),
+        );
+    }
+    handle.logical_run_continuation_ready.set(false);
+
+    let run_limit = if limit < 0 {
+        RunLimit::Unlimited
+    } else {
+        #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+        RunLimit::Count(limit as usize)
+    };
+
+    match handle.engine.continue_run(run_limit) {
+        Ok(result) => {
+            let reason = FerricHaltReason::from(result.halt_reason);
+            handle
+                .logical_run_continuation_ready
+                .set(reason == FerricHaltReason::LimitReached);
+            prune_cleared_output_snapshots(handle.engine, handle.output_cstrings);
+            if !out_fired.is_null() {
+                *out_fired = result.rules_fired as u64;
+            }
+            if !out_reason.is_null() {
+                *out_reason = reason;
             }
             FerricError::Ok
         }

--- a/crates/ferric-rules-ffi/src/engine.rs
+++ b/crates/ferric-rules-ffi/src/engine.rs
@@ -2501,11 +2501,11 @@ pub unsafe extern "C" fn ferric_engine_run_ex(
 /// current logical run — whether or not it then succeeds — and a later
 /// continuation attempt returns `FerricError::InvalidArgument`.
 ///
-/// A call rejected before it reaches engine state changes nothing, including
-/// continuation eligibility: a null handle, a thread-affinity violation, and a
-/// reentrant call from a host callback all leave the logical run intact for the
-/// owner thread to continue. On any error, output parameters are left
-/// unchanged.
+/// A call rejected before it reaches engine state changes no runtime or
+/// continuation state, though it still publishes its documented error: a null
+/// handle, a thread-affinity violation, and a reentrant call from a host
+/// callback all leave the logical run intact for the owner thread to continue.
+/// On any error, output parameters are left unchanged.
 ///
 /// Host cancellation is distinct from an engine halt: stop calling this
 /// function, report cancellation in the host API, and use

--- a/crates/ferric-rules-ffi/src/engine.rs
+++ b/crates/ferric-rules-ffi/src/engine.rs
@@ -2454,11 +2454,11 @@ pub unsafe extern "C" fn ferric_engine_run_ex(
     out_fired: *mut u64,
     out_reason: *mut FerricHaltReason,
 ) -> FerricError {
-    let handle = match borrow_engine_mut_preserving_logical_run(engine) {
+    // `borrow_engine_mut` already ends any in-flight logical run.
+    let handle = match borrow_engine_mut(engine) {
         Ok(h) => h,
         Err(code) => return code,
     };
-    handle.logical_run_continuation_ready.set(false);
 
     let run_limit = if limit < 0 {
         RunLimit::Unlimited
@@ -2496,9 +2496,10 @@ pub unsafe extern "C" fn ferric_engine_run_ex(
 /// cumulative total. Hosts should accumulate `out_fired` across chunks. A
 /// result other than `LimitReached` is terminal for the logical run.
 ///
-/// Read-only raw-engine queries may be called between chunks. Starting a fresh
-/// run or calling another runtime-mutating raw-engine function ends the current
-/// logical run; a later continuation attempt then returns
+/// Read-only raw-engine queries and `ferric_engine_clear_error` may be called
+/// between chunks. Starting a fresh run or calling any other
+/// runtime-mutating raw-engine function ends the current logical run — even if
+/// that call itself fails — and a later continuation attempt then returns
 /// `FerricError::InvalidArgument`. On any error, output parameters are left
 /// unchanged.
 ///

--- a/crates/ferric-rules-ffi/src/lib.rs
+++ b/crates/ferric-rules-ffi/src/lib.rs
@@ -41,6 +41,13 @@
 //!   unrepresentable content instead of returning empty/truncated strings.
 //!   Length-reporting copy and serialization APIs preserve exact bytes.
 //!
+//! - **Logical-run continuation**: `ferric_engine_run_ex` starts a fresh logical
+//!   run. After it returns `LimitReached`, `ferric_engine_continue_run_ex` runs
+//!   another bounded chunk without clearing a pending halt request or action
+//!   diagnostics. Chunk counts are per-call; terminal reasons close
+//!   continuation eligibility. Host cancellation remains a distinct,
+//!   host-owned outcome.
+//!
 //! - **Panic containment**: Every C export is generated around a non-extern
 //!   implementation and catches ordinary Rust panics before they reach the ABI.
 //!   `ffi-dev` and `ffi-release` retain unwind support for that purpose. A

--- a/crates/ferric-rules-ffi/src/tests.rs
+++ b/crates/ferric-rules-ffi/src/tests.rs
@@ -64,6 +64,9 @@ mod contract_lock;
 mod ffi_expansion;
 
 #[cfg(test)]
+mod logical_run_continuation;
+
+#[cfg(test)]
 mod template_assertion;
 
 #[cfg(test)]

--- a/crates/ferric-rules-ffi/src/tests/contract_lock.rs
+++ b/crates/ferric-rules-ffi/src/tests/contract_lock.rs
@@ -11,12 +11,12 @@
 use crate::engine::{
     ferric_engine_action_diagnostic_copy, ferric_engine_action_diagnostic_count,
     ferric_engine_assert_string, ferric_engine_clear_action_diagnostics, ferric_engine_clear_error,
-    ferric_engine_fact_count, ferric_engine_free, ferric_engine_get_fact_field,
-    ferric_engine_get_fact_field_count, ferric_engine_get_global, ferric_engine_get_output,
-    ferric_engine_get_output_copy, ferric_engine_last_error, ferric_engine_last_error_copy,
-    ferric_engine_load_string, ferric_engine_new, ferric_engine_new_with_config,
-    ferric_engine_reset, ferric_engine_retract, ferric_engine_run, ferric_engine_step,
-    FerricEngine,
+    ferric_engine_continue_run_ex, ferric_engine_fact_count, ferric_engine_free,
+    ferric_engine_get_fact_field, ferric_engine_get_fact_field_count, ferric_engine_get_global,
+    ferric_engine_get_output, ferric_engine_get_output_copy, ferric_engine_last_error,
+    ferric_engine_last_error_copy, ferric_engine_load_string, ferric_engine_new,
+    ferric_engine_new_with_config, ferric_engine_reset, ferric_engine_retract, ferric_engine_run,
+    ferric_engine_run_ex, ferric_engine_step, FerricEngine,
 };
 use crate::error::{
     ferric_clear_error_global, ferric_last_error_global, ferric_last_error_global_copy, FerricError,
@@ -24,7 +24,7 @@ use crate::error::{
 use crate::types::{
     ferric_string_free, ferric_value_array_free, ferric_value_free, ferric_value_multifield_copy,
     ferric_value_string_bytes, ferric_value_symbol_bytes, FerricConfig, FerricConflictStrategy,
-    FerricStringEncoding, FerricValue,
+    FerricHaltReason, FerricStringEncoding, FerricValue,
 };
 use std::os::raw::c_char;
 
@@ -51,6 +51,18 @@ fn contract_lock_canonical_function_names_exist() {
     // execution
     let _: unsafe extern "C" fn(*mut FerricEngine, i64, *mut u64) -> FerricError =
         ferric_engine_run;
+    let _: unsafe extern "C" fn(
+        *mut FerricEngine,
+        i64,
+        *mut u64,
+        *mut FerricHaltReason,
+    ) -> FerricError = ferric_engine_run_ex;
+    let _: unsafe extern "C" fn(
+        *mut FerricEngine,
+        i64,
+        *mut u64,
+        *mut FerricHaltReason,
+    ) -> FerricError = ferric_engine_continue_run_ex;
     let _: unsafe extern "C" fn(*mut FerricEngine, *mut i32) -> FerricError = ferric_engine_step;
 
     // error retrieval — per-engine
@@ -593,6 +605,15 @@ fn contract_lock_null_engine_pointer_returns_null_pointer_error() {
         assert_eq!(ferric_engine_reset(null_engine), FerricError::NullPointer);
         assert_eq!(
             ferric_engine_run(null_engine, -1, std::ptr::null_mut()),
+            FerricError::NullPointer
+        );
+        assert_eq!(
+            ferric_engine_continue_run_ex(
+                null_engine,
+                -1,
+                std::ptr::null_mut(),
+                std::ptr::null_mut()
+            ),
             FerricError::NullPointer
         );
         assert_eq!(

--- a/crates/ferric-rules-ffi/src/tests/ffi_expansion.rs
+++ b/crates/ferric-rules-ffi/src/tests/ffi_expansion.rs
@@ -17,23 +17,23 @@
 //!   `ferric_engine_halt`, `ferric_engine_push_input`, `ferric_engine_clear`
 //! - Convenience variants: `ferric_engine_new_with_source`,
 //!   `ferric_engine_new_with_source_config`, `ferric_engine_clear_output`,
-//!   `ferric_engine_run_ex`, `ferric_engine_continue_run_ex`
+//!   `ferric_engine_run_ex`
 
 use std::ffi::{CStr, CString};
 use std::ptr;
 
 use crate::engine::{
     ferric_engine_agenda_count, ferric_engine_assert_ordered, ferric_engine_clear,
-    ferric_engine_clear_output, ferric_engine_continue_run_ex, ferric_engine_current_module,
-    ferric_engine_fact_ids, ferric_engine_find_fact_ids, ferric_engine_focus_stack_depth,
-    ferric_engine_focus_stack_entry, ferric_engine_free, ferric_engine_get_fact_relation,
-    ferric_engine_get_fact_template_name, ferric_engine_get_fact_type, ferric_engine_get_focus,
-    ferric_engine_halt, ferric_engine_is_halted, ferric_engine_load_string,
-    ferric_engine_module_count, ferric_engine_module_name, ferric_engine_new,
-    ferric_engine_new_with_source, ferric_engine_new_with_source_config, ferric_engine_push_input,
-    ferric_engine_reset, ferric_engine_rule_count, ferric_engine_rule_info, ferric_engine_run,
-    ferric_engine_run_ex, ferric_engine_template_count, ferric_engine_template_name,
-    ferric_engine_template_slot_count, ferric_engine_template_slot_name,
+    ferric_engine_clear_output, ferric_engine_current_module, ferric_engine_fact_ids,
+    ferric_engine_find_fact_ids, ferric_engine_focus_stack_depth, ferric_engine_focus_stack_entry,
+    ferric_engine_free, ferric_engine_get_fact_relation, ferric_engine_get_fact_template_name,
+    ferric_engine_get_fact_type, ferric_engine_get_focus, ferric_engine_halt,
+    ferric_engine_is_halted, ferric_engine_load_string, ferric_engine_module_count,
+    ferric_engine_module_name, ferric_engine_new, ferric_engine_new_with_source,
+    ferric_engine_new_with_source_config, ferric_engine_push_input, ferric_engine_reset,
+    ferric_engine_rule_count, ferric_engine_rule_info, ferric_engine_run, ferric_engine_run_ex,
+    ferric_engine_template_count, ferric_engine_template_name, ferric_engine_template_slot_count,
+    ferric_engine_template_slot_name,
 };
 use crate::error::FerricError;
 use crate::types::{
@@ -1635,85 +1635,5 @@ fn run_ex_action_error() {
         assert_eq!(reason, FerricHaltReason::ActionError);
 
         ferric_engine_free(engine);
-    }
-}
-
-fn exact_boundary_halt_program(boundary: u64) -> CString {
-    assert!(boundary > 0);
-    let target = boundary - 1;
-    CString::new(format!(
-        r"
-        (deffacts start (position 0))
-        (defrule halt-at-boundary
-            (declare (salience 100))
-            (position {target})
-            =>
-            (halt))
-        (defrule advance
-            ?current <- (position ?n&:(< ?n {target}))
-            =>
-            (retract ?current)
-            (assert (position (+ ?n 1))))
-        (defrule after-halt
-            (declare (salience -100))
-            ?current <- (position {target})
-            =>
-            (retract ?current)
-            (assert (past-boundary)))
-        "
-    ))
-    .unwrap()
-}
-
-unsafe fn run_exact_boundary_program(
-    source: &CStr,
-    chunk_size: Option<u64>,
-) -> (u64, FerricHaltReason, usize) {
-    let engine = ferric_engine_new();
-    assert_eq!(
-        ferric_engine_load_string(engine, source.as_ptr()),
-        FerricError::Ok
-    );
-    assert_eq!(ferric_engine_reset(engine), FerricError::Ok);
-
-    let mut total_fired = 0;
-    let mut reason = FerricHaltReason::AgendaEmpty;
-    let limit = chunk_size.map_or(-1, |size| i64::try_from(size).unwrap());
-    let mut chunk_fired = 0;
-    assert_eq!(
-        ferric_engine_run_ex(engine, limit, &mut chunk_fired, &mut reason),
-        FerricError::Ok
-    );
-    total_fired += chunk_fired;
-
-    while chunk_size.is_some() && reason == FerricHaltReason::LimitReached {
-        assert_eq!(
-            ferric_engine_continue_run_ex(engine, limit, &mut chunk_fired, &mut reason),
-            FerricError::Ok
-        );
-        total_fired += chunk_fired;
-    }
-
-    let mut agenda_count = 0;
-    assert_eq!(
-        ferric_engine_agenda_count(engine, &mut agenda_count),
-        FerricError::Ok
-    );
-    ferric_engine_free(engine);
-    (total_fired, reason, agenda_count)
-}
-
-#[test]
-fn chunked_run_matches_one_shot_at_exact_halt_boundaries() {
-    unsafe {
-        for (boundary, chunk_size) in [(1, 1), (100, 100), (200, 100)] {
-            let source = exact_boundary_halt_program(boundary);
-            let one_shot = run_exact_boundary_program(&source, None);
-            let chunked = run_exact_boundary_program(&source, Some(chunk_size));
-            assert_eq!(
-                chunked, one_shot,
-                "chunked execution diverged at exact halt boundary {boundary}"
-            );
-        }
     }
 }

--- a/crates/ferric-rules-ffi/src/tests/ffi_expansion.rs
+++ b/crates/ferric-rules-ffi/src/tests/ffi_expansion.rs
@@ -17,23 +17,23 @@
 //!   `ferric_engine_halt`, `ferric_engine_push_input`, `ferric_engine_clear`
 //! - Convenience variants: `ferric_engine_new_with_source`,
 //!   `ferric_engine_new_with_source_config`, `ferric_engine_clear_output`,
-//!   `ferric_engine_run_ex`
+//!   `ferric_engine_run_ex`, `ferric_engine_continue_run_ex`
 
 use std::ffi::{CStr, CString};
 use std::ptr;
 
 use crate::engine::{
     ferric_engine_agenda_count, ferric_engine_assert_ordered, ferric_engine_clear,
-    ferric_engine_clear_output, ferric_engine_current_module, ferric_engine_fact_ids,
-    ferric_engine_find_fact_ids, ferric_engine_focus_stack_depth, ferric_engine_focus_stack_entry,
-    ferric_engine_free, ferric_engine_get_fact_relation, ferric_engine_get_fact_template_name,
-    ferric_engine_get_fact_type, ferric_engine_get_focus, ferric_engine_halt,
-    ferric_engine_is_halted, ferric_engine_load_string, ferric_engine_module_count,
-    ferric_engine_module_name, ferric_engine_new, ferric_engine_new_with_source,
-    ferric_engine_new_with_source_config, ferric_engine_push_input, ferric_engine_reset,
-    ferric_engine_rule_count, ferric_engine_rule_info, ferric_engine_run, ferric_engine_run_ex,
-    ferric_engine_template_count, ferric_engine_template_name, ferric_engine_template_slot_count,
-    ferric_engine_template_slot_name,
+    ferric_engine_clear_output, ferric_engine_continue_run_ex, ferric_engine_current_module,
+    ferric_engine_fact_ids, ferric_engine_find_fact_ids, ferric_engine_focus_stack_depth,
+    ferric_engine_focus_stack_entry, ferric_engine_free, ferric_engine_get_fact_relation,
+    ferric_engine_get_fact_template_name, ferric_engine_get_fact_type, ferric_engine_get_focus,
+    ferric_engine_halt, ferric_engine_is_halted, ferric_engine_load_string,
+    ferric_engine_module_count, ferric_engine_module_name, ferric_engine_new,
+    ferric_engine_new_with_source, ferric_engine_new_with_source_config, ferric_engine_push_input,
+    ferric_engine_reset, ferric_engine_rule_count, ferric_engine_rule_info, ferric_engine_run,
+    ferric_engine_run_ex, ferric_engine_template_count, ferric_engine_template_name,
+    ferric_engine_template_slot_count, ferric_engine_template_slot_name,
 };
 use crate::error::FerricError;
 use crate::types::{
@@ -1635,5 +1635,85 @@ fn run_ex_action_error() {
         assert_eq!(reason, FerricHaltReason::ActionError);
 
         ferric_engine_free(engine);
+    }
+}
+
+fn exact_boundary_halt_program(boundary: u64) -> CString {
+    assert!(boundary > 0);
+    let target = boundary - 1;
+    CString::new(format!(
+        r"
+        (deffacts start (position 0))
+        (defrule halt-at-boundary
+            (declare (salience 100))
+            (position {target})
+            =>
+            (halt))
+        (defrule advance
+            ?current <- (position ?n&:(< ?n {target}))
+            =>
+            (retract ?current)
+            (assert (position (+ ?n 1))))
+        (defrule after-halt
+            (declare (salience -100))
+            ?current <- (position {target})
+            =>
+            (retract ?current)
+            (assert (past-boundary)))
+        "
+    ))
+    .unwrap()
+}
+
+unsafe fn run_exact_boundary_program(
+    source: &CStr,
+    chunk_size: Option<u64>,
+) -> (u64, FerricHaltReason, usize) {
+    let engine = ferric_engine_new();
+    assert_eq!(
+        ferric_engine_load_string(engine, source.as_ptr()),
+        FerricError::Ok
+    );
+    assert_eq!(ferric_engine_reset(engine), FerricError::Ok);
+
+    let mut total_fired = 0;
+    let mut reason = FerricHaltReason::AgendaEmpty;
+    let limit = chunk_size.map_or(-1, |size| i64::try_from(size).unwrap());
+    let mut chunk_fired = 0;
+    assert_eq!(
+        ferric_engine_run_ex(engine, limit, &mut chunk_fired, &mut reason),
+        FerricError::Ok
+    );
+    total_fired += chunk_fired;
+
+    while chunk_size.is_some() && reason == FerricHaltReason::LimitReached {
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, limit, &mut chunk_fired, &mut reason),
+            FerricError::Ok
+        );
+        total_fired += chunk_fired;
+    }
+
+    let mut agenda_count = 0;
+    assert_eq!(
+        ferric_engine_agenda_count(engine, &mut agenda_count),
+        FerricError::Ok
+    );
+    ferric_engine_free(engine);
+    (total_fired, reason, agenda_count)
+}
+
+#[test]
+fn chunked_run_matches_one_shot_at_exact_halt_boundaries() {
+    unsafe {
+        for (boundary, chunk_size) in [(1, 1), (100, 100), (200, 100)] {
+            let source = exact_boundary_halt_program(boundary);
+            let one_shot = run_exact_boundary_program(&source, None);
+            let chunked = run_exact_boundary_program(&source, Some(chunk_size));
+            assert_eq!(
+                chunked, one_shot,
+                "chunked execution diverged at exact halt boundary {boundary}"
+            );
+        }
     }
 }

--- a/crates/ferric-rules-ffi/src/tests/header.rs
+++ b/crates/ferric-rules-ffi/src/tests/header.rs
@@ -158,6 +158,7 @@ fn header_documents_logical_run_continuation_contract() {
         "Each call reports only that chunk's fired count",
         "exact-boundary halt requests",
         "Host cancellation is not HALT_REQUESTED",
+        "Canceling does not guarantee an un-halted engine",
         "whether or not it then",
         "rejected before it reaches engine state",
         "leaves output parameters unchanged",

--- a/crates/ferric-rules-ffi/src/tests/header.rs
+++ b/crates/ferric-rules-ffi/src/tests/header.rs
@@ -150,6 +150,24 @@ fn header_documents_active_only_pinned_halt() {
 }
 
 #[test]
+fn header_documents_logical_run_continuation_contract() {
+    let header = read_committed_header();
+    for required in [
+        "LOGICAL RUN CONTINUATION",
+        "ferric_engine_continue_run_ex",
+        "Each call reports only that chunk's fired count",
+        "exact-boundary halt requests",
+        "Host cancellation is not HALT_REQUESTED",
+        "leaves output parameters unchanged",
+    ] {
+        assert!(
+            header.contains(required),
+            "logical-run continuation contract is missing from ferric.h: {required}"
+        );
+    }
+}
+
+#[test]
 fn header_contains_capacity_wait_async_entry_points() {
     let header = read_committed_header();
     assert!(
@@ -272,7 +290,7 @@ fn ci_runs_debug_and_release_panic_containment_harness() {
     assert!(script.contains("FERRIC_FFI_TEST_PANIC_INJECTION_BUILD=1"));
     assert!(script.contains("--features serde"));
     assert!(script.contains("panic_containment.c"));
-    assert!(script.contains("expected 100 header exports"));
+    assert!(script.contains("expected 101 header exports"));
 }
 
 #[test]
@@ -331,7 +349,7 @@ fn every_authored_c_export_uses_the_generated_boundary_wrapper() {
     exports.dedup();
     assert_eq!(
         exports.len(),
-        100,
+        101,
         "the export audit count changed; verify every new return category has a panic sentinel"
     );
 }

--- a/crates/ferric-rules-ffi/src/tests/header.rs
+++ b/crates/ferric-rules-ffi/src/tests/header.rs
@@ -158,6 +158,7 @@ fn header_documents_logical_run_continuation_contract() {
         "Each call reports only that chunk's fired count",
         "exact-boundary halt requests",
         "Host cancellation is not HALT_REQUESTED",
+        "even if that call fails",
         "leaves output parameters unchanged",
     ] {
         assert!(

--- a/crates/ferric-rules-ffi/src/tests/header.rs
+++ b/crates/ferric-rules-ffi/src/tests/header.rs
@@ -158,7 +158,8 @@ fn header_documents_logical_run_continuation_contract() {
         "Each call reports only that chunk's fired count",
         "exact-boundary halt requests",
         "Host cancellation is not HALT_REQUESTED",
-        "even if that call fails",
+        "whether or not it then",
+        "rejected before it reaches engine state",
         "leaves output parameters unchanged",
     ] {
         assert!(

--- a/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
+++ b/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
@@ -3,11 +3,11 @@
 use std::ffi::{CStr, CString};
 
 use crate::engine::{
-    ferric_engine_action_diagnostic_count, ferric_engine_agenda_count,
+    ferric_engine_action_diagnostic_count, ferric_engine_agenda_count, ferric_engine_clear_error,
     ferric_engine_continue_run_ex, ferric_engine_fact_count, ferric_engine_free,
     ferric_engine_halt, ferric_engine_is_halted, ferric_engine_last_error,
-    ferric_engine_load_string, ferric_engine_new, ferric_engine_reset, ferric_engine_run_ex,
-    FerricEngine,
+    ferric_engine_load_string, ferric_engine_new, ferric_engine_reset, ferric_engine_retract,
+    ferric_engine_run_ex, FerricEngine,
 };
 use crate::error::FerricError;
 use crate::types::FerricHaltReason;
@@ -273,6 +273,258 @@ fn fresh_run_clears_an_exact_boundary_halt_without_resetting_working_memory() {
             facts_after,
             facts_before + 1,
             "the fresh run must execute the preserved agenda instead of resetting working memory"
+        );
+
+        ferric_engine_free(engine);
+    }
+}
+
+/// Everything a host can observe about a finished logical run.
+#[derive(Debug, PartialEq, Eq)]
+struct RunObservation {
+    fired: u64,
+    reason: FerricHaltReason,
+    agenda: usize,
+    diagnostics: usize,
+}
+
+/// Execute `source` as one logical run and report the observable outcome.
+///
+/// `chunk_size` of `None` runs the program in a single unlimited call;
+/// `Some(n)` drives it as an `n`-activation chunk loop, exactly as a
+/// cancelable host would.
+unsafe fn observe_logical_run(source: &str, chunk_size: Option<u64>) -> RunObservation {
+    let engine = ferric_engine_new();
+    load_and_reset(engine, source);
+
+    let limit = chunk_size.map_or(-1, |size| i64::try_from(size).unwrap());
+    let mut chunk_fired = 0;
+    let mut reason = FerricHaltReason::AgendaEmpty;
+    assert_eq!(
+        ferric_engine_run_ex(engine, limit, &mut chunk_fired, &mut reason),
+        FerricError::Ok
+    );
+    let mut fired = chunk_fired;
+
+    while chunk_size.is_some() && reason == FerricHaltReason::LimitReached {
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, limit, &mut chunk_fired, &mut reason),
+            FerricError::Ok
+        );
+        fired += chunk_fired;
+    }
+
+    let mut agenda = 0;
+    assert_eq!(
+        ferric_engine_agenda_count(engine, &mut agenda),
+        FerricError::Ok
+    );
+    let diagnostics = action_diagnostic_count(engine);
+    ferric_engine_free(engine);
+
+    RunObservation {
+        fired,
+        reason,
+        agenda,
+        diagnostics,
+    }
+}
+
+/// A program that fires exactly `boundary` rules and then halts, leaving one
+/// lower-salience activation on the agenda.
+fn exact_boundary_halt_program(boundary: u64) -> String {
+    assert!(boundary > 0);
+    let target = boundary - 1;
+    format!(
+        r"
+        (deffacts start (position 0))
+        (defrule halt-at-boundary
+            (declare (salience 100))
+            (position {target})
+            =>
+            (halt))
+        (defrule advance
+            ?current <- (position ?n&:(< ?n {target}))
+            =>
+            (retract ?current)
+            (assert (position (+ ?n 1))))
+        (defrule after-halt
+            (declare (salience -100))
+            ?current <- (position {target})
+            =>
+            (retract ?current)
+            (assert (past-boundary)))
+        "
+    )
+}
+
+#[test]
+fn chunked_run_matches_one_shot_at_exact_halt_boundaries() {
+    unsafe {
+        // Chunk sizes that land exactly on the halting activation are the
+        // regression case: without continuation the next chunk clears the
+        // pending halt and fires one rule too many.
+        for (boundary, chunk_size) in [(1, 1), (100, 100), (200, 100), (200, 200), (100, 7)] {
+            let source = exact_boundary_halt_program(boundary);
+            let one_shot = observe_logical_run(&source, None);
+            let chunked = observe_logical_run(&source, Some(chunk_size));
+            assert_eq!(
+                one_shot.reason,
+                FerricHaltReason::HaltRequested,
+                "boundary {boundary} must halt in one-shot execution"
+            );
+            assert_eq!(one_shot.fired, boundary);
+            assert_eq!(
+                chunked, one_shot,
+                "chunked execution diverged at exact halt boundary {boundary}"
+            );
+        }
+    }
+}
+
+#[test]
+fn chunked_run_matches_one_shot_for_diagnostics_and_agenda() {
+    unsafe {
+        let one_shot = observe_logical_run(EARLY_DIAGNOSTIC_PROGRAM, None);
+        assert!(
+            one_shot.diagnostics > 0,
+            "the fixture must emit at least one diagnostic"
+        );
+        for chunk_size in [1, 2, 3] {
+            assert_eq!(
+                observe_logical_run(EARLY_DIAGNOSTIC_PROGRAM, Some(chunk_size)),
+                one_shot,
+                "chunk size {chunk_size} lost diagnostics or agenda state"
+            );
+        }
+    }
+}
+
+#[test]
+fn host_cancellation_is_distinct_from_every_engine_terminal_state() {
+    unsafe {
+        // A host that cancels simply stops submitting chunks. The engine is
+        // then in a state no terminal halt reason can produce: the last chunk
+        // reported LimitReached, nothing is halted, and work remains queued.
+        let source = exact_boundary_halt_program(100);
+        let engine = ferric_engine_new();
+        load_and_reset(engine, &source);
+
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_run_ex(engine, 10, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        let mut total_fired = fired;
+        // Two chunks in, the host observes cancellation and stops.
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, 10, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        total_fired += fired;
+
+        assert_eq!(total_fired, 20);
+        assert_eq!(
+            reason,
+            FerricHaltReason::LimitReached,
+            "an abandoned chunk loop must not look like an engine halt"
+        );
+
+        let mut halted = 1;
+        assert_eq!(
+            ferric_engine_is_halted(engine, &mut halted),
+            FerricError::Ok
+        );
+        assert_eq!(halted, 0, "cancellation must not set the engine halt flag");
+
+        let mut agenda = 0;
+        assert_eq!(
+            ferric_engine_agenda_count(engine, &mut agenda),
+            FerricError::Ok
+        );
+        assert!(
+            agenda > 0,
+            "cancellation must leave pending work on the agenda"
+        );
+
+        // Reporting cancellation and starting the next logical run is legal and
+        // completes the work the canceled run left behind.
+        assert_eq!(
+            ferric_engine_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 80, "the fresh run resumes from the preserved agenda");
+        assert_eq!(reason, FerricHaltReason::HaltRequested);
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn read_only_queries_and_error_maintenance_preserve_continuation() {
+    unsafe {
+        let engine = ferric_engine_new();
+        load_and_reset(engine, TWO_ACTIVATION_PROGRAM);
+
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_run_ex(engine, 1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(reason, FerricHaltReason::LimitReached);
+
+        // Everything a host may legitimately do between chunks.
+        let mut facts = 0;
+        assert_eq!(
+            ferric_engine_fact_count(engine, &mut facts),
+            FerricError::Ok
+        );
+        let mut agenda = 0;
+        assert_eq!(
+            ferric_engine_agenda_count(engine, &mut agenda),
+            FerricError::Ok
+        );
+        let mut halted = 1;
+        assert_eq!(
+            ferric_engine_is_halted(engine, &mut halted),
+            FerricError::Ok
+        );
+        let _ = action_diagnostic_count(engine);
+        assert_eq!(ferric_engine_clear_error(engine), FerricError::Ok);
+
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok,
+            "read-only queries and error maintenance must not end the logical run"
+        );
+        assert_eq!(reason, FerricHaltReason::AgendaEmpty);
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn a_failed_mutating_call_still_ends_the_logical_run() {
+    unsafe {
+        let engine = ferric_engine_new();
+        load_and_reset(engine, TWO_ACTIVATION_PROGRAM);
+
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_run_ex(engine, 1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(reason, FerricHaltReason::LimitReached);
+
+        // Retracting a fact ID that was never asserted fails, but the call is
+        // still a mutating entry point and closes continuation eligibility.
+        assert_ne!(ferric_engine_retract(engine, u64::MAX), FerricError::Ok);
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::InvalidArgument
         );
 
         ferric_engine_free(engine);

--- a/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
+++ b/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
@@ -2,12 +2,16 @@
 
 use std::ffi::{CStr, CString};
 
+#[cfg(feature = "serde")]
+use crate::engine::{
+    ferric_bytes_free, ferric_engine_deserialize_bincode, ferric_engine_serialize_bincode,
+};
 use crate::engine::{
     ferric_engine_action_diagnostic_count, ferric_engine_agenda_count, ferric_engine_clear_error,
     ferric_engine_continue_run_ex, ferric_engine_fact_count, ferric_engine_free,
     ferric_engine_halt, ferric_engine_is_halted, ferric_engine_last_error,
     ferric_engine_load_string, ferric_engine_new, ferric_engine_reset, ferric_engine_retract,
-    ferric_engine_run_ex, FerricEngine,
+    ferric_engine_run, ferric_engine_run_ex, ferric_engine_step, FerricEngine,
 };
 use crate::error::FerricError;
 use crate::types::FerricHaltReason;
@@ -526,6 +530,359 @@ fn a_failed_mutating_call_still_ends_the_logical_run() {
             ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
             FerricError::InvalidArgument
         );
+
+        ferric_engine_free(engine);
+    }
+}
+
+const ACTION_ERROR_PROGRAM: &str = r"
+    (defrule first (initial-fact) => (assert (go)))
+    (defrule boom (go) => (/ 1 0) (assert (never)))
+";
+
+/// Drive one chunk and assert the logical run is eligible to continue.
+unsafe fn start_eligible_logical_run(engine: *mut FerricEngine, source: &str) {
+    load_and_reset(engine, source);
+    let mut fired = 0;
+    let mut reason = FerricHaltReason::AgendaEmpty;
+    assert_eq!(
+        ferric_engine_run_ex(engine, 1, &mut fired, &mut reason),
+        FerricError::Ok
+    );
+    assert_eq!(reason, FerricHaltReason::LimitReached);
+}
+
+#[test]
+fn a_wrong_thread_mutating_call_leaves_the_logical_run_intact() {
+    unsafe {
+        let engine = ferric_engine_new();
+        start_eligible_logical_run(engine, TWO_ACTIVATION_PROGRAM);
+
+        // A wrong-thread call is rejected before it reaches engine state, so
+        // per the thread-affinity contract it must change nothing at all —
+        // including this engine's continuation eligibility.
+        let engine_addr = engine as usize;
+        let rejected = std::thread::spawn(move || {
+            let engine = engine_addr as *mut FerricEngine;
+            ferric_engine_reset(engine)
+        })
+        .join()
+        .unwrap();
+        assert_eq!(rejected, FerricError::ThreadViolation);
+
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok,
+            "a rejected wrong-thread call must not end the owner's logical run"
+        );
+        assert_eq!(fired, 1);
+        assert_eq!(reason, FerricHaltReason::AgendaEmpty);
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn a_wrong_thread_continuation_is_rejected_without_consuming_eligibility() {
+    unsafe {
+        let engine = ferric_engine_new();
+        start_eligible_logical_run(engine, TWO_ACTIVATION_PROGRAM);
+
+        let engine_addr = engine as usize;
+        let (code, fired, reason) = std::thread::spawn(move || {
+            let engine = engine_addr as *mut FerricEngine;
+            let mut fired = 55;
+            let mut reason = FerricHaltReason::ActionError;
+            let code = ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason);
+            (code, fired, reason)
+        })
+        .join()
+        .unwrap();
+        assert_eq!(code, FerricError::ThreadViolation);
+        assert_eq!(fired, 55);
+        assert_eq!(reason, FerricHaltReason::ActionError);
+
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(reason, FerricHaltReason::AgendaEmpty);
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn every_terminal_halt_reason_ends_continuation_eligibility() {
+    unsafe {
+        // AgendaEmpty is covered by the lifecycle test above; check the two
+        // remaining terminal reasons.
+        let engine = ferric_engine_new();
+        start_eligible_logical_run(engine, ACTION_ERROR_PROGRAM);
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(reason, FerricHaltReason::ActionError);
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::InvalidArgument,
+            "ActionError is terminal for the logical run"
+        );
+        ferric_engine_free(engine);
+
+        let engine = ferric_engine_new();
+        let halting = exact_boundary_halt_program(2);
+        start_eligible_logical_run(engine, &halting);
+        // Chunk two lands exactly on the halting activation.
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, 1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(reason, FerricHaltReason::LimitReached);
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, 1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 0);
+        assert_eq!(reason, FerricHaltReason::HaltRequested);
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::InvalidArgument,
+            "HaltRequested is terminal for the logical run"
+        );
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn zero_limit_chunks_fire_nothing_and_stay_eligible() {
+    unsafe {
+        let engine = ferric_engine_new();
+        load_and_reset(engine, &exact_boundary_halt_program(2));
+
+        let mut fired = 7;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_run_ex(engine, 0, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 0);
+        assert_eq!(reason, FerricHaltReason::LimitReached);
+
+        for _ in 0..2 {
+            assert_eq!(
+                ferric_engine_continue_run_ex(engine, 0, &mut fired, &mut reason),
+                FerricError::Ok
+            );
+            assert_eq!(fired, 0);
+            assert_eq!(reason, FerricHaltReason::LimitReached);
+        }
+
+        // Run up to and including the halting activation, then confirm that a
+        // zero-limit chunk reports the neutral boundary rather than the pending
+        // halt — the halt surfaces on the next chunk that can actually run.
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, 2, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 2);
+        assert_eq!(reason, FerricHaltReason::LimitReached);
+        let mut halted = 0;
+        assert_eq!(
+            ferric_engine_is_halted(engine, &mut halted),
+            FerricError::Ok
+        );
+        assert_eq!(halted, 1);
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, 0, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(reason, FerricHaltReason::LimitReached);
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 0);
+        assert_eq!(reason, FerricHaltReason::HaltRequested);
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn continuation_accepts_null_output_pointers_on_the_success_path() {
+    unsafe {
+        let engine = ferric_engine_new();
+        start_eligible_logical_run(engine, TWO_ACTIVATION_PROGRAM);
+
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, std::ptr::null_mut(), std::ptr::null_mut()),
+            FerricError::Ok
+        );
+        // The discarded reason was AgendaEmpty, so eligibility must be closed.
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::InvalidArgument
+        );
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn legacy_run_and_step_do_not_participate_in_logical_runs() {
+    unsafe {
+        // `ferric_engine_run` cannot report LimitReached, so it never arms
+        // continuation even when it stops at its limit.
+        let engine = ferric_engine_new();
+        load_and_reset(engine, TWO_ACTIVATION_PROGRAM);
+        let mut legacy_fired = 0;
+        assert_eq!(
+            ferric_engine_run(engine, 1, &mut legacy_fired),
+            FerricError::Ok
+        );
+        assert_eq!(legacy_fired, 1);
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::InvalidArgument
+        );
+        ferric_engine_free(engine);
+
+        // A single-activation step is a mutating call and ends the logical run.
+        let engine = ferric_engine_new();
+        start_eligible_logical_run(engine, TWO_ACTIVATION_PROGRAM);
+        let mut stepped = 0;
+        assert_eq!(ferric_engine_step(engine, &mut stepped), FerricError::Ok);
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::InvalidArgument
+        );
+        ferric_engine_free(engine);
+    }
+}
+
+/// Caller storage plus the outcome of a same-engine runtime call attempted
+/// from inside a serialization allocator callback.
+#[cfg(feature = "serde")]
+struct ReentrantResetContext {
+    engine: *mut FerricEngine,
+    storage: Vec<u8>,
+    reset_result: FerricError,
+}
+
+#[cfg(feature = "serde")]
+unsafe extern "C" fn reentrant_reset_allocator(
+    size: usize,
+    context: *mut std::ffi::c_void,
+) -> *mut u8 {
+    let context = &mut *context.cast::<ReentrantResetContext>();
+    context.reset_result = ferric_engine_reset(context.engine);
+    context.storage.resize(size, 0);
+    context.storage.as_mut_ptr()
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn a_reentrant_mutating_call_leaves_the_logical_run_intact() {
+    unsafe {
+        let engine = ferric_engine_new();
+        start_eligible_logical_run(engine, TWO_ACTIVATION_PROGRAM);
+
+        // Serialization is a read-only query, and the mutating call its
+        // allocator callback attempts is rejected before it reaches engine
+        // state. Neither may end the owner's logical run.
+        let mut context = ReentrantResetContext {
+            engine,
+            storage: Vec::new(),
+            reset_result: FerricError::Ok,
+        };
+        let mut data = std::ptr::null_mut();
+        let mut len = 0;
+        assert_eq!(
+            ferric_engine_serialize_bincode(
+                engine,
+                Some(reentrant_reset_allocator),
+                std::ptr::addr_of_mut!(context).cast::<std::ffi::c_void>(),
+                &mut data,
+                &mut len,
+            ),
+            FerricError::Ok
+        );
+        assert_eq!(
+            context.reset_result,
+            FerricError::InternalError,
+            "same-engine runtime reentry must be rejected"
+        );
+
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok,
+            "a rejected reentrant call must not end the logical run"
+        );
+        assert_eq!(fired, 1);
+        assert_eq!(reason, FerricHaltReason::AgendaEmpty);
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn continuation_eligibility_is_per_handle_and_not_serialized() {
+    unsafe {
+        let engine = ferric_engine_new();
+        start_eligible_logical_run(engine, TWO_ACTIVATION_PROGRAM);
+
+        let mut data = std::ptr::null_mut();
+        let mut len = 0;
+        assert_eq!(
+            ferric_engine_serialize_bincode(
+                engine,
+                None,
+                std::ptr::null_mut(),
+                &mut data,
+                &mut len
+            ),
+            FerricError::Ok
+        );
+
+        let mut restored = std::ptr::null_mut();
+        assert_eq!(
+            ferric_engine_deserialize_bincode(data, len, &mut restored),
+            FerricError::Ok
+        );
+        ferric_bytes_free(data, len);
+
+        let mut fired = 42;
+        let mut reason = FerricHaltReason::ActionError;
+        assert_eq!(
+            ferric_engine_continue_run_ex(restored, -1, &mut fired, &mut reason),
+            FerricError::InvalidArgument,
+            "a restored handle always begins a fresh logical run"
+        );
+        assert_eq!(fired, 42);
+        assert_eq!(reason, FerricHaltReason::ActionError);
+        ferric_engine_free(restored);
+
+        // Serializing is a read-only query, so the source handle is untouched.
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(reason, FerricHaltReason::AgendaEmpty);
 
         ferric_engine_free(engine);
     }

--- a/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
+++ b/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
@@ -887,3 +887,44 @@ fn continuation_eligibility_is_per_handle_and_not_serialized() {
         ferric_engine_free(engine);
     }
 }
+
+#[test]
+fn repeated_fresh_runs_overfire_at_an_exact_halt_boundary() {
+    unsafe {
+        // The reproducer from FR-CABI-009, kept as a characterization test.
+        // A host that chunks a long run with repeated `ferric_engine_run_ex`
+        // calls discards the halt each chunk cleared. At a 100-activation
+        // boundary with a 100-activation chunk the run reports 101 fired
+        // rules instead of 100, and the engine ends up un-halted with the
+        // post-halt rule already fired. This is correct fresh-run behavior —
+        // it is why `ferric_engine_continue_run_ex` exists.
+        let source = exact_boundary_halt_program(100);
+        let engine = ferric_engine_new();
+        load_and_reset(engine, &source);
+
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        let mut total = 0;
+        loop {
+            assert_eq!(
+                ferric_engine_run_ex(engine, 100, &mut fired, &mut reason),
+                FerricError::Ok
+            );
+            total += fired;
+            if reason != FerricHaltReason::LimitReached {
+                break;
+            }
+        }
+
+        assert_eq!(total, 101, "the naive chunk loop fires one rule too many");
+        assert_eq!(reason, FerricHaltReason::AgendaEmpty);
+
+        // The continuation-based loop agrees with one-shot execution instead.
+        assert_eq!(
+            observe_logical_run(&source, Some(100)),
+            observe_logical_run(&source, None)
+        );
+
+        ferric_engine_free(engine);
+    }
+}

--- a/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
+++ b/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
@@ -510,7 +510,7 @@ fn read_only_queries_and_error_maintenance_preserve_continuation() {
 }
 
 #[test]
-fn a_failed_mutating_call_still_ends_the_logical_run() {
+fn a_failed_call_that_reached_engine_state_still_ends_the_logical_run() {
     unsafe {
         let engine = ferric_engine_new();
         load_and_reset(engine, TWO_ACTIVATION_PROGRAM);

--- a/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
+++ b/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
@@ -1,0 +1,280 @@
+//! Raw C logical-run continuation contract tests.
+
+use std::ffi::{CStr, CString};
+
+use crate::engine::{
+    ferric_engine_action_diagnostic_count, ferric_engine_agenda_count,
+    ferric_engine_continue_run_ex, ferric_engine_fact_count, ferric_engine_free,
+    ferric_engine_halt, ferric_engine_is_halted, ferric_engine_last_error,
+    ferric_engine_load_string, ferric_engine_new, ferric_engine_reset, ferric_engine_run_ex,
+    FerricEngine,
+};
+use crate::error::FerricError;
+use crate::types::FerricHaltReason;
+
+unsafe fn load_and_reset(engine: *mut FerricEngine, source: &str) {
+    let source = CString::new(source).unwrap();
+    assert_eq!(
+        ferric_engine_load_string(engine, source.as_ptr()),
+        FerricError::Ok
+    );
+    assert_eq!(ferric_engine_reset(engine), FerricError::Ok);
+}
+
+unsafe fn action_diagnostic_count(engine: *const FerricEngine) -> usize {
+    let mut count = usize::MAX;
+    assert_eq!(
+        ferric_engine_action_diagnostic_count(engine, &mut count),
+        FerricError::Ok
+    );
+    count
+}
+
+const TWO_ACTIVATION_PROGRAM: &str = r"
+    (defrule first (initial-fact) => (assert (next)))
+    (defrule second (next) => (assert (done)))
+";
+
+const EARLY_DIAGNOSTIC_PROGRAM: &str = r"
+    (defrule seed
+        (initial-fact)
+        =>
+        (assert (marker keep))
+        (assert (candidate 1))
+        (assert (follow-up)))
+    (defrule bad-match
+        (candidate ?value&:(/ 1 0))
+        =>
+        (assert (must-not-fire)))
+    (defrule finish
+        ?pending <- (follow-up)
+        =>
+        (retract ?pending)
+        (assert (done)))
+";
+
+#[test]
+fn continuation_rejects_invalid_lifecycle_without_writing_outputs() {
+    unsafe {
+        let engine = ferric_engine_new();
+        let mut fired = 77;
+        let mut reason = FerricHaltReason::ActionError;
+
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::InvalidArgument
+        );
+        assert_eq!(fired, 77);
+        assert_eq!(reason, FerricHaltReason::ActionError);
+        let error = ferric_engine_last_error(engine);
+        assert!(!error.is_null());
+        assert!(CStr::from_ptr(error)
+            .to_string_lossy()
+            .contains("requires a preceding logical-run chunk"));
+
+        load_and_reset(engine, TWO_ACTIVATION_PROGRAM);
+        assert_eq!(
+            ferric_engine_run_ex(engine, 1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 1);
+        assert_eq!(reason, FerricHaltReason::LimitReached);
+
+        let mut agenda_count = 0;
+        assert_eq!(
+            ferric_engine_agenda_count(engine, &mut agenda_count),
+            FerricError::Ok
+        );
+        assert_eq!(agenda_count, 1);
+
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 1);
+        assert_eq!(reason, FerricHaltReason::AgendaEmpty);
+
+        fired = 88;
+        reason = FerricHaltReason::HaltRequested;
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::InvalidArgument
+        );
+        assert_eq!(fired, 88);
+        assert_eq!(reason, FerricHaltReason::HaltRequested);
+
+        assert_eq!(ferric_engine_reset(engine), FerricError::Ok);
+        assert_eq!(
+            ferric_engine_run_ex(engine, 1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(reason, FerricHaltReason::LimitReached);
+        assert_eq!(ferric_engine_halt(engine), FerricError::Ok);
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::InvalidArgument,
+            "runtime mutation between chunks must end continuation eligibility"
+        );
+
+        ferric_engine_free(engine);
+
+        fired = 99;
+        reason = FerricHaltReason::ActionError;
+        assert_eq!(
+            ferric_engine_continue_run_ex(std::ptr::null_mut(), -1, &mut fired, &mut reason),
+            FerricError::NullPointer
+        );
+        assert_eq!(fired, 99);
+        assert_eq!(reason, FerricHaltReason::ActionError);
+    }
+}
+
+#[test]
+fn continuation_preserves_diagnostics_from_an_early_chunk() {
+    unsafe {
+        let engine = ferric_engine_new();
+        load_and_reset(engine, EARLY_DIAGNOSTIC_PROGRAM);
+
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_run_ex(engine, 1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 1);
+        assert_eq!(reason, FerricHaltReason::LimitReached);
+        let early_count = action_diagnostic_count(engine);
+        assert!(early_count > 0, "the first chunk must emit a diagnostic");
+
+        assert_eq!(
+            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 1);
+        assert_eq!(reason, FerricHaltReason::AgendaEmpty);
+        assert_eq!(
+            action_diagnostic_count(engine),
+            early_count,
+            "continuation must not clear diagnostics from an earlier chunk"
+        );
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn fresh_run_resets_execution_diagnostics_without_resetting_working_memory() {
+    unsafe {
+        let engine = ferric_engine_new();
+        load_and_reset(engine, EARLY_DIAGNOSTIC_PROGRAM);
+
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_run_ex(engine, 1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(reason, FerricHaltReason::LimitReached);
+        assert!(action_diagnostic_count(engine) > 0);
+
+        let mut facts_before = 0;
+        assert_eq!(
+            ferric_engine_fact_count(engine, &mut facts_before),
+            FerricError::Ok
+        );
+        assert!(facts_before > 0);
+
+        assert_eq!(
+            ferric_engine_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 1);
+        assert_eq!(reason, FerricHaltReason::AgendaEmpty);
+        assert_eq!(
+            action_diagnostic_count(engine),
+            0,
+            "a fresh logical run must clear prior execution diagnostics"
+        );
+
+        let mut facts_after = 0;
+        assert_eq!(
+            ferric_engine_fact_count(engine, &mut facts_after),
+            FerricError::Ok
+        );
+        assert_eq!(
+            facts_after, facts_before,
+            "starting a fresh logical run must not reset working memory"
+        );
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
+fn fresh_run_clears_an_exact_boundary_halt_without_resetting_working_memory() {
+    unsafe {
+        let engine = ferric_engine_new();
+        load_and_reset(
+            engine,
+            r"
+            (defrule halt-first
+                (declare (salience 100))
+                (initial-fact)
+                =>
+                (halt))
+            (defrule after-halt
+                (declare (salience -100))
+                (initial-fact)
+                =>
+                (assert (done)))
+            ",
+        );
+
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_run_ex(engine, 1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 1);
+        assert_eq!(reason, FerricHaltReason::LimitReached);
+
+        let mut halted = 0;
+        assert_eq!(
+            ferric_engine_is_halted(engine, &mut halted),
+            FerricError::Ok
+        );
+        assert_eq!(halted, 1);
+
+        let mut facts_before = 0;
+        assert_eq!(
+            ferric_engine_fact_count(engine, &mut facts_before),
+            FerricError::Ok
+        );
+
+        assert_eq!(
+            ferric_engine_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 1);
+        assert_eq!(reason, FerricHaltReason::AgendaEmpty);
+        assert_eq!(
+            ferric_engine_is_halted(engine, &mut halted),
+            FerricError::Ok
+        );
+        assert_eq!(halted, 0);
+
+        let mut facts_after = 0;
+        assert_eq!(
+            ferric_engine_fact_count(engine, &mut facts_after),
+            FerricError::Ok
+        );
+        assert_eq!(
+            facts_after,
+            facts_before + 1,
+            "the fresh run must execute the preserved agenda instead of resetting working memory"
+        );
+
+        ferric_engine_free(engine);
+    }
+}

--- a/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
+++ b/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
@@ -466,6 +466,64 @@ fn host_cancellation_is_distinct_from_every_engine_terminal_state() {
 }
 
 #[test]
+fn cancellation_does_not_guarantee_an_unhalted_engine() {
+    unsafe {
+        // Cancelling at an arbitrary chunk boundary leaves the engine
+        // un-halted, but cancelling at a chunk that landed exactly on the
+        // activation calling `(halt)` does not: that chunk still reports
+        // LimitReached while the halt latch is already set. Hosts that care
+        // must query `ferric_engine_is_halted` rather than infer it from the
+        // last halt reason.
+        let engine = ferric_engine_new();
+        load_and_reset(engine, &exact_boundary_halt_program(100));
+
+        let mut fired = 0;
+        let mut reason = FerricHaltReason::AgendaEmpty;
+        assert_eq!(
+            ferric_engine_run_ex(engine, 100, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(fired, 100);
+        assert_eq!(
+            reason,
+            FerricHaltReason::LimitReached,
+            "the halting activation is the last one the limit permits"
+        );
+
+        // The host cancels here and never sees HaltRequested.
+        let mut halted = 0;
+        assert_eq!(
+            ferric_engine_is_halted(engine, &mut halted),
+            FerricError::Ok
+        );
+        assert_eq!(
+            halted, 1,
+            "a chunk that ran the halting activation leaves the engine halted"
+        );
+
+        let mut agenda = 0;
+        assert_eq!(
+            ferric_engine_agenda_count(engine, &mut agenda),
+            FerricError::Ok
+        );
+        assert!(agenda > 0, "cancellation still leaves the agenda intact");
+
+        // Starting the next logical run clears the latch, as documented.
+        assert_eq!(
+            ferric_engine_run_ex(engine, -1, &mut fired, &mut reason),
+            FerricError::Ok
+        );
+        assert_eq!(
+            ferric_engine_is_halted(engine, &mut halted),
+            FerricError::Ok
+        );
+        assert_eq!(halted, 0);
+
+        ferric_engine_free(engine);
+    }
+}
+
+#[test]
 fn read_only_queries_and_error_maintenance_preserve_continuation() {
     unsafe {
         let engine = ferric_engine_new();

--- a/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
+++ b/crates/ferric-rules-ffi/src/tests/logical_run_continuation.rs
@@ -719,22 +719,56 @@ fn zero_limit_chunks_fire_nothing_and_stay_eligible() {
 #[test]
 fn continuation_accepts_null_output_pointers_on_the_success_path() {
     unsafe {
-        let engine = ferric_engine_new();
-        start_eligible_logical_run(engine, TWO_ACTIVATION_PROGRAM);
+        // Either output may be discarded independently. Whichever pointer is
+        // supplied still receives its value, and the discarded reason still
+        // drives eligibility.
+        for (want_fired, want_reason) in [(false, false), (true, false), (false, true)] {
+            let engine = ferric_engine_new();
+            start_eligible_logical_run(engine, TWO_ACTIVATION_PROGRAM);
 
-        assert_eq!(
-            ferric_engine_continue_run_ex(engine, -1, std::ptr::null_mut(), std::ptr::null_mut()),
-            FerricError::Ok
-        );
-        // The discarded reason was AgendaEmpty, so eligibility must be closed.
-        let mut fired = 0;
-        let mut reason = FerricHaltReason::AgendaEmpty;
-        assert_eq!(
-            ferric_engine_continue_run_ex(engine, -1, &mut fired, &mut reason),
-            FerricError::InvalidArgument
-        );
+            let mut fired = u64::MAX;
+            let mut reason = FerricHaltReason::LimitReached;
+            let fired_out = if want_fired {
+                std::ptr::addr_of_mut!(fired)
+            } else {
+                std::ptr::null_mut()
+            };
+            let reason_out = if want_reason {
+                std::ptr::addr_of_mut!(reason)
+            } else {
+                std::ptr::null_mut()
+            };
+            assert_eq!(
+                ferric_engine_continue_run_ex(engine, -1, fired_out, reason_out),
+                FerricError::Ok,
+                "null outputs must not affect the success path ({want_fired}, {want_reason})"
+            );
+            if want_fired {
+                assert_eq!(fired, 1);
+            } else {
+                assert_eq!(fired, u64::MAX, "a null out_fired must not be written");
+            }
+            if want_reason {
+                assert_eq!(reason, FerricHaltReason::AgendaEmpty);
+            } else {
+                assert_eq!(
+                    reason,
+                    FerricHaltReason::LimitReached,
+                    "a null out_reason must not be written"
+                );
+            }
 
-        ferric_engine_free(engine);
+            // The run reached AgendaEmpty, so eligibility must be closed even
+            // when the host discarded that reason.
+            let mut probe_fired = 0;
+            let mut probe_reason = FerricHaltReason::AgendaEmpty;
+            assert_eq!(
+                ferric_engine_continue_run_ex(engine, -1, &mut probe_fired, &mut probe_reason),
+                FerricError::InvalidArgument
+            );
+
+            ferric_engine_free(engine);
+        }
     }
 }
 

--- a/crates/ferric-rules-ffi/src/types.rs
+++ b/crates/ferric-rules-ffi/src/types.rs
@@ -155,7 +155,8 @@ pub enum FerricFactType {
     Template = 1,
 }
 
-/// C-facing halt reason returned by `ferric_engine_run_ex`.
+/// C-facing halt reason returned by `ferric_engine_run_ex` and
+/// `ferric_engine_continue_run_ex`.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FerricHaltReason {

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -857,10 +857,12 @@ Contract:
 - Read-only queries and `ferric_engine_clear_error` may be interleaved between
   chunks. Any other call that reaches engine state ends the logical run,
   whether or not it then succeeds — a rejected `ferric_engine_retract` counts.
-- A call rejected *before* it reaches engine state changes nothing, including
-  continuation eligibility. Consistent with the thread-affinity contract below,
-  a null handle, a wrong-thread call, and a reentrant call from a host callback
-  all leave the logical run intact for the owner thread to continue.
+- A call rejected *before* it reaches engine state changes no runtime or
+  continuation state, though it still publishes its documented error on the
+  channels described under Error Handling. Consistent with the thread-affinity
+  contract below, a null handle, a wrong-thread call, and a reentrant call from
+  a host callback all leave the logical run intact for the owner thread to
+  continue.
 - Absent host cancellation, a chunked run and an equivalent one-shot run report
   the same total fired count, halt reason, agenda state, and action
   diagnostics.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -855,8 +855,12 @@ Contract:
   eligibility.
 - `*out_fired` is that chunk's count, not a running total. Hosts accumulate it.
 - Read-only queries and `ferric_engine_clear_error` may be interleaved between
-  chunks. Any other runtime-mutating call — including a failed one — ends the
-  logical run.
+  chunks. Any other call that reaches engine state ends the logical run,
+  whether or not it then succeeds — a rejected `ferric_engine_retract` counts.
+- A call rejected *before* it reaches engine state changes nothing, including
+  continuation eligibility. Consistent with the thread-affinity contract below,
+  a null handle, a wrong-thread call, and a reentrant call from a host callback
+  all leave the logical run intact for the owner thread to continue.
 - Absent host cancellation, a chunked run and an equivalent one-shot run report
   the same total fired count, halt reason, agenda state, and action
   diagnostics.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -866,10 +866,18 @@ Contract:
 - Absent host cancellation, a chunked run and an equivalent one-shot run report
   the same total fired count, halt reason, agenda state, and action
   diagnostics.
-- Host cancellation is not `FERRIC_HALT_REASON_HALT_REQUESTED`. A canceling
-  host stops submitting chunks and reports its own outcome; the engine is left
-  un-halted with its remaining agenda intact, and the next logical run starts
-  with `ferric_engine_run_ex`.
+- Host cancellation is not `FERRIC_HALT_REASON_HALT_REQUESTED`. The ABI has no
+  canceled state: a canceling host stops submitting chunks, reports its own
+  outcome, and starts any later logical run with `ferric_engine_run_ex`. The
+  agenda is left intact.
+- Cancellation does **not** guarantee an un-halted engine. The halt flag
+  reflects whatever the chunks that did run executed. If a chunk landed exactly
+  on an activation that called `(halt)`, that chunk still reports
+  `FERRIC_HALT_REASON_LIMIT_REACHED` — the pending halt only surfaces as
+  `HALT_REQUESTED` on the next chunk that can run — so a host canceling at that
+  boundary leaves a halted engine. Query `ferric_engine_is_halted` if the
+  distinction matters; `ferric_engine_run_ex` clears the flag either way when it
+  starts the next logical run.
 - Continuation eligibility is per-handle and is not serialized. A handle
   produced by `ferric_engine_deserialize_*` always begins a fresh logical run.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -813,6 +813,60 @@ if (ferric_engine_get_output_copy(engine, "t", NULL, 0, &output_len) ==
 ferric_engine_free(engine);
 ```
 
+### Logical Run Continuation
+
+`ferric_engine_run_ex` always begins a *fresh logical run*: it clears any
+pending halt request and the accumulated action diagnostics, but leaves working
+memory, the agenda, globals, and captured output untouched. Hosts that split
+one long run into bounded chunks — to poll for cancellation between them —
+must not use repeated `ferric_engine_run_ex` calls for that, because each call
+discards the halt flag and diagnostics that the previous chunk produced. A rule
+set that halts on its 100th activation then fires 101 rules through a
+100-activation chunk loop.
+
+`ferric_engine_continue_run_ex` resumes the current logical run instead:
+
+```c
+uint64_t chunk_fired = 0, total_fired = 0;
+FerricHaltReason reason;
+
+if (ferric_engine_run_ex(engine, CHUNK, &chunk_fired, &reason) != FERRIC_ERROR_OK)
+    return -1;
+total_fired += chunk_fired;
+
+while (reason == FERRIC_HALT_REASON_LIMIT_REACHED) {
+    if (host_canceled())   // cancellation is the host's outcome, not the engine's
+        break;
+    if (ferric_engine_continue_run_ex(engine, CHUNK, &chunk_fired, &reason) !=
+        FERRIC_ERROR_OK)
+        return -1;
+    total_fired += chunk_fired;
+}
+```
+
+Contract:
+
+- Continuation is legal only after `ferric_engine_run_ex` or a previous
+  continuation returned `FERRIC_HALT_REASON_LIMIT_REACHED`. Any other call
+  returns `FERRIC_ERROR_INVALID_ARGUMENT`, records a per-engine message, and
+  leaves `*out_fired` and `*out_reason` unmodified.
+- `FERRIC_HALT_REASON_AGENDA_EMPTY`, `FERRIC_HALT_REASON_HALT_REQUESTED`, and
+  `FERRIC_HALT_REASON_ACTION_ERROR` are terminal and end continuation
+  eligibility.
+- `*out_fired` is that chunk's count, not a running total. Hosts accumulate it.
+- Read-only queries and `ferric_engine_clear_error` may be interleaved between
+  chunks. Any other runtime-mutating call — including a failed one — ends the
+  logical run.
+- Absent host cancellation, a chunked run and an equivalent one-shot run report
+  the same total fired count, halt reason, agenda state, and action
+  diagnostics.
+- Host cancellation is not `FERRIC_HALT_REASON_HALT_REQUESTED`. A canceling
+  host stops submitting chunks and reports its own outcome; the engine is left
+  un-halted with its remaining agenda intact, and the next logical run starts
+  with `ferric_engine_run_ex`.
+- Continuation eligibility is per-handle and is not serialized. A handle
+  produced by `ferric_engine_deserialize_*` always begins a fresh logical run.
+
 ### Thread Affinity
 
 Engine instances are bound to their creating thread (`!Send + !Sync`):

--- a/scripts/ffi-panic-harness.sh
+++ b/scripts/ffi-panic-harness.sh
@@ -36,8 +36,8 @@ audit_symbols() {
 
     sed -nE 's/.*[ *](ferric_[a-z0-9_]+)\(.*/\1/p' \
         crates/ferric-rules-ffi/ferric.h | sort -u >"$expected"
-    if [[ $(wc -l <"$expected") -ne 100 ]]; then
-        echo "ffi-panic-harness: expected 100 header exports" >&2
+    if [[ $(wc -l <"$expected") -ne 101 ]]; then
+        echo "ffi-panic-harness: expected 101 header exports" >&2
         exit 1
     fi
     while IFS= read -r symbol; do


### PR DESCRIPTION
Closes #118

## Scope

FR-CABI-009 exposes logical-run continuation at the C ABI. `ferric_engine_run_ex`
starts a *fresh* logical run — clearing the pending halt request and action
diagnostics without touching working memory, the agenda, globals, or output —
and the new `ferric_engine_continue_run_ex` resumes that same logical run for
one more bounded chunk, preserving both.

The runtime already distinguished the two (`Engine::run` vs `Engine::continue_run`,
`crates/ferric-rules-runtime/src/engine.rs`); only the fresh-run half was
reachable from C. A cancelable host that chunked a long run through repeated
`ferric_engine_run_ex` calls therefore discarded whatever the previous chunk had
established.

Continuation eligibility is per-handle owner-thread state (`Cell<bool>` on
`FerricEngine`): armed only by a `LimitReached` result, cleared by every
mutating entry point through `borrow_engine_mut`. Misuse returns
`FERRIC_ERROR_INVALID_ARGUMENT` with a per-engine message and leaves both output
parameters untouched. No new `FerricError` variant was added — that would be an
ABI change requiring every binding's error mapping to move — and
`InvalidArgument` already covers "this call is not valid here".

## Red-before-fix evidence

The issue's reproducer is now a permanent characterization test,
`repeated_fresh_runs_overfire_at_an_exact_halt_boundary`: a rule set that halts
on its 100th activation reports **101** rules fired through a 100-activation
`ferric_engine_run_ex` chunk loop and ends up un-halted with the post-halt rule
already fired, versus **100** and `HALT_REQUESTED` one-shot. The same program
through a `ferric_engine_continue_run_ex` loop matches one-shot execution
exactly.

## Contract

Documented in the generated `ferric.h` preamble (`LOGICAL RUN CONTINUATION`),
the export's rustdoc, and `docs/compatibility.md` §16.13:

- Continuation is legal only after `LimitReached`. `AGENDA_EMPTY`,
  `HALT_REQUESTED`, and `ACTION_ERROR` are terminal and close eligibility.
- `*out_fired` is per-chunk, not cumulative. Hosts accumulate.
- Read-only queries and `ferric_engine_clear_error` may be interleaved between
  chunks. Any other call that **reaches engine state** ends the logical run,
  whether or not it then succeeds.
- A call **rejected before** it reaches engine state changes nothing, including
  eligibility. This keeps the continuation contract consistent with the
  thread-affinity contract, which promises a wrong-thread call mutates no state
  — and is the only sound option, since clearing the flag from a non-owner
  thread would race the owner's `Cell<bool>`.
- Host cancellation is not `HALT_REQUESTED`. A canceling host stops submitting
  chunks and reports its own outcome; the engine is left un-halted with its
  agenda intact.
- Eligibility is per-handle and not serialized; a deserialized handle starts a
  fresh logical run.

## Validation

- `just preflight-pr` — passed (fmt, workspace clippy `-D warnings`, workspace
  tests, cargo check, examples, Python fmt/lint/tests/bindings, Go lint, TS
  lint, license notices)
- `cargo test -p ferric-rules-ffi` — 329 passed; `--features serde` — 333 passed
- `cargo test -p ferric-rules-runtime` — 847 passed
- `just test-go` — passed; `just test-napi` — 35/35 passed
- `just ffi-panic-harness` — passed in both debug and release FFI profiles;
  the header export audit moves 100 → 101
- `just build-go-ffi` then `git diff --exit-code` on both committed headers —
  clean (CI's drift gate)

## Review

Reviewed by Codex (`gpt-5.3-codex`, xhigh) across two rounds before/while
opening.

**Round 1** found a genuine contradiction: the first draft of the contract said
a mutating call closes continuation "even if that call fails", which conflicts
with the thread-affinity guarantee for wrong-thread and reentrant rejections.
Implementation kept, documentation corrected (see the contract section above),
and the chosen semantics locked by tests for both the wrong-thread and the
reentrant-callback path. Round 1 also listed nine coverage gaps; eight are now
covered by tests.

**Round 2** confirmed the state-machine reasoning and accepted the doc fix, with
two minor follow-ups, both applied:

1. "changes nothing" overstated pre-entry immutability — a rejected call *does*
   publish its documented error to the per-engine and/or global channel. Now
   worded as "changes no runtime or continuation state, though it still
   publishes its documented error."
2. The null-output test covered only the both-null case; it now covers all three
   discarding combinations and asserts the null pointer is left untouched.

The one gap deliberately not closed is a dedicated panic-injection test for
`ferric_engine_continue_run_ex`. Codex agreed this is justified:
`every_authored_c_export_uses_the_generated_boundary_wrapper` structurally
audits that this export carries the generated wrapper, the macro mechanically
wires `PanicTarget::RawEngine`, and the native panic harness already exercises
that return/target category.

**GitHub Codex reviewer** raised one P2 on the cancellation contract, applied in
`264d354`: the bullet promised a canceling host is "left un-halted with its
remaining agenda intact". The agenda half holds; the un-halted half fails at
exactly the boundary this feature exists to handle, because `run_inner` checks
the halt latch at the top of each iteration — a chunk landing on the activation
that calls `(halt)` reports `LimitReached` with the latch already set. Contract
reworded and locked by `cancellation_does_not_guarantee_an_unhalted_engine`.

The hosted `claude-review` check also ran on this branch and reported no
findings.

## Acceptance criteria

- Chunked and one-shot execution return identical fired count, halt reason,
  agenda state, and action diagnostics absent host cancellation —
  `chunked_run_matches_one_shot_at_exact_halt_boundaries` (boundaries 1/100/200
  against chunk sizes 1/100/200/7) and
  `chunked_run_matches_one_shot_for_diagnostics_and_agenda` (chunk sizes 1/2/3)
  compare all four observables.
- Exact-boundary halts at 1, 100, and 200 activations are preserved.
- Diagnostics emitted in an early chunk survive the final result.
- A canceled run is distinguishable from every engine terminal state —
  `host_cancellation_is_distinct_from_every_engine_terminal_state`.
- Starting a new logical run resets only documented state: halt request and
  action diagnostics, not working memory or the agenda.
- API lifecycle is documented in the header, rustdoc, and compatibility guide;
  misuse is rejected with `INVALID_ARGUMENT` and unmodified outputs.

## Follow-ups (not in scope)

- **FR-GO-005 (#127)** — `Engine.RunWithLimit` in `bindings/go/engine.go` still
  chunks with repeated `ferric_engine_run_ex`; it now has the export it needs.
- **FR-NODE-002** — informed by the same contract.
- The Rust-level `Engine::continue_run` remains `#[doc(hidden)]`; promoting it
  to documented public API is a separate semver decision.
