### PR TITLE
fix(compat): classify diagnostics by execution phase

### DIFF
--- a/.github/workflows/compat-compare.yml
+++ b/.github/workflows/compat-compare.yml
@@ -73,7 +73,11 @@ jobs:
       - name: Assess base branch
         run: |
           git checkout ${{ inputs.base_sha }}
-          git checkout ${{ inputs.head_sha }} -- tools/ferric-tools/
+          # Assess both revisions through the head observer protocol.
+          git checkout ${{ inputs.head_sha }} -- \
+            tools/ferric-tools/ \
+            scripts/clips-reference.sh \
+            crates/ferric-rules-cli/src/commands/compat_observe.rs
           cargo build --release -p ferric-rules-cli
           uv run --project tools/ferric-tools ferric-compat-scan
           # Materialize head-format harnesses for base sources without modifying

--- a/crates/ferric-rules-cli/src/commands/compat_observe.rs
+++ b/crates/ferric-rules-cli/src/commands/compat_observe.rs
@@ -24,6 +24,7 @@ use slotmap::Key as _;
 
 const SCHEMA_NAME: &str = "ferric.compat-observation";
 const SCHEMA_VERSION: u8 = 1;
+const DIAGNOSTIC_TAXONOMY_VERSION: u8 = 1;
 const MAX_FIXTURE_ID_BYTES: usize = 128;
 const MIN_NONCE_HEX_BYTES: usize = 32;
 const MAX_NONCE_HEX_BYTES: usize = 128;
@@ -103,8 +104,8 @@ pub fn execute(
         Ok(source) => source,
         Err(error) => {
             observation.diagnostics.push(Diagnostic::error(
-                Phase::Load,
-                "io-error",
+                Phase::Harness,
+                "harness-error",
                 format!("failed to read {}: {error}", file_path.display()),
             ));
             return emit_failed_observation(observation, &engine);
@@ -114,8 +115,8 @@ pub fn execute(
     let actual_composed_sha256 = lowercase_sha256(&source_bytes);
     if actual_composed_sha256 != observation.fixture.composed_sha256 {
         observation.diagnostics.push(Diagnostic::error(
-            Phase::Load,
-            "digest-mismatch",
+            Phase::Harness,
+            "harness-error",
             format!(
                 "composed input digest mismatch: expected {}, observed {actual_composed_sha256}",
                 observation.fixture.composed_sha256
@@ -128,8 +129,8 @@ pub fn execute(
         Ok(source) => source,
         Err(error) => {
             observation.diagnostics.push(Diagnostic::error(
-                Phase::Load,
-                "encoding-error",
+                Phase::Harness,
+                "harness-error",
                 format!("composed input is not valid UTF-8: {error}"),
             ));
             return emit_failed_observation(observation, &engine);
@@ -139,6 +140,7 @@ pub fn execute(
     let load_result = match engine.load_str(source) {
         Ok(result) => result,
         Err(errors) => {
+            observation.phase_reached = load_failure_phase(&errors);
             observation
                 .diagnostics
                 .extend(errors.iter().map(load_error_diagnostic));
@@ -149,14 +151,14 @@ pub fn execute(
         load_result
             .warnings
             .into_iter()
-            .map(|message| Diagnostic::warning(Phase::Load, "load-warning", message)),
+            .map(|message| Diagnostic::warning(Phase::Load, "construct-error", message, true)),
     );
 
     observation.phase_reached = Phase::Reset;
     if let Err(error) = engine.reset() {
         observation.diagnostics.push(Diagnostic::error(
             Phase::Reset,
-            "runtime-error",
+            "evaluation-error",
             format!("reset failed: {error}"),
         ));
         return emit_failed_observation(observation, &engine);
@@ -168,14 +170,18 @@ pub fn execute(
         Err(error) => {
             observation.diagnostics.push(Diagnostic::error(
                 Phase::Run,
-                "runtime-error",
+                "evaluation-error",
                 format!("execution failed: {error}"),
             ));
             return emit_failed_observation(observation, &engine);
         }
     };
 
-    observation.phase_reached = Phase::PostRun;
+    observation.phase_reached = if matches!(run_result.halt_reason, HaltReason::ActionError) {
+        Phase::Run
+    } else {
+        Phase::PostRun
+    };
     match capture_state(&engine, Some(run_result)) {
         Ok(state) => {
             observation.apply_capture(state);
@@ -189,7 +195,7 @@ pub fn execute(
         Err(error) => {
             observation
                 .diagnostics
-                .push(Diagnostic::error(Phase::PostRun, "capture-error", error));
+                .push(Diagnostic::error(Phase::Harness, "harness-error", error));
             emit_observation(&observation, 1)
         }
     }
@@ -198,12 +204,17 @@ pub fn execute(
 fn emit_failed_observation(mut observation: Observation, engine: &Engine) -> i32 {
     match capture_state(engine, None) {
         Ok(state) => observation.apply_capture(state),
-        Err(error) => observation.diagnostics.push(Diagnostic::error(
-            observation.phase_reached,
-            "capture-error",
-            error,
-        )),
+        Err(error) => {
+            observation
+                .diagnostics
+                .push(Diagnostic::error(Phase::Harness, "harness-error", error));
+        }
     }
+    // COMPLETE attests that the adapter finished capturing the terminal
+    // envelope; it does not imply that the fixture reached or completed run.
+    observation
+        .lifecycle
+        .push(LifecycleRecord::complete(&observation.fixture));
     emit_observation(&observation, 1)
 }
 
@@ -263,10 +274,12 @@ fn capture_state(engine: &Engine, run_result: Option<RunResult>) -> Result<Captu
         })
         .collect();
 
+    let action_diagnostic_continued =
+        !run_result.is_some_and(|result| matches!(result.halt_reason, HaltReason::ActionError));
     let action_diagnostics = engine
         .action_diagnostics()
         .iter()
-        .map(action_error_diagnostic)
+        .map(|error| action_error_diagnostic(error, action_diagnostic_continued))
         .collect();
 
     let run = run_result.map(|result| RunObservation {
@@ -407,32 +420,33 @@ fn canonical_float(value: f64) -> String {
 }
 
 fn load_error_diagnostic(error: &LoadError) -> Diagnostic {
-    let category = match error {
-        LoadError::Parse(_) => "parse-error",
-        LoadError::Interpret(_) => "interpret-error",
-        LoadError::UnsupportedForm { .. } => "unsupported-form",
-        LoadError::InvalidAssert(_) => "invalid-assert",
-        LoadError::InvalidDefrule(_) => "invalid-defrule",
-        LoadError::Compile(_) => "compile-error",
-        LoadError::Validation(_) => "validation-error",
-        LoadError::Engine(_) => "engine-error",
-        LoadError::Io(_) => "io-error",
+    let (phase, category) = match error {
+        LoadError::Parse(_) => (Phase::Parse, "syntax-error"),
+        LoadError::Interpret(_)
+        | LoadError::UnsupportedForm { .. }
+        | LoadError::InvalidAssert(_)
+        | LoadError::InvalidDefrule(_)
+        | LoadError::Compile(_)
+        | LoadError::Validation(_)
+        | LoadError::Engine(_)
+        | LoadError::Io(_) => (Phase::Load, "construct-error"),
     };
-    Diagnostic::error(Phase::Load, category, error.to_string())
+    Diagnostic::error(phase, category, error.to_string())
 }
 
-fn action_error_diagnostic(error: &ActionError) -> Diagnostic {
-    let category = match error {
-        ActionError::UnknownAction(_) => "unknown-action",
-        ActionError::UnboundVariable(_) => "unbound-variable",
-        ActionError::FactNotFound(_) => "fact-not-found",
-        ActionError::InvalidAssert => "invalid-assert",
-        ActionError::InvalidRetract => "invalid-retract",
-        ActionError::Encoding(_) => "encoding-error",
-        ActionError::EvalError(_) | ActionError::Evaluator(_) => "evaluation-error",
-        ActionError::RuleReturn => "control-flow",
-    };
-    Diagnostic::warning(Phase::Run, category, error.to_string())
+fn load_failure_phase(errors: &[LoadError]) -> Phase {
+    if errors
+        .iter()
+        .all(|error| matches!(error, LoadError::Parse(_)))
+    {
+        Phase::Parse
+    } else {
+        Phase::Load
+    }
+}
+
+fn action_error_diagnostic(error: &ActionError, continued: bool) -> Diagnostic {
+    Diagnostic::warning(Phase::Run, "evaluation-error", error.to_string(), continued)
 }
 
 #[derive(Serialize)]
@@ -518,10 +532,12 @@ struct FixtureIdentity {
 #[serde(rename_all = "kebab-case")]
 enum Phase {
     Start,
+    Parse,
     Load,
     Reset,
     Run,
     PostRun,
+    Harness,
 }
 
 #[derive(Serialize)]
@@ -626,27 +642,33 @@ struct ChannelObservation {
 
 #[derive(Serialize)]
 struct Diagnostic {
+    taxonomy_version: u8,
     phase: Phase,
     severity: Severity,
     category: &'static str,
+    continued: bool,
     message: String,
 }
 
 impl Diagnostic {
     fn error(phase: Phase, category: &'static str, message: String) -> Self {
         Self {
+            taxonomy_version: DIAGNOSTIC_TAXONOMY_VERSION,
             phase,
             severity: Severity::Error,
             category,
+            continued: false,
             message,
         }
     }
 
-    fn warning(phase: Phase, category: &'static str, message: String) -> Self {
+    fn warning(phase: Phase, category: &'static str, message: String, continued: bool) -> Self {
         Self {
+            taxonomy_version: DIAGNOSTIC_TAXONOMY_VERSION,
             phase,
             severity: Severity::Warning,
             category,
+            continued,
             message,
         }
     }

--- a/crates/ferric-rules-cli/tests/compat_observe.rs
+++ b/crates/ferric-rules-cli/tests/compat_observe.rs
@@ -226,7 +226,7 @@ fn successful_observation_captures_typed_state_and_lifecycle() {
 }
 
 #[test]
-fn digest_mismatch_emits_parseable_start_only_partial_observation() {
+fn digest_mismatch_emits_completed_harness_failure_observation() {
     let output = observe(SOURCE, &"0".repeat(64));
     assert_exit_code(&output, 1);
     assert!(stderr_str(&output).is_empty());
@@ -234,10 +234,13 @@ fn digest_mismatch_emits_parseable_start_only_partial_observation() {
     let observation = parse_single_observation(&output);
     assert_eq!(observation["phase_reached"], "load");
     assert!(observation["run"].is_null());
-    assert_eq!(observation["lifecycle"].as_array().unwrap().len(), 1);
+    assert_eq!(observation["lifecycle"].as_array().unwrap().len(), 2);
     assert_eq!(observation["lifecycle"][0]["event"], "START");
-    assert_eq!(observation["diagnostics"][0]["phase"], "load");
-    assert_eq!(observation["diagnostics"][0]["category"], "digest-mismatch");
+    assert_eq!(observation["lifecycle"][1]["event"], "COMPLETE");
+    assert_eq!(observation["diagnostics"][0]["taxonomy_version"], 1);
+    assert_eq!(observation["diagnostics"][0]["phase"], "harness");
+    assert_eq!(observation["diagnostics"][0]["category"], "harness-error");
+    assert_eq!(observation["diagnostics"][0]["continued"], false);
     assert_eq!(observation["modules"]["current"], "MAIN");
 }
 
@@ -272,8 +275,29 @@ fn distinct_source_and_composed_digests_remain_bound_without_false_verification(
 }
 
 #[test]
-fn load_failure_emits_parseable_start_only_partial_observation() {
+fn parse_failure_emits_completed_versioned_syntax_diagnostic() {
     let invalid_source = "(defrule incomplete";
+    let digest = sha256(invalid_source.as_bytes());
+    let output = observe(invalid_source, &digest);
+    assert_exit_code(&output, 1);
+    assert!(stderr_str(&output).is_empty());
+
+    let observation = parse_single_observation(&output);
+    assert_eq!(observation["phase_reached"], "parse");
+    assert!(observation["run"].is_null());
+    assert_eq!(observation["lifecycle"].as_array().unwrap().len(), 2);
+    assert_eq!(observation["lifecycle"][0]["event"], "START");
+    assert_eq!(observation["lifecycle"][1]["event"], "COMPLETE");
+    assert_eq!(observation["diagnostics"][0]["taxonomy_version"], 1);
+    assert_eq!(observation["diagnostics"][0]["phase"], "parse");
+    assert_eq!(observation["diagnostics"][0]["severity"], "error");
+    assert_eq!(observation["diagnostics"][0]["category"], "syntax-error");
+    assert_eq!(observation["diagnostics"][0]["continued"], false);
+}
+
+#[test]
+fn construct_failure_is_distinct_from_parse_failure() {
+    let invalid_source = "(not-a-clips-construct)";
     let digest = sha256(invalid_source.as_bytes());
     let output = observe(invalid_source, &digest);
     assert_exit_code(&output, 1);
@@ -282,10 +306,28 @@ fn load_failure_emits_parseable_start_only_partial_observation() {
     let observation = parse_single_observation(&output);
     assert_eq!(observation["phase_reached"], "load");
     assert!(observation["run"].is_null());
-    assert_eq!(observation["lifecycle"].as_array().unwrap().len(), 1);
-    assert_eq!(observation["lifecycle"][0]["event"], "START");
-    assert_eq!(observation["diagnostics"][0]["severity"], "error");
-    assert_eq!(observation["diagnostics"][0]["category"], "parse-error");
+    assert_eq!(observation["lifecycle"][1]["event"], "COMPLETE");
+    assert_eq!(observation["diagnostics"][0]["taxonomy_version"], 1);
+    assert_eq!(observation["diagnostics"][0]["phase"], "load");
+    assert_eq!(observation["diagnostics"][0]["category"], "construct-error");
+    assert_eq!(observation["diagnostics"][0]["continued"], false);
+}
+
+#[test]
+fn nonfatal_load_diagnostic_records_that_execution_continued() {
+    let source = "42";
+    let digest = sha256(source.as_bytes());
+    let output = observe(source, &digest);
+    assert_exit_code(&output, 0);
+
+    let observation = parse_single_observation(&output);
+    assert_eq!(observation["phase_reached"], "post-run");
+    assert_eq!(observation["run"]["halt_reason"], "agenda-empty");
+    assert_eq!(observation["diagnostics"][0]["taxonomy_version"], 1);
+    assert_eq!(observation["diagnostics"][0]["phase"], "load");
+    assert_eq!(observation["diagnostics"][0]["severity"], "warning");
+    assert_eq!(observation["diagnostics"][0]["category"], "construct-error");
+    assert_eq!(observation["diagnostics"][0]["continued"], true);
 }
 
 #[test]
@@ -328,16 +370,19 @@ fn action_error_stops_before_halt_and_is_captured_without_output_leakage() {
     assert!(stderr_str(&output).is_empty());
 
     let observation = parse_single_observation(&output);
+    assert_eq!(observation["phase_reached"], "run");
     assert_eq!(observation["run"]["rules_fired"], 1);
     assert_eq!(observation["run"]["halt_reason"], "action-error");
     assert_eq!(observation["run"]["agenda_size"], 1);
     assert_eq!(observation["run"]["halted"], false);
     assert_eq!(observation["diagnostics"][0]["phase"], "run");
     assert_eq!(observation["diagnostics"][0]["severity"], "warning");
+    assert_eq!(observation["diagnostics"][0]["taxonomy_version"], 1);
     assert_eq!(
         observation["diagnostics"][0]["category"],
         "evaluation-error"
     );
+    assert_eq!(observation["diagnostics"][0]["continued"], false);
     assert!(observation["channels"]
         .as_array()
         .unwrap()

--- a/docker/clips-reference/ferric-clips-observer.c
+++ b/docker/clips-reference/ferric-clips-observer.c
@@ -20,13 +20,16 @@
 #define DIGEST_LENGTH 64
 #define AUTH_KEY_HEX_LENGTH 64
 #define AUTH_KEY_LENGTH 32
+#define DIAGNOSTIC_TAXONOMY_VERSION 1
 #define MAX_CONFIG_LENGTH                                                     \
   (MAX_NONCE_LENGTH + MAX_TOKEN_LENGTH + (2 * DIGEST_LENGTH) +               \
    AUTH_KEY_HEX_LENGTH + 5)
 #define MAX_PROBE_PAYLOAD (16U * 1024U * 1024U)
+#define MAX_DIAGNOSTIC_PAYLOAD MAX_PROBE_PAYLOAD
 
 #define NATIVE_EMIT_FUNCTION "ferric-compat-native-emit"
 #define NATIVE_COMPLETE_FUNCTION "ferric-compat-native-complete"
+#define DIAGNOSTIC_ROUTER_NAME "ferric-diagnostic-observer"
 
 struct observer_config {
   char nonce[MAX_NONCE_LENGTH + 1];
@@ -34,6 +37,12 @@ struct observer_config {
   char source_sha256[DIGEST_LENGTH + 1];
   char composed_sha256[DIGEST_LENGTH + 1];
   unsigned char auth_key[AUTH_KEY_LENGTH];
+};
+
+struct diagnostic_buffer {
+  char *data;
+  size_t length;
+  size_t capacity;
 };
 
 static struct observer_config config;
@@ -44,6 +53,9 @@ static int observed_evaluation_error = 0;
 static int observer_after_run = 0;
 static int observer_complete = 0;
 static int protocol_violation = 0;
+static struct diagnostic_buffer diagnostic_output = {NULL, 0, 0};
+static const char *active_diagnostic_phase = NULL;
+static int phase_sequence = 0;
 
 static void write_all(int descriptor, const char *data, size_t length) {
   size_t written = 0;
@@ -124,6 +136,143 @@ static void emit_lifecycle(int sequence, const char *event) {
   emit_formatted_record("LIFECYCLE|%d|%s|%s|%s|%s", sequence, event,
                         config.fixture_id, config.source_sha256,
                         config.composed_sha256);
+}
+
+static void emit_phase(const char *phase, const char *event,
+                       const char *status) {
+  phase_sequence++;
+  if (status == NULL) {
+    emit_formatted_record("PHASE|%d|%s|%s", phase_sequence, phase, event);
+  } else {
+    emit_formatted_record("PHASE|%d|%s|%s|%s", phase_sequence, phase, event,
+                          status);
+  }
+}
+
+static void emit_diagnostic(const char *phase, int continued,
+                            const char *payload, size_t payload_length) {
+  char header[96];
+  int header_length;
+  char *record;
+
+  header_length = snprintf(header, sizeof(header), "DIAGNOSTIC|%d|%s|%d|%zu|",
+                           DIAGNOSTIC_TAXONOMY_VERSION, phase,
+                           continued != 0, payload_length);
+  if (header_length <= 0 || (size_t)header_length >= sizeof(header)) {
+    fail("diagnostic header is too long");
+  }
+  if (payload_length > MAX_DIAGNOSTIC_PAYLOAD ||
+      payload_length > SIZE_MAX - (size_t)header_length) {
+    fail("diagnostic record length overflow");
+  }
+  record = malloc((size_t)header_length + payload_length);
+  if (record == NULL) {
+    fail("could not allocate a diagnostic record");
+  }
+  (void)memcpy(record, header, (size_t)header_length);
+  if (payload_length != 0) {
+    (void)memcpy(record + header_length, payload, payload_length);
+  }
+  emit_authenticated(record, (size_t)header_length + payload_length);
+  (void)memset(record, 0, (size_t)header_length + payload_length);
+  free(record);
+}
+
+static void append_diagnostic_output(const char *text) {
+  const size_t text_length = strlen(text);
+  size_t required;
+  size_t capacity;
+  char *resized;
+
+  if (text_length > MAX_DIAGNOSTIC_PAYLOAD - diagnostic_output.length) {
+    fail("CLIPS diagnostic output is too long");
+  }
+  required = diagnostic_output.length + text_length;
+  if (required <= diagnostic_output.capacity) {
+    (void)memcpy(diagnostic_output.data + diagnostic_output.length, text,
+                 text_length);
+    diagnostic_output.length = required;
+    return;
+  }
+
+  capacity = diagnostic_output.capacity == 0 ? 1024 : diagnostic_output.capacity;
+  while (capacity < required) {
+    if (capacity > MAX_DIAGNOSTIC_PAYLOAD / 2) {
+      capacity = MAX_DIAGNOSTIC_PAYLOAD;
+    } else {
+      capacity *= 2;
+    }
+  }
+  resized = realloc(diagnostic_output.data, capacity);
+  if (resized == NULL) {
+    fail("could not allocate CLIPS diagnostic output");
+  }
+  diagnostic_output.data = resized;
+  diagnostic_output.capacity = capacity;
+  (void)memcpy(diagnostic_output.data + diagnostic_output.length, text,
+               text_length);
+  diagnostic_output.length = required;
+}
+
+static int diagnostic_router_query(void *environment,
+                                   const char *logical_name) {
+  if (environment != observer_environment || active_diagnostic_phase == NULL) {
+    return 0;
+  }
+  return strcmp(logical_name, "werror") == 0 ||
+         strcmp(logical_name, "wwarning") == 0;
+}
+
+static int diagnostic_router_print(void *environment,
+                                   const char *logical_name,
+                                   const char *text) {
+  (void)logical_name;
+  if (environment != observer_environment || active_diagnostic_phase == NULL ||
+      text == NULL) {
+    return 0;
+  }
+  write_all(STDERR_FILENO, text, strlen(text));
+  append_diagnostic_output(text);
+  return 1;
+}
+
+static void begin_diagnostic_phase(const char *phase) {
+  if (active_diagnostic_phase != NULL) {
+    fail("diagnostic phases overlap");
+  }
+  diagnostic_output.length = 0;
+  emit_phase(phase, "BEGIN", NULL);
+  active_diagnostic_phase = phase;
+}
+
+static void end_diagnostic_phase(const char *phase, int has_diagnostic,
+                                 int continued) {
+  const char *status;
+
+  if (active_diagnostic_phase == NULL ||
+      strcmp(active_diagnostic_phase, phase) != 0) {
+    fail("diagnostic phase ended out of order");
+  }
+  active_diagnostic_phase = NULL;
+  if (has_diagnostic) {
+    emit_diagnostic(phase, continued, diagnostic_output.data,
+                    diagnostic_output.length);
+    status = continued ? "CONTINUED" : "ERROR";
+  } else {
+    status = "OK";
+  }
+  diagnostic_output.length = 0;
+  emit_phase(phase, "END", status);
+}
+
+static void release_diagnostic_output(void) {
+  if (diagnostic_output.data != NULL) {
+    (void)memset(diagnostic_output.data, 0, diagnostic_output.capacity);
+    free(diagnostic_output.data);
+  }
+  diagnostic_output.data = NULL;
+  diagnostic_output.length = 0;
+  diagnostic_output.capacity = 0;
 }
 
 static int valid_nonce(const char *nonce) {
@@ -391,6 +540,12 @@ int main(int argc, char **argv) {
   void *environment;
   long long rules_fired;
   long long agenda_size;
+  int load_failed;
+  int reset_evaluation_error;
+  int reset_halt_execution;
+  int reset_halt_rules;
+  int reset_diagnostic;
+  int run_failed;
   int result = 0;
 
   if (argc != 3 || strcmp(argv[1], "--source") != 0) {
@@ -421,15 +576,41 @@ int main(int argc, char **argv) {
     (void)DestroyEnvironment(environment);
     return 127;
   }
-
-  if (EnvLoad(environment, source_path) != 1) {
-    mark_violation("source-load-failed");
+  if (!EnvAddRouter(environment, DIAGNOSTIC_ROUTER_NAME, 30,
+                    diagnostic_router_query, diagnostic_router_print, NULL,
+                    NULL, NULL)) {
+    fprintf(stderr,
+            "ferric CLIPS observer: cannot register diagnostic router\n");
     (void)DestroyEnvironment(environment);
-    return 1;
+    return 127;
   }
 
   emit_lifecycle(0, "START");
+  begin_diagnostic_phase("load");
+  load_failed = EnvLoad(environment, source_path) != 1;
+  end_diagnostic_phase("load", load_failed, 0);
+  if (load_failed) {
+    emit_lifecycle(3, "COMPLETE");
+    observer_complete = 1;
+    (void)DestroyEnvironment(environment);
+    observer_environment = NULL;
+    release_diagnostic_output();
+    (void)memset(&config, 0, sizeof(config));
+    return 1;
+  }
+
+  SetEvaluationError(environment, FALSE);
+  begin_diagnostic_phase("reset");
   EnvReset(environment);
+  reset_evaluation_error = GetEvaluationError(environment) != 0;
+  reset_halt_execution = GetHaltExecution(environment) != 0;
+  reset_halt_rules = EnvGetHaltRules(environment) != 0;
+  reset_diagnostic = reset_evaluation_error || reset_halt_execution ||
+                     reset_halt_rules;
+  end_diagnostic_phase("reset", reset_diagnostic, reset_diagnostic);
+  SetEvaluationError(environment, FALSE);
+  SetHaltExecution(environment, FALSE);
+  EnvSetHaltRules(environment, FALSE);
   observed_halt_rules = 0;
   observed_halt_execution = 0;
   observed_evaluation_error = 0;
@@ -439,6 +620,7 @@ int main(int argc, char **argv) {
     (void)DestroyEnvironment(environment);
     return 127;
   }
+  begin_diagnostic_phase("run");
   rules_fired = EnvRun(environment, -1);
   observe_after_firing(environment);
   if (!EnvRemoveRunFunction(environment, "ferric-native-observer")) {
@@ -446,6 +628,9 @@ int main(int argc, char **argv) {
     (void)DestroyEnvironment(environment);
     return 127;
   }
+  run_failed = observed_evaluation_error != 0 ||
+               (observed_halt_execution != 0 && observed_halt_rules == 0);
+  end_diagnostic_phase("run", run_failed, 0);
   agenda_size = count_agenda(environment);
   emit_formatted_record(
       "RUN|-1|%lld|%d|%d|%d|%lld|%d", rules_fired,
@@ -454,9 +639,14 @@ int main(int argc, char **argv) {
       agenda_size, protocol_violation != 0);
   observer_after_run = 1;
 
-  evaluate_probe_operations(environment);
-  if (!observer_complete) {
-    mark_violation("completion-missing");
+  if (run_failed) {
+    emit_lifecycle(3, "COMPLETE");
+    observer_complete = 1;
+  } else {
+    evaluate_probe_operations(environment);
+    if (!observer_complete) {
+      mark_violation("completion-missing");
+    }
   }
   if (protocol_violation) {
     result = 1;
@@ -466,6 +656,7 @@ int main(int argc, char **argv) {
     return 127;
   }
   observer_environment = NULL;
+  release_diagnostic_output();
   (void)memset(&config, 0, sizeof(config));
   return result;
 }

--- a/docs/compatibility-assessment.md
+++ b/docs/compatibility-assessment.md
@@ -45,9 +45,11 @@ started.
 
 ## Observation boundary
 
-Every run receives a fresh 128-bit nonce. Both engines must produce exactly one
-nonce- and digest-bound `START`/`COMPLETE` lifecycle and a complete post-run
-observation.
+Every run receives a fresh 128-bit nonce. Successful observations must produce
+exactly one nonce- and digest-bound `START`/`COMPLETE` lifecycle and a complete
+post-run observation. A semantic load, reset, or run failure may instead end at
+its authenticated terminal phase record; incomplete or out-of-order protocol
+evidence remains invalid.
 
 Ferric exposes this through the hidden `ferric compat-observe` command, leaving
 the public `ferric run --json` contract unchanged. Reference CLIPS is loaded by
@@ -60,6 +62,13 @@ identity, and authentication binding are consumed before the CLIPS environment
 is created and never enter the fixture-visible environment or command stream.
 Parsing uses byte offsets, so UTF-8 values are framed by their encoded byte
 length.
+
+The native adapter installs a dedicated CLIPS error router and emits explicit
+authenticated `load`, `reset`, and `run` phase boundaries. Router bytes are
+teed immediately to raw stderr, while CLIPS load/evaluation/halt state decides
+whether they become a diagnostic; fixture text alone cannot create one.
+Diagnostic payloads are length-framed so native messages containing delimiters
+or newlines remain exact.
 
 The native observer is built into `ferric-rules/clips-reference:latest` from
 `docker/clips-reference/`. Rebuild that local image after changing the
@@ -90,8 +99,24 @@ A valid semantic mismatch is `divergent`. A missing declaration is
 `pending/oracle-missing`. Missing, stale, malformed, incomplete, spoofed, or
 unsupported evidence is `pending/oracle-invalid:*`; the exact composed input
 is retained under `.ferric-compat/failures/`, when one exists, and
-`compat-run` exits nonzero. Expected diagnostics remain invalid until
-phase-aware diagnostic classification is implemented.
+`compat-run` exits nonzero.
+
+Diagnostics use taxonomy version 1 and retain their engine-native message
+alongside the canonical fields `phase`, `category`, and `continued`. The
+semantic mappings are `parse/syntax-error`, `load/construct-error`, and
+`reset|run/evaluation-error`. Multiple native diagnostics may collapse only
+when all canonical fields agree. Unknown categories, versions, or mixed
+diagnostic states fail closed. A known phase, category, or continuation
+mismatch is `divergent`; matching terminal diagnostics without a complete
+semantic oracle are `incompatible`, never `equivalent`.
+
+Process termination is recorded independently as `exit`, `timeout`, `signal`,
+or `spawn-error`, with exit status and signal number where available. It does
+not overwrite authenticated engine diagnostics. Timeout and signal evidence
+also retains the last authenticated active phase when one was observed. Raw
+stdout and stderr bytes remain losslessly encoded under each result's
+`raw_output` field, while readable channel text and observation envelopes
+remain in the manifest for audit.
 
 Manifest-v2 output-based results are deliberately reset during schema-v3
 migration. Undeclared fixtures remain pending instead of preserving legacy
@@ -108,8 +133,9 @@ just compat-run
 just compat-report
 ```
 
-`compat-report` exposes declaration, lifecycle, effect, version, and
-normalization coverage. Compare a baseline and candidate with:
+`compat-report` exposes declaration, lifecycle, effect, oracle version,
+normalization, diagnostic phase/category/continuation, and process termination
+evidence. Compare a baseline and candidate with:
 
 ```console
 just compat-diff BASE_MANIFEST HEAD_MANIFEST

--- a/scripts/clips-reference.sh
+++ b/scripts/clips-reference.sh
@@ -14,6 +14,7 @@ OBSERVER_FIXTURE_ID=""
 OBSERVER_SOURCE_SHA256=""
 OBSERVER_COMPOSED_SHA256=""
 OBSERVER_AUTH_KEY=""
+OBSERVER_CONTAINER_NAME=""
 WORKDIR_IN_CONTAINER="/workspace"
 
 usage() {
@@ -48,6 +49,9 @@ Run options:
                         Bind native observations to composed bytes (internal)
   --observer-auth-key <key>
                         Authenticate native observation records (internal)
+  --observer-container-name <name>
+                        Assign a caller-owned Docker name for timeout cleanup
+                        (internal; structured observer only)
   --quiet               Execute stdin with CLIPS batch* semantics, suppressing
                         the interactive banner, prompts, and return values
 
@@ -186,6 +190,7 @@ run_command() {
 
   local clips_args=()
   local observer_args=()
+  local container_name_args=()
   if [[ "$QUIET" -eq 1 && -z "$OBSERVER_NONCE" ]]; then
     clips_args+=("-f2" "/dev/stdin")
   fi
@@ -211,13 +216,19 @@ run_command() {
       echo "error: --observer-auth-key must encode 32 bytes as lowercase hexadecimal" >&2
       exit 1
     fi
+    if [[ ! "$OBSERVER_CONTAINER_NAME" =~ ^[a-z0-9][a-z0-9_.-]{0,127}$ ]]; then
+      echo "error: structured observer requires a protocol-safe container name" >&2
+      exit 1
+    fi
     observer_args+=(
       "--ferric-observer"
       "--source"
       "${container_files[0]}"
     )
+    container_name_args+=("--name" "$OBSERVER_CONTAINER_NAME")
   elif [[ -n "$OBSERVER_FIXTURE_ID" || -n "$OBSERVER_SOURCE_SHA256" ||
-          -n "$OBSERVER_COMPOSED_SHA256" || -n "$OBSERVER_AUTH_KEY" ]]; then
+          -n "$OBSERVER_COMPOSED_SHA256" || -n "$OBSERVER_AUTH_KEY" ||
+          -n "$OBSERVER_CONTAINER_NAME" ]]; then
     echo "error: observer bindings require --observer-nonce" >&2
     exit 1
   fi
@@ -238,6 +249,7 @@ run_command() {
       printf '(exit)\n'
     fi
   } | docker run --rm -i \
+      ${container_name_args[@]+"${container_name_args[@]}"} \
       -v "${repo_root}:${WORKDIR_IN_CONTAINER}:ro" \
       -w "$WORKDIR_IN_CONTAINER" \
       "$full_image" \
@@ -298,6 +310,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --observer-auth-key)
       OBSERVER_AUTH_KEY="$2"
+      shift 2
+      ;;
+    --observer-container-name)
+      OBSERVER_CONTAINER_NAME="$2"
       shift 2
       ;;
     --quiet)

--- a/tools/ferric-tools/src/ferric_tools/compat/clips_oracle.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/clips_oracle.py
@@ -397,6 +397,14 @@ def _parse_native_records(
         cursor = end
 
     semantic_bytes = _remove_intervals(raw, intervals)
+    if interrupted and not records:
+        public_prefix = b"\n" + reserved_prefix
+        prefix_start = semantic_bytes.rfind(public_prefix)
+        if prefix_start >= 0:
+            trailing_bytes = semantic_bytes[prefix_start:]
+            if len(trailing_bytes) < len(exact_prefix) and exact_prefix.startswith(trailing_bytes):
+                semantic_bytes = semantic_bytes[:prefix_start]
+                issues.append("truncated-native-record")
     if reserved_prefix in semantic_bytes:
         issues.append("unexpected-native-reserved-prefix")
     semantic_stderr = (

--- a/tools/ferric-tools/src/ferric_tools/compat/clips_oracle.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/clips_oracle.py
@@ -17,6 +17,13 @@ import re
 from collections.abc import Iterable
 from dataclasses import dataclass
 
+from ferric_tools.compat.diagnostics import (
+    DIAGNOSTIC_TAXONOMY_VERSION,
+    ENGINE_DIAGNOSTIC_CATEGORIES,
+    ENGINE_DIAGNOSTIC_PHASES,
+    UNKNOWN_DIAGNOSTIC,
+)
+
 ORACLE_SCHEMA = "ferric.compat-observation"
 ORACLE_VERSION = 1
 RECORD_PREFIX = "__FERRIC_COMPAT_ORACLE_V1__|"
@@ -27,10 +34,29 @@ _TOKEN_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
 _DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
 _NONCE_RE = re.compile(r"^[0-9a-f]{32,128}$")
 _AUTH_KEY_RE = re.compile(r"^[0-9a-f]{64}$")
-_DIAGNOSTIC_RE = re.compile(r"\[[A-Z][A-Z0-9]*\d+\]")
+_CLIPS_DIAGNOSTIC_CODE_RE = re.compile(r"(?m)^[ \t]*\[([A-Z][A-Z0-9]*\d+)\]")
 _HARNESS_LINE_RE = re.compile(r"^FERRIC-HARNESS\|(?P<version>\d+)\|(?P<body>.*)$")
-_MAX_PROBE_PAYLOAD = 16 * 1024 * 1024
+_MAX_NATIVE_PAYLOAD = 16 * 1024 * 1024
 _PROBE_KINDS = frozenset({"PHASE", "MODULE", "FOCUS", "FACT", "SLOT", "VALUE", "GLOBAL"})
+_NATIVE_PHASES = ("load", "reset", "run")
+_NATIVE_PHASE_STATUSES = frozenset({"OK", "CONTINUED", "ERROR"})
+_LOAD_SYNTAX_DIAGNOSTIC_FAMILIES = frozenset({"CSTRCPSR", "SCANNER"})
+_LOAD_SYNTAX_DIAGNOSTIC_CODES = frozenset({"PRNTUTIL2"})
+_LOAD_CONSTRUCT_DIAGNOSTIC_FAMILIES = frozenset(
+    {
+        "ARGACCES",
+        "CLASSPSR",
+        "DFFCTPSR",
+        "DFFNXPSR",
+        "EXPRNPSR",
+        "GENRCPSR",
+        "GLOBLPSR",
+        "INHERPSR",
+        "MODULPSR",
+        "RULEPSR",
+        "TMPLTPSR",
+    }
+)
 
 
 class ClipsOracleProtocolError(ValueError):
@@ -210,6 +236,7 @@ def _parse_native_records(
     *,
     nonce: str,
     auth_key: str,
+    interrupted: bool = False,
 ) -> tuple[list[_NativeRecord], str, list[str]]:
     exact_prefix = f"\n{NATIVE_RECORD_PREFIX}{nonce}|".encode()
     reserved_prefix = NATIVE_RECORD_PREFIX.encode()
@@ -227,27 +254,63 @@ def _parse_native_records(
         kind_end = raw.find(b"|", kind_start)
         newline = raw.find(b"\n", kind_start)
         if newline >= 0 and (kind_end < 0 or newline < kind_end):
-            kind = _decode_utf8(raw[kind_start:newline], label="native record kind")
             end = newline + 1
-            records.append(_NativeRecord(kind, (), None, start, end))
+            issues.append("native-authentication-malformed")
             intervals.append((start, end))
             cursor = end
             continue
         if kind_end < 0:
-            raise ClipsOracleProtocolError("native record has no kind delimiter")
+            issues.append("truncated-native-record")
+            intervals.append((start, len(raw)))
+            break
         kind = _decode_utf8(raw[kind_start:kind_end], label="native record kind")
         payload_start = kind_end + 1
 
-        if kind == "PROBE":
-            length_end = raw.find(b"|", payload_start)
+        if kind in {"PROBE", "DIAGNOSTIC"}:
+            framed_fields: list[bytes] = []
+            length_start = payload_start
+            if kind == "DIAGNOSTIC":
+                metadata_truncated = False
+                for _ in range(3):
+                    field_end = raw.find(b"|", length_start)
+                    if field_end < 0:
+                        metadata_truncated = True
+                        break
+                    framed_fields.append(raw[length_start:field_end])
+                    length_start = field_end + 1
+                if metadata_truncated:
+                    issues.append("truncated-native-record")
+                    intervals.append((start, len(raw)))
+                    break
+            length_end = raw.find(b"|", length_start)
             if length_end < 0:
-                raise ClipsOracleProtocolError("native PROBE length is truncated")
+                issues.append("truncated-native-record")
+                intervals.append((start, len(raw)))
+                break
             try:
-                payload_length = int(raw[payload_start:length_end])
-            except ValueError as error:
-                raise ClipsOracleProtocolError("native PROBE length is not an integer") from error
-            if payload_length < 0 or payload_length > _MAX_PROBE_PAYLOAD:
-                raise ClipsOracleProtocolError("native PROBE length is out of range")
+                payload_length = int(raw[length_start:length_end])
+            except ValueError:
+                end_of_line = raw.find(b"\n", length_end + 1)
+                if end_of_line < 0:
+                    issues.append("truncated-native-record")
+                    intervals.append((start, len(raw)))
+                    break
+                end = end_of_line + 1
+                issues.append("native-framing-malformed")
+                intervals.append((start, end))
+                cursor = end
+                continue
+            if payload_length < 0 or payload_length > _MAX_NATIVE_PAYLOAD:
+                end_of_line = raw.find(b"\n", length_end + 1)
+                if end_of_line < 0:
+                    issues.append("truncated-native-record")
+                    intervals.append((start, len(raw)))
+                    break
+                end = end_of_line + 1
+                issues.append("native-framing-malformed")
+                intervals.append((start, end))
+                cursor = end
+                continue
             value_start = length_end + 1
             value_end = value_start + payload_length
             mac_start = value_end + 1
@@ -258,7 +321,16 @@ def _parse_native_records(
                 or mac_end >= len(raw)
                 or raw[mac_end] != ord("\n")
             ):
-                raise ClipsOracleProtocolError("native PROBE payload length does not match record")
+                end_of_line = raw.find(b"\n", min(value_end, len(raw)))
+                if end_of_line < 0:
+                    issues.append("truncated-native-record")
+                    intervals.append((start, len(raw)))
+                    break
+                end = end_of_line + 1
+                issues.append("native-framing-malformed")
+                intervals.append((start, end))
+                cursor = end
+                continue
             end = mac_end + 1
             logical_record = raw[kind_start:value_end]
             supplied_mac = raw[mac_start:mac_end]
@@ -274,16 +346,24 @@ def _parse_native_records(
             if not hmac.compare_digest(supplied_mac, expected_mac):
                 issues.append("native-authentication-failed")
             else:
-                records.append(_NativeRecord(kind, (), raw[value_start:value_end], start, end))
+                fields = tuple(
+                    _decode_utf8(field, label=f"native {kind} field") for field in framed_fields
+                )
+                records.append(_NativeRecord(kind, fields, raw[value_start:value_end], start, end))
         else:
             end_of_line = raw.find(b"\n", payload_start)
             if end_of_line < 0:
-                raise ClipsOracleProtocolError("native record is not newline terminated")
+                issues.append("truncated-native-record")
+                intervals.append((start, len(raw)))
+                break
             end = end_of_line + 1
             authenticated = raw[kind_start:end_of_line]
             logical_record, separator, supplied_mac = authenticated.rpartition(b"|")
             if not separator or len(supplied_mac) != 64:
-                raise ClipsOracleProtocolError("native record authentication is malformed")
+                issues.append("native-authentication-malformed")
+                intervals.append((start, end))
+                cursor = end
+                continue
             expected_mac = (
                 hmac.new(
                     auth_key_bytes,
@@ -298,9 +378,15 @@ def _parse_native_records(
             else:
                 logical_kind, kind_separator, logical_payload = logical_record.partition(b"|")
                 if not kind_separator:
-                    raise ClipsOracleProtocolError("native record has no logical payload")
+                    issues.append("native-record-malformed")
+                    intervals.append((start, end))
+                    cursor = end
+                    continue
                 if _decode_utf8(logical_kind, label="native logical record kind") != kind:
-                    raise ClipsOracleProtocolError("native record kind is inconsistent")
+                    issues.append("native-record-malformed")
+                    intervals.append((start, end))
+                    cursor = end
+                    continue
                 fields = tuple(
                     _decode_utf8(field, label=f"native {kind} field")
                     for field in logical_payload.split(b"|")
@@ -313,7 +399,11 @@ def _parse_native_records(
     semantic_bytes = _remove_intervals(raw, intervals)
     if reserved_prefix in semantic_bytes:
         issues.append("unexpected-native-reserved-prefix")
-    semantic_stderr = _decode_utf8(semantic_bytes, label="semantic stderr")
+    semantic_stderr = (
+        semantic_bytes.decode("utf-8", errors="replace")
+        if interrupted
+        else _decode_utf8(semantic_bytes, label="semantic stderr")
+    )
     return records, semantic_stderr, issues
 
 
@@ -367,6 +457,157 @@ def _parse_int(text: str, *, issue: str, issues: list[str]) -> int | None:
         return None
 
 
+def _load_diagnostic_taxonomy(message: str) -> tuple[str, str]:
+    """Classify only allowlisted CLIPS load-diagnostic families."""
+    codes = set(_CLIPS_DIAGNOSTIC_CODE_RE.findall(message))
+    syntax_codes = {
+        code
+        for code in codes
+        if code in _LOAD_SYNTAX_DIAGNOSTIC_CODES
+        or any(code.startswith(family) for family in _LOAD_SYNTAX_DIAGNOSTIC_FAMILIES)
+    }
+    construct_codes = {
+        code
+        for code in codes
+        if any(code.startswith(family) for family in _LOAD_CONSTRUCT_DIAGNOSTIC_FAMILIES)
+    }
+    if codes and syntax_codes == codes:
+        return "parse", "syntax-error"
+    if codes and construct_codes == codes:
+        return "load", "construct-error"
+    return UNKNOWN_DIAGNOSTIC, UNKNOWN_DIAGNOSTIC
+
+
+def _parse_native_diagnostic(
+    record: _NativeRecord,
+    *,
+    issues: list[str],
+) -> tuple[dict, str, bool] | None:
+    if len(record.fields) != 3 or record.payload is None:
+        issues.append("native-diagnostic-field-count")
+        return None
+    version_text, native_phase, continued_text = record.fields
+    if version_text != str(DIAGNOSTIC_TAXONOMY_VERSION):
+        issues.append("native-diagnostic-taxonomy-version")
+        return None
+    if native_phase not in _NATIVE_PHASES:
+        issues.append("native-diagnostic-phase")
+        return None
+    if continued_text not in {"0", "1"}:
+        issues.append("native-diagnostic-continued")
+        return None
+
+    continued = continued_text == "1"
+    message = _decode_utf8(record.payload, label="native DIAGNOSTIC payload")
+    if native_phase == "load":
+        phase, category = _load_diagnostic_taxonomy(message)
+    else:
+        phase, category = native_phase, "evaluation-error"
+    if phase != UNKNOWN_DIAGNOSTIC and phase not in ENGINE_DIAGNOSTIC_PHASES:
+        issues.append("native-diagnostic-canonical-phase")
+        return None
+    if category != UNKNOWN_DIAGNOSTIC and category not in ENGINE_DIAGNOSTIC_CATEGORIES:
+        issues.append("native-diagnostic-canonical-category")
+        return None
+    return (
+        {
+            "taxonomy_version": DIAGNOSTIC_TAXONOMY_VERSION,
+            "phase": phase,
+            "category": category,
+            "continued": continued,
+            "channel": "stderr",
+            "message": message,
+        },
+        native_phase,
+        continued,
+    )
+
+
+def _parse_native_phase_records(
+    records: list[_NativeRecord],
+    *,
+    diagnostic_states: list[tuple[dict, str, bool]],
+    lifecycle_complete: bool,
+    issues: list[str],
+) -> tuple[list[dict], str | None]:
+    phase_records = [record for record in records if record.kind == "PHASE"]
+    phases: list[dict] = []
+    active_phase: str | None = None
+    next_phase_index = 0
+    expected_sequence = 1
+    statuses: dict[str, str] = {}
+
+    for record in phase_records:
+        if len(record.fields) not in {3, 4}:
+            issues.append("native-phase-field-count")
+            continue
+        sequence_text, phase, event, *status_fields = record.fields
+        sequence = _parse_int(
+            sequence_text,
+            issue="native-phase-sequence",
+            issues=issues,
+        )
+        if sequence is None:
+            continue
+        if sequence != expected_sequence:
+            issues.append("native-phase-sequence-order")
+        expected_sequence = sequence + 1
+        if phase not in _NATIVE_PHASES:
+            issues.append("native-phase-name")
+        status = status_fields[0] if status_fields else None
+
+        if event == "BEGIN":
+            if status is not None:
+                issues.append("native-phase-begin-status")
+            if active_phase is not None:
+                issues.append("native-phase-overlap")
+            if next_phase_index >= len(_NATIVE_PHASES) or phase != _NATIVE_PHASES[next_phase_index]:
+                issues.append("native-phase-order")
+            active_phase = phase
+            phases.append({"sequence": sequence, "phase": phase, "event": "begin"})
+        elif event == "END":
+            if status not in _NATIVE_PHASE_STATUSES:
+                issues.append("native-phase-status")
+            if active_phase != phase:
+                issues.append("native-phase-end-without-begin")
+            else:
+                active_phase = None
+                next_phase_index += 1
+            if status is not None:
+                statuses[phase] = status
+            phases.append(
+                {
+                    "sequence": sequence,
+                    "phase": phase,
+                    "event": "end",
+                    "status": status,
+                }
+            )
+        else:
+            issues.append("native-phase-event")
+
+    if lifecycle_complete and active_phase is not None:
+        issues.append("native-phase-incomplete")
+
+    diagnostics_by_phase: dict[str, list[bool]] = {}
+    for _diagnostic, native_phase, continued in diagnostic_states:
+        diagnostics_by_phase.setdefault(native_phase, []).append(continued)
+    if any(len(values) != 1 for values in diagnostics_by_phase.values()):
+        issues.append("native-diagnostic-cardinality")
+    for phase, status in statuses.items():
+        continued_values = diagnostics_by_phase.get(phase, [])
+        expected_continued = status == "CONTINUED"
+        if (status == "OK" and continued_values) or (
+            status in {"CONTINUED", "ERROR"} and continued_values != [expected_continued]
+        ):
+            issues.append("native-phase-diagnostic-status")
+    for phase in diagnostics_by_phase:
+        if phase not in statuses and not (not lifecycle_complete and active_phase == phase):
+            issues.append("native-diagnostic-outside-phase")
+
+    return phases, active_phase
+
+
 def parse_probe_output(
     raw_stdout: str | bytes,
     *,
@@ -377,6 +618,7 @@ def parse_probe_output(
     composed_sha256: str,
     auth_key: str,
     harnessed: bool = False,
+    interrupted: bool = False,
 ) -> dict:
     """Parse one quiet CLIPS invocation into a structured observation."""
     fixture_id = _require_token(fixture_id, label="fixture id")
@@ -391,39 +633,60 @@ def parse_probe_output(
         stderr_bytes,
         nonce=nonce,
         auth_key=auth_key,
+        interrupted=interrupted,
     )
+    diagnostic_protocol_issues = [
+        issue
+        for issue in protocol_issues
+        if issue
+        in {
+            "native-authentication-failed",
+            "native-authentication-malformed",
+            "native-framing-malformed",
+            "native-record-malformed",
+            "unexpected-native-reserved-prefix",
+        }
+    ]
 
-    allowed_native_kinds = {"LIFECYCLE", "RUN", "PROBE", "ISSUE"}
+    def add_protocol_issue(issue: str, *, diagnostic: bool = False) -> None:
+        protocol_issues.append(issue)
+        if diagnostic:
+            diagnostic_protocol_issues.append(issue)
+
+    allowed_native_kinds = {"LIFECYCLE", "PHASE", "RUN", "PROBE", "DIAGNOSTIC", "ISSUE"}
     unknown_native_kinds = [
         record.kind for record in native_records if record.kind not in allowed_native_kinds
     ]
     if unknown_native_kinds:
-        protocol_issues.append("unknown-native-record-kind")
+        add_protocol_issue("unknown-native-record-kind", diagnostic=True)
 
     for record in native_records:
         if record.kind == "ISSUE":
             if len(record.fields) != 1 or not record.fields[0]:
-                protocol_issues.append("native-issue-field-count")
+                add_protocol_issue("native-issue-field-count", diagnostic=True)
             else:
-                protocol_issues.append(f"native-{record.fields[0]}")
+                add_protocol_issue(f"native-{record.fields[0]}", diagnostic=True)
 
     lifecycle_records = [record for record in native_records if record.kind == "LIFECYCLE"]
     lifecycle: list[dict] = []
     expected_binding = (fixture_id, source_sha256, composed_sha256)
     for record in lifecycle_records:
         if len(record.fields) != 5:
-            protocol_issues.append("lifecycle-field-count")
+            add_protocol_issue("lifecycle-field-count", diagnostic=True)
             continue
         sequence_text, event, bound_fixture, bound_source, bound_composed = record.fields
+        lifecycle_issues: list[str] = []
         sequence = _parse_int(
             sequence_text,
             issue="lifecycle-sequence",
-            issues=protocol_issues,
+            issues=lifecycle_issues,
         )
+        protocol_issues.extend(lifecycle_issues)
+        diagnostic_protocol_issues.extend(lifecycle_issues)
         if sequence is None:
             continue
         if (bound_fixture, bound_source, bound_composed) != expected_binding:
-            protocol_issues.append("lifecycle-binding")
+            add_protocol_issue("lifecycle-binding", diagnostic=True)
         lifecycle.append(
             {
                 "sequence": sequence,
@@ -435,26 +698,88 @@ def parse_probe_output(
             }
         )
 
-    if [entry["event"] for entry in lifecycle] != ["start", "complete"]:
-        protocol_issues.append("lifecycle-cardinality-or-order")
-    if lifecycle and [entry["sequence"] for entry in lifecycle] != [0, 3]:
-        protocol_issues.append("lifecycle-sequence-order")
+    lifecycle_complete = [entry["event"] for entry in lifecycle] == ["start", "complete"] and [
+        entry["sequence"] for entry in lifecycle
+    ] == [0, 3]
+    parsed_diagnostic_records: list[tuple[_NativeRecord, tuple[dict, str, bool]]] = []
+    for record in native_records:
+        if record.kind != "DIAGNOSTIC":
+            continue
+        diagnostic_issues: list[str] = []
+        state = _parse_native_diagnostic(record, issues=diagnostic_issues)
+        protocol_issues.extend(diagnostic_issues)
+        diagnostic_protocol_issues.extend(diagnostic_issues)
+        if state is not None:
+            parsed_diagnostic_records.append((record, state))
+    diagnostic_states = [state for _record, state in parsed_diagnostic_records]
+    diagnostics = [state[0] for state in diagnostic_states]
+    run_diagnostic_present = any(state[1] == "run" for state in diagnostic_states)
+    terminal_diagnostics = [state for state in diagnostic_states if not state[2]]
+    if len(terminal_diagnostics) > 1:
+        add_protocol_issue("native-terminal-diagnostic-cardinality", diagnostic=True)
+    terminal_diagnostic = terminal_diagnostics[0] if terminal_diagnostics else None
+
+    phase_issues: list[str] = []
+    native_phases, active_phase = _parse_native_phase_records(
+        native_records,
+        diagnostic_states=diagnostic_states,
+        lifecycle_complete=lifecycle_complete,
+        issues=phase_issues,
+    )
+    protocol_issues.extend(phase_issues)
+    diagnostic_protocol_issues.extend(phase_issues)
+    if not native_phases:
+        add_protocol_issue("native-phase-records-missing", diagnostic=bool(diagnostics))
+    lifecycle_start_only = [entry["event"] for entry in lifecycle] == ["start"] and [
+        entry["sequence"] for entry in lifecycle
+    ] == [0]
+    partial_active_path = active_phase is not None and lifecycle_start_only
+    partial_terminal_path = (
+        terminal_diagnostic is not None and active_phase is None and lifecycle_start_only
+    )
+    partial_path = partial_active_path or partial_terminal_path
+    if not lifecycle_complete and not partial_path:
+        if [entry["event"] for entry in lifecycle] != ["start", "complete"]:
+            protocol_issues.append("lifecycle-cardinality-or-order")
+        if lifecycle and [entry["sequence"] for entry in lifecycle] != [0, 3]:
+            protocol_issues.append("lifecycle-sequence-order")
+    ended_phases = [phase["phase"] for phase in native_phases if phase["event"] == "end"]
+    if terminal_diagnostic is None or terminal_diagnostic[1] == "run":
+        expected_ended_phases = list(_NATIVE_PHASES)
+    else:
+        terminal_phase_index = _NATIVE_PHASES.index(terminal_diagnostic[1])
+        expected_ended_phases = list(_NATIVE_PHASES[: terminal_phase_index + 1])
+    if (lifecycle_complete or partial_terminal_path) and ended_phases != expected_ended_phases:
+        add_protocol_issue("native-phase-terminal-path", diagnostic=True)
 
     native_run_records = [record for record in native_records if record.kind == "RUN"]
     native_run: dict[str, int] | None = None
-    if len(native_run_records) != 1:
-        protocol_issues.append(
-            "native-run-metadata-missing" if not native_run_records else "native-run-cardinality"
+    run_expected = not partial_path and (
+        terminal_diagnostic is None or terminal_diagnostic[1] == "run"
+    )
+    partial_terminal_run = (
+        partial_path and terminal_diagnostic is not None and terminal_diagnostic[1] == "run"
+    )
+    if partial_terminal_run and not native_run_records:
+        add_protocol_issue("native-run-metadata-missing", diagnostic=True)
+    elif len(native_run_records) != (1 if run_expected or partial_terminal_run else 0):
+        add_protocol_issue(
+            "native-run-metadata-missing" if not native_run_records else "native-run-cardinality",
+            diagnostic=run_diagnostic_present,
         )
-    else:
+    elif native_run_records:
         record = native_run_records[0]
         if len(record.fields) != 7:
-            protocol_issues.append("native-run-field-count")
+            add_protocol_issue("native-run-field-count", diagnostic=run_diagnostic_present)
         else:
+            run_issues: list[str] = []
             numeric_fields = [
-                _parse_int(field, issue="native-run-numeric-field", issues=protocol_issues)
+                _parse_int(field, issue="native-run-numeric-field", issues=run_issues)
                 for field in record.fields
             ]
+            protocol_issues.extend(run_issues)
+            if run_diagnostic_present:
+                diagnostic_protocol_issues.extend(run_issues)
             if all(value is not None for value in numeric_fields):
                 (
                     run_limit,
@@ -481,7 +806,7 @@ def parse_probe_output(
                     or agenda_size < 0
                     or observer_violation not in {0, 1}
                 ):
-                    protocol_issues.append("native-run-value")
+                    add_protocol_issue("native-run-value", diagnostic=run_diagnostic_present)
                 else:
                     native_run = {
                         "run_limit": run_limit,
@@ -493,22 +818,63 @@ def parse_probe_output(
                         "observer_violation": observer_violation,
                     }
                     if observer_violation:
-                        protocol_issues.append("native-observer-violation")
+                        add_protocol_issue("native-observer-violation", diagnostic=True)
 
     record_positions = {id(record): index for index, record in enumerate(native_records)}
-    if len(lifecycle_records) == 2 and len(native_run_records) == 1:
+    if lifecycle_records:
         start_position = record_positions[id(lifecycle_records[0])]
+        if start_position != 0:
+            add_protocol_issue("native-record-order", diagnostic=bool(diagnostics))
+    if len(lifecycle_records) == 2:
+        complete_position = record_positions[id(lifecycle_records[1])]
+        if complete_position != len(native_records) - 1:
+            add_protocol_issue("native-record-order", diagnostic=bool(diagnostics))
+    if len(lifecycle_records) == 2 and len(native_run_records) == 1:
         run_position = record_positions[id(native_run_records[0])]
         complete_position = record_positions[id(lifecycle_records[1])]
         probe_positions = [
             record_positions[id(record)] for record in native_records if record.kind == "PROBE"
         ]
-        if not (
-            start_position < run_position
-            and all(run_position < position < complete_position for position in probe_positions)
-            and complete_position == len(native_records) - 1
-        ):
+        if not (all(run_position < position < complete_position for position in probe_positions)):
             protocol_issues.append("native-record-order")
+
+    phase_boundaries: dict[str, tuple[int, int]] = {}
+    for phase in _NATIVE_PHASES:
+        matching = [
+            record
+            for record in native_records
+            if record.kind == "PHASE" and len(record.fields) >= 2 and record.fields[1] == phase
+        ]
+        if len(matching) == 2:
+            phase_boundaries[phase] = (
+                record_positions[id(matching[0])],
+                record_positions[id(matching[1])],
+            )
+    for record, (_diagnostic, native_phase, _continued) in parsed_diagnostic_records:
+        boundary = phase_boundaries.get(native_phase)
+        active_begin_positions = [
+            record_positions[id(phase_record)]
+            for phase_record in native_records
+            if phase_record.kind == "PHASE"
+            and len(phase_record.fields) >= 3
+            and phase_record.fields[1:3] == (native_phase, "BEGIN")
+        ]
+        inside_completed_phase = boundary is not None and (
+            boundary[0] < record_positions[id(record)] < boundary[1]
+        )
+        inside_interrupted_phase = (
+            not lifecycle_complete
+            and active_phase == native_phase
+            and len(active_begin_positions) == 1
+            and active_begin_positions[0] < record_positions[id(record)]
+        )
+        if not (inside_completed_phase or inside_interrupted_phase):
+            add_protocol_issue("native-diagnostic-record-order", diagnostic=True)
+    if len(native_run_records) == 1:
+        run_boundary = phase_boundaries.get("run")
+        run_position = record_positions[id(native_run_records[0])]
+        if run_boundary is None or run_position <= run_boundary[1]:
+            add_protocol_issue("native-run-record-order", diagnostic=run_diagnostic_present)
 
     records = [
         _parse_probe_payload(record.payload)
@@ -521,8 +887,16 @@ def parse_probe_output(
 
     phase_records = [record for record in records if record.kind == "PHASE"]
     phase_values = [record.fields for record in phase_records]
-    if phase_values != [("1", "RESET_COMPLETE"), ("2", "RUN_COMPLETE")]:
+    probes_expected = terminal_diagnostic is None and not partial_path
+    if terminal_diagnostic is not None and terminal_diagnostic[1] == "run":
+        # The native observer deliberately stops after authenticated RUN
+        # metadata on an evaluation failure. Empty fact/module/global
+        # placeholders are not a final-state snapshot.
+        protocol_issues.append("post-run-state-missing")
+    if probes_expected and phase_values != [("1", "RESET_COMPLETE"), ("2", "RUN_COMPLETE")]:
         protocol_issues.append("phase-cardinality-or-order")
+    elif not probes_expected and records:
+        protocol_issues.append("probe-after-terminal-diagnostic")
 
     facts_by_sequence: dict[int, dict] = {}
     slots_by_key: dict[tuple[int, int], dict] = {}
@@ -651,13 +1025,15 @@ def parse_probe_output(
     if fact_sequences != list(range(1, len(fact_sequences) + 1)):
         protocol_issues.append("fact-sequence-order")
 
+    slots_by_sequence: dict[int, list[dict]] = {}
+    for (fact_sequence, _slot_index), slot in slots_by_key.items():
+        slots_by_sequence.setdefault(fact_sequence, []).append(slot)
+    for fact_slots in slots_by_sequence.values():
+        fact_slots.sort(key=lambda slot: slot["index"])
+
     facts: list[dict] = []
     for sequence, fact in sorted(facts_by_sequence.items()):
-        fact_slots = [
-            slot
-            for (fact_sequence, _), slot in sorted(slots_by_key.items())
-            if fact_sequence == sequence
-        ]
+        fact_slots = slots_by_sequence.get(sequence, [])
         if len(fact_slots) != fact["_slot_count"]:
             protocol_issues.append("fact-slot-count")
         if [slot["index"] for slot in fact_slots] != list(range(1, len(fact_slots) + 1)):
@@ -698,17 +1074,18 @@ def parse_probe_output(
 
     modules = {"current": None, "focus": None, "focus_stack": []}
     module_records = [record for record in records if record.kind == "MODULE"]
-    if len(module_records) == 1 and len(module_records[0].fields) == 1:
-        modules["current"] = module_records[0].fields[0]
-    else:
-        protocol_issues.append("module-cardinality")
     focus_records = [record for record in records if record.kind == "FOCUS"]
-    if any(len(record.fields) != 1 or not record.fields[0] for record in focus_records):
-        protocol_issues.append("focus-record")
-    modules["focus_stack"] = [
-        record.fields[0] for record in focus_records if len(record.fields) == 1
-    ]
-    modules["focus"] = modules["focus_stack"][-1] if modules["focus_stack"] else None
+    if probes_expected:
+        if len(module_records) == 1 and len(module_records[0].fields) == 1:
+            modules["current"] = module_records[0].fields[0]
+        else:
+            protocol_issues.append("module-cardinality")
+        if any(len(record.fields) != 1 or not record.fields[0] for record in focus_records):
+            protocol_issues.append("focus-record")
+        modules["focus_stack"] = [
+            record.fields[0] for record in focus_records if len(record.fields) == 1
+        ]
+        modules["focus"] = modules["focus_stack"][-1] if modules["focus_stack"] else None
 
     globals_observed: dict[str, dict] = {}
     for record in records:
@@ -722,7 +1099,11 @@ def parse_probe_output(
             protocol_issues.append("duplicate-global")
         globals_observed[name] = _typed_value(type_name, record.value)
 
-    semantic_stdout = _decode_utf8(stdout_bytes, label="semantic stdout")
+    semantic_stdout = (
+        stdout_bytes.decode("utf-8", errors="replace")
+        if interrupted
+        else _decode_utf8(stdout_bytes, label="semantic stdout")
+    )
     harness_records: list[dict] = []
     feature_lines: list[str] = []
     for line in semantic_stdout.splitlines(keepends=True):
@@ -737,18 +1118,6 @@ def parse_probe_output(
 
     if RECORD_PREFIX in semantic_stdout or NATIVE_RECORD_PREFIX in semantic_stdout:
         protocol_issues.append("unexpected-reserved-prefix")
-
-    diagnostics: list[dict] = []
-    for channel, text in (("stdout", semantic_stdout), ("stderr", semantic_stderr)):
-        for match in _DIAGNOSTIC_RE.finditer(text):
-            diagnostics.append(
-                {
-                    "phase": "unknown",
-                    "category": match.group(0),
-                    "continuation": "unknown",
-                    "channel": channel,
-                }
-            )
 
     if native_run is None:
         run_state = None
@@ -771,9 +1140,35 @@ def parse_probe_output(
             "halted": halt_reason != "agenda_empty",
         }
 
-    complete = not protocol_issues and len(lifecycle) == 2 and lifecycle[-1]["event"] == "complete"
-    reached_run = native_run is not None
-    phase_reached = "post_run" if complete else ("run" if reached_run else "load")
+    if (
+        terminal_diagnostic is not None
+        and terminal_diagnostic[1] == "run"
+        and (
+            native_run is None
+            or not (
+                native_run["evaluation_error"]
+                or (native_run["halt_execution"] and not native_run["halt_rules"])
+            )
+        )
+    ):
+        add_protocol_issue("native-run-diagnostic-state", diagnostic=True)
+
+    complete = not protocol_issues and lifecycle_complete and probes_expected
+    if complete:
+        phase_reached = "post_run"
+    elif terminal_diagnostic is not None:
+        canonical_phase = terminal_diagnostic[0]["phase"]
+        phase_reached = (
+            terminal_diagnostic[1] if canonical_phase == UNKNOWN_DIAGNOSTIC else canonical_phase
+        )
+    elif active_phase is not None:
+        phase_reached = active_phase
+    elif native_run is not None:
+        phase_reached = "run"
+    elif ended_phases:
+        phase_reached = ended_phases[-1]
+    else:
+        phase_reached = "load"
 
     return {
         "schema": ORACLE_SCHEMA,
@@ -786,6 +1181,7 @@ def parse_probe_output(
             "composed_sha256": composed_sha256,
         },
         "phase_reached": phase_reached,
+        "active_phase": active_phase,
         "lifecycle": lifecycle,
         "run": run_state,
         "fired_rules": None,
@@ -800,6 +1196,8 @@ def parse_probe_output(
         "instrumentation": {
             "harness_records": harness_records,
             "native_run_records": len(native_run_records),
+            "native_phases": native_phases,
+            "active_phase": active_phase,
         },
         "capabilities": {
             "fact_modules": True,
@@ -808,4 +1206,5 @@ def parse_probe_output(
             "native_run_metadata": True,
         },
         "protocol_issues": protocol_issues,
+        "diagnostic_protocol_issues": diagnostic_protocol_issues,
     }

--- a/tools/ferric-tools/src/ferric_tools/compat/diagnostics.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/diagnostics.py
@@ -1,0 +1,173 @@
+"""Shared diagnostic and process-termination evidence for compatibility runs."""
+
+from __future__ import annotations
+
+DIAGNOSTIC_TAXONOMY_VERSION = 1
+
+DIAGNOSTIC_SCHEMA = "ferric.compat-diagnostic"
+ENGINE_DIAGNOSTIC_PHASES = frozenset({"parse", "load", "reset", "run"})
+ENGINE_DIAGNOSTIC_CATEGORIES = frozenset({"syntax-error", "construct-error", "evaluation-error"})
+SEMANTIC_DIAGNOSTIC_PAIRS = frozenset(
+    {
+        ("parse", "syntax-error"),
+        ("load", "construct-error"),
+        ("reset", "evaluation-error"),
+        ("run", "evaluation-error"),
+    }
+)
+UNKNOWN_DIAGNOSTIC = "unknown"
+PROCESS_DIAGNOSTIC_PHASES = frozenset({"process", "harness"})
+PROCESS_DIAGNOSTIC_CATEGORIES = frozenset({"timeout", "signal", "nonzero-exit", "harness-error"})
+
+_VALID_DIAGNOSTIC_PAIRS = frozenset(
+    {
+        ("none", "none"),
+        *SEMANTIC_DIAGNOSTIC_PAIRS,
+        ("process", "timeout"),
+        ("process", "signal"),
+        ("process", "nonzero-exit"),
+        ("harness", "harness-error"),
+        (UNKNOWN_DIAGNOSTIC, UNKNOWN_DIAGNOSTIC),
+    }
+)
+
+
+def diagnostic(
+    phase: str,
+    category: str,
+    *,
+    continued: bool,
+) -> dict[str, object]:
+    """Create one versioned, engine-neutral diagnostic summary."""
+    return {
+        "schema": DIAGNOSTIC_SCHEMA,
+        "version": DIAGNOSTIC_TAXONOMY_VERSION,
+        "phase": phase,
+        "category": category,
+        "continued": continued,
+    }
+
+
+def termination(
+    *,
+    exit_code: int | None,
+    timed_out: bool,
+    spawn_error: bool = False,
+) -> dict[str, object]:
+    """Describe process termination without conflating it with engine diagnostics."""
+    if timed_out:
+        return {"kind": "timeout", "exit_code": None, "signal": None}
+    if spawn_error:
+        return {"kind": "spawn-error", "exit_code": None, "signal": None}
+    if type(exit_code) is not int:
+        return {"kind": "unknown", "exit_code": None, "signal": None}
+    if exit_code < 0:
+        return {"kind": "signal", "exit_code": None, "signal": -exit_code}
+    return {"kind": "exit", "exit_code": exit_code, "signal": None}
+
+
+def process_diagnostic(result: dict) -> dict[str, object] | None:
+    """Return a transport/harness diagnostic for an untrusted observer result."""
+    if result.get("not_run") is True:
+        return None
+    process = result.get("termination")
+    if not isinstance(process, dict):
+        exit_code = result.get("exit_code")
+        if (
+            type(exit_code) is int
+            and exit_code < 0
+            and result.get("timed_out") is not True
+            and result.get("spawn_error") is not True
+        ):
+            # Historical and synthetic manifests used -1 as a generic
+            # "not run" sentinel. Only an explicit termination envelope can
+            # prove that a negative code represents a process signal.
+            process = {"kind": "unknown", "exit_code": None, "signal": None}
+        else:
+            process = termination(
+                exit_code=exit_code,
+                timed_out=result.get("timed_out") is True,
+                spawn_error=result.get("spawn_error") is True,
+            )
+    kind = process.get("kind")
+    if kind == "timeout":
+        return diagnostic("process", "timeout", continued=False)
+    if kind == "signal":
+        return diagnostic("process", "signal", continued=False)
+    if kind == "spawn-error" or result.get("harness_error") is True:
+        return diagnostic("harness", "harness-error", continued=False)
+    if kind == "exit" and process.get("exit_code") != 0:
+        return diagnostic("process", "nonzero-exit", continued=False)
+    if result.get("observation_error"):
+        return diagnostic("harness", "harness-error", continued=False)
+    return None
+
+
+def validated_result_diagnostic(raw: object) -> dict[str, object] | None:
+    """Validate an already-canonical result diagnostic without coercion."""
+    if not isinstance(raw, dict):
+        return None
+    version = raw.get("version")
+    phase = raw.get("phase")
+    category = raw.get("category")
+    continued = raw.get("continued")
+    if (
+        raw.get("schema") != DIAGNOSTIC_SCHEMA
+        or type(version) is not int
+        or version != DIAGNOSTIC_TAXONOMY_VERSION
+        or type(phase) is not str
+        or type(category) is not str
+        or type(continued) is not bool
+        or (phase, category) not in _VALID_DIAGNOSTIC_PAIRS
+    ):
+        return None
+    if (phase, category) == ("none", "none") and not continued:
+        return None
+    if phase in {"process", "harness", UNKNOWN_DIAGNOSTIC} and continued:
+        return None
+    return {
+        "schema": DIAGNOSTIC_SCHEMA,
+        "version": version,
+        "phase": phase,
+        "category": category,
+        "continued": continued,
+    }
+
+
+def diagnostic_evidence_state(
+    result: object,
+) -> tuple[str, tuple[str, str, bool] | None]:
+    """Distinguish trusted, missing, malformed, and harness diagnostic evidence."""
+    if isinstance(result, dict) and result.get("harness_error") is True:
+        return "harness", ("harness", "harness-error", False)
+    if not isinstance(result, dict) or "diagnostic" not in result:
+        return "missing", None
+    canonical = validated_result_diagnostic(result.get("diagnostic"))
+    if canonical is None:
+        return "invalid", None
+    state = (
+        str(canonical["phase"]),
+        str(canonical["category"]),
+        bool(canonical["continued"]),
+    )
+    if state[0] == "harness":
+        return "harness", state
+    if state[0] == UNKNOWN_DIAGNOSTIC:
+        return "invalid", state
+    return "valid", state
+
+
+def result_diagnostic_view(result: object) -> dict[str, object]:
+    """Return a defensive report view of one persisted engine result."""
+    if not isinstance(result, dict):
+        return diagnostic(UNKNOWN_DIAGNOSTIC, UNKNOWN_DIAGNOSTIC, continued=False)
+    raw = result.get("diagnostic")
+    if isinstance(raw, dict):
+        canonical = validated_result_diagnostic(raw)
+        if canonical is not None:
+            return canonical
+        return diagnostic(UNKNOWN_DIAGNOSTIC, UNKNOWN_DIAGNOSTIC, continued=False)
+    fallback = process_diagnostic(result)
+    if fallback is not None:
+        return fallback
+    return diagnostic("none", "none", continued=True)

--- a/tools/ferric-tools/src/ferric_tools/compat/diff.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/diff.py
@@ -9,6 +9,7 @@ import typer
 from rich.console import Console
 
 from ferric_tools._manifest import load_manifest
+from ferric_tools.compat.diagnostics import result_diagnostic_view
 from ferric_tools.compat.report import compute_oracle_coverage, oracle_evidence_view
 
 app = typer.Typer(help="Compare two compat manifests.")
@@ -37,6 +38,62 @@ LEGACY_RUNNER_CLASSIFICATIONS = {
     "float-normalized-match": frozenset({"equivalent"}),
     "output-mismatch": frozenset({"divergent"}),
 }
+
+
+def _termination_snapshot(result: object) -> tuple[object, object, object, object]:
+    if not isinstance(result, dict):
+        return ("unknown", None, None, None)
+    raw = result.get("termination")
+    if not isinstance(raw, dict):
+        return ("unknown", result.get("exit_code"), None, None)
+    return (
+        raw.get("kind"),
+        raw.get("exit_code"),
+        raw.get("signal"),
+        raw.get("active_phase"),
+    )
+
+
+def _engine_diagnostic_snapshot(result: object) -> tuple[object, ...]:
+    view = result_diagnostic_view(result)
+    return (
+        view["version"],
+        view["phase"],
+        view["category"],
+        view["continued"],
+        *_termination_snapshot(result),
+    )
+
+
+def _diagnostic_snapshot(info: object) -> tuple[tuple[object, ...], ...]:
+    if not isinstance(info, dict):
+        return tuple(_engine_diagnostic_snapshot(None) for _engine in ("ferric", "clips"))
+    return tuple(_engine_diagnostic_snapshot(info.get(engine)) for engine in ("ferric", "clips"))
+
+
+def _diagnostic_label(info: dict) -> str:
+    labels: list[str] = []
+    for engine in ("ferric", "clips"):
+        result = info.get(engine)
+        view = result_diagnostic_view(result)
+        termination_kind, exit_code, signal, active_phase = _termination_snapshot(result)
+        termination_label = str(termination_kind)
+        if signal is not None:
+            termination_label += f"({signal})"
+        elif exit_code is not None:
+            termination_label += f"({exit_code})"
+        if active_phase is not None:
+            termination_label += f"@{active_phase}"
+        labels.append(
+            f"{engine}={view['phase']}/{view['category']}/"
+            f"continued:{str(view['continued']).lower()};termination:{termination_label}"
+        )
+    return ", ".join(labels)
+
+
+def _reason_with_diagnostics(reason: str, info: dict) -> str:
+    detail = f"diagnostics: {_diagnostic_label(info)}"
+    return f"{reason}; {detail}" if reason else detail
 
 
 def fmt_delta(n: int) -> str:
@@ -226,7 +283,14 @@ def compute_diff(base: dict, head: dict) -> tuple[dict, dict, list, list, list]:
         ):
             continue
 
-        entry = (key, b_cls, b_reason, h_cls, h_reason)
+        diagnostics_changed = _diagnostic_snapshot(b) != _diagnostic_snapshot(h)
+        entry = (
+            key,
+            b_cls,
+            _reason_with_diagnostics(b_reason, b) if diagnostics_changed else b_reason,
+            h_cls,
+            _reason_with_diagnostics(h_reason, h) if diagnostics_changed else h_reason,
+        )
         oracle_losses = _oracle_loss_details(
             b,
             h,
@@ -238,19 +302,27 @@ def compute_diff(base: dict, head: dict) -> tuple[dict, dict, list, list, list]:
                 (
                     key,
                     b_cls,
-                    b_reason,
+                    entry[2],
                     h_cls,
-                    _reason_with_oracle_loss(h_reason, oracle_losses),
+                    _reason_with_oracle_loss(entry[4], oracle_losses),
                 )
             )
             continue
 
         if b_cls == h_cls:
-            if b_reason != h_reason:
+            if b_reason != h_reason or diagnostics_changed:
                 # A reason change within the same semantic classification is
                 # neutral. This is especially important during manifest and
                 # oracle schema migrations, where legacy reasons are replaced.
-                reason_changes.append((key, b_cls, b_reason, h_cls, h_reason))
+                reason_changes.append(
+                    (
+                        key,
+                        b_cls,
+                        entry[2],
+                        h_cls,
+                        entry[4],
+                    )
+                )
             continue
 
         if _is_v3_oracle_reset(
@@ -448,7 +520,9 @@ def _change_kind(
     base_classification = base_info["classification"]
     head_classification = head_info["classification"]
     if base_classification == head_classification:
-        if base_info.get("reason", "") != head_info.get("reason", ""):
+        if base_info.get("reason", "") != head_info.get("reason", "") or _diagnostic_snapshot(
+            base_info
+        ) != _diagnostic_snapshot(head_info):
             return "reason-changed", []
         return "unchanged", []
 
@@ -466,6 +540,28 @@ def _change_kind(
     return change, []
 
 
+def _tsv_diagnostic_fields(prefix: str, info: dict | None) -> dict[str, object]:
+    fields: dict[str, object] = {}
+    for engine in ("ferric", "clips"):
+        result = info.get(engine) if info is not None else None
+        view = result_diagnostic_view(result)
+        termination_kind, exit_code, signal, active_phase = _termination_snapshot(result)
+        stem = f"{prefix}_{engine}"
+        fields.update(
+            {
+                f"{stem}_diagnostic_version": view["version"],
+                f"{stem}_diagnostic_phase": view["phase"],
+                f"{stem}_diagnostic_category": view["category"],
+                f"{stem}_diagnostic_continued": view["continued"],
+                f"{stem}_termination": termination_kind,
+                f"{stem}_exit": exit_code,
+                f"{stem}_signal": signal,
+                f"{stem}_active_phase": active_phase,
+            }
+        )
+    return fields
+
+
 def write_tsv(base: dict, head: dict, tsv_path: str) -> None:
     """Write per-file raw data as TSV."""
     base_files = base.get("files", {})
@@ -479,6 +575,38 @@ def write_tsv(base: dict, head: dict, tsv_path: str) -> None:
         "base_reason",
         "head_classification",
         "head_reason",
+        "base_ferric_diagnostic_version",
+        "base_ferric_diagnostic_phase",
+        "base_ferric_diagnostic_category",
+        "base_ferric_diagnostic_continued",
+        "base_ferric_termination",
+        "base_ferric_exit",
+        "base_ferric_signal",
+        "base_ferric_active_phase",
+        "head_ferric_diagnostic_version",
+        "head_ferric_diagnostic_phase",
+        "head_ferric_diagnostic_category",
+        "head_ferric_diagnostic_continued",
+        "head_ferric_termination",
+        "head_ferric_exit",
+        "head_ferric_signal",
+        "head_ferric_active_phase",
+        "base_clips_diagnostic_version",
+        "base_clips_diagnostic_phase",
+        "base_clips_diagnostic_category",
+        "base_clips_diagnostic_continued",
+        "base_clips_termination",
+        "base_clips_exit",
+        "base_clips_signal",
+        "base_clips_active_phase",
+        "head_clips_diagnostic_version",
+        "head_clips_diagnostic_phase",
+        "head_clips_diagnostic_category",
+        "head_clips_diagnostic_continued",
+        "head_clips_termination",
+        "head_clips_exit",
+        "head_clips_signal",
+        "head_clips_active_phase",
         "base_oracle_status",
         "head_oracle_status",
         "base_oracle_version",
@@ -519,6 +647,8 @@ def write_tsv(base: dict, head: dict, tsv_path: str) -> None:
                     "base_reason": b_reason,
                     "head_classification": h_cls,
                     "head_reason": h_reason,
+                    **_tsv_diagnostic_fields("base", b),
+                    **_tsv_diagnostic_fields("head", h),
                     "base_oracle_status": base_oracle["status"] if base_oracle else "",
                     "head_oracle_status": head_oracle["status"] if head_oracle else "",
                     "base_oracle_version": (

--- a/tools/ferric-tools/src/ferric_tools/compat/oracle.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/oracle.py
@@ -12,6 +12,8 @@ import re
 from dataclasses import dataclass
 from enum import StrEnum
 
+from ferric_tools.compat.diagnostics import SEMANTIC_DIAGNOSTIC_PAIRS
+
 DECLARATION_VERSION = 1
 OBSERVATION_VERSION = 1
 
@@ -506,12 +508,22 @@ def _diagnostic(raw: object, *, field: str) -> DiagnosticState:
     )
     phase = _string(diagnostic_object["phase"], field=f"{field}.phase")
     category = _string(diagnostic_object["category"], field=f"{field}.category")
-    if phase == "unknown" or category == "unknown":
-        _fail(field, "unknown diagnostic evidence is not valid")
     continued = diagnostic_object["continued"]
     if type(continued) is not bool:
         _fail(f"{field}.continued", "must be a boolean")
     assert isinstance(continued, bool)
+    pair = (phase, category)
+    if pair == ("none", "none"):
+        if not continued:
+            _fail(
+                f"{field}.continued",
+                "must be true when no diagnostic was observed",
+            )
+    elif pair not in SEMANTIC_DIAGNOSTIC_PAIRS:
+        _fail(
+            field,
+            f"unsupported semantic diagnostic phase/category pair: {phase!r}/{category!r}",
+        )
     return DiagnosticState(phase=phase, category=category, continued=continued)
 
 

--- a/tools/ferric-tools/src/ferric_tools/compat/projection.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/projection.py
@@ -9,6 +9,13 @@ from __future__ import annotations
 
 import re
 
+from ferric_tools.compat.diagnostics import (
+    DIAGNOSTIC_TAXONOMY_VERSION,
+    ENGINE_DIAGNOSTIC_CATEGORIES,
+    ENGINE_DIAGNOSTIC_PHASES,
+    UNKNOWN_DIAGNOSTIC,
+)
+
 _OBSERVATION_SCHEMA = "ferric.compat-observation"
 _OBSERVATION_VERSION = 1
 _HARNESS_LINE_RE = re.compile(r"^FERRIC-HARNESS\|\d+\|.*(?:\r?\n)?$")
@@ -21,6 +28,21 @@ _HALT_REASONS = frozenset(
         "halt-requested",
         "action-error",
         "not-run",
+    }
+)
+_DIAGNOSTIC_CATEGORY_BY_PHASE = {
+    "parse": "syntax-error",
+    "load": "construct-error",
+    "reset": "evaluation-error",
+    "run": "evaluation-error",
+}
+_INTERRUPTED_TAIL_PROTOCOL_ISSUES = frozenset(
+    {
+        "lifecycle-cardinality-or-order",
+        "native-phase-records-missing",
+        "native-run-metadata-missing",
+        "phase-cardinality-or-order",
+        "module-cardinality",
     }
 )
 
@@ -171,38 +193,119 @@ def _strip_harness_output(text: str) -> tuple[str, list[str]]:
     return "".join(semantic_lines), instrumentation
 
 
-def _canonical_diagnostic(raw: dict, *, engine: str) -> dict:
+def _canonical_diagnostic(
+    raw: dict,
+    *,
+    engine: str,
+    interrupted: bool = False,
+    preserve_unknown: bool = False,
+    diagnostic_subset: bool = False,
+) -> dict:
     diagnostics = raw.get("diagnostics")
     if type(diagnostics) is not list or not all(
         type(diagnostic) is dict for diagnostic in diagnostics
     ):
         raise ObservationProjectionError(f"{engine} diagnostics are malformed")
-    protocol_issues = (
-        raw.get("protocol_issues", []) if engine == "ferric" else raw.get("protocol_issues")
-    )
-    if type(protocol_issues) is not list:
-        raise ObservationProjectionError(f"{engine} protocol issue evidence is malformed")
-    if protocol_issues:
-        raise ObservationProjectionError(
-            f"{engine} protocol violations: {', '.join(map(str, protocol_issues))}"
+    if engine == "ferric":
+        protocol_issues = raw.get("protocol_issues", [])
+    elif diagnostic_subset:
+        protocol_issues = raw.get(
+            "diagnostic_protocol_issues",
+            raw.get("protocol_issues"),
         )
-    if diagnostics:
-        # Phase-aware diagnostic equivalence is deliberately unavailable until
-        # FR-COMPAT-005 (#119). Unknown evidence fails strict oracle validation.
-        return {"phase": "unknown", "category": "unknown", "continued": False}
-    return {"phase": "none", "category": "none", "continued": True}
+    else:
+        protocol_issues = raw.get("protocol_issues")
+    if type(protocol_issues) is not list or not all(
+        type(issue) is str for issue in protocol_issues
+    ):
+        raise ObservationProjectionError(f"{engine} protocol issue evidence is malformed")
+    allowed_protocol_issues = set(_INTERRUPTED_TAIL_PROTOCOL_ISSUES)
+    if interrupted and "native-run-metadata-missing" in protocol_issues:
+        # The parser also reports this state check when interruption cut off
+        # the RUN record. It is contradictory, rather than incomplete, when a
+        # RUN record was present and explicitly denied the diagnostic state.
+        allowed_protocol_issues.add("native-run-diagnostic-state")
+    unexpected_protocol_issues = (
+        [issue for issue in protocol_issues if issue not in allowed_protocol_issues]
+        if interrupted
+        else protocol_issues
+    )
+    if unexpected_protocol_issues:
+        raise ObservationProjectionError(
+            f"{engine} protocol violations: {', '.join(map(str, unexpected_protocol_issues))}"
+        )
+    if not diagnostics:
+        return {"phase": "none", "category": "none", "continued": True}
+
+    summaries: list[tuple[str, str, bool]] = []
+    for index, raw_diagnostic in enumerate(diagnostics):
+        assert isinstance(raw_diagnostic, dict)
+        taxonomy_version = raw_diagnostic.get("taxonomy_version")
+        phase = raw_diagnostic.get("phase")
+        category = raw_diagnostic.get("category")
+        continued = raw_diagnostic.get("continued")
+        if type(taxonomy_version) is not int or taxonomy_version != DIAGNOSTIC_TAXONOMY_VERSION:
+            raise ObservationProjectionError(
+                f"{engine} diagnostic {index} taxonomy version is unsupported"
+            )
+        unknown_pair = (phase, category) == (UNKNOWN_DIAGNOSTIC, UNKNOWN_DIAGNOSTIC)
+        if type(phase) is not str or (
+            phase not in ENGINE_DIAGNOSTIC_PHASES and not (preserve_unknown and unknown_pair)
+        ):
+            raise ObservationProjectionError(
+                f"{engine} diagnostic {index} phase is unsupported: {phase!r}"
+            )
+        if type(category) is not str or (
+            category not in ENGINE_DIAGNOSTIC_CATEGORIES and not (preserve_unknown and unknown_pair)
+        ):
+            raise ObservationProjectionError(
+                f"{engine} diagnostic {index} category is unsupported: {category!r}"
+            )
+        expected_category = _DIAGNOSTIC_CATEGORY_BY_PHASE.get(phase)
+        if not unknown_pair and category != expected_category:
+            raise ObservationProjectionError(
+                f"{engine} diagnostic {index} phase/category pair is unsupported: "
+                f"{phase!r}/{category!r}"
+            )
+        if type(continued) is not bool:
+            raise ObservationProjectionError(
+                f"{engine} diagnostic {index} continuation is malformed"
+            )
+        if type(raw_diagnostic.get("message")) is not str:
+            raise ObservationProjectionError(f"{engine} diagnostic {index} message is malformed")
+        if engine == "ferric":
+            if raw_diagnostic.get("severity") not in {"error", "warning"}:
+                raise ObservationProjectionError(
+                    f"{engine} diagnostic {index} severity is unsupported"
+                )
+        elif raw_diagnostic.get("channel") != "stderr":
+            raise ObservationProjectionError(f"{engine} diagnostic {index} channel is unsupported")
+        summaries.append((phase, category, continued))
+
+    first = summaries[0]
+    if any(summary != first for summary in summaries[1:]):
+        raise ObservationProjectionError(
+            f"{engine} diagnostics are heterogeneous and cannot be collapsed"
+        )
+    phase, category, continued = first
+    return {"phase": phase, "category": category, "continued": continued}
 
 
-def _canonical_markers(raw: dict, *, engine: str) -> list[dict]:
+def _canonical_markers(
+    raw: dict,
+    *,
+    engine: str,
+    interrupted: bool = False,
+) -> list[dict]:
     fixture = raw.get("fixture")
     lifecycle = raw.get("lifecycle")
     if type(fixture) is not dict or type(lifecycle) is not list:
         raise ObservationProjectionError("observation identity or lifecycle is malformed")
-    expected_sequences = (0, 1) if engine == "ferric" else (0, 3)
+    complete_sequences = (0, 1) if engine == "ferric" else (0, 3)
     sequences = [record.get("sequence") if type(record) is dict else None for record in lifecycle]
+    expected_sequences = (0,) if interrupted and tuple(sequences) == (0,) else complete_sequences
     if (
-        len(sequences) != 2
-        or not all(type(sequence) is int for sequence in sequences)
+        not all(type(sequence) is int for sequence in sequences)
         or tuple(sequences) != expected_sequences
     ):
         raise ObservationProjectionError(f"{engine} lifecycle sequence is malformed")
@@ -225,14 +328,20 @@ def _canonical_markers(raw: dict, *, engine: str) -> list[dict]:
                 "nonce": record.get("nonce"),
             }
         )
-    if [marker["kind"] for marker in markers] != ["START", "COMPLETE"]:
+    expected_kinds = ["START"] if expected_sequences == (0,) else ["START", "COMPLETE"]
+    if [marker["kind"] for marker in markers] != expected_kinds:
         raise ObservationProjectionError(f"{engine} lifecycle event order is malformed")
     return markers
 
 
 def _phase(raw: object) -> str:
-    if raw in {"post-run", "post_run"}:
+    if type(raw) is not str:
+        raise ObservationProjectionError(f"unsupported observed phase: {raw!r}")
+    normalized = raw.replace("_", "-")
+    if normalized == "post-run":
         return "run-complete"
+    if normalized in ENGINE_DIAGNOSTIC_PHASES:
+        return normalized
     raise ObservationProjectionError(f"unsupported observed phase: {raw!r}")
 
 
@@ -259,6 +368,93 @@ def _validate_raw_envelope(raw: dict, *, engine: str) -> None:
         raise ObservationProjectionError(f"{engine} observation engine identity is malformed")
 
 
+def _validate_diagnostic_context(
+    raw: dict,
+    *,
+    engine: str,
+    canonical: dict,
+    interrupted: bool,
+) -> None:
+    """Validate phase/run fields that directly attest a diagnostic summary."""
+    diagnostic_phase = canonical["phase"]
+    if diagnostic_phase in {"none", UNKNOWN_DIAGNOSTIC}:
+        return
+
+    observed_phase = _phase(raw.get("phase_reached"))
+    run = raw.get("run")
+    if canonical["continued"]:
+        if interrupted:
+            phase_order = {"parse": 0, "load": 1, "reset": 2, "run": 3, "run-complete": 4}
+            if phase_order[observed_phase] < phase_order[diagnostic_phase]:
+                raise ObservationProjectionError(
+                    f"{engine} continued diagnostic precedes its observed phase"
+                )
+            return
+        if observed_phase != "run-complete" or type(run) is not dict:
+            raise ObservationProjectionError(f"{engine} continued diagnostic lacks a completed run")
+        return
+
+    if observed_phase != diagnostic_phase:
+        raise ObservationProjectionError(
+            f"{engine} terminal phase and diagnostic phase are inconsistent"
+        )
+    if diagnostic_phase == "run":
+        if run is None and interrupted:
+            return
+        if type(run) is not dict or _halt_reason(run.get("halt_reason")) != "action-error":
+            raise ObservationProjectionError(
+                f"{engine} terminal run diagnostic lacks an action-error halt"
+            )
+    elif run is not None:
+        raise ObservationProjectionError(
+            f"{engine} terminal pre-run diagnostic contains run evidence"
+        )
+
+
+def project_observation_diagnostic(
+    raw: object,
+    *,
+    engine: str,
+    expected_fixture: dict[str, str],
+    interrupted: bool = False,
+) -> dict:
+    """Validate the trusted diagnostic subset before full semantic projection."""
+    if type(raw) is not dict:
+        raise ObservationProjectionError(f"{engine} observation is not an object")
+    _validate_raw_envelope(raw, engine=engine)
+    fixture = raw.get("fixture")
+    if type(fixture) is not dict:
+        raise ObservationProjectionError(f"{engine} fixture identity is malformed")
+    for field in ("id", "nonce", "source_sha256", "composed_sha256"):
+        if fixture.get(field) != expected_fixture.get(field):
+            raise ObservationProjectionError(
+                f"{engine} fixture identity field {field!r} does not match the invocation"
+            )
+    for marker_index, marker in enumerate(
+        _canonical_markers(raw, engine=engine, interrupted=interrupted)
+    ):
+        for field in ("id", "nonce", "source_sha256", "composed_sha256"):
+            if marker.get(field) != expected_fixture.get(field):
+                raise ObservationProjectionError(
+                    f"{engine} lifecycle marker {marker_index} field {field!r} "
+                    "does not match the invocation"
+                )
+    canonical = _canonical_diagnostic(
+        raw,
+        engine=engine,
+        interrupted=interrupted,
+        preserve_unknown=True,
+        diagnostic_subset=True,
+    )
+    _validate_diagnostic_context(
+        raw,
+        engine=engine,
+        canonical=canonical,
+        interrupted=interrupted,
+    )
+    return canonical
+
+
 def _validate_capabilities(
     raw: dict,
     *,
@@ -269,16 +465,18 @@ def _validate_capabilities(
     capabilities = raw.get("capabilities")
     if type(capabilities) is not dict:
         raise ObservationProjectionError(f"{engine} capabilities are malformed")
-    required = {"fact_modules"}
+    completed_run = type(raw.get("run")) is dict
+    required = {"fact_modules"} if completed_run else set()
     if engine == "ferric":
         required.add("composed_digest_verification")
-        if require_firing_names:
+        if require_firing_names and completed_run:
             required.add("fired_rule_names")
-        if require_globals:
+        if require_globals and completed_run:
             required.add("global_values")
     else:
-        required.add("rules_fired")
-        if require_firing_names:
+        if completed_run:
+            required.add("rules_fired")
+        if require_firing_names and completed_run:
             required.add("fired_rule_names")
     unavailable = sorted(name for name in required if capabilities.get(name) is not True)
     if unavailable:
@@ -345,16 +543,67 @@ def _base_projection(
     run = raw.get("run")
     if type(fixture) is not dict:
         raise ObservationProjectionError(f"{engine} fixture identity is malformed")
-    if type(run) is not dict:
-        raise ObservationProjectionError(f"{engine} did not complete a run")
+    if run is not None and type(run) is not dict:
+        raise ObservationProjectionError(f"{engine} run observation is malformed")
+    diagnostic = _canonical_diagnostic(raw, engine=engine)
+    observed_phase = _phase(raw.get("phase_reached"))
     raw_facts = raw.get("facts")
     if type(raw_facts) is not list:
         raise ObservationProjectionError(f"{engine} facts are malformed")
-    facts = [_canonical_fact(fact, engine=engine, harnessed=harnessed) for fact in raw_facts]
-    fact_ids = [fact["id"] for fact in facts]
-    if len(fact_ids) != len(set(fact_ids)):
-        raise ObservationProjectionError(f"{engine} observation contains a duplicate fact id")
-    facts = [fact for fact in facts if fact["origin"] != "instrumentation"]
+    if run is None:
+        if diagnostic["phase"] == "none":
+            raise ObservationProjectionError(
+                f"{engine} did not complete a run and has no semantic diagnostic"
+            )
+        if diagnostic["continued"]:
+            raise ObservationProjectionError(
+                f"{engine} diagnostic claims continuation without a completed run"
+            )
+        if observed_phase != diagnostic["phase"]:
+            raise ObservationProjectionError(
+                f"{engine} terminal phase and diagnostic phase are inconsistent"
+            )
+        # A stopped load/reset/run does not provide a comparable final-state
+        # snapshot. Preserve the envelope and channels, but do not project any
+        # partial engine state as semantic evidence.
+        facts: list[dict] = []
+        run_projection = {"limit": None, "halt_reason": "not-run"}
+    else:
+        assert isinstance(run, dict)
+        facts = [_canonical_fact(fact, engine=engine, harnessed=harnessed) for fact in raw_facts]
+        fact_ids = [fact["id"] for fact in facts]
+        if len(fact_ids) != len(set(fact_ids)):
+            raise ObservationProjectionError(f"{engine} observation contains a duplicate fact id")
+        facts = [fact for fact in facts if fact["origin"] != "instrumentation"]
+        halt_reason = _halt_reason(run.get("halt_reason"))
+        run_projection = {"limit": None, "halt_reason": halt_reason}
+        if diagnostic["phase"] == "none":
+            if observed_phase != "run-complete":
+                raise ObservationProjectionError(
+                    f"{engine} stopped before run completion without a diagnostic"
+                )
+        elif diagnostic["continued"]:
+            if observed_phase != "run-complete":
+                raise ObservationProjectionError(
+                    f"{engine} continued diagnostic lacks a completed run"
+                )
+        elif diagnostic["phase"] != "run" or observed_phase != "run":
+            raise ObservationProjectionError(
+                f"{engine} non-continuing diagnostic is inconsistent with run evidence"
+            )
+        terminal_run_diagnostic = {
+            "phase": "run",
+            "category": "evaluation-error",
+            "continued": False,
+        }
+        if halt_reason == "action-error" and diagnostic != terminal_run_diagnostic:
+            raise ObservationProjectionError(
+                f"{engine} action-error halt lacks a matching evaluation diagnostic"
+            )
+        if diagnostic == terminal_run_diagnostic and halt_reason != "action-error":
+            raise ObservationProjectionError(
+                f"{engine} terminal run diagnostic lacks an action-error halt"
+            )
     return (
         {
             "version": 1,
@@ -363,14 +612,11 @@ def _base_projection(
             "composed_sha256": fixture.get("composed_sha256"),
             "nonce": fixture.get("nonce"),
             "markers": _canonical_markers(raw, engine=engine),
-            "phase": _phase(raw.get("phase_reached")),
+            "phase": observed_phase,
             "effects": [_fact_effect(fact) for fact in facts],
             "facts": facts,
-            "diagnostic": _canonical_diagnostic(raw, engine=engine),
-            "run": {
-                "limit": None,
-                "halt_reason": _halt_reason(run.get("halt_reason")),
-            },
+            "diagnostic": diagnostic,
+            "run": run_projection,
             "globals": None,
         },
         facts,
@@ -395,12 +641,15 @@ def project_ferric_observation(
         require_globals=require_globals,
     )
     projected, _facts = _base_projection(raw, engine="ferric", harnessed=harnessed)
-    run = raw["run"]
-    assert isinstance(run, dict)
-    rules_fired = run.get("rules_fired")
-    if type(rules_fired) is not int or rules_fired < 0:
-        raise ObservationProjectionError("Ferric firing count is unavailable")
-    if harnessed:
+    run = raw.get("run")
+    if run is None:
+        rules_fired = 0
+    else:
+        assert isinstance(run, dict)
+        rules_fired = run.get("rules_fired")
+        if type(rules_fired) is not int or rules_fired < 0:
+            raise ObservationProjectionError("Ferric firing count is unavailable")
+    if harnessed and run is not None:
         raise ObservationProjectionError(
             "Ferric cannot separate harness firings from fixture firings"
         )
@@ -436,17 +685,20 @@ def project_clips_observation(
         require_firing_names=require_firing_names,
     )
     projected, _facts = _base_projection(raw, engine="clips", harnessed=harnessed)
-    run = raw["run"]
-    assert isinstance(run, dict)
-    rules_fired = run.get("rules_fired")
-    if type(rules_fired) is not int or rules_fired < 0:
-        raise ObservationProjectionError("CLIPS firing count is unavailable")
-    if harnessed:
+    run = raw.get("run")
+    if run is None:
+        rules_fired = 0
+    else:
+        assert isinstance(run, dict)
+        rules_fired = run.get("rules_fired")
+        if type(rules_fired) is not int or rules_fired < 0:
+            raise ObservationProjectionError("CLIPS firing count is unavailable")
+    if harnessed and run is not None:
         raise ObservationProjectionError(
             "CLIPS cannot separate harness firings from fixture firings"
         )
     fired_rules = raw.get("fired_rules")
-    if require_firing_names:
+    if require_firing_names and run is not None:
         if type(fired_rules) is not list or not all(
             type(rule) is str and rule for rule in fired_rules
         ):

--- a/tools/ferric-tools/src/ferric_tools/compat/report.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/report.py
@@ -12,6 +12,7 @@ from rich.console import Console
 
 from ferric_tools._manifest import load_manifest
 from ferric_tools._paths import examples_dir as default_examples_dir
+from ferric_tools.compat.diagnostics import result_diagnostic_view
 from ferric_tools.compat.oracle import SUPPORTED_NORMALIZERS
 
 app = typer.Typer(help="Generate compatibility assessment reports.")
@@ -157,6 +158,56 @@ def _format_counter(counter: dict[str, int]) -> str:
     return ", ".join(f"{name}: {count:,}" for name, count in sorted(counter.items()))
 
 
+def _termination_view(result: dict) -> dict:
+    raw = result.get("termination")
+    if not isinstance(raw, dict):
+        return {
+            "kind": "",
+            "exit_code": result.get("exit_code"),
+            "signal": None,
+            "active_phase": None,
+        }
+    return {
+        "kind": raw.get("kind", ""),
+        "exit_code": raw.get("exit_code"),
+        "signal": raw.get("signal"),
+        "active_phase": raw.get("active_phase"),
+    }
+
+
+def _diagnostic_line(engine: str, result: dict) -> str | None:
+    diagnostic = result_diagnostic_view(result)
+    if diagnostic["phase"] == "none" and diagnostic["category"] == "none":
+        return None
+    process = _termination_view(result)
+    line = (
+        f"{engine}: diagnostic v{diagnostic['version']} "
+        f"{diagnostic['phase']}/{diagnostic['category']} "
+        f"continued={str(diagnostic['continued']).lower()}; "
+        f"termination={process['kind'] or 'unknown'}"
+    )
+    if process["signal"] is not None:
+        line += f" signal={process['signal']}"
+    elif process["exit_code"] is not None:
+        line += f" exit={process['exit_code']}"
+    if process["active_phase"] is not None:
+        line += f" active-phase={process['active_phase']}"
+    return line
+
+
+def _diagnostic_entries(manifest: dict) -> list[tuple[str, dict, list[str]]]:
+    entries: list[tuple[str, dict, list[str]]] = []
+    for path, info in sorted(manifest["files"].items()):
+        details = [
+            line
+            for engine in ("ferric", "clips")
+            if (line := _diagnostic_line(engine, info.get(engine) or {})) is not None
+        ]
+        if details:
+            entries.append((path, info, details))
+    return entries
+
+
 def print_summary(manifest: dict) -> None:
     """Print summary to stdout."""
     summary = manifest["summary"]
@@ -254,6 +305,15 @@ def print_summary(manifest: dict) -> None:
                     print(f"    ferric: {f_out!r}")
                     print(f"    clips:  {c_out!r}")
 
+    diagnostic_entries = _diagnostic_entries(manifest)
+    if diagnostic_entries:
+        print()
+        print(f"Diagnostic evidence ({len(diagnostic_entries)}):")
+        for path, info, details in diagnostic_entries:
+            print(f"  {path} ({info['classification']}: {info['reason']})")
+            for detail in details:
+                print(f"    {detail}")
+
 
 _FIELDNAMES = [
     "path",
@@ -266,9 +326,23 @@ _FIELDNAMES = [
     "ferric_exit",
     "ferric_duration_ms",
     "ferric_timed_out",
+    "ferric_termination",
+    "ferric_signal",
+    "ferric_active_phase",
+    "ferric_diagnostic_version",
+    "ferric_diagnostic_phase",
+    "ferric_diagnostic_category",
+    "ferric_diagnostic_continued",
     "clips_exit",
     "clips_duration_ms",
     "clips_timed_out",
+    "clips_termination",
+    "clips_signal",
+    "clips_active_phase",
+    "clips_diagnostic_version",
+    "clips_diagnostic_phase",
+    "clips_diagnostic_category",
+    "clips_diagnostic_continued",
     "oracle_selected",
     "oracle_declaration",
     "oracle_status",
@@ -291,6 +365,10 @@ def _write_delimited(manifest: dict, out_path: str, delimiter: str) -> None:
         for path, info in sorted(manifest["files"].items()):
             ferric = info.get("ferric") or {}
             clips = info.get("clips") or {}
+            ferric_diagnostic = result_diagnostic_view(ferric)
+            clips_diagnostic = result_diagnostic_view(clips)
+            ferric_termination = _termination_view(ferric)
+            clips_termination = _termination_view(clips)
             oracle = oracle_evidence_view(info)
             writer.writerow(
                 {
@@ -304,9 +382,23 @@ def _write_delimited(manifest: dict, out_path: str, delimiter: str) -> None:
                     "ferric_exit": ferric.get("exit_code", ""),
                     "ferric_duration_ms": ferric.get("duration_ms", ""),
                     "ferric_timed_out": ferric.get("timed_out", ""),
+                    "ferric_termination": ferric_termination["kind"],
+                    "ferric_signal": ferric_termination["signal"],
+                    "ferric_active_phase": ferric_termination["active_phase"],
+                    "ferric_diagnostic_version": ferric_diagnostic["version"],
+                    "ferric_diagnostic_phase": ferric_diagnostic["phase"],
+                    "ferric_diagnostic_category": ferric_diagnostic["category"],
+                    "ferric_diagnostic_continued": ferric_diagnostic["continued"],
                     "clips_exit": clips.get("exit_code", ""),
                     "clips_duration_ms": clips.get("duration_ms", ""),
                     "clips_timed_out": clips.get("timed_out", ""),
+                    "clips_termination": clips_termination["kind"],
+                    "clips_signal": clips_termination["signal"],
+                    "clips_active_phase": clips_termination["active_phase"],
+                    "clips_diagnostic_version": clips_diagnostic["version"],
+                    "clips_diagnostic_phase": clips_diagnostic["phase"],
+                    "clips_diagnostic_category": clips_diagnostic["category"],
+                    "clips_diagnostic_continued": clips_diagnostic["continued"],
                     "oracle_selected": oracle["selected"],
                     "oracle_declaration": oracle["declaration"],
                     "oracle_status": oracle["status"],
@@ -423,6 +515,16 @@ def write_report(
         lines.append("")
         for k, v in divergent:
             lines.append(f"- `{k}` ({v['reason']})")
+
+    diagnostic_entries = _diagnostic_entries(manifest)
+    if diagnostic_entries:
+        lines.append("")
+        lines.append(f"### Diagnostic evidence ({len(diagnostic_entries)})")
+        lines.append("")
+        for path, info, details in diagnostic_entries:
+            lines.append(f"- `{path}` ({info['classification']}: {info['reason']})")
+            for detail in details:
+                lines.append(f"  - {detail}")
 
     with open(report_path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines))

--- a/tools/ferric-tools/src/ferric_tools/compat/run.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/run.py
@@ -94,6 +94,7 @@ _EMPTY_INTERRUPTION_PROTOCOL_ISSUES = frozenset(
         "native-run-metadata-missing",
         "phase-cardinality-or-order",
         "module-cardinality",
+        "truncated-native-record",
     }
 )
 

--- a/tools/ferric-tools/src/ferric_tools/compat/run.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/run.py
@@ -7,12 +7,14 @@ the manifest with classification results.
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import copy
 import json
 import os
 import re
 import secrets
+import signal
 import subprocess
 import sys
 import tempfile
@@ -45,7 +47,17 @@ from ferric_tools._paths import (
     repo_root,
 )
 from ferric_tools._subprocess import parallel_run
-from ferric_tools.compat.clips_oracle import build_probe_operations, parse_probe_output
+from ferric_tools.compat.clips_oracle import (
+    ClipsOracleProtocolError,
+    build_probe_operations,
+    parse_probe_output,
+)
+from ferric_tools.compat.diagnostics import (
+    diagnostic,
+    diagnostic_evidence_state,
+    process_diagnostic,
+    termination,
+)
 from ferric_tools.compat.oracle import (
     DECLARATION_VERSION,
     EvidenceStatus,
@@ -57,14 +69,33 @@ from ferric_tools.compat.projection import (
     ObservationProjectionError,
     project_clips_observation,
     project_ferric_observation,
+    project_observation_diagnostic,
 )
 
 app = typer.Typer(help="Run CLIPS compatibility assessment.")
 console = Console(stderr=True)
 VALID_RUNABILITY = {"batch", "interactive", "library", "standalone", "unknown"}
 FAILED_CLASSIFICATIONS = {"divergent", "incompatible"}
+INVALID_RUNTIME_EVIDENCE_REASONS = frozenset(
+    {
+        "diagnostic-invalid",
+        "diagnostic-missing",
+        "harness-failure",
+        "termination-invalid",
+        "termination-missing",
+    }
+)
 COMPAT_WORKSPACE = Path(".ferric-compat")
 IS_WINDOWS = os.name == "nt"
+_EMPTY_INTERRUPTION_PROTOCOL_ISSUES = frozenset(
+    {
+        "native-phase-records-missing",
+        "lifecycle-cardinality-or-order",
+        "native-run-metadata-missing",
+        "phase-cardinality-or-order",
+        "module-cardinality",
+    }
+)
 
 
 class CompatibilityWorkspaceError(RuntimeError):
@@ -302,14 +333,6 @@ def _retain_failure_artifact(
         ) from error
 
 
-def _timeout_text(value: str | bytes | None) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, bytes):
-        return value.decode("utf-8", errors="replace")
-    return value
-
-
 def _output_bytes(value: str | bytes | None) -> bytes:
     if value is None:
         return b""
@@ -320,6 +343,108 @@ def _output_bytes(value: str | bytes | None) -> bytes:
 
 def _display_output(value: bytes) -> str:
     return value.decode("utf-8", errors="replace")
+
+
+def _attach_raw_output(result: dict, *, stdout: bytes, stderr: bytes) -> dict:
+    """Persist exact process bytes alongside their human-readable views."""
+    result["raw_output"] = {
+        "encoding": "base64",
+        "stdout": base64.b64encode(stdout).decode("ascii"),
+        "stderr": base64.b64encode(stderr).decode("ascii"),
+    }
+    return result
+
+
+def _with_termination(result: dict, *, spawn_error: bool = False) -> dict:
+    """Attach process state without treating it as an engine diagnostic."""
+    if spawn_error:
+        result["spawn_error"] = True
+    result["termination"] = termination(
+        exit_code=result["exit_code"],
+        timed_out=result["timed_out"],
+        spawn_error=spawn_error,
+    )
+    return result
+
+
+def _clips_wrapper_termination(exit_code: int) -> dict[str, object]:
+    """Normalize Docker's documented 128+signal transport status."""
+    # The observer runs in a Linux container even when the compatibility tool
+    # runs on another host. Linux signal numbers occupy 1..64, including the
+    # realtime range that is absent from some host-side Python enums.
+    if 129 <= exit_code <= 192:
+        return {"kind": "signal", "exit_code": None, "signal": exit_code - 128}
+    return termination(exit_code=exit_code, timed_out=False)
+
+
+def _terminate_process_tree(process: subprocess.Popen) -> None:
+    """Terminate the isolated CLIPS wrapper and all local pipeline children."""
+    if IS_WINDOWS:
+        try:
+            subprocess.run(
+                ["taskkill", "/PID", str(process.pid), "/T", "/F"],
+                capture_output=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            process.kill()
+        return
+    with contextlib.suppress(ProcessLookupError):
+        os.killpg(process.pid, signal.SIGKILL)
+
+
+def _remove_clips_container(container_name: str) -> None:
+    """Force-remove the uniquely named observer container after interruption."""
+    if re.fullmatch(r"ferric-compat-[0-9a-f]{32}", container_name) is None:
+        raise ValueError("refusing to remove an unrecognized CLIPS container name")
+    # The local process group is already dead. A missing daemon/container is
+    # expected when startup lost the race with the timeout.
+    with contextlib.suppress(OSError, subprocess.SubprocessError):
+        subprocess.run(
+            ["docker", "rm", "--force", container_name],
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+
+
+def _run_clips_process(
+    command: list[str],
+    *,
+    timeout_secs: int,
+    root: str,
+    container_name: str | None = None,
+) -> subprocess.CompletedProcess:
+    """Run the shell/Docker observer with a wall-clock process-tree timeout."""
+    popen_options: dict[str, object] = {
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": False,
+        "cwd": root,
+    }
+    if IS_WINDOWS:
+        popen_options["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_options["start_new_session"] = True
+    process = subprocess.Popen(command, **popen_options)
+    try:
+        stdout, stderr = process.communicate(timeout=timeout_secs)
+    except subprocess.TimeoutExpired as error:
+        _terminate_process_tree(process)
+        if container_name is not None:
+            _remove_clips_container(container_name)
+        try:
+            stdout, stderr = process.communicate(timeout=5)
+        except subprocess.TimeoutExpired:
+            stdout, stderr = error.output, error.stderr
+        raise subprocess.TimeoutExpired(
+            command,
+            timeout_secs,
+            output=stdout,
+            stderr=stderr,
+        ) from error
+    return subprocess.CompletedProcess(command, process.returncode, stdout, stderr)
 
 
 def run_ferric_observer(
@@ -352,37 +477,60 @@ def run_ferric_observer(
         proc = subprocess.run(
             command,
             capture_output=True,
-            text=True,
+            text=False,
             timeout=timeout_secs,
             cwd=root,
         )
+        raw_stdout = _output_bytes(proc.stdout)
+        raw_stderr = _output_bytes(proc.stderr)
         duration_ms = int((time.monotonic() - start) * 1000)
-        result = {
-            "exit_code": proc.returncode,
-            "stdout": proc.stdout,
-            "stderr": proc.stderr,
-            "duration_ms": duration_ms,
-            "timed_out": False,
-        }
+        result = _attach_raw_output(
+            _with_termination(
+                {
+                    "exit_code": proc.returncode,
+                    "stdout": _display_output(raw_stdout),
+                    "stderr": _display_output(raw_stderr),
+                    "duration_ms": duration_ms,
+                    "timed_out": False,
+                }
+            ),
+            stdout=raw_stdout,
+            stderr=raw_stderr,
+        )
     except subprocess.TimeoutExpired as error:
+        raw_stdout = _output_bytes(error.stdout)
+        raw_stderr = _output_bytes(error.stderr)
         duration_ms = int((time.monotonic() - start) * 1000)
-        return {
-            "exit_code": -1,
-            "stdout": _timeout_text(error.stdout),
-            "stderr": _timeout_text(error.stderr) or f"timeout after {timeout_secs}s",
-            "duration_ms": duration_ms,
-            "timed_out": True,
-            "observation_error": "observer timed out before terminal evidence",
-        }
-    except FileNotFoundError:
-        return {
-            "exit_code": -1,
-            "stdout": "",
-            "stderr": f"ferric binary not found: {ferric_bin}",
-            "duration_ms": 0,
-            "timed_out": False,
-            "observation_error": "observer executable not found",
-        }
+        return _attach_raw_output(
+            _with_termination(
+                {
+                    "exit_code": None,
+                    "stdout": _display_output(raw_stdout),
+                    "stderr": _display_output(raw_stderr) or f"timeout after {timeout_secs}s",
+                    "duration_ms": duration_ms,
+                    "timed_out": True,
+                    "observation_error": "observer timed out before terminal evidence",
+                }
+            ),
+            stdout=raw_stdout,
+            stderr=raw_stderr,
+        )
+    except OSError as error:
+        return _attach_raw_output(
+            _with_termination(
+                {
+                    "exit_code": None,
+                    "stdout": "",
+                    "stderr": f"cannot start ferric observer {ferric_bin}: {error}",
+                    "duration_ms": 0,
+                    "timed_out": False,
+                    "observation_error": "observer executable could not be started",
+                },
+                spawn_error=True,
+            ),
+            stdout=b"",
+            stderr=b"",
+        )
 
     try:
         if result["stdout"].count("\n") != 1 or not result["stdout"].endswith("\n"):
@@ -391,7 +539,11 @@ def run_ferric_observer(
         if type(observation) is not dict:
             raise ValueError("observation must be a JSON object")
     except (json.JSONDecodeError, ValueError) as error:
-        result["observation_error"] = str(error)
+        if (result.get("termination") or {}).get("kind") == "signal":
+            result["observation_error"] = "observer was signaled before terminal evidence"
+        else:
+            result["observation_error"] = str(error)
+            result["harness_error"] = True
     else:
         result["observation"] = observation
     return result
@@ -424,6 +576,7 @@ def run_clips_observer(
         globals_to_capture=globals_to_capture,
     )
     auth_key = secrets.token_hex(32)
+    container_name = f"ferric-compat-{auth_key[:32]}"
     command = [
         script,
         "run",
@@ -438,6 +591,8 @@ def run_clips_observer(
         composed_sha256,
         "--observer-auth-key",
         auth_key,
+        "--observer-container-name",
+        container_name,
         "--file",
         str(resolved_path),
     ]
@@ -448,46 +603,70 @@ def run_clips_observer(
     raw_stdout = b""
     raw_stderr = b""
     try:
-        proc = subprocess.run(
+        proc = _run_clips_process(
             command,
-            capture_output=True,
-            text=False,
-            timeout=timeout_secs,
-            cwd=root,
+            timeout_secs=timeout_secs,
+            root=root,
+            container_name=container_name,
         )
         raw_stdout = _output_bytes(proc.stdout)
         raw_stderr = _output_bytes(proc.stderr)
         duration_ms = int((time.monotonic() - start) * 1000)
-        result = {
-            "exit_code": proc.returncode,
-            "stdout": _display_output(raw_stdout),
-            "stderr": _display_output(raw_stderr),
-            "duration_ms": duration_ms,
-            "timed_out": False,
-        }
+        result = _attach_raw_output(
+            _with_termination(
+                {
+                    "exit_code": proc.returncode,
+                    "stdout": _display_output(raw_stdout),
+                    "stderr": _display_output(raw_stderr),
+                    "duration_ms": duration_ms,
+                    "timed_out": False,
+                }
+            ),
+            stdout=raw_stdout,
+            stderr=raw_stderr,
+        )
+        result["termination"] = _clips_wrapper_termination(proc.returncode)
+        if proc.returncode in {125, 126, 127}:
+            result["harness_error"] = True
+            result["observation_error"] = (
+                f"reference observer transport failed with status {proc.returncode}"
+            )
     except subprocess.TimeoutExpired as error:
         duration_ms = int((time.monotonic() - start) * 1000)
         raw_stdout = _output_bytes(error.stdout)
         raw_stderr = _output_bytes(error.stderr)
         partial_stdout = _display_output(raw_stdout)
         partial_stderr = _display_output(raw_stderr)
-        result = {
-            "exit_code": -1,
-            "stdout": partial_stdout,
-            "stderr": partial_stderr or f"timeout after {timeout_secs}s",
-            "duration_ms": duration_ms,
-            "timed_out": True,
-            "observation_error": "reference observer timed out before terminal evidence",
-        }
-    except FileNotFoundError:
-        return {
-            "exit_code": -1,
-            "stdout": "",
-            "stderr": f"harness script not found: {script}",
-            "duration_ms": 0,
-            "timed_out": False,
-            "observation_error": "reference observer executable not found",
-        }
+        result = _attach_raw_output(
+            _with_termination(
+                {
+                    "exit_code": None,
+                    "stdout": partial_stdout,
+                    "stderr": partial_stderr or f"timeout after {timeout_secs}s",
+                    "duration_ms": duration_ms,
+                    "timed_out": True,
+                    "observation_error": "reference observer timed out before terminal evidence",
+                }
+            ),
+            stdout=raw_stdout,
+            stderr=raw_stderr,
+        )
+    except OSError as error:
+        return _attach_raw_output(
+            _with_termination(
+                {
+                    "exit_code": None,
+                    "stdout": "",
+                    "stderr": f"cannot start reference observer {script}: {error}",
+                    "duration_ms": 0,
+                    "timed_out": False,
+                    "observation_error": "reference observer executable could not be started",
+                },
+                spawn_error=True,
+            ),
+            stdout=b"",
+            stderr=b"",
+        )
 
     try:
         observation = parse_probe_output(
@@ -499,9 +678,20 @@ def run_clips_observer(
             composed_sha256=composed_sha256,
             auth_key=auth_key,
             harnessed=harnessed,
+            interrupted=(result.get("termination") or {}).get("kind") in {"signal", "timeout"},
         )
-    except (ValueError, RuntimeError) as error:
+    except ClipsOracleProtocolError as error:
         result["observation_error"] = str(error)
+        result["harness_error"] = True
+    except (ValueError, RuntimeError) as error:
+        if (result.get("termination") or {}).get("kind") in {"signal", "timeout"}:
+            result.setdefault(
+                "observation_error",
+                "reference observer was interrupted before parsable terminal evidence",
+            )
+        else:
+            result["observation_error"] = str(error)
+            result["harness_error"] = True
     else:
         result["observation"] = observation
     return result
@@ -521,6 +711,10 @@ def _oracle_outcome(evaluation) -> tuple[str, str, dict]:
         evaluation.ferric.status is EvidenceStatus.VALID
         and evaluation.clips.status is EvidenceStatus.VALID
     )
+    observations_completed = observations_valid and all(
+        evidence.value is not None and evidence.value.run.halt_reason != "not-run"
+        for evidence in (evaluation.ferric, evaluation.clips)
+    )
     effect_mismatch = any(mismatch["field"] == "effects" for mismatch in mismatches)
     normalizations = (
         list(evaluation.declaration.value.normalizers)
@@ -535,8 +729,8 @@ def _oracle_outcome(evaluation) -> tuple[str, str, dict]:
         "version": 1,
         "declaration": declaration_valid,
         "reached": observations_valid,
-        "completed": observations_valid,
-        "effect": observations_valid and not effect_mismatch,
+        "completed": observations_completed,
+        "effect": observations_completed and not effect_mismatch,
         "normalizations": normalizations,
         "violations": violations,
         "evaluation": evaluation_dict,
@@ -562,11 +756,95 @@ def classify_results(
     evaluation=None,
 ) -> tuple[str, str]:
     """Classify only from independently validated structured evidence."""
-    del ferric_result, clips_result
+    diagnostic_outcome = _diagnostic_outcome(ferric_result, clips_result)
     if evaluation is None:
-        return "pending", "oracle-missing"
+        return diagnostic_outcome or ("pending", "oracle-missing")
+    if diagnostic_outcome is not None:
+        classification, reason = diagnostic_outcome
+        complete_terminal_oracle = (
+            classification == "incompatible"
+            and reason == "diagnostic-match-without-complete-oracle"
+            and all(
+                evidence.status is EvidenceStatus.VALID
+                and evidence.value is not None
+                and evidence.value.run.halt_reason != "not-run"
+                for evidence in (evaluation.ferric, evaluation.clips)
+            )
+        )
+        if not complete_terminal_oracle:
+            return diagnostic_outcome
     classification, reason, _evidence = _oracle_outcome(evaluation)
     return classification, reason
+
+
+def _termination_state(result: dict | None) -> tuple[str, tuple[object, ...] | None]:
+    if not isinstance(result, dict) or "termination" not in result:
+        return "missing", None
+    raw = result.get("termination")
+    if not isinstance(raw, dict):
+        return "invalid", None
+    kind = raw.get("kind")
+    exit_code = raw.get("exit_code")
+    signal = raw.get("signal")
+    active_phase = raw.get("active_phase")
+    if active_phase is not None and active_phase not in {"load", "reset", "run"}:
+        return "invalid", None
+    if kind == "exit" and type(exit_code) is int and exit_code >= 0 and signal is None:
+        return "valid", (kind, exit_code, None, active_phase)
+    if kind == "signal" and exit_code is None and type(signal) is int and signal > 0:
+        return "valid", (kind, None, signal, active_phase)
+    if kind in {"timeout", "spawn-error"} and exit_code is None and signal is None:
+        return "valid", (kind, None, None, active_phase)
+    return "invalid", None
+
+
+def _diagnostic_outcome(
+    ferric_result: dict,
+    clips_result: dict | None,
+) -> tuple[str, str] | None:
+    """Classify trusted terminal diagnostics when full oracle evidence is unavailable."""
+    ferric_status, ferric = diagnostic_evidence_state(ferric_result)
+    clips_status, clips = diagnostic_evidence_state(clips_result)
+    statuses = {ferric_status, clips_status}
+    if "harness" in statuses:
+        return "pending", "harness-failure"
+    if "invalid" in statuses:
+        return "pending", "diagnostic-invalid"
+    if ferric_status == clips_status == "missing":
+        return None
+    if "missing" in statuses:
+        known = clips if ferric is None else ferric
+        if known is not None and known[0] == "none":
+            return None
+        return "pending", "diagnostic-missing"
+    assert ferric is not None and clips is not None
+    for index, field in enumerate(("phase", "category", "continued")):
+        if ferric[index] != clips[index]:
+            return "divergent", f"diagnostic-{field}-mismatch"
+
+    ferric_termination_status, ferric_termination = _termination_state(ferric_result)
+    clips_termination_status, clips_termination = _termination_state(clips_result)
+    termination_statuses = {ferric_termination_status, clips_termination_status}
+    if "invalid" in termination_statuses:
+        return "pending", "termination-invalid"
+    if termination_statuses == {"missing"}:
+        pass
+    elif "missing" in termination_statuses:
+        return "pending", "termination-missing"
+    else:
+        assert ferric_termination is not None and clips_termination is not None
+        for index, field in enumerate(("kind", "exit-code", "signal", "active-phase")):
+            if ferric_termination[index] != clips_termination[index]:
+                return "divergent", f"termination-{field}-mismatch"
+        if ferric_termination[0] in {"timeout", "signal"}:
+            return "incompatible", "termination-match-without-complete-oracle"
+    if ferric[0] != "none" and ferric[2] is False:
+        return "incompatible", "diagnostic-match-without-complete-oracle"
+    if ferric_termination is not None and (
+        ferric_termination[0] == "exit" and ferric_termination[1] != 0
+    ):
+        return "incompatible", "termination-nonzero-exit-match"
+    return None
 
 
 def _missing_oracle_evidence() -> dict:
@@ -602,33 +880,103 @@ def _invalid_preflight_evidence(error: str) -> dict:
     }
 
 
+def _is_empty_clips_interruption(observation: object, *, engine: str) -> bool:
+    """Recognize a kill before the native observer emitted authenticated evidence."""
+    if engine != "clips" or type(observation) is not dict:
+        return False
+    protocol_issues = observation.get("protocol_issues")
+    return (
+        observation.get("lifecycle") == []
+        and observation.get("diagnostics") == []
+        and observation.get("active_phase") is None
+        and type(protocol_issues) is list
+        and all(type(issue) is str for issue in protocol_issues)
+        and set(protocol_issues).issubset(_EMPTY_INTERRUPTION_PROTOCOL_ISSUES)
+    )
+
+
 def _project_result(
     result: dict,
     *,
     engine: str,
     harnessed: bool,
+    expected_fixture: dict[str, str] | None = None,
     require_firing_names: bool = False,
     require_globals: bool = False,
 ) -> dict:
     """Project one successful observer result or return invalid evidence."""
     observation = result.get("observation")
-    if result.get("timed_out"):
-        error = result.get("observation_error", f"{engine} observer timed out")
+    process = result.get("termination")
+    if not isinstance(process, dict):
+        process = termination(
+            exit_code=result.get("exit_code"),
+            timed_out=result.get("timed_out") is True,
+            spawn_error=result.get("spawn_error") is True,
+        )
+        result["termination"] = process
+    process_kind = process.get("kind")
+    interrupted = process_kind in {"timeout", "signal"}
+    if process_kind in {"timeout", "signal", "spawn-error"} and type(observation) is dict:
+        instrumentation = observation.get("instrumentation")
+        active_phase = (
+            instrumentation.get("active_phase") if isinstance(instrumentation, dict) else None
+        )
+        if active_phase in {"load", "reset", "run"}:
+            process["active_phase"] = active_phase
+
+    if result.get("harness_error") is True:
+        error = result.get("observation_error", f"{engine} observer harness failed")
+        result["diagnostic"] = diagnostic("harness", "harness-error", continued=False)
         result["projection_error"] = error
         return _invalid_observation(error)
-    if result.get("exit_code") != 0:
+
+    trusted_diagnostic: dict | None = None
+    validate_diagnostic_subset = not interrupted or not _is_empty_clips_interruption(
+        observation,
+        engine=engine,
+    )
+    if (
+        expected_fixture is not None
+        and type(observation) is dict
+        and observation.get("schema") == "ferric.compat-observation"
+        and validate_diagnostic_subset
+    ):
+        try:
+            trusted_diagnostic = project_observation_diagnostic(
+                observation,
+                engine=engine,
+                expected_fixture=expected_fixture,
+                interrupted=interrupted,
+            )
+        except ObservationProjectionError as error:
+            result["diagnostic"] = diagnostic("harness", "harness-error", continued=False)
+            result["projection_error"] = str(error)
+            return _invalid_observation(str(error))
+    if process_kind in {"timeout", "signal", "spawn-error"}:
         error = result.get(
             "observation_error",
-            f"{engine} observer exited with status {result.get('exit_code')!r}",
+            f"{engine} observer terminated as {process_kind}",
         )
+        if trusted_diagnostic is not None and trusted_diagnostic["phase"] != "none":
+            result["diagnostic"] = diagnostic(
+                trusted_diagnostic["phase"],
+                trusted_diagnostic["category"],
+                continued=trusted_diagnostic["continued"],
+            )
+        else:
+            result["diagnostic"] = process_diagnostic(result)
         result["projection_error"] = error
         return _invalid_observation(error)
     if engine == "ferric" and result.get("stderr"):
         error = "ferric observer emitted out-of-band stderr"
+        result["diagnostic"] = diagnostic("harness", "harness-error", continued=False)
         result["projection_error"] = error
         return _invalid_observation(error)
     if type(observation) is not dict:
         error = result.get("observation_error", f"{engine} observation is missing")
+        result["diagnostic"] = process_diagnostic(result) or diagnostic(
+            "harness", "harness-error", continued=False
+        )
         result["projection_error"] = error
         return _invalid_observation(error)
 
@@ -647,8 +995,33 @@ def _project_result(
                 require_firing_names=require_firing_names,
             )
     except ObservationProjectionError as error:
+        if trusted_diagnostic is not None and trusted_diagnostic["phase"] != "none":
+            result["diagnostic"] = diagnostic(
+                trusted_diagnostic["phase"],
+                trusted_diagnostic["category"],
+                continued=trusted_diagnostic["continued"],
+            )
+        else:
+            result["diagnostic"] = diagnostic("harness", "harness-error", continued=False)
         result["projection_error"] = str(error)
         return _invalid_observation(str(error))
+
+    canonical_diagnostic = projected.get("diagnostic")
+    if type(canonical_diagnostic) is not dict:
+        error = f"{engine} projected diagnostic is malformed"
+        result["diagnostic"] = diagnostic("harness", "harness-error", continued=False)
+        result["projection_error"] = error
+        return _invalid_observation(error)
+    result["diagnostic"] = diagnostic(
+        canonical_diagnostic["phase"],
+        canonical_diagnostic["category"],
+        continued=canonical_diagnostic["continued"],
+    )
+    if result.get("exit_code") != 0 and canonical_diagnostic.get("phase") == "none":
+        error = f"{engine} observer exited with status {result.get('exit_code')!r}"
+        result["diagnostic"] = process_diagnostic(result)
+        result["projection_error"] = error
+        return _invalid_observation(error)
 
     result["canonical_observation"] = projected
     return projected
@@ -744,6 +1117,12 @@ def process_file(args: tuple) -> tuple:
         if declaration_evidence.status is EvidenceStatus.VALID:
             fixture_id = runtime_declaration["id"]
             nonce = runtime_declaration["nonce"]
+            expected_fixture = {
+                "id": fixture_id,
+                "nonce": nonce,
+                "source_sha256": source_digest,
+                "composed_sha256": composed_digest,
+            }
             ferric_result = run_ferric_observer(
                 run_path,
                 ferric,
@@ -758,6 +1137,7 @@ def process_file(args: tuple) -> tuple:
                 ferric_result,
                 engine="ferric",
                 harnessed=harness is not None,
+                expected_fixture=expected_fixture,
                 require_firing_names=(
                     runtime_declaration["expectations"]["firings"]["names"] is not None
                 ),
@@ -765,12 +1145,13 @@ def process_file(args: tuple) -> tuple:
             )
         else:
             ferric_result = {
-                "exit_code": -1,
+                "exit_code": None,
                 "stdout": "",
                 "stderr": "oracle declaration is invalid for the current source",
                 "duration_ms": 0,
                 "timed_out": False,
                 "observation_error": "oracle declaration validation failed",
+                "not_run": True,
             }
             ferric_observation = None
 
@@ -805,13 +1186,14 @@ def process_file(args: tuple) -> tuple:
                 clips_result,
                 engine="clips",
                 harnessed=harness is not None,
+                expected_fixture=expected_fixture,
                 require_firing_names=(
                     runtime_declaration["expectations"]["firings"]["names"] is not None
                 ),
             )
         else:
             clips_result = {
-                "exit_code": -1,
+                "exit_code": None,
                 "stdout": "",
                 "stderr": (
                     "reference observer was skipped"
@@ -825,6 +1207,7 @@ def process_file(args: tuple) -> tuple:
                     if skip_clips
                     else "oracle declaration validation failed"
                 ),
+                "not_run": True,
             }
             clips_observation = (
                 _invalid_observation("reference observer was skipped") if skip_clips else None
@@ -837,7 +1220,12 @@ def process_file(args: tuple) -> tuple:
             expected_source_sha256=source_digest,
             expected_composed_sha256=composed_digest,
         )
-        classification, reason, evidence = _oracle_outcome(evaluation)
+        _oracle_classification, _oracle_reason, evidence = _oracle_outcome(evaluation)
+        classification, reason = classify_results(
+            ferric_result,
+            clips_result,
+            evaluation=evaluation,
+        )
         for engine_name, engine_result in (
             ("ferric", ferric_result),
             ("clips", clips_result),
@@ -860,7 +1248,7 @@ def process_file(args: tuple) -> tuple:
             )
 
         retain_failure = classification in FAILED_CLASSIFICATIONS or reason.startswith(
-            "oracle-invalid"
+            ("oracle-invalid", "diagnostic-", "termination-", "harness-")
         )
         if composed_content is not None and composed_digest is not None:
             composed_metadata: dict[str, str | int] = {
@@ -1288,6 +1676,18 @@ def main(
             print(f"  {rel_path} ({reason})")
             for violation in ferric_r["oracle_evidence"].get("violations", [])[:3]:
                 print(f"    {violation}")
+
+    invalid_runtime = [
+        (rel_path, values)
+        for rel_path, values in results.items()
+        if values[3] in INVALID_RUNTIME_EVIDENCE_REASONS
+    ]
+    if invalid_runtime:
+        print(f"\nInvalid runtime evidence ({len(invalid_runtime)}):")
+        for rel_path, (_ferric_r, _clips_r, _classification, reason) in invalid_runtime[:20]:
+            print(f"  {rel_path} ({reason})")
+
+    if invalid or invalid_runtime:
         raise typer.Exit(1)
 
 

--- a/tools/ferric-tools/tests/test_clips_oracle.py
+++ b/tools/ferric-tools/tests/test_clips_oracle.py
@@ -12,6 +12,7 @@ from ferric_tools.compat.clips_oracle import (
     NATIVE_EMIT_FUNCTION,
     NATIVE_RECORD_PREFIX,
     RECORD_PREFIX,
+    ClipsOracleProtocolError,
     build_probe_operations,
     parse_probe_output,
 )
@@ -41,6 +42,30 @@ def _probe(payload: str, *, nonce: str = NONCE) -> bytes:
     return _authenticated(
         f"PROBE|{len(encoded)}|".encode() + encoded,
         nonce=nonce,
+    )
+
+
+def _phase(sequence: int, phase: str, event: str, status: str | None = None) -> bytes:
+    fields: tuple[object, ...] = (sequence, phase, event)
+    if status is not None:
+        fields += (status,)
+    return _native_record("PHASE", *fields)
+
+
+def _diagnostic(
+    phase: str,
+    message: str,
+    *,
+    continued: bool,
+    taxonomy_version: int = 1,
+) -> bytes:
+    payload = message.encode()
+    return _authenticated(
+        (
+            f"DIAGNOSTIC|{taxonomy_version}|{phase}|{int(continued)}|{len(payload)}|".encode()
+            + payload
+        ),
+        nonce=NONCE,
     )
 
 
@@ -77,6 +102,12 @@ def _observation_stderr(
 ) -> bytes:
     records = [
         _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+        _phase(1, "load", "BEGIN"),
+        _phase(2, "load", "END", "OK"),
+        _phase(3, "reset", "BEGIN"),
+        _phase(4, "reset", "END", "OK"),
+        _phase(5, "run", "BEGIN"),
+        _phase(6, "run", "END", "OK"),
         run_metadata if run_metadata is not None else _native_run_metadata(),
         _probe("PHASE|1|RESET_COMPLETE"),
         _probe("PHASE|2|RUN_COMPLETE"),
@@ -96,6 +127,7 @@ def _parse(
     *,
     harnessed: bool = False,
     raw_stderr: bytes | None = None,
+    interrupted: bool = False,
 ) -> dict:
     return parse_probe_output(
         raw_stdout,
@@ -106,6 +138,7 @@ def _parse(
         composed_sha256=DIGEST,
         auth_key=AUTH_KEY,
         harnessed=harnessed,
+        interrupted=interrupted,
     )
 
 
@@ -152,6 +185,35 @@ def test_fixture_watch_shaped_output_remains_semantic_and_cannot_change_count():
     assert observation["run"]["rules_fired"] == 1
     assert observation["fired_rules"] is None
     assert observation["channels"][0]["text"] == output
+
+
+def test_bracketed_user_output_is_not_inferred_to_be_a_diagnostic():
+    output = "[EXPRNPSR3] this is fixture output, not an engine diagnostic\n"
+
+    observation = _parse(output)
+
+    assert observation["protocol_issues"] == []
+    assert observation["diagnostics"] == []
+    assert observation["channels"][0]["text"] == output
+
+    stderr_observation = _parse(raw_stderr=_observation_stderr(semantic_stderr=output.encode()))
+    assert stderr_observation["protocol_issues"] == []
+    assert stderr_observation["diagnostics"] == []
+    assert stderr_observation["channels"][1]["text"] == output
+
+
+def test_user_werror_output_remains_semantic_on_a_successful_run():
+    output = b"[USER123] fixture-selected werror output\n"
+
+    observation = _parse(raw_stderr=_observation_stderr(semantic_stderr=output))
+
+    assert observation["protocol_issues"] == []
+    assert observation["phase_reached"] == "post_run"
+    assert observation["diagnostics"] == []
+    assert observation["channels"][1] == {
+        "name": "stderr",
+        "text": output.decode(),
+    }
 
 
 def test_native_metadata_distinguishes_halt_on_last_activation_from_agenda_empty():
@@ -205,6 +267,7 @@ def test_fixture_cannot_supply_native_metadata_with_another_nonce():
     )
 
     assert "unexpected-native-reserved-prefix" in observation["protocol_issues"]
+    assert "unexpected-native-reserved-prefix" in observation["diagnostic_protocol_issues"]
     assert observation["phase_reached"] == "run"
 
 
@@ -226,7 +289,53 @@ def test_same_nonce_record_with_invalid_authentication_is_rejected():
     observation = _parse(raw_stderr=_observation_stderr(extra_before_complete=forged))
 
     assert "native-authentication-failed" in observation["protocol_issues"]
+    assert "native-authentication-failed" in observation["diagnostic_protocol_issues"]
     assert observation["phase_reached"] == "run"
+
+
+@pytest.mark.parametrize("kind", ["PROBE", "RUN"])
+def test_same_nonce_bare_record_is_authentication_corruption(kind):
+    bare = f"\n{NATIVE_RECORD_PREFIX}{NONCE}|{kind}\n".encode()
+    observation = _parse(
+        raw_stderr=_observation_stderr(complete=False, extra_before_complete=bare),
+        interrupted=True,
+    )
+
+    assert "native-authentication-malformed" in observation["protocol_issues"]
+    assert "native-authentication-malformed" in observation["diagnostic_protocol_issues"]
+
+
+def test_interrupted_semantic_utf8_tail_is_retained_with_replacement():
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+            b"partial UTF-8: \xe2",
+        ]
+    )
+
+    observation = _parse(raw_stderr=stderr, interrupted=True)
+
+    assert observation["protocol_issues"] == []
+    assert observation["channels"][1]["text"] == "partial UTF-8: \ufffd"
+
+
+def test_authenticated_invalid_utf8_is_hard_protocol_corruption_when_interrupted():
+    payload = b"\xff"
+    invalid = _authenticated(
+        f"DIAGNOSTIC|1|load|0|{len(payload)}|".encode() + payload,
+        nonce=NONCE,
+    )
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+            invalid,
+        ]
+    )
+
+    with pytest.raises(ClipsOracleProtocolError, match="DIAGNOSTIC payload"):
+        _parse(raw_stderr=stderr, interrupted=True)
 
 
 def test_extra_native_run_violates_exact_setup():
@@ -273,6 +382,340 @@ def test_semantic_stderr_is_preserved_around_native_records():
         "name": "stderr",
         "text": "feature warning\n",
     }
+
+
+def test_load_parser_diagnostic_is_a_completed_parse_failure():
+    message = "\n[PRNTUTIL2] Syntax Error: Check appropriate syntax for defrule.\n"
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+            message.encode(),
+            _diagnostic("load", message, continued=False),
+            _phase(2, "load", "END", "ERROR"),
+            _native_record("LIFECYCLE", 3, "COMPLETE", FIXTURE_ID, DIGEST, DIGEST),
+        ]
+    )
+
+    observation = _parse(raw_stderr=stderr)
+
+    assert observation["protocol_issues"] == []
+    assert observation["phase_reached"] == "parse"
+    assert observation["run"] is None
+    assert observation["diagnostics"] == [
+        {
+            "taxonomy_version": 1,
+            "phase": "parse",
+            "category": "syntax-error",
+            "continued": False,
+            "channel": "stderr",
+            "message": message,
+        }
+    ]
+    assert observation["channels"][1]["text"] == message
+
+
+def test_load_construct_diagnostic_is_distinct_from_parser_failure():
+    message = "\n[EXPRNPSR3] Missing function declaration for missing-function.\n"
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+            message.encode(),
+            _diagnostic("load", message, continued=False),
+            _phase(2, "load", "END", "ERROR"),
+            _native_record("LIFECYCLE", 3, "COMPLETE", FIXTURE_ID, DIGEST, DIGEST),
+        ]
+    )
+
+    observation = _parse(raw_stderr=stderr)
+
+    assert observation["protocol_issues"] == []
+    assert observation["phase_reached"] == "load"
+    assert observation["diagnostics"][0]["category"] == "construct-error"
+    assert observation["diagnostics"][0]["continued"] is False
+    assert observation["diagnostics"][0]["message"] == message
+
+
+def test_completed_load_diagnostic_survives_interruption_before_lifecycle_complete():
+    message = "\n[EXPRNPSR3] Missing function declaration for missing-function.\n"
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+            message.encode(),
+            _diagnostic("load", message, continued=False),
+            _phase(2, "load", "END", "ERROR"),
+        ]
+    )
+
+    observation = _parse(raw_stderr=stderr)
+
+    assert observation["protocol_issues"] == []
+    assert observation["phase_reached"] == "load"
+    assert observation["lifecycle"] == [
+        {
+            "sequence": 0,
+            "event": "start",
+            "fixture_id": FIXTURE_ID,
+            "nonce": NONCE,
+            "source_sha256": DIGEST,
+            "composed_sha256": DIGEST,
+        }
+    ]
+    assert observation["diagnostics"][0]["category"] == "construct-error"
+
+
+def test_authenticated_diagnostic_survives_interruption_before_phase_end():
+    message = "\n[EXPRNPSR3] Missing function declaration for missing-function.\n"
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+            message.encode(),
+            _diagnostic("load", message, continued=False),
+        ]
+    )
+
+    observation = _parse(raw_stderr=stderr)
+
+    assert observation["protocol_issues"] == []
+    assert observation["active_phase"] == "load"
+    assert observation["phase_reached"] == "load"
+    assert observation["diagnostics"][0]["category"] == "construct-error"
+
+
+def test_reset_diagnostic_can_continue_to_a_successful_run():
+    message = "\n[PRNTUTIL7] Attempt to divide by zero in / function.\n"
+    stderr = _observation_stderr().replace(
+        _phase(4, "reset", "END", "OK"),
+        message.encode()
+        + _diagnostic("reset", message, continued=True)
+        + _phase(4, "reset", "END", "CONTINUED"),
+        1,
+    )
+
+    observation = _parse(raw_stderr=stderr)
+
+    assert observation["protocol_issues"] == []
+    assert observation["phase_reached"] == "post_run"
+    assert observation["run"]["halt_reason"] == "agenda_empty"
+    assert observation["diagnostics"] == [
+        {
+            "taxonomy_version": 1,
+            "phase": "reset",
+            "category": "evaluation-error",
+            "continued": True,
+            "channel": "stderr",
+            "message": message,
+        }
+    ]
+    assert observation["channels"][1]["text"] == message
+
+
+def test_reset_terminal_diagnostic_is_valid_without_run_records():
+    message = "\n[PRNTUTIL7] Reset evaluation failed.\n"
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+            _phase(2, "load", "END", "OK"),
+            _phase(3, "reset", "BEGIN"),
+            message.encode(),
+            _diagnostic("reset", message, continued=False),
+            _phase(4, "reset", "END", "ERROR"),
+            _native_record("LIFECYCLE", 3, "COMPLETE", FIXTURE_ID, DIGEST, DIGEST),
+        ]
+    )
+
+    observation = _parse(raw_stderr=stderr)
+
+    assert observation["protocol_issues"] == []
+    assert observation["phase_reached"] == "reset"
+    assert observation["run"] is None
+    assert observation["diagnostics"][0]["category"] == "evaluation-error"
+    assert observation["diagnostics"][0]["continued"] is False
+
+
+def test_run_diagnostic_is_terminal_and_retains_run_metadata():
+    message = (
+        "[ARGACCES5] Function + expected argument #1 to be of type integer or float\n"
+        "[PRCCODE4] Execution halted during the actions of defrule first.\n"
+    )
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+            _phase(2, "load", "END", "OK"),
+            _phase(3, "reset", "BEGIN"),
+            _phase(4, "reset", "END", "OK"),
+            _phase(5, "run", "BEGIN"),
+            message.encode(),
+            _diagnostic("run", message, continued=False),
+            _phase(6, "run", "END", "ERROR"),
+            _native_run_metadata(evaluation_error=1),
+            _native_record("LIFECYCLE", 3, "COMPLETE", FIXTURE_ID, DIGEST, DIGEST),
+        ]
+    )
+
+    observation = _parse(raw_stderr=stderr)
+
+    assert observation["protocol_issues"] == ["post-run-state-missing"]
+    assert observation["phase_reached"] == "run"
+    assert observation["run"]["halt_reason"] == "error"
+    assert observation["diagnostics"][0] == {
+        "taxonomy_version": 1,
+        "phase": "run",
+        "category": "evaluation-error",
+        "continued": False,
+        "channel": "stderr",
+        "message": message,
+    }
+
+
+def test_completed_run_diagnostic_survives_interruption_before_run_metadata():
+    message = "[PRCCODE4] Execution halted during the actions of defrule first.\n"
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+            _phase(2, "load", "END", "OK"),
+            _phase(3, "reset", "BEGIN"),
+            _phase(4, "reset", "END", "OK"),
+            _phase(5, "run", "BEGIN"),
+            message.encode(),
+            _diagnostic("run", message, continued=False),
+            _phase(6, "run", "END", "ERROR"),
+        ]
+    )
+
+    observation = _parse(raw_stderr=stderr)
+
+    assert observation["protocol_issues"] == [
+        "native-run-metadata-missing",
+        "post-run-state-missing",
+        "native-run-diagnostic-state",
+    ]
+    assert observation["phase_reached"] == "run"
+    assert observation["diagnostics"][0]["category"] == "evaluation-error"
+
+
+def test_native_run_metadata_must_follow_run_phase_end():
+    message = "[PRCCODE4] Execution halted during the actions of defrule first.\n"
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _native_run_metadata(evaluation_error=1),
+            _phase(1, "load", "BEGIN"),
+            _phase(2, "load", "END", "OK"),
+            _phase(3, "reset", "BEGIN"),
+            _phase(4, "reset", "END", "OK"),
+            _phase(5, "run", "BEGIN"),
+            message.encode(),
+            _diagnostic("run", message, continued=False),
+            _phase(6, "run", "END", "ERROR"),
+            _native_record("LIFECYCLE", 3, "COMPLETE", FIXTURE_ID, DIGEST, DIGEST),
+        ]
+    )
+
+    observation = _parse(raw_stderr=stderr)
+
+    assert "native-run-record-order" in observation["protocol_issues"]
+
+
+def test_unknown_load_diagnostic_is_retained_as_fail_closed_evidence():
+    message = "\n[MYSTERY1] An unrecognized CLIPS diagnostic family.\n"
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+            message.encode(),
+            _diagnostic("load", message, continued=False),
+            _phase(2, "load", "END", "ERROR"),
+            _native_record("LIFECYCLE", 3, "COMPLETE", FIXTURE_ID, DIGEST, DIGEST),
+        ]
+    )
+
+    observation = _parse(raw_stderr=stderr)
+
+    assert observation["protocol_issues"] == []
+    assert observation["phase_reached"] == "load"
+    assert observation["diagnostics"][0]["phase"] == "unknown"
+    assert observation["diagnostics"][0]["category"] == "unknown"
+    assert observation["diagnostics"][0]["message"] == message
+
+
+def test_malformed_diagnostic_metadata_fails_closed():
+    payload = b"[CSTRCPSR2] malformed record"
+    malformed = _authenticated(
+        f"DIAGNOSTIC|1|load|maybe|{len(payload)}|".encode() + payload,
+        nonce=NONCE,
+    )
+    stderr = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+            malformed,
+            _phase(2, "load", "END", "ERROR"),
+            _native_record("LIFECYCLE", 3, "COMPLETE", FIXTURE_ID, DIGEST, DIGEST),
+        ]
+    )
+
+    observation = _parse(raw_stderr=stderr)
+
+    assert "native-diagnostic-continued" in observation["protocol_issues"]
+    assert observation["phase_reached"] != "post_run"
+
+
+def test_diagnostic_payload_length_mismatch_is_a_protocol_error():
+    malformed = _authenticated(
+        b"DIAGNOSTIC|1|load|0|999|[CSTRCPSR2] truncated",
+        nonce=NONCE,
+    )
+
+    observation = _parse(raw_stderr=malformed)
+
+    assert "truncated-native-record" in observation["protocol_issues"]
+    assert observation["phase_reached"] != "post_run"
+
+
+@pytest.mark.parametrize("phase", ["load", "reset", "run"])
+def test_authenticated_active_phase_is_retained_for_interrupted_invocation(phase):
+    phase_index = ("load", "reset", "run").index(phase)
+    records = [_native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST)]
+    sequence = 1
+    for completed_phase in ("load", "reset", "run")[:phase_index]:
+        records.extend(
+            [
+                _phase(sequence, completed_phase, "BEGIN"),
+                _phase(sequence + 1, completed_phase, "END", "OK"),
+            ]
+        )
+        sequence += 2
+    records.append(_phase(sequence, phase, "BEGIN"))
+
+    observation = _parse(raw_stderr=b"".join(records))
+
+    assert observation["protocol_issues"] == []
+    assert observation["active_phase"] == phase
+    assert observation["phase_reached"] == phase
+    assert observation["run"] is None
+
+
+def test_truncated_trailing_record_does_not_erase_authenticated_active_phase():
+    authenticated_prefix = b"".join(
+        [
+            _native_record("LIFECYCLE", 0, "START", FIXTURE_ID, DIGEST, DIGEST),
+            _phase(1, "load", "BEGIN"),
+        ]
+    )
+    truncated = f"\n{NATIVE_RECORD_PREFIX}{NONCE}|DIAGNOSTIC|1|load|0|999|partial".encode()
+
+    observation = _parse(raw_stderr=authenticated_prefix + truncated)
+
+    assert observation["active_phase"] == "load"
+    assert observation["phase_reached"] == "load"
+    assert observation["protocol_issues"] == ["truncated-native-record"]
 
 
 @pytest.mark.parametrize(

--- a/tools/ferric-tools/tests/test_clips_oracle.py
+++ b/tools/ferric-tools/tests/test_clips_oracle.py
@@ -271,6 +271,31 @@ def test_fixture_cannot_supply_native_metadata_with_another_nonce():
     assert observation["phase_reached"] == "run"
 
 
+@pytest.mark.parametrize(
+    "raw_stderr",
+    [
+        f"\n{NATIVE_RECORD_PREFIX}".encode(),
+        f"\n{NATIVE_RECORD_PREFIX}{NONCE}".encode(),
+    ],
+)
+def test_interrupted_initial_native_header_prefix_is_truncated(raw_stderr):
+    observation = _parse(raw_stderr=raw_stderr, interrupted=True)
+
+    assert "truncated-native-record" in observation["protocol_issues"]
+    assert "unexpected-native-reserved-prefix" not in observation["protocol_issues"]
+    assert observation["lifecycle"] == []
+
+
+def test_interrupted_wrong_nonce_header_prefix_remains_protocol_corruption():
+    raw_stderr = f"\n{NATIVE_RECORD_PREFIX}{'f' * 32}".encode()
+
+    observation = _parse(raw_stderr=raw_stderr, interrupted=True)
+
+    assert "truncated-native-record" not in observation["protocol_issues"]
+    assert "unexpected-native-reserved-prefix" in observation["protocol_issues"]
+    assert "unexpected-native-reserved-prefix" in observation["diagnostic_protocol_issues"]
+
+
 def test_same_nonce_unknown_native_record_is_rejected():
     observation = _parse(
         raw_stderr=_observation_stderr(extra_before_complete=_native_record("FORGED", "payload"))

--- a/tools/ferric-tools/tests/test_compat_diff.py
+++ b/tools/ferric-tools/tests/test_compat_diff.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import csv
 
+from ferric_tools.compat.diagnostics import diagnostic
 from ferric_tools.compat.diff import compute_diff, format_markdown, write_tsv
 from ferric_tools.compat.report import compute_oracle_coverage
 
@@ -57,6 +58,20 @@ def _file_entry(classification: str, reason: str = "", *, oracle: dict | None = 
     if oracle is not None:
         entry["oracle_evidence"] = oracle
     return entry
+
+
+def _engine_result(
+    phase: str,
+    category: str,
+    *,
+    continued: bool,
+    exit_code: int = 1,
+) -> dict:
+    return {
+        "exit_code": exit_code,
+        "diagnostic": diagnostic(phase, category, continued=continued),
+        "termination": {"kind": "exit", "exit_code": exit_code, "signal": None},
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -122,6 +137,56 @@ def test_compute_diff_reason_change_within_same_classification():
     assert reason_changes[0][0] == "c.clp"
     assert len(regressions) == 0
     assert len(real_improvements) == 0
+
+
+def test_compute_diff_exposes_phase_change_with_unchanged_classification_and_reason():
+    base_entry = _file_entry("divergent", "diagnostic-phase-mismatch")
+    base_entry["ferric"] = _engine_result("load", "construct-error", continued=False)
+    base_entry["clips"] = _engine_result("run", "evaluation-error", continued=False)
+    head_entry = _file_entry("divergent", "diagnostic-phase-mismatch")
+    head_entry["ferric"] = _engine_result("run", "evaluation-error", continued=False)
+    head_entry["clips"] = _engine_result("load", "construct-error", continued=False)
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(
+        _manifest({"phase.clp": base_entry}),
+        _manifest({"phase.clp": head_entry}),
+    )
+
+    assert regressions == []
+    assert improvements == []
+    assert len(reason_changes) == 1
+    assert "ferric=load/construct-error" in reason_changes[0][2]
+    assert "ferric=run/evaluation-error" in reason_changes[0][4]
+
+
+def test_compute_diff_exposes_diagnostics_when_classification_changes():
+    base_entry = _file_entry("pending", "diagnostic-invalid")
+    base_entry["ferric"] = _engine_result("load", "construct-error", continued=False)
+    base_entry["clips"] = _engine_result("run", "evaluation-error", continued=False)
+    head_entry = _file_entry("divergent", "diagnostic-phase-mismatch")
+    head_entry["ferric"] = _engine_result("run", "evaluation-error", continued=False)
+    head_entry["clips"] = _engine_result("load", "construct-error", continued=False)
+
+    _bc, _hc, regressions, improvements, reason_changes = compute_diff(
+        _manifest({"phase.clp": base_entry}),
+        _manifest({"phase.clp": head_entry}),
+    )
+
+    assert improvements == [
+        (
+            "phase.clp",
+            "pending",
+            base_entry["reason"] + "; diagnostics: "
+            "ferric=load/construct-error/continued:false;termination:exit(1), "
+            "clips=run/evaluation-error/continued:false;termination:exit(1)",
+            "divergent",
+            head_entry["reason"] + "; diagnostics: "
+            "ferric=run/evaluation-error/continued:false;termination:exit(1), "
+            "clips=load/construct-error/continued:false;termination:exit(1)",
+        )
+    ]
+    assert regressions == []
+    assert reason_changes == []
 
 
 def test_compute_diff_counts_reflect_head_manifest():
@@ -634,6 +699,41 @@ def test_write_tsv_marks_oracle_coverage_loss_as_regression(tmp_path):
     assert rows[0]["head_oracle_status"] == "invalid"
     assert rows[0]["head_oracle_normalizations"] == "fact-ids"
     assert "completed true\u2192false" in rows[0]["oracle_regression"]
+
+
+def test_write_tsv_includes_diagnostic_and_termination_evidence(tmp_path):
+    base_entry = {**_file_entry("divergent", "same"), "source": "fixtures"}
+    base_entry["ferric"] = _engine_result("load", "construct-error", continued=False)
+    base_entry["clips"] = _engine_result("run", "evaluation-error", continued=False)
+    head_entry = {**_file_entry("divergent", "same"), "source": "fixtures"}
+    head_entry["ferric"] = _engine_result("run", "evaluation-error", continued=False)
+    head_entry["clips"] = {
+        "exit_code": -9,
+        "diagnostic": diagnostic("process", "signal", continued=False),
+        "termination": {
+            "kind": "signal",
+            "exit_code": None,
+            "signal": 9,
+            "active_phase": "run",
+        },
+    }
+    output = tmp_path / "diagnostics.tsv"
+
+    write_tsv(
+        _manifest({"phase.clp": base_entry}),
+        _manifest({"phase.clp": head_entry}),
+        str(output),
+    )
+
+    with output.open(newline="", encoding="utf-8") as stream:
+        row = next(csv.DictReader(stream, delimiter="\t"))
+    assert row["change"] == "reason-changed"
+    assert row["base_ferric_diagnostic_phase"] == "load"
+    assert row["head_ferric_diagnostic_phase"] == "run"
+    assert row["head_clips_diagnostic_category"] == "signal"
+    assert row["head_clips_termination"] == "signal"
+    assert row["head_clips_signal"] == "9"
+    assert row["head_clips_active_phase"] == "run"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/ferric-tools/tests/test_compat_oracle.py
+++ b/tools/ferric-tools/tests/test_compat_oracle.py
@@ -259,6 +259,59 @@ def test_declaration_and_observation_versions_are_independently_strict(target):
     assert evidence.issues[0].field == "version"
 
 
+@pytest.mark.parametrize("target", ["declaration", "observation"])
+@pytest.mark.parametrize(
+    ("phase", "category", "continued", "issue_suffix"),
+    [
+        ("unknown", "unknown", False, ""),
+        ("process", "timeout", False, ""),
+        ("harness", "harness-error", False, ""),
+        ("run", "syntax-error", False, ""),
+        ("parse", "none", False, ""),
+        ("none", "none", False, ".continued"),
+    ],
+)
+def test_diagnostic_taxonomy_fails_closed_for_declarations_and_observations(
+    target,
+    phase,
+    category,
+    continued,
+    issue_suffix,
+):
+    declaration = _declaration()
+    observation = _observation()
+    if target == "declaration":
+        diagnostic = declaration["expectations"]["diagnostic"]
+        field = "expectations.diagnostic"
+    else:
+        diagnostic = observation["diagnostic"]
+        field = "diagnostic"
+    diagnostic.update(
+        {
+            "phase": phase,
+            "category": category,
+            "continued": continued,
+        }
+    )
+
+    declaration_evidence = validate_declaration(
+        declaration,
+        expected_source_sha256=SOURCE_DIGEST,
+        expected_composed_sha256=COMPOSED_DIGEST,
+    )
+    if target == "declaration":
+        evidence = declaration_evidence
+    else:
+        assert declaration_evidence.value is not None
+        evidence = validate_observation(
+            observation,
+            declaration=declaration_evidence.value,
+        )
+
+    assert evidence.status is EvidenceStatus.INVALID
+    assert evidence.issues[0].field == f"{field}{issue_suffix}"
+
+
 def test_unknown_normalizer_fails_closed():
     declaration = _declaration(normalizers=["whitespace"])
 

--- a/tools/ferric-tools/tests/test_compat_projection.py
+++ b/tools/ferric-tools/tests/test_compat_projection.py
@@ -11,6 +11,7 @@ from ferric_tools.compat.projection import (
     ObservationProjectionError,
     project_clips_observation,
     project_ferric_observation,
+    project_observation_diagnostic,
 )
 
 FIXTURE_ID = "ferric-oracle.empty-output-state"
@@ -70,6 +71,28 @@ def _raw_fact(
             }
         ],
     }
+
+
+def _raw_diagnostic(
+    engine: str,
+    *,
+    phase: str,
+    category: str,
+    continued: bool,
+    message: str = "fixture diagnostic",
+) -> dict[str, object]:
+    diagnostic: dict[str, object] = {
+        "taxonomy_version": 1,
+        "phase": phase,
+        "category": category,
+        "continued": continued,
+        "message": message,
+    }
+    if engine == "ferric":
+        diagnostic["severity"] = "warning" if continued else "error"
+    else:
+        diagnostic["channel"] = "stderr"
+    return diagnostic
 
 
 def _raw_observation(engine: str) -> dict[str, object]:
@@ -208,8 +231,26 @@ def test_seed_ordered_result_projects_to_equivalent_non_vacuous_evidence():
 def test_action_error_halt_reason_is_canonical_across_adapters():
     ferric_raw = _raw_observation("ferric")
     ferric_raw["run"]["halt_reason"] = "action-error"
+    ferric_raw["phase_reached"] = "run"
+    ferric_raw["diagnostics"] = [
+        _raw_diagnostic(
+            "ferric",
+            phase="run",
+            category="evaluation-error",
+            continued=False,
+        )
+    ]
     clips_raw = _raw_observation("clips")
     clips_raw["run"]["halt_reason"] = "error"
+    clips_raw["phase_reached"] = "run"
+    clips_raw["diagnostics"] = [
+        _raw_diagnostic(
+            "clips",
+            phase="run",
+            category="evaluation-error",
+            continued=False,
+        )
+    ]
 
     ferric = project_ferric_observation(ferric_raw, harnessed=False)
     clips = project_clips_observation(clips_raw, harnessed=False)
@@ -218,6 +259,12 @@ def test_action_error_halt_reason_is_canonical_across_adapters():
     assert clips["firings"] == [{"rule": "counted-firing-1", "origin": "fixture"}]
 
     declaration = _declaration()
+    declaration["expectations"]["phase"] = "run"
+    declaration["expectations"]["diagnostic"] = {
+        "phase": "run",
+        "category": "evaluation-error",
+        "continued": False,
+    }
     declaration["expectations"]["run"]["halt_reason"] = "action-error"
     evaluation = evaluate_oracle(
         declaration,
@@ -230,6 +277,24 @@ def test_action_error_halt_reason_is_canonical_across_adapters():
     assert evaluation.status is EvidenceStatus.VALID
     assert evaluation.equivalent
     assert evaluation.mismatches == ()
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_terminal_run_diagnostic_requires_action_error_halt(engine):
+    raw = _raw_observation(engine)
+    raw["phase_reached"] = "run"
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            engine,
+            phase="run",
+            category="evaluation-error",
+            continued=False,
+        )
+    ]
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+
+    with pytest.raises(ObservationProjectionError, match="lacks an action-error halt"):
+        projector(raw, harnessed=False)
 
 
 def test_generated_clips_harness_activity_fails_when_firings_cannot_be_attributed():
@@ -353,6 +418,12 @@ def test_clips_protocol_issue_fails_closed():
 
     with pytest.raises(ObservationProjectionError, match="protocol violations"):
         project_clips_observation(raw, harnessed=False)
+    with pytest.raises(ObservationProjectionError, match="protocol violations"):
+        project_observation_diagnostic(
+            raw,
+            engine="clips",
+            expected_fixture=_identity(),
+        )
 
 
 def test_unavailable_declared_ferric_capability_fails_closed():
@@ -380,39 +451,413 @@ def test_unavailable_declared_ferric_capability_fails_closed():
         )
 
 
-def test_expected_diagnostic_projection_remains_invalid_until_structured_support():
-    ferric_raw = _raw_observation("ferric")
-    clips_raw = _raw_observation("clips")
-    ferric_raw["diagnostics"] = [
-        {
-            "phase": "load",
-            "severity": "error",
-            "category": "parse-error",
-            "message": "fixture diagnostic",
-        }
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+@pytest.mark.parametrize(
+    ("phase", "category"),
+    [
+        ("parse", "syntax-error"),
+        ("load", "construct-error"),
+        ("reset", "evaluation-error"),
+    ],
+)
+def test_completed_pre_run_diagnostic_projects_without_partial_state(
+    engine,
+    phase,
+    category,
+):
+    raw = _raw_observation(engine)
+    raw["phase_reached"] = phase
+    raw["run"] = None
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            engine,
+            phase=phase,
+            category=category,
+            continued=False,
+        )
     ]
+    raw["channels"][0]["text"] = "diagnostic output\n"
+    if engine == "ferric":
+        raw["channels"][0]["present"] = True
+
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+    projected = projector(raw, harnessed=False)
+
+    assert projected["phase"] == phase
+    assert projected["diagnostic"] == {
+        "phase": phase,
+        "category": category,
+        "continued": False,
+    }
+    assert projected["run"] == {"limit": None, "halt_reason": "not-run"}
+    assert projected["firings"] == []
+    assert projected["effects"] == []
+    assert projected["facts"] == []
+    assert projected["channels"]["stdout"] == "diagnostic output\n"
+    assert [marker["kind"] for marker in projected["markers"]] == ["START", "COMPLETE"]
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_homogeneous_diagnostics_collapse_but_heterogeneous_diagnostics_fail(engine):
+    raw = _raw_observation(engine)
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            engine,
+            phase="load",
+            category="construct-error",
+            continued=True,
+            message="first construct diagnostic",
+        ),
+        _raw_diagnostic(
+            engine,
+            phase="load",
+            category="construct-error",
+            continued=True,
+            message="second construct diagnostic",
+        ),
+    ]
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+
+    projected = projector(raw, harnessed=False)
+    assert projected["diagnostic"] == {
+        "phase": "load",
+        "category": "construct-error",
+        "continued": True,
+    }
+
+    raw["diagnostics"][1] = _raw_diagnostic(
+        engine,
+        phase="run",
+        category="evaluation-error",
+        continued=True,
+    )
+    with pytest.raises(ObservationProjectionError, match="heterogeneous"):
+        projector(raw, harnessed=False)
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("taxonomy_version", 2, "taxonomy version"),
+        ("phase", "unknown", "phase is unsupported"),
+        ("category", "unknown", "category is unsupported"),
+        ("category", "evaluation-error", "phase/category pair"),
+        ("continued", "unknown", "continuation is malformed"),
+        ("message", 7, "message is malformed"),
+    ],
+)
+def test_unknown_or_malformed_diagnostic_taxonomy_fails_closed(
+    engine,
+    field,
+    value,
+    message,
+):
+    raw = _raw_observation(engine)
+    diagnostic = _raw_diagnostic(
+        engine,
+        phase="parse",
+        category="syntax-error",
+        continued=True,
+    )
+    diagnostic[field] = value
+    raw["diagnostics"] = [diagnostic]
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+
+    with pytest.raises(ObservationProjectionError, match=message):
+        projector(raw, harnessed=False)
+
+
+@pytest.mark.parametrize(
+    ("engine", "field", "value", "message"),
+    [
+        ("ferric", "severity", "fatal", "severity is unsupported"),
+        ("clips", "channel", "t", "channel is unsupported"),
+    ],
+)
+def test_engine_specific_diagnostic_metadata_fails_closed(engine, field, value, message):
+    raw = _raw_observation(engine)
+    diagnostic = _raw_diagnostic(
+        engine,
+        phase="run",
+        category="evaluation-error",
+        continued=False,
+    )
+    diagnostic[field] = value
+    raw["diagnostics"] = [diagnostic]
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+
+    with pytest.raises(ObservationProjectionError, match=message):
+        projector(raw, harnessed=False)
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_harness_diagnostic_is_not_projected_as_semantic_evidence(engine):
+    raw = _raw_observation(engine)
+    raw["phase_reached"] = "load"
+    raw["run"] = None
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            engine,
+            phase="harness",
+            category="harness-error",
+            continued=False,
+        )
+    ]
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+
+    with pytest.raises(ObservationProjectionError, match="phase is unsupported"):
+        projector(raw, harnessed=False)
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_bound_diagnostic_subset_survives_unrelated_projection_failure(engine):
+    raw = _raw_observation(engine)
+    raw["phase_reached"] = "parse"
+    raw["run"] = None
+    raw["facts"] = "malformed partial state"
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            engine,
+            phase="parse",
+            category="syntax-error",
+            continued=False,
+        )
+    ]
+    projector = project_ferric_observation if engine == "ferric" else project_clips_observation
+
+    assert project_observation_diagnostic(
+        raw,
+        engine=engine,
+        expected_fixture=_identity(),
+    ) == {
+        "phase": "parse",
+        "category": "syntax-error",
+        "continued": False,
+    }
+    with pytest.raises(ObservationProjectionError, match="facts are malformed"):
+        projector(raw, harnessed=False)
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_diagnostic_subset_rejects_wrong_invocation_binding(engine):
+    raw = _raw_observation(engine)
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            engine,
+            phase="load",
+            category="construct-error",
+            continued=True,
+        )
+    ]
+    expected_fixture = _identity()
+    expected_fixture["nonce"] = "f" * 32
+
+    with pytest.raises(ObservationProjectionError, match=r"nonce.*does not match"):
+        project_observation_diagnostic(
+            raw,
+            engine=engine,
+            expected_fixture=expected_fixture,
+        )
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_diagnostic_subset_preserves_unknown_evidence_for_fail_closed_classification(engine):
+    raw = _raw_observation(engine)
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            engine,
+            phase="unknown",
+            category="unknown",
+            continued=False,
+        )
+    ]
+
+    assert project_observation_diagnostic(
+        raw,
+        engine=engine,
+        expected_fixture=_identity(),
+    ) == {"phase": "unknown", "category": "unknown", "continued": False}
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_diagnostic_subset_rejects_harness_evidence(engine):
+    raw = _raw_observation(engine)
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            engine,
+            phase="harness",
+            category="harness-error",
+            continued=False,
+        )
+    ]
+
+    with pytest.raises(ObservationProjectionError, match="phase is unsupported"):
+        project_observation_diagnostic(raw, engine=engine, expected_fixture=_identity())
+
+
+@pytest.mark.parametrize("engine", ["ferric", "clips"])
+def test_diagnostic_subset_rejects_spoofed_lifecycle_binding(engine):
+    raw = _raw_observation(engine)
+    raw["lifecycle"][0]["nonce"] = "f" * 32
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            engine,
+            phase="run",
+            category="evaluation-error",
+            continued=False,
+        )
+    ]
+
+    with pytest.raises(ObservationProjectionError, match=r"lifecycle marker 0.*nonce"):
+        project_observation_diagnostic(raw, engine=engine, expected_fixture=_identity())
+
+
+def test_interrupted_run_diagnostic_rejects_contradictory_native_run_state():
+    raw = _raw_observation("clips")
+    raw["lifecycle"] = raw["lifecycle"][:1]
+    raw["phase_reached"] = "run"
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            "clips",
+            phase="run",
+            category="evaluation-error",
+            continued=False,
+        )
+    ]
+    raw["protocol_issues"] = ["native-run-diagnostic-state"]
+
+    with pytest.raises(ObservationProjectionError, match="native-run-diagnostic-state"):
+        project_observation_diagnostic(
+            raw,
+            engine="clips",
+            expected_fixture=_identity(),
+            interrupted=True,
+        )
+
+    raw["protocol_issues"].append("native-run-metadata-missing")
+    raw["run"] = None
+    assert project_observation_diagnostic(
+        raw,
+        engine="clips",
+        expected_fixture=_identity(),
+        interrupted=True,
+    ) == {"phase": "run", "category": "evaluation-error", "continued": False}
+
+
+def test_interrupted_diagnostic_subset_ignores_only_unrelated_partial_probe_tail():
+    raw = _raw_observation("clips")
+    raw["lifecycle"] = raw["lifecycle"][:1]
+    raw["phase_reached"] = "run"
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            "clips",
+            phase="reset",
+            category="evaluation-error",
+            continued=True,
+        )
+    ]
+    raw["protocol_issues"] = [
+        "lifecycle-cardinality-or-order",
+        "fact-slot-count",
+        "slot-item-positions",
+    ]
+    raw["diagnostic_protocol_issues"] = []
+
+    assert project_observation_diagnostic(
+        raw,
+        engine="clips",
+        expected_fixture=_identity(),
+        interrupted=True,
+    ) == {"phase": "reset", "category": "evaluation-error", "continued": True}
+
+
+def test_interrupted_terminal_diagnostic_is_trusted_before_phase_end():
+    raw = _raw_observation("clips")
+    raw["lifecycle"] = raw["lifecycle"][:1]
+    raw["phase_reached"] = "load"
+    raw["run"] = None
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            "clips",
+            phase="load",
+            category="construct-error",
+            continued=False,
+        )
+    ]
+    raw["protocol_issues"] = []
+    raw["diagnostic_protocol_issues"] = []
+
+    assert project_observation_diagnostic(
+        raw,
+        engine="clips",
+        expected_fixture=_identity(),
+        interrupted=True,
+    ) == {"phase": "load", "category": "construct-error", "continued": False}
+
+
+def test_terminal_run_diagnostic_without_post_run_state_is_not_complete_oracle():
+    raw = _raw_observation("clips")
+    raw["phase_reached"] = "run"
+    raw["run"]["halt_reason"] = "error"
+    raw["diagnostics"] = [
+        _raw_diagnostic(
+            "clips",
+            phase="run",
+            category="evaluation-error",
+            continued=False,
+        )
+    ]
+    raw["protocol_issues"] = ["post-run-state-missing"]
+    raw["diagnostic_protocol_issues"] = []
+
+    assert project_observation_diagnostic(
+        raw,
+        engine="clips",
+        expected_fixture=_identity(),
+    ) == {"phase": "run", "category": "evaluation-error", "continued": False}
+    with pytest.raises(ObservationProjectionError, match="post-run-state-missing"):
+        project_clips_observation(raw, harnessed=False)
+
+
+def test_ferric_and_clips_diagnostic_phase_category_mismatch_remains_divergent():
+    ferric_raw = _raw_observation("ferric")
+    ferric_raw["diagnostics"] = [
+        _raw_diagnostic(
+            "ferric",
+            phase="parse",
+            category="syntax-error",
+            continued=True,
+        )
+    ]
+    clips_raw = _raw_observation("clips")
     clips_raw["diagnostics"] = [
-        {
-            "phase": "unknown",
-            "category": "[EXPRNPSR3]",
-            "continuation": "unknown",
-            "channel": "stdout",
-        }
+        _raw_diagnostic(
+            "clips",
+            phase="load",
+            category="construct-error",
+            continued=True,
+        )
     ]
 
     ferric = project_ferric_observation(ferric_raw, harnessed=False)
     clips = project_clips_observation(clips_raw, harnessed=False)
-    assert ferric["diagnostic"]["phase"] == clips["diagnostic"]["phase"] == "unknown"
-
+    declaration = _declaration()
+    declaration["expectations"]["diagnostic"] = {
+        "phase": "parse",
+        "category": "syntax-error",
+        "continued": True,
+    }
     evaluation = evaluate_oracle(
-        _declaration(),
+        declaration,
         ferric,
         clips,
         expected_source_sha256=SOURCE_DIGEST,
         expected_composed_sha256=COMPOSED_DIGEST,
     )
 
-    assert evaluation.status is EvidenceStatus.INVALID
+    mismatch_fields = {(mismatch.scope, mismatch.field) for mismatch in evaluation.mismatches}
+    assert evaluation.status is EvidenceStatus.VALID
     assert not evaluation.equivalent
-    assert evaluation.ferric.issues[0].field == "diagnostic"
-    assert evaluation.clips.issues[0].field == "diagnostic"
+    assert ("engines", "diagnostic.phase") in mismatch_fields
+    assert ("engines", "diagnostic.category") in mismatch_fields

--- a/tools/ferric-tools/tests/test_compat_report.py
+++ b/tools/ferric-tools/tests/test_compat_report.py
@@ -6,6 +6,7 @@ import csv
 
 import pytest
 
+from ferric_tools.compat.diagnostics import diagnostic
 from ferric_tools.compat.report import (
     _write_delimited,
     compute_oracle_coverage,
@@ -188,6 +189,50 @@ def test_delimited_report_exposes_per_file_oracle_evidence(tmp_path, delimiter, 
     refused = rows["legacy-equivalent.clp"]
     assert refused["oracle_status"] == "invalid"
     assert refused["oracle_refused_equivalent"] == "True"
+
+
+def test_reports_expose_phase_diagnostic_and_independent_termination(tmp_path, capsys):
+    manifest = _manifest()
+    divergent = manifest["files"]["missing.clp"]
+    divergent["reason"] = "diagnostic-phase-mismatch"
+    divergent["ferric"] = {
+        "exit_code": 1,
+        "diagnostic": diagnostic("load", "construct-error", continued=False),
+        "termination": {"kind": "exit", "exit_code": 1, "signal": None},
+    }
+    divergent["clips"] = {
+        "exit_code": -9,
+        "diagnostic": diagnostic("run", "evaluation-error", continued=False),
+        "termination": {
+            "kind": "signal",
+            "exit_code": None,
+            "signal": 9,
+            "active_phase": "run",
+        },
+    }
+    report = tmp_path / "compat.md"
+    table = tmp_path / "compat.csv"
+
+    print_summary(manifest)
+    write_report(manifest, str(report))
+    _write_delimited(manifest, str(table), ",")
+
+    summary = capsys.readouterr().out
+    assert "Diagnostic evidence (1):" in summary
+    assert "ferric: diagnostic v1 load/construct-error" in summary
+    assert "clips: diagnostic v1 run/evaluation-error" in summary
+    assert "termination=signal signal=9 active-phase=run" in summary
+    markdown = report.read_text(encoding="utf-8")
+    assert "### Diagnostic evidence (1)" in markdown
+    assert "ferric: diagnostic v1 load/construct-error" in markdown
+    with table.open(newline="", encoding="utf-8") as stream:
+        row = {item["path"]: item for item in csv.DictReader(stream)}["missing.clp"]
+    assert row["ferric_diagnostic_phase"] == "load"
+    assert row["ferric_diagnostic_category"] == "construct-error"
+    assert row["clips_diagnostic_phase"] == "run"
+    assert row["clips_termination"] == "signal"
+    assert row["clips_signal"] == "9"
+    assert row["clips_active_phase"] == "run"
 
 
 @pytest.mark.parametrize(

--- a/tools/ferric-tools/tests/test_compat_run.py
+++ b/tools/ferric-tools/tests/test_compat_run.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import base64
 import os
 import subprocess
+import sys
 import threading
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -195,6 +198,1122 @@ def test_classify_results_rejects_matching_empty_output_without_oracle():
     assert result == ("pending", "oracle-missing")
 
 
+@pytest.mark.parametrize(
+    ("field", "ferric_value", "clips_value", "reason"),
+    [
+        ("continued", False, True, "diagnostic-continued-mismatch"),
+    ],
+)
+def test_classify_results_treats_known_diagnostic_mismatches_as_divergent(
+    field,
+    ferric_value,
+    clips_value,
+    reason,
+):
+    ferric_diagnostic = run_module.diagnostic("parse", "syntax-error", continued=False)
+    clips_diagnostic = run_module.diagnostic("parse", "syntax-error", continued=False)
+    ferric_diagnostic[field] = ferric_value
+    clips_diagnostic[field] = clips_value
+
+    result = run_module.classify_results(
+        {**_engine_result(), "diagnostic": ferric_diagnostic},
+        {**_engine_result(), "diagnostic": clips_diagnostic},
+    )
+
+    assert result == ("divergent", reason)
+
+
+def test_classify_results_treats_known_phase_mismatch_as_divergent():
+    result = run_module.classify_results(
+        {
+            **_engine_result(),
+            "diagnostic": run_module.diagnostic("parse", "syntax-error", continued=False),
+        },
+        {
+            **_engine_result(),
+            "diagnostic": run_module.diagnostic("run", "evaluation-error", continued=False),
+        },
+    )
+
+    assert result == ("divergent", "diagnostic-phase-mismatch")
+
+
+def test_classify_results_never_calls_matching_terminal_diagnostics_equivalent():
+    terminal = run_module.diagnostic("run", "evaluation-error", continued=False)
+
+    result = run_module.classify_results(
+        {**_engine_result(), "diagnostic": terminal},
+        {**_engine_result(), "diagnostic": terminal},
+    )
+
+    assert result == ("incompatible", "diagnostic-match-without-complete-oracle")
+
+
+def test_matching_pre_run_terminal_diagnostics_override_oracle_mismatches():
+    digest = "a" * 64
+    declaration = _oracle_declaration(digest)
+    identity = {
+        "fixture_id": declaration["id"],
+        "nonce": declaration["nonce"],
+        "source_sha256": digest,
+        "composed_sha256": digest,
+    }
+    observation = _canonical_observation(identity, fact_id=1, rule="compute")
+    observation.update(
+        {
+            "phase": "load",
+            "firings": [],
+            "effects": [],
+            "facts": [],
+            "diagnostic": {
+                "phase": "load",
+                "category": "construct-error",
+                "continued": False,
+            },
+            "run": {"limit": None, "halt_reason": "not-run"},
+        }
+    )
+    evaluation = run_module.evaluate_oracle(
+        declaration,
+        observation,
+        observation,
+        expected_source_sha256=digest,
+        expected_composed_sha256=digest,
+    )
+    terminal = run_module.diagnostic("load", "construct-error", continued=False)
+    result = {**_engine_result(exit_code=1), "diagnostic": terminal}
+    result["termination"] = run_module.termination(exit_code=1, timed_out=False)
+
+    assert evaluation.status is run_module.EvidenceStatus.VALID
+    assert not evaluation.equivalent
+    assert run_module._oracle_outcome(evaluation)[2]["completed"] is False
+    assert run_module.classify_results(result, dict(result), evaluation) == (
+        "incompatible",
+        "diagnostic-match-without-complete-oracle",
+    )
+
+
+def test_complete_action_error_oracle_can_still_be_equivalent():
+    digest = "a" * 64
+    declaration = _oracle_declaration(digest)
+    declaration["expectations"]["phase"] = "run"
+    declaration["expectations"]["diagnostic"] = {
+        "phase": "run",
+        "category": "evaluation-error",
+        "continued": False,
+    }
+    declaration["expectations"]["run"]["halt_reason"] = "action-error"
+    identity = {
+        "fixture_id": declaration["id"],
+        "nonce": declaration["nonce"],
+        "source_sha256": digest,
+        "composed_sha256": digest,
+    }
+    observation = _canonical_observation(identity, fact_id=1, rule="compute")
+    observation["phase"] = "run"
+    observation["diagnostic"] = {
+        "phase": "run",
+        "category": "evaluation-error",
+        "continued": False,
+    }
+    observation["run"]["halt_reason"] = "action-error"
+    evaluation = run_module.evaluate_oracle(
+        declaration,
+        observation,
+        observation,
+        expected_source_sha256=digest,
+        expected_composed_sha256=digest,
+    )
+    terminal = run_module.diagnostic("run", "evaluation-error", continued=False)
+    result = {**_engine_result(), "diagnostic": terminal}
+    result["termination"] = run_module.termination(exit_code=0, timed_out=False)
+
+    assert evaluation.equivalent
+    assert run_module._oracle_outcome(evaluation)[2]["completed"] is True
+    assert run_module.classify_results(result, dict(result), evaluation) == (
+        "equivalent",
+        "oracle-v1-match",
+    )
+
+
+def test_matching_continued_diagnostics_still_require_oracle_evidence():
+    continued = run_module.diagnostic("reset", "evaluation-error", continued=True)
+
+    result = run_module.classify_results(
+        {**_engine_result(), "diagnostic": continued},
+        {**_engine_result(), "diagnostic": continued},
+    )
+
+    assert result == ("pending", "oracle-missing")
+
+
+def test_matching_timeout_remains_terminal_after_a_continued_diagnostic():
+    continued = run_module.diagnostic("reset", "evaluation-error", continued=True)
+    result = {
+        **_engine_result(exit_code=-1),
+        "diagnostic": continued,
+        "termination": {
+            **run_module.termination(exit_code=None, timed_out=True),
+            "active_phase": "run",
+        },
+    }
+
+    assert run_module.classify_results(result, dict(result)) == (
+        "incompatible",
+        "termination-match-without-complete-oracle",
+    )
+
+
+def test_matching_nonzero_exit_cannot_be_equivalent_after_continued_diagnostic():
+    continued = run_module.diagnostic("reset", "evaluation-error", continued=True)
+    result = {
+        **_engine_result(exit_code=7),
+        "diagnostic": continued,
+        "termination": run_module.termination(exit_code=7, timed_out=False),
+    }
+
+    assert run_module.classify_results(result, dict(result)) == (
+        "incompatible",
+        "termination-nonzero-exit-match",
+    )
+
+
+@pytest.mark.parametrize(
+    ("untrusted", "expected"),
+    [
+        (run_module.diagnostic("unknown", "unknown", continued=False), "diagnostic-invalid"),
+        (
+            run_module.diagnostic("harness", "harness-error", continued=False),
+            "harness-failure",
+        ),
+    ],
+)
+def test_untrusted_diagnostic_never_becomes_semantic_divergence(untrusted, expected):
+    semantic = run_module.diagnostic("run", "evaluation-error", continued=False)
+
+    result = run_module.classify_results(
+        {**_engine_result(), "diagnostic": untrusted},
+        {**_engine_result(), "diagnostic": semantic},
+    )
+
+    assert result == ("pending", expected)
+
+
+def test_explicit_harness_failure_takes_precedence_over_semantic_diagnostic():
+    semantic = run_module.diagnostic("run", "evaluation-error", continued=False)
+
+    result = run_module.classify_results(
+        {**_engine_result(), "diagnostic": semantic, "harness_error": True},
+        {**_engine_result(), "diagnostic": semantic},
+    )
+
+    assert result == ("pending", "harness-failure")
+
+
+def test_matching_semantic_diagnostics_preserve_termination_mismatch():
+    semantic = run_module.diagnostic("run", "evaluation-error", continued=False)
+    ferric = {
+        **_engine_result(exit_code=1),
+        "diagnostic": semantic,
+        "termination": run_module.termination(exit_code=1, timed_out=False),
+    }
+    clips = {
+        **_engine_result(exit_code=-9),
+        "diagnostic": semantic,
+        "termination": run_module.termination(exit_code=-9, timed_out=False),
+    }
+
+    assert run_module.classify_results(ferric, clips) == (
+        "divergent",
+        "termination-kind-mismatch",
+    )
+
+
+def test_timeout_active_phase_mismatch_is_divergent():
+    timeout = run_module.diagnostic("process", "timeout", continued=False)
+    ferric = {
+        **_engine_result(exit_code=-1),
+        "diagnostic": timeout,
+        "termination": {
+            **run_module.termination(exit_code=-1, timed_out=True),
+            "active_phase": "load",
+        },
+    }
+    clips = {
+        **_engine_result(exit_code=-1),
+        "diagnostic": timeout,
+        "termination": {
+            **run_module.termination(exit_code=-1, timed_out=True),
+            "active_phase": "run",
+        },
+    }
+
+    assert run_module.classify_results(ferric, clips) == (
+        "divergent",
+        "termination-active-phase-mismatch",
+    )
+
+
+def test_process_metadata_distinguishes_timeout_signal_exit_and_spawn_failure():
+    timeout_result = {
+        **_engine_result(exit_code=-1),
+        "timed_out": True,
+        "termination": run_module.termination(exit_code=-1, timed_out=True),
+        "observation_error": "timed out",
+    }
+    signal_result = {
+        **_engine_result(exit_code=-9),
+        "termination": run_module.termination(exit_code=-9, timed_out=False),
+    }
+    exit_result = {
+        **_engine_result(exit_code=7),
+        "termination": run_module.termination(exit_code=7, timed_out=False),
+    }
+    spawn_result = {
+        **_engine_result(exit_code=-1),
+        "spawn_error": True,
+        "termination": run_module.termination(
+            exit_code=-1,
+            timed_out=False,
+            spawn_error=True,
+        ),
+    }
+
+    assert timeout_result["termination"] == {
+        "kind": "timeout",
+        "exit_code": None,
+        "signal": None,
+    }
+    assert signal_result["termination"] == {
+        "kind": "signal",
+        "exit_code": None,
+        "signal": 9,
+    }
+    assert exit_result["termination"] == {
+        "kind": "exit",
+        "exit_code": 7,
+        "signal": None,
+    }
+    assert spawn_result["termination"] == {
+        "kind": "spawn-error",
+        "exit_code": None,
+        "signal": None,
+    }
+    assert run_module.process_diagnostic(timeout_result)["category"] == "timeout"
+    assert run_module.process_diagnostic(signal_result)["category"] == "signal"
+    assert run_module.process_diagnostic(exit_result)["category"] == "nonzero-exit"
+    assert run_module.process_diagnostic(spawn_result)["category"] == "harness-error"
+    assert (
+        run_module.process_diagnostic(
+            {"exit_code": -1, "timed_out": False, "stderr": "synthetic not-run result"}
+        )
+        is None
+    )
+    assert (
+        run_module.process_diagnostic(
+            {"exit_code": None, "observation_error": "skipped", "not_run": True}
+        )
+        is None
+    )
+
+
+def test_run_ferric_observer_retains_partial_timeout_output(monkeypatch, tmp_path):
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(
+            cmd=["ferric"],
+            timeout=1,
+            output=b'{"partial":true}',
+            stderr=b"partial diagnostic",
+        )
+
+    monkeypatch.setattr(run_module.subprocess, "run", timeout)
+
+    result = run_module.run_ferric_observer(
+        str(tmp_path / "fixture.clp"),
+        "ferric",
+        str(tmp_path),
+        1,
+        fixture_id="fixture.timeout",
+        nonce="0" * 32,
+        source_sha256="a" * 64,
+        composed_sha256="a" * 64,
+    )
+
+    assert result["stdout"] == '{"partial":true}'
+    assert result["stderr"] == "partial diagnostic"
+    assert base64.b64decode(result["raw_output"]["stdout"]) == b'{"partial":true}'
+    assert base64.b64decode(result["raw_output"]["stderr"]) == b"partial diagnostic"
+    assert result["termination"]["kind"] == "timeout"
+
+
+def test_run_ferric_observer_converts_permission_error_to_spawn_failure(monkeypatch, tmp_path):
+    def denied(*_args, **_kwargs):
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(run_module.subprocess, "run", denied)
+
+    result = run_module.run_ferric_observer(
+        "fixture.clp",
+        "./target/debug/ferric",
+        str(tmp_path),
+        1,
+        fixture_id="fixture.spawn",
+        nonce="0" * 32,
+        source_sha256="a" * 64,
+        composed_sha256="a" * 64,
+    )
+
+    assert result["termination"] == {
+        "kind": "spawn-error",
+        "exit_code": None,
+        "signal": None,
+    }
+    assert result["spawn_error"] is True
+    assert "permission denied" in result["stderr"]
+
+
+def test_run_ferric_observer_preserves_signal_without_complete_json(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        run_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=[],
+            returncode=-9,
+            stdout="",
+            stderr="partial native stderr",
+        ),
+    )
+
+    result = run_module.run_ferric_observer(
+        "fixture.clp",
+        "./target/debug/ferric",
+        str(tmp_path),
+        1,
+        fixture_id="fixture.signal",
+        nonce="0" * 32,
+        source_sha256="a" * 64,
+        composed_sha256="a" * 64,
+    )
+    projected = run_module._project_result(result, engine="ferric", harnessed=False)
+
+    assert result["stdout"] == ""
+    assert result["stderr"] == "partial native stderr"
+    assert result["termination"] == {"kind": "signal", "exit_code": None, "signal": 9}
+    assert result.get("harness_error") is None
+    assert projected == {"observation_error": "observer was signaled before terminal evidence"}
+    assert result["diagnostic"] == run_module.diagnostic("process", "signal", continued=False)
+
+
+def test_run_clips_observer_converts_permission_error_to_spawn_failure(monkeypatch, tmp_path):
+    source = tmp_path / "fixture.clp"
+    source.write_text("(deffacts startup (ready))\n")
+
+    def denied(*_args, **_kwargs):
+        raise PermissionError("permission denied")
+
+    monkeypatch.setattr(run_module, "_run_clips_process", denied)
+
+    result = run_module.run_clips_observer(
+        str(source),
+        str(tmp_path),
+        "scripts/clips-reference.sh",
+        1,
+        fixture_id="fixture.spawn",
+        nonce="0" * 32,
+        source_sha256="a" * 64,
+        composed_sha256="a" * 64,
+        globals_to_capture=(),
+        harnessed=False,
+    )
+
+    assert result["termination"] == {
+        "kind": "spawn-error",
+        "exit_code": None,
+        "signal": None,
+    }
+    assert result["spawn_error"] is True
+    assert "permission denied" in result["stderr"]
+
+
+@pytest.mark.parametrize(
+    ("returncode", "expected_kind", "expected_signal"),
+    [(137, "signal", 9), (163, "signal", 35), (127, "exit", None)],
+)
+def test_clips_wrapper_preserves_signal_and_internal_failure_status(
+    monkeypatch,
+    tmp_path,
+    returncode,
+    expected_kind,
+    expected_signal,
+):
+    source = tmp_path / "fixture.clp"
+    source.write_text("(deffacts startup (ready))\n")
+
+    def completed(*_args, **_kwargs):
+        return subprocess.CompletedProcess(
+            args=[],
+            returncode=returncode,
+            stdout=b"partial stdout",
+            stderr=b"partial stderr",
+        )
+
+    monkeypatch.setattr(run_module, "_run_clips_process", completed)
+    monkeypatch.setattr(run_module, "parse_probe_output", lambda *_args, **_kwargs: {})
+
+    result = run_module.run_clips_observer(
+        str(source),
+        str(tmp_path),
+        "scripts/clips-reference.sh",
+        1,
+        fixture_id="fixture.process",
+        nonce="0" * 32,
+        source_sha256="a" * 64,
+        composed_sha256="a" * 64,
+        globals_to_capture=(),
+        harnessed=False,
+    )
+
+    assert result["stdout"] == "partial stdout"
+    assert result["stderr"] == "partial stderr"
+    assert base64.b64decode(result["raw_output"]["stdout"]) == b"partial stdout"
+    assert base64.b64decode(result["raw_output"]["stderr"]) == b"partial stderr"
+    assert result["termination"]["kind"] == expected_kind
+    if expected_signal is not None:
+        assert result["termination"]["signal"] == expected_signal
+        assert result.get("harness_error") is None
+    else:
+        assert result["harness_error"] is True
+        assert "status 127" in result["observation_error"]
+        projected = run_module._project_result(result, engine="clips", harnessed=False)
+        assert projected == {"observation_error": result["observation_error"]}
+        assert result["diagnostic"] == run_module.diagnostic(
+            "harness", "harness-error", continued=False
+        )
+
+
+@pytest.mark.skipif(run_module.IS_WINDOWS, reason="POSIX process-group regression")
+def test_run_clips_process_kills_descendants_holding_capture_fds(tmp_path):
+    child = "import time; time.sleep(30)"
+    parent = (
+        "import subprocess, sys, time; "
+        f"subprocess.Popen([sys.executable, '-c', {child!r}]); "
+        "print('ready', flush=True); time.sleep(30)"
+    )
+
+    started = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired) as caught:
+        run_module._run_clips_process(
+            [sys.executable, "-c", parent],
+            timeout_secs=0.1,
+            root=str(tmp_path),
+        )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 2
+    assert b"ready" in (caught.value.stdout or b"")
+
+
+def test_run_clips_process_force_removes_named_container_on_timeout(monkeypatch, tmp_path):
+    class FakeProcess:
+        pid = 4242
+        returncode = -9
+
+        def __init__(self):
+            self.communications = 0
+
+        def communicate(self, *, timeout):
+            self.communications += 1
+            if self.communications == 1:
+                raise subprocess.TimeoutExpired([], timeout, output=b"partial")
+            return b"partial", b"diagnostic"
+
+    process = FakeProcess()
+    removed: list[str] = []
+    monkeypatch.setattr(run_module.subprocess, "Popen", lambda *_args, **_kwargs: process)
+    monkeypatch.setattr(run_module, "_terminate_process_tree", lambda _process: None)
+    monkeypatch.setattr(run_module, "_remove_clips_container", removed.append)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        run_module._run_clips_process(
+            ["clips-reference"],
+            timeout_secs=1,
+            root=str(tmp_path),
+            container_name="ferric-compat-" + "a" * 32,
+        )
+
+    assert removed == ["ferric-compat-" + "a" * 32]
+
+
+@pytest.mark.parametrize(
+    ("process_result", "expected_kind", "expected_category"),
+    [
+        (
+            subprocess.CompletedProcess([], 137, b"partial stdout", b"partial stderr"),
+            "signal",
+            "signal",
+        ),
+        (
+            subprocess.TimeoutExpired(
+                [],
+                1,
+                output=b"partial stdout",
+                stderr=b"partial stderr",
+            ),
+            "timeout",
+            "timeout",
+        ),
+    ],
+)
+def test_interrupted_clips_parse_failure_preserves_process_termination(
+    monkeypatch,
+    tmp_path,
+    process_result,
+    expected_kind,
+    expected_category,
+):
+    source = tmp_path / "fixture.clp"
+    source.write_text("(deffacts startup (ready))\n")
+
+    def run_process(*_args, **_kwargs):
+        if isinstance(process_result, BaseException):
+            raise process_result
+        return process_result
+
+    monkeypatch.setattr(run_module, "_run_clips_process", run_process)
+    monkeypatch.setattr(
+        run_module,
+        "parse_probe_output",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("truncated record")),
+    )
+
+    result = run_module.run_clips_observer(
+        str(source),
+        str(tmp_path),
+        "scripts/clips-reference.sh",
+        1,
+        fixture_id="fixture.interrupted",
+        nonce="0" * 32,
+        source_sha256="a" * 64,
+        composed_sha256="a" * 64,
+        globals_to_capture=(),
+        harnessed=False,
+    )
+    projected = run_module._project_result(result, engine="clips", harnessed=False)
+
+    assert result["stdout"] == "partial stdout"
+    assert result["stderr"] == "partial stderr"
+    assert result["termination"]["kind"] == expected_kind
+    assert result.get("harness_error") is None
+    assert projected == {
+        "observation_error": "reference observer timed out before terminal evidence"
+        if expected_kind == "timeout"
+        else "reference observer was interrupted before parsable terminal evidence"
+    }
+    assert result["diagnostic"] == run_module.diagnostic(
+        "process", expected_category, continued=False
+    )
+
+
+def test_interrupted_clips_retains_invalid_utf8_bytes_losslessly(monkeypatch, tmp_path):
+    source = tmp_path / "fixture.clp"
+    source.write_text("(deffacts startup (ready))\n")
+
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired([], 1, output=b"stdout \xc3", stderr=b"stderr \xff")
+
+    monkeypatch.setattr(run_module, "_run_clips_process", timeout)
+
+    result = run_module.run_clips_observer(
+        str(source),
+        str(tmp_path),
+        "scripts/clips-reference.sh",
+        1,
+        fixture_id="fixture.invalid-utf8",
+        nonce="0" * 32,
+        source_sha256="a" * 64,
+        composed_sha256="a" * 64,
+        globals_to_capture=(),
+        harnessed=False,
+    )
+
+    assert result["stdout"] == "stdout \ufffd"
+    assert result["stderr"] == "stderr \ufffd"
+    assert base64.b64decode(result["raw_output"]["stdout"]) == b"stdout \xc3"
+    assert base64.b64decode(result["raw_output"]["stderr"]) == b"stderr \xff"
+    assert result["termination"]["kind"] == "timeout"
+
+
+def test_interrupted_clips_hard_protocol_corruption_is_harness_failure(
+    monkeypatch,
+    tmp_path,
+):
+    source = tmp_path / "fixture.clp"
+    source.write_text("(deffacts startup (ready))\n")
+
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired([], 1, output=b"partial", stderr=b"corrupt")
+
+    def corrupt(*_args, **_kwargs):
+        raise run_module.ClipsOracleProtocolError("authenticated payload is invalid UTF-8")
+
+    monkeypatch.setattr(run_module, "_run_clips_process", timeout)
+    monkeypatch.setattr(run_module, "parse_probe_output", corrupt)
+
+    result = run_module.run_clips_observer(
+        str(source),
+        str(tmp_path),
+        "scripts/clips-reference.sh",
+        1,
+        fixture_id="fixture.corrupt",
+        nonce="0" * 32,
+        source_sha256="a" * 64,
+        composed_sha256="a" * 64,
+        globals_to_capture=(),
+        harnessed=False,
+    )
+    projected = run_module._project_result(result, engine="clips", harnessed=False)
+
+    assert result["termination"]["kind"] == "timeout"
+    assert result["harness_error"] is True
+    assert projected == {"observation_error": "authenticated payload is invalid UTF-8"}
+    assert result["diagnostic"] == run_module.diagnostic(
+        "harness", "harness-error", continued=False
+    )
+
+
+def test_partial_timeout_preserves_authenticated_active_phase():
+    result = {
+        **_engine_result(exit_code=-1),
+        "timed_out": True,
+        "observation_error": "observer timed out before terminal evidence",
+        "termination": run_module.termination(exit_code=-1, timed_out=True),
+        "observation": {
+            "instrumentation": {"active_phase": "reset"},
+        },
+    }
+
+    projected = run_module._project_result(
+        result,
+        engine="clips",
+        harnessed=False,
+    )
+
+    assert projected == {"observation_error": "observer timed out before terminal evidence"}
+    assert result["diagnostic"]["category"] == "timeout"
+    assert result["termination"]["active_phase"] == "reset"
+
+
+def test_signal_before_native_start_remains_process_signal():
+    expected_fixture = {
+        "id": "fixture.early-signal",
+        "nonce": "0" * 32,
+        "source_sha256": "a" * 64,
+        "composed_sha256": "b" * 64,
+    }
+    result = {
+        **_engine_result(exit_code=-9),
+        "observation": {
+            "schema": "ferric.compat-observation",
+            "version": 1,
+            "engine": {"name": "clips", "version": "test"},
+            "fixture": dict(expected_fixture),
+            "lifecycle": [],
+            "diagnostics": [],
+            "active_phase": None,
+            "instrumentation": {"active_phase": None},
+            "protocol_issues": [
+                "native-phase-records-missing",
+                "lifecycle-cardinality-or-order",
+                "native-run-metadata-missing",
+                "phase-cardinality-or-order",
+                "module-cardinality",
+            ],
+        },
+        "termination": run_module.termination(exit_code=-9, timed_out=False),
+    }
+
+    projected = run_module._project_result(
+        result,
+        engine="clips",
+        harnessed=False,
+        expected_fixture=expected_fixture,
+    )
+
+    assert projected == {"observation_error": "clips observer terminated as signal"}
+    assert result["diagnostic"] == run_module.diagnostic("process", "signal", continued=False)
+
+
+def test_signal_after_lifecycle_start_before_phase_begin_remains_process_signal():
+    expected_fixture = {
+        "id": "fixture.start-only",
+        "nonce": "0" * 32,
+        "source_sha256": "a" * 64,
+        "composed_sha256": "b" * 64,
+    }
+    result = {
+        **_engine_result(exit_code=-9),
+        "observation": {
+            "schema": "ferric.compat-observation",
+            "version": 1,
+            "engine": {"name": "clips", "version": "test"},
+            "fixture": dict(expected_fixture),
+            "phase_reached": "load",
+            "lifecycle": [
+                {
+                    "sequence": 0,
+                    "event": "start",
+                    "fixture_id": expected_fixture["id"],
+                    "nonce": expected_fixture["nonce"],
+                    "source_sha256": expected_fixture["source_sha256"],
+                    "composed_sha256": expected_fixture["composed_sha256"],
+                }
+            ],
+            "diagnostics": [],
+            "active_phase": None,
+            "instrumentation": {"active_phase": None},
+            "protocol_issues": [
+                "native-phase-records-missing",
+                "lifecycle-cardinality-or-order",
+                "lifecycle-sequence-order",
+                "native-run-metadata-missing",
+                "phase-cardinality-or-order",
+                "module-cardinality",
+            ],
+            "diagnostic_protocol_issues": [],
+        },
+        "termination": run_module.termination(exit_code=-9, timed_out=False),
+    }
+
+    projected = run_module._project_result(
+        result,
+        engine="clips",
+        harnessed=False,
+        expected_fixture=expected_fixture,
+    )
+
+    assert projected == {"observation_error": "clips observer terminated as signal"}
+    assert result["diagnostic"] == run_module.diagnostic("process", "signal", continued=False)
+
+
+def test_interrupted_authenticated_protocol_corruption_is_harness_failure():
+    expected_fixture = {
+        "id": "fixture.corrupt",
+        "nonce": "0" * 32,
+        "source_sha256": "a" * 64,
+        "composed_sha256": "b" * 64,
+    }
+    result = {
+        **_engine_result(exit_code=-9),
+        "observation": {
+            "schema": "ferric.compat-observation",
+            "version": 1,
+            "engine": {"name": "clips", "version": "test"},
+            "fixture": dict(expected_fixture),
+            "lifecycle": [
+                {
+                    "sequence": 0,
+                    "event": "start",
+                    "fixture_id": expected_fixture["id"],
+                    "nonce": expected_fixture["nonce"],
+                    "source_sha256": expected_fixture["source_sha256"],
+                    "composed_sha256": expected_fixture["composed_sha256"],
+                }
+            ],
+            "diagnostics": [],
+            "active_phase": "load",
+            "instrumentation": {"active_phase": "load"},
+            "protocol_issues": ["truncated-native-record"],
+        },
+        "termination": run_module.termination(exit_code=-9, timed_out=False),
+    }
+
+    projected = run_module._project_result(
+        result,
+        engine="clips",
+        harnessed=False,
+        expected_fixture=expected_fixture,
+    )
+
+    assert "truncated-native-record" in projected["observation_error"]
+    assert result["diagnostic"] == run_module.diagnostic(
+        "harness", "harness-error", continued=False
+    )
+    assert result["termination"]["active_phase"] == "load"
+
+
+def test_projection_failure_preserves_trusted_bound_semantic_diagnostic(monkeypatch):
+    expected_fixture = {
+        "id": "fixture.diagnostic",
+        "nonce": "0" * 32,
+        "source_sha256": "a" * 64,
+        "composed_sha256": "b" * 64,
+    }
+    observation = {
+        "schema": "ferric.compat-observation",
+        "version": 1,
+        "engine": {"name": "ferric", "version": "test"},
+        "fixture": dict(expected_fixture),
+        "phase_reached": "parse",
+        "run": None,
+        "lifecycle": [
+            {
+                "sequence": sequence,
+                "event": event,
+                "fixture_id": expected_fixture["id"],
+                "nonce": expected_fixture["nonce"],
+                "source_sha256": expected_fixture["source_sha256"],
+                "composed_sha256": expected_fixture["composed_sha256"],
+            }
+            for sequence, event in ((0, "start"), (1, "complete"))
+        ],
+        "diagnostics": [
+            {
+                "taxonomy_version": 1,
+                "phase": "parse",
+                "category": "syntax-error",
+                "continued": False,
+                "severity": "error",
+                "message": "raw parse message",
+            }
+        ],
+    }
+    result = {
+        **_engine_result(exit_code=1),
+        "observation": observation,
+        "termination": run_module.termination(exit_code=1, timed_out=False),
+    }
+
+    def incomplete_projection(*_args, **_kwargs):
+        raise run_module.ObservationProjectionError("terminal state is incomplete")
+
+    monkeypatch.setattr(run_module, "project_ferric_observation", incomplete_projection)
+
+    projected = run_module._project_result(
+        result,
+        engine="ferric",
+        harnessed=False,
+        expected_fixture=expected_fixture,
+    )
+
+    assert projected == {"observation_error": "terminal state is incomplete"}
+    assert result["diagnostic"] == run_module.diagnostic("parse", "syntax-error", continued=False)
+    assert result["observation"]["diagnostics"][0]["message"] == "raw parse message"
+
+
+def test_projection_does_not_preserve_diagnostic_contradicted_by_run_state():
+    expected_fixture = {
+        "id": "fixture.contradiction",
+        "nonce": "0" * 32,
+        "source_sha256": "a" * 64,
+        "composed_sha256": "b" * 64,
+    }
+    observation = {
+        "schema": "ferric.compat-observation",
+        "version": 1,
+        "engine": {"name": "ferric", "version": "test"},
+        "fixture": dict(expected_fixture),
+        "phase_reached": "run",
+        "run": {"halt_reason": "agenda_empty"},
+        "lifecycle": [
+            {
+                "sequence": sequence,
+                "event": event,
+                "fixture_id": expected_fixture["id"],
+                "nonce": expected_fixture["nonce"],
+                "source_sha256": expected_fixture["source_sha256"],
+                "composed_sha256": expected_fixture["composed_sha256"],
+            }
+            for sequence, event in ((0, "start"), (1, "complete"))
+        ],
+        "diagnostics": [
+            {
+                "taxonomy_version": 1,
+                "phase": "run",
+                "category": "evaluation-error",
+                "continued": False,
+                "severity": "error",
+                "message": "claimed action failure",
+            }
+        ],
+    }
+    result = {
+        **_engine_result(),
+        "observation": observation,
+        "termination": run_module.termination(exit_code=0, timed_out=False),
+    }
+
+    projected = run_module._project_result(
+        result,
+        engine="ferric",
+        harnessed=False,
+        expected_fixture=expected_fixture,
+    )
+
+    assert "lacks an action-error halt" in projected["observation_error"]
+    assert result["diagnostic"] == run_module.diagnostic(
+        "harness", "harness-error", continued=False
+    )
+
+
+@pytest.mark.parametrize(("exit_code", "timed_out"), [(-1, True), (-15, False)])
+def test_interruption_preserves_prior_trusted_semantic_diagnostic(exit_code, timed_out):
+    expected_fixture = {
+        "id": "fixture.interrupted",
+        "nonce": "0" * 32,
+        "source_sha256": "a" * 64,
+        "composed_sha256": "b" * 64,
+    }
+    observation = {
+        "schema": "ferric.compat-observation",
+        "version": 1,
+        "engine": {"name": "clips", "version": "test"},
+        "fixture": dict(expected_fixture),
+        "lifecycle": [
+            {
+                "sequence": 0,
+                "event": "start",
+                "fixture_id": expected_fixture["id"],
+                "nonce": expected_fixture["nonce"],
+                "source_sha256": expected_fixture["source_sha256"],
+                "composed_sha256": expected_fixture["composed_sha256"],
+            }
+        ],
+        "diagnostics": [
+            {
+                "taxonomy_version": 1,
+                "phase": "reset",
+                "category": "evaluation-error",
+                "continued": True,
+                "channel": "stderr",
+                "message": "reset evaluation error",
+            }
+        ],
+        "phase_reached": "run",
+        "active_phase": "run",
+        "run": None,
+        "instrumentation": {"active_phase": "run"},
+        "protocol_issues": ["lifecycle-cardinality-or-order"],
+    }
+    result = {
+        **_engine_result(exit_code=exit_code),
+        "timed_out": timed_out,
+        "observation": observation,
+        "observation_error": "observer was interrupted",
+        "termination": run_module.termination(exit_code=exit_code, timed_out=timed_out),
+    }
+
+    projected = run_module._project_result(
+        result,
+        engine="clips",
+        harnessed=False,
+        expected_fixture=expected_fixture,
+    )
+
+    assert projected == {"observation_error": "observer was interrupted"}
+    assert result["diagnostic"] == run_module.diagnostic(
+        "reset", "evaluation-error", continued=True
+    )
+    assert result["termination"]["kind"] == ("timeout" if timed_out else "signal")
+    assert result["termination"]["active_phase"] == "run"
+
+
+def test_unknown_trusted_semantic_taxonomy_stays_unknown_not_harness(monkeypatch):
+    expected_fixture = {
+        "id": "fixture.unknown",
+        "nonce": "0" * 32,
+        "source_sha256": "a" * 64,
+        "composed_sha256": "b" * 64,
+    }
+    observation = {
+        "schema": "ferric.compat-observation",
+        "version": 1,
+        "engine": {"name": "clips", "version": "test"},
+        "fixture": dict(expected_fixture),
+        "lifecycle": [
+            {
+                "sequence": sequence,
+                "event": event,
+                "fixture_id": expected_fixture["id"],
+                "nonce": expected_fixture["nonce"],
+                "source_sha256": expected_fixture["source_sha256"],
+                "composed_sha256": expected_fixture["composed_sha256"],
+            }
+            for sequence, event in ((0, "start"), (3, "complete"))
+        ],
+        "diagnostics": [
+            {
+                "taxonomy_version": 1,
+                "phase": "unknown",
+                "category": "unknown",
+                "continued": False,
+                "channel": "stderr",
+                "message": "[NEWCODE1] unclassified native diagnostic",
+            }
+        ],
+        "protocol_issues": [],
+    }
+    result = {
+        **_engine_result(exit_code=1),
+        "observation": observation,
+        "termination": run_module.termination(exit_code=1, timed_out=False),
+    }
+
+    def incomplete_projection(*_args, **_kwargs):
+        raise run_module.ObservationProjectionError("unknown diagnostic taxonomy")
+
+    monkeypatch.setattr(run_module, "project_clips_observation", incomplete_projection)
+
+    projected = run_module._project_result(
+        result,
+        engine="clips",
+        harnessed=False,
+        expected_fixture=expected_fixture,
+    )
+
+    assert projected == {"observation_error": "unknown diagnostic taxonomy"}
+    assert result["diagnostic"] == run_module.diagnostic("unknown", "unknown", continued=False)
+
+
+def test_unbound_semantic_diagnostic_is_harness_failure():
+    expected_fixture = {
+        "id": "fixture.expected",
+        "nonce": "0" * 32,
+        "source_sha256": "a" * 64,
+        "composed_sha256": "b" * 64,
+    }
+    observation = {
+        "schema": "ferric.compat-observation",
+        "version": 1,
+        "engine": {"name": "ferric", "version": "test"},
+        "fixture": {**expected_fixture, "id": "fixture.spoofed"},
+        "diagnostics": [
+            {
+                "taxonomy_version": 1,
+                "phase": "run",
+                "category": "evaluation-error",
+                "continued": False,
+            }
+        ],
+    }
+    result = {
+        **_engine_result(exit_code=1),
+        "observation": observation,
+        "termination": run_module.termination(exit_code=1, timed_out=False),
+    }
+
+    projected = run_module._project_result(
+        result,
+        engine="ferric",
+        harnessed=False,
+        expected_fixture=expected_fixture,
+    )
+
+    assert "does not match the invocation" in projected["observation_error"]
+    assert result["diagnostic"] == run_module.diagnostic(
+        "harness", "harness-error", continued=False
+    )
+
+
 def test_structured_process_binds_actual_bytes_and_fresh_nonce(tmp_path, monkeypatch):
     root = tmp_path / "repo"
     source = root / "tests" / "examples" / "fixture.clp"
@@ -333,7 +1452,7 @@ def test_nonzero_structured_observer_is_invalid_and_retains_source(tmp_path, mon
 
     _, ferric_result, clips_result, classification, reason = result
     assert classification == "pending"
-    assert reason == "oracle-invalid:evidence"
+    assert reason == "harness-failure"
     assert ferric_result["oracle_evidence"]["status"] == "invalid"
     assert clips_result is not None
     assert clips_result["oracle_evidence"] == ferric_result["oracle_evidence"]
@@ -583,7 +1702,23 @@ def test_runner_persists_missing_source_as_invalid_before_engine_preflight(
     assert persisted_entry["clips"] is None
 
 
-def test_runner_persists_invalid_evidence_before_nonzero_exit(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    ("reason", "heading"),
+    [
+        ("oracle-invalid:markers", "Invalid oracle evidence (1)"),
+        ("diagnostic-invalid", "Invalid runtime evidence (1)"),
+        ("diagnostic-missing", "Invalid runtime evidence (1)"),
+        ("harness-failure", "Invalid runtime evidence (1)"),
+        ("termination-invalid", "Invalid runtime evidence (1)"),
+        ("termination-missing", "Invalid runtime evidence (1)"),
+    ],
+)
+def test_runner_persists_invalid_evidence_before_nonzero_exit(
+    tmp_path,
+    monkeypatch,
+    reason,
+    heading,
+):
     root = tmp_path / "repo"
     examples = root / "tests" / "examples"
     source = examples / "fixture.clp"
@@ -640,7 +1775,7 @@ def test_runner_persists_invalid_evidence_before_nonzero_exit(tmp_path, monkeypa
             {**_engine_result(exit_code=1), "oracle_evidence": evidence},
             {**_engine_result(), "oracle_evidence": evidence},
             "pending",
-            "oracle-invalid:markers",
+            reason,
         )
 
     monkeypatch.setattr(run_module, "repo_root", lambda: root)
@@ -665,11 +1800,11 @@ def test_runner_persists_invalid_evidence_before_nonzero_exit(tmp_path, monkeypa
     )
 
     assert result.exit_code == 1
-    assert "Invalid oracle evidence (1)" in result.output
+    assert heading in result.output
     persisted = load_manifest(manifest_path)
     persisted_entry = persisted["files"]["fixture.clp"]
     assert persisted_entry["classification"] == "pending"
-    assert persisted_entry["reason"] == "oracle-invalid:markers"
+    assert persisted_entry["reason"] == reason
     assert persisted_entry["oracle_evidence"] == evidence
 
 
@@ -1169,6 +2304,7 @@ def test_clips_reference_script_preserves_unicode_quotes_and_rejects_symlink(
 
     observer_nonce = "0123456789abcdef0123456789abcdef"
     observer_auth_key = "c" * 64
+    observer_container_name = "ferric-compat-" + "d" * 32
     observer_result = subprocess.run(
         [
             str(script),
@@ -1184,6 +2320,8 @@ def test_clips_reference_script_preserves_unicode_quotes_and_rejects_symlink(
             "b" * 64,
             "--observer-auth-key",
             observer_auth_key,
+            "--observer-container-name",
+            observer_container_name,
             "--file",
             str(fixture),
         ],
@@ -1197,6 +2335,7 @@ def test_clips_reference_script_preserves_unicode_quotes_and_rejects_symlink(
     observer_args = captured_args.read_text(encoding="utf-8").splitlines()
     assert "--ferric-observer" in observer_args
     assert "--source" in observer_args
+    assert observer_args[observer_args.index("--name") + 1] == observer_container_name
     assert '/workspace/fixtures/rules space Ω "quoted".clp' in observer_args
     assert observer_nonce not in observer_args
     assert observer_auth_key not in observer_args

--- a/tools/ferric-tools/tests/test_compat_run.py
+++ b/tools/ferric-tools/tests/test_compat_run.py
@@ -903,7 +903,8 @@ def test_partial_timeout_preserves_authenticated_active_phase():
     assert result["termination"]["active_phase"] == "reset"
 
 
-def test_signal_before_native_start_remains_process_signal():
+@pytest.mark.parametrize("extra_issue", [None, "truncated-native-record"])
+def test_signal_before_or_during_native_start_remains_process_signal(extra_issue):
     expected_fixture = {
         "id": "fixture.early-signal",
         "nonce": "0" * 32,
@@ -927,6 +928,7 @@ def test_signal_before_native_start_remains_process_signal():
                 "native-run-metadata-missing",
                 "phase-cardinality-or-order",
                 "module-cardinality",
+                *([extra_issue] if extra_issue is not None else []),
             ],
         },
         "termination": run_module.termination(exit_code=-9, timed_out=False),

--- a/tools/ferric-tools/tests/test_compat_run.py
+++ b/tools/ferric-tools/tests/test_compat_run.py
@@ -18,6 +18,7 @@ from ferric_tools._harness import HARNESS_GENERATION_VERSION, ResolvedHarness, s
 from ferric_tools._manifest import load_manifest, save_manifest
 from ferric_tools._paths import repo_root
 from ferric_tools.compat import run as run_module
+from ferric_tools.compat.clips_oracle import NATIVE_RECORD_PREFIX
 
 
 def _resolved_harness(
@@ -812,6 +813,68 @@ def test_interrupted_clips_parse_failure_preserves_process_termination(
     assert result["diagnostic"] == run_module.diagnostic(
         "process", expected_category, continued=False
     )
+
+
+@pytest.mark.parametrize(
+    "partial_start",
+    [
+        pytest.param(f"\n{NATIVE_RECORD_PREFIX}".encode(), id="after-prefix"),
+        pytest.param(
+            f"\n{NATIVE_RECORD_PREFIX}{'0' * 32}".encode(),
+            id="after-nonce",
+        ),
+        pytest.param(
+            f"\n{NATIVE_RECORD_PREFIX}{'0' * 32}|LIFECYCLE|0|STA".encode(),
+            id="during-record",
+        ),
+    ],
+)
+def test_signal_during_initial_native_record_remains_process_signal(
+    monkeypatch,
+    tmp_path,
+    partial_start,
+):
+    source = tmp_path / "fixture.clp"
+    source.write_text("(deffacts startup (ready))\n")
+    fixture_id = "fixture.initial-record"
+    nonce = "0" * 32
+    source_digest = "a" * 64
+    monkeypatch.setattr(
+        run_module,
+        "_run_clips_process",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess([], 137, b"", partial_start),
+    )
+
+    result = run_module.run_clips_observer(
+        str(source),
+        str(tmp_path),
+        "scripts/clips-reference.sh",
+        1,
+        fixture_id=fixture_id,
+        nonce=nonce,
+        source_sha256=source_digest,
+        composed_sha256=source_digest,
+        globals_to_capture=(),
+        harnessed=False,
+    )
+    projected = run_module._project_result(
+        result,
+        engine="clips",
+        harnessed=False,
+        expected_fixture={
+            "id": fixture_id,
+            "nonce": nonce,
+            "source_sha256": source_digest,
+            "composed_sha256": source_digest,
+        },
+    )
+
+    assert result["observation"]["lifecycle"] == []
+    assert "truncated-native-record" in result["observation"]["protocol_issues"]
+    assert result.get("harness_error") is None
+    assert result["termination"] == {"kind": "signal", "exit_code": None, "signal": 9}
+    assert projected == {"observation_error": "clips observer terminated as signal"}
+    assert result["diagnostic"] == run_module.diagnostic("process", "signal", continued=False)
 
 
 def test_interrupted_clips_retains_invalid_utf8_bytes_losslessly(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- add a shared, versioned diagnostic and termination taxonomy for Ferric and CLIPS
- capture authenticated native CLIPS load/reset/run diagnostics without scanning user output
- preserve partial and interrupted evidence, exact raw bytes, and diagnostic/termination changes in reports and diffs
- enforce process-tree/container timeout cleanup and fail closed on malformed or incomplete evidence

## Validation

- `just preflight-pr`
- `just compat-run`
- `just compat-report`
- real Docker smokes for parse, construct, reset, run, bracket/werror output, and timeout cleanup

Closes #119