### PR TITLE
[FR-COMPAT-006] Make compatibility feature scanning string- and comment-aware

### DIFF
--- a/.github/workflows/compat-compare.yml
+++ b/.github/workflows/compat-compare.yml
@@ -74,6 +74,12 @@ jobs:
       - name: Assess base branch
         run: |
           git checkout ${{ inputs.base_sha }}
+          # Retain the base scanner's own pre-run result before installing any
+          # head tooling. The run comparison below intentionally uses the head
+          # observer protocol, but scanner changes must compare each revision's
+          # native scanner output.
+          uv run --project tools/ferric-tools ferric-compat-scan
+          cp tests/examples/compat-manifest.json /tmp/base-compat-scan-manifest.json
           # Assess both revisions through the head observer protocol.
           git checkout ${{ inputs.head_sha }} -- \
             tools/ferric-tools/ \
@@ -98,7 +104,22 @@ jobs:
         run: cargo build --release -p ferric-rules-cli
 
       - name: Run compat scan
-        run: uv run --project tools/ferric-tools ferric-compat-scan
+        run: |
+          uv run --project tools/ferric-tools ferric-compat-scan
+          cp tests/examples/compat-manifest.json /tmp/head-compat-scan-manifest.json
+
+      - name: Generate retained scanner comparison
+        run: |
+          uv run --project tools/ferric-tools ferric-compat-diff \
+            /tmp/base-compat-scan-manifest.json /tmp/head-compat-scan-manifest.json \
+            --scanner-only \
+            --tsv /tmp/compat-scanner-diff.tsv \
+            --json /tmp/compat-scanner-diff.json \
+            --report /tmp/compat-scanner-diff-report.md \
+            --repo "${{ github.repository }}" \
+            --base-sha "${{ inputs.base_sha }}" \
+            --head-sha "${{ inputs.head_sha }}"
+          cat /tmp/compat-scanner-diff-report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run compat assessment
         run: uv run --project tools/ferric-tools ferric-compat-run --workers 4 --timeout 30
@@ -119,10 +140,21 @@ jobs:
             --head-sha "${{ inputs.head_sha }}" \
             >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Append retained scanner comparison
+        if: always()
+        run: |
+          if [[ -f /tmp/compat-scanner-diff-report.md ]]; then
+            if [[ -s /tmp/compat-diff-report.md ]]; then
+              printf '\n' >> /tmp/compat-diff-report.md
+            fi
+            cat /tmp/compat-scanner-diff-report.md >> /tmp/compat-diff-report.md
+          fi
+
       - name: Copy head manifest
         run: cp tests/examples/compat-manifest.json /tmp/head-compat-manifest.json
 
       - name: Upload artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: compat-diff-report
@@ -130,5 +162,10 @@ jobs:
           path: |
             /tmp/compat-diff.tsv
             /tmp/compat-diff-report.md
+            /tmp/compat-scanner-diff.tsv
+            /tmp/compat-scanner-diff.json
+            /tmp/compat-scanner-diff-report.md
             /tmp/head-compat-manifest.json
             /tmp/base-compat-manifest.json
+            /tmp/head-compat-scan-manifest.json
+            /tmp/base-compat-scan-manifest.json

--- a/docs/compatibility-assessment.md
+++ b/docs/compatibility-assessment.md
@@ -56,6 +56,23 @@ stop. The manifest's top-level `oracle_protocol_version: 1` continues to name
 the shared observation/evaluation protocol; each declaration and evidence
 record carries its own version.
 
+## Static source classification
+
+`compat-scan` makes one lexical pass over each raw source and classifies only
+recognized form heads. Strings, comments, and symbol substrings cannot create
+feature detections; real form heads remain case-insensitive, including nested
+forms. Every successfully decoded entry carries `feature_scan` version 1 with a
+`valid` or `invalid` status, ordered detections, and lexical issues. Each
+detection records its feature, category, reason, and exact form-head and
+enclosing-form spans; each issue records its kind, reason, and exact span. Spans
+use half-open UTF-8 byte offsets plus 1-based line and column coordinates.
+
+Malformed source is fail-closed as
+`incompatible/malformed-source` with runability `unknown`, and explicit
+compatibility-run selection refuses it. This preserves any trustworthy
+detections found before the lexical error without silently treating the file as
+runnable or compatible.
+
 ## Observation boundary
 
 Every run receives a fresh 128-bit nonce. Successful observations must produce
@@ -177,6 +194,18 @@ evidence. Compare a baseline and candidate with:
 ```console
 just compat-diff BASE_MANIFEST HEAD_MANIFEST
 ```
+
+The PR compatibility workflow also retains a scanner-only comparison. It
+captures each revision's manifest immediately after `compat-scan`, before
+`compat-run` can replace the scanner's classification and reason with runtime
+results. The Markdown and TSV summaries compare `features`,
+`unsupported_features`, classification, reason, runability, and structured scan
+status and issues. The JSON artifact additionally retains the complete
+`feature_scan` detections, reasons, issues, and exact spans for every reported
+file. A base manifest without `feature_scan` is identified as legacy evidence
+instead of reporting every file as changed. Scanner changes are review evidence
+and do not fail CI; failure to generate the retained artifacts does fail the
+workflow.
 
 For schema-v3 heads, the diff gate rejects every unverified equivalence claim,
 including a legacy claim copied forward unchanged, as well as evidence-coverage

--- a/tools/ferric-tools/src/ferric_tools/_clips_parser.py
+++ b/tools/ferric-tools/src/ferric_tools/_clips_parser.py
@@ -6,10 +6,11 @@ and keyword classification shared by compat-scan, bat-analyze, and harness-gen.
 
 from __future__ import annotations
 
-import re
+from collections.abc import Iterable
+from dataclasses import dataclass
 
 # ---------------------------------------------------------------------------
-# Feature detection patterns
+# Feature catalog
 # ---------------------------------------------------------------------------
 
 SUPPORTED_CONSTRUCTS = [
@@ -38,28 +39,401 @@ INTERACTIVE_IO = ["read", "readline"]
 LOADING_COMMANDS = ["batch", "batch*", "load", "load*"]
 
 
-def _build_keyword_pattern(keywords: list[str]) -> re.Pattern[str]:
-    """Build a regex matching (keyword ... at a word boundary."""
-    escaped = [re.escape(k) for k in keywords]
-    return re.compile(r"\(\s*(?:" + "|".join(escaped) + r")(?:\s|[)\"])", re.IGNORECASE)
-
-
-PAT_COOL = _build_keyword_pattern(COOL_CONSTRUCTS)
-PAT_UNSUPPORTED_CONTROL = (
-    _build_keyword_pattern(UNSUPPORTED_CONTROL) if UNSUPPORTED_CONTROL else None
-)
-PAT_UNSUPPORTED_IO = _build_keyword_pattern(UNSUPPORTED_IO)
-PAT_INTERACTIVE = _build_keyword_pattern(INTERACTIVE_IO)
-PAT_LOADING = _build_keyword_pattern(LOADING_COMMANDS)
-PAT_DEFRULE = re.compile(r"\(\s*defrule\s", re.IGNORECASE)
-PAT_DEFFACTS = re.compile(r"\(\s*deffacts\s", re.IGNORECASE)
-PAT_PRINTOUT = re.compile(r"\(\s*printout\s", re.IGNORECASE)
-
 _ALL_CONSTRUCTS = SUPPORTED_CONSTRUCTS + COOL_CONSTRUCTS
-PAT_ALL_CONSTRUCTS = {
-    kw: re.compile(r"\(\s*" + re.escape(kw) + r"(?:\s|[)\"])", re.IGNORECASE)
-    for kw in _ALL_CONSTRUCTS
+
+
+# ---------------------------------------------------------------------------
+# Raw-source lexical feature scanning
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SourceSpan:
+    """A half-open UTF-8 byte span with 1-based source locations."""
+
+    start_byte: int
+    end_byte: int
+    start_line: int
+    start_column: int
+    end_line: int
+    end_column: int
+
+    def to_dict(self) -> dict[str, int]:
+        """Return the stable JSON representation of this span."""
+        return {
+            "start_byte": self.start_byte,
+            "end_byte": self.end_byte,
+            "start_line": self.start_line,
+            "start_column": self.start_column,
+            "end_line": self.end_line,
+            "end_column": self.end_column,
+        }
+
+
+@dataclass(frozen=True)
+class FeatureDetection:
+    """One recognized form head in CLIPS source."""
+
+    feature: str
+    category: str
+    reason: str
+    head_span: SourceSpan
+    form_span: SourceSpan
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the stable JSON representation of this detection."""
+        return {
+            "feature": self.feature,
+            "category": self.category,
+            "reason": self.reason,
+            "head_span": self.head_span.to_dict(),
+            "form_span": self.form_span.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class LexicalIssue:
+    """A structural source problem found while scanning."""
+
+    kind: str
+    reason: str
+    span: SourceSpan
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the stable JSON representation of this issue."""
+        return {
+            "kind": self.kind,
+            "reason": self.reason,
+            "span": self.span.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class FeatureScan:
+    """Structured result of lexically scanning raw CLIPS source."""
+
+    detections: tuple[FeatureDetection, ...]
+    issues: tuple[LexicalIssue, ...]
+
+    @property
+    def feature_names(self) -> tuple[str, ...]:
+        """Return reported feature names, deduplicated in source order."""
+        return _deduplicate(
+            detection.feature
+            for detection in self.detections
+            if detection.feature in _REPORTED_FEATURES
+        )
+
+    @property
+    def unsupported_feature_names(self) -> tuple[str, ...]:
+        """Return unsupported feature names, deduplicated in source order."""
+        return _deduplicate(
+            detection.feature
+            for detection in self.detections
+            if detection.feature in _UNSUPPORTED_FEATURES
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the versioned JSON representation consumed by compat-scan."""
+        return {
+            "version": 1,
+            "status": "invalid" if self.issues else "valid",
+            "detections": [detection.to_dict() for detection in self.detections],
+            "issues": [issue.to_dict() for issue in self.issues],
+        }
+
+
+@dataclass(frozen=True)
+class _FeatureSpec:
+    category: str
+    reason: str
+
+
+@dataclass
+class _FormFrame:
+    start: int
+    awaiting_head: bool = True
+    detection_index: int | None = None
+
+
+@dataclass
+class _DetectionDraft:
+    feature: str
+    spec: _FeatureSpec
+    head_start: int
+    head_end: int
+    form_start: int
+    form_end: int | None = None
+
+
+@dataclass(frozen=True)
+class _IssueDraft:
+    kind: str
+    start: int
+    end: int
+
+
+def _deduplicate(values: Iterable[str]) -> tuple[str, ...]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        if value not in seen:
+            result.append(value)
+            seen.add(value)
+    return tuple(result)
+
+
+_FEATURE_SPECS = {
+    **{
+        feature: _FeatureSpec(category="supported-construct", reason="supported-form")
+        for feature in SUPPORTED_CONSTRUCTS
+    },
+    **{
+        feature: _FeatureSpec(category="cool-construct", reason="unsupported-form")
+        for feature in COOL_CONSTRUCTS
+    },
+    "printout": _FeatureSpec(category="output", reason="supported-output"),
+    **{
+        feature: _FeatureSpec(category="unsupported-control", reason="unsupported-control")
+        for feature in UNSUPPORTED_CONTROL
+    },
+    **{
+        feature: _FeatureSpec(category="file-io", reason="unsupported-io")
+        for feature in UNSUPPORTED_IO
+    },
+    **{
+        feature: _FeatureSpec(category="interactive-io", reason="interactive")
+        for feature in INTERACTIVE_IO
+    },
+    **{
+        feature: _FeatureSpec(category="loading-command", reason="unsupported-command")
+        for feature in LOADING_COMMANDS
+    },
 }
+
+_REPORTED_FEATURES = frozenset((*_ALL_CONSTRUCTS, "printout"))
+_UNSUPPORTED_FEATURES = frozenset(
+    (*COOL_CONSTRUCTS, *UNSUPPORTED_CONTROL, *UNSUPPORTED_IO, *INTERACTIVE_IO, *LOADING_COMMANDS)
+)
+
+# CLIPS 6.30 ScanSymbol terminators not already handled as whitespace,
+# comments, strings, or parentheses. A leading "<" starts a symbol, while
+# "&", "|", and "~" are standalone tokens even at the start of a form.
+_CLIPS_SYMBOL_TERMINATORS = frozenset("<&|~")
+_CLIPS_STANDALONE_TOKENS = frozenset("&|~")
+_CLIPS_WHITESPACE = frozenset(" \n\f\r\t")
+# GetToken returns STOP when NUL or ETX begins the next token. ScanString and
+# the comment-skipping loop consume them as ordinary content instead.
+_CLIPS_HARD_STOPS = frozenset("\x00\x03")
+
+
+def _is_ascii_control(character: str) -> bool:
+    """Match non-printing single-byte characters from CLIPS ScanSymbol."""
+    codepoint = ord(character)
+    return codepoint < 0x20 or codepoint == 0x7F
+
+
+def _is_invalid_control(character: str) -> bool:
+    """Reject controls CLIPS returns as unknown tokens or premature EOF."""
+    return _is_ascii_control(character) and character not in _CLIPS_WHITESPACE
+
+
+class _SourceMap:
+    """Map requested character offsets to UTF-8 bytes and source locations."""
+
+    def __init__(self, source: str, boundaries: Iterable[int]) -> None:
+        remaining = set(boundaries)
+        self._positions: dict[int, tuple[int, int, int]] = {}
+        if not remaining:
+            return
+
+        byte_offset = 0
+        line = 1
+        column = 1
+        previous_was_carriage_return = False
+        for index, character in enumerate(source):
+            if index in remaining:
+                self._positions[index] = (byte_offset, line, column)
+                remaining.remove(index)
+                if not remaining:
+                    return
+            byte_offset += len(character.encode("utf-8"))
+            if character == "\r":
+                line += 1
+                column = 1
+                previous_was_carriage_return = True
+            elif character == "\n":
+                if not previous_was_carriage_return:
+                    line += 1
+                column = 1
+                previous_was_carriage_return = False
+            else:
+                column += 1
+                previous_was_carriage_return = False
+
+        source_length = len(source)
+        if source_length in remaining:
+            self._positions[source_length] = (byte_offset, line, column)
+            remaining.remove(source_length)
+        if remaining:
+            raise ValueError("source span boundary is outside the source")
+
+    def span(self, start: int, end: int) -> SourceSpan:
+        start_byte, start_line, start_column = self._positions[start]
+        end_byte, end_line, end_column = self._positions[end]
+        return SourceSpan(
+            start_byte=start_byte,
+            end_byte=end_byte,
+            start_line=start_line,
+            start_column=start_column,
+            end_line=end_line,
+            end_column=end_column,
+        )
+
+
+def scan_features(source: str) -> FeatureScan:
+    """Scan raw CLIPS source for recognized form heads and lexical issues.
+
+    Strings, comments, and symbol substrings cannot produce detections. All
+    completed and partial detections survive structural errors so callers can
+    report both the evidence found and why the source is not safely classifiable.
+    """
+    frames: list[_FormFrame] = []
+    detections: list[_DetectionDraft] = []
+    issues: list[_IssueDraft] = []
+    source_length = len(source)
+    scan_end = source_length
+    index = 0
+
+    while index < source_length:
+        character = source[index]
+
+        if character == ";":
+            while index < source_length and source[index] not in "\r\n":
+                index += 1
+            continue
+
+        if character == '"':
+            if frames and frames[-1].awaiting_head:
+                frames[-1].awaiting_head = False
+            string_start = index
+            index += 1
+            while index < source_length:
+                if source[index] == "\\":
+                    index += min(2, source_length - index)
+                    continue
+                if source[index] == '"':
+                    index += 1
+                    break
+                index += 1
+            else:
+                issues.append(
+                    _IssueDraft(
+                        kind="unterminated-string",
+                        start=string_start,
+                        end=source_length,
+                    )
+                )
+            continue
+
+        if _is_invalid_control(character):
+            issues.append(_IssueDraft(kind="invalid-control-character", start=index, end=index + 1))
+            if character in _CLIPS_HARD_STOPS:
+                scan_end = index
+                break
+            if frames and frames[-1].awaiting_head:
+                frames[-1].awaiting_head = False
+            index += 1
+            continue
+
+        if character == "(":
+            if frames and frames[-1].awaiting_head:
+                frames[-1].awaiting_head = False
+            frames.append(_FormFrame(start=index))
+            index += 1
+            continue
+
+        if character == ")":
+            if frames:
+                frame = frames.pop()
+                if frame.detection_index is not None:
+                    detections[frame.detection_index].form_end = index + 1
+            else:
+                issues.append(_IssueDraft(kind="unmatched-close", start=index, end=index + 1))
+            index += 1
+            continue
+
+        if not frames or not frames[-1].awaiting_head or character in _CLIPS_WHITESPACE:
+            index += 1
+            continue
+
+        head_start = index
+        if character in _CLIPS_STANDALONE_TOKENS:
+            frames[-1].awaiting_head = False
+            index += 1
+            continue
+        while (
+            index < source_length
+            and source[index] not in _CLIPS_WHITESPACE
+            and source[index] not in '();"'
+        ):
+            if index > head_start and (
+                source[index] in _CLIPS_SYMBOL_TERMINATORS or _is_ascii_control(source[index])
+            ):
+                break
+            index += 1
+        frame = frames[-1]
+        frame.awaiting_head = False
+        feature = source[head_start:index].casefold()
+        if spec := _FEATURE_SPECS.get(feature):
+            frame.detection_index = len(detections)
+            detections.append(
+                _DetectionDraft(
+                    feature=feature,
+                    spec=spec,
+                    head_start=head_start,
+                    head_end=index,
+                    form_start=frame.start,
+                )
+            )
+
+    for frame in frames:
+        issues.append(_IssueDraft(kind="unclosed-form", start=frame.start, end=scan_end))
+
+    boundaries = {
+        boundary
+        for detection in detections
+        for boundary in (
+            detection.head_start,
+            detection.head_end,
+            detection.form_start,
+            detection.form_end if detection.form_end is not None else scan_end,
+        )
+    }
+    boundaries.update(boundary for issue in issues for boundary in (issue.start, issue.end))
+    source_map = _SourceMap(source, boundaries)
+    finalized_detections = tuple(
+        FeatureDetection(
+            feature=detection.feature,
+            category=detection.spec.category,
+            reason=detection.spec.reason,
+            head_span=source_map.span(detection.head_start, detection.head_end),
+            form_span=source_map.span(
+                detection.form_start,
+                detection.form_end if detection.form_end is not None else scan_end,
+            ),
+        )
+        for detection in detections
+    )
+    finalized_issues = tuple(
+        LexicalIssue(
+            kind=issue.kind,
+            reason=issue.kind,
+            span=source_map.span(issue.start, issue.end),
+        )
+        for issue in sorted(issues, key=lambda issue: (issue.start, issue.end, issue.kind))
+    )
+    return FeatureScan(detections=finalized_detections, issues=finalized_issues)
 
 
 # ---------------------------------------------------------------------------
@@ -82,11 +456,19 @@ def strip_comments(text: str) -> str:
             result.append("")
             continue
         in_string = False
+        escaped = False
         clean: list[str] = []
         for ch in line:
-            if ch == '"':
-                in_string = not in_string
-            if ch == ";" and not in_string:
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif ch == "\\":
+                    escaped = True
+                elif ch == '"':
+                    in_string = False
+            elif ch == '"':
+                in_string = True
+            elif ch == ";":
                 break
             clean.append(ch)
         result.append("".join(clean))
@@ -99,53 +481,29 @@ def strip_comments(text: str) -> str:
 
 
 def detect_features(content: str) -> tuple[list[str], list[str]]:
-    """Detect CLIPS language features in (comment-stripped) content.
+    """Detect CLIPS language features in raw or comment-stripped content.
 
-    Returns (features, unsupported).
+    Returns ``(features, unsupported)`` with the historical ordering and
+    deduplication used by existing bat and compatibility-tool consumers.
     """
-    features: list[str] = []
-    unsupported: list[str] = []
+    result = scan_features(content)
+    detected_features = set(result.feature_names)
+    detected_unsupported = set(result.unsupported_feature_names)
 
-    for kw, pat in PAT_ALL_CONSTRUCTS.items():
-        if pat.search(content):
-            features.append(kw)
-
-    if PAT_PRINTOUT.search(content):
-        features.append("printout")
-
-    # COOL
-    for kw in COOL_CONSTRUCTS:
-        if kw in features:
-            unsupported.append(kw)
-
-    # Unsupported control flow
-    if PAT_UNSUPPORTED_CONTROL and PAT_UNSUPPORTED_CONTROL.search(content):
-        for kw in UNSUPPORTED_CONTROL:
-            pat = re.compile(r"\(\s*" + re.escape(kw) + r"(?:\s|[)\"])", re.IGNORECASE)
-            if pat.search(content):
-                unsupported.append(kw)
-
-    # File I/O
-    if PAT_UNSUPPORTED_IO.search(content):
-        for kw in UNSUPPORTED_IO:
-            pat = re.compile(r"\(\s*" + re.escape(kw) + r"(?:\s|[)\"])", re.IGNORECASE)
-            if pat.search(content):
-                unsupported.append(kw)
-
-    # Interactive I/O
-    if PAT_INTERACTIVE.search(content):
-        for kw in INTERACTIVE_IO:
-            pat = re.compile(r"\(\s*" + re.escape(kw) + r"(?:\s|[)\"])", re.IGNORECASE)
-            if pat.search(content):
-                unsupported.append(kw)
-
-    # Loading commands
-    if PAT_LOADING.search(content):
-        for kw in LOADING_COMMANDS:
-            pat = re.compile(r"\(\s*" + re.escape(kw) + r"(?:\s|[)\"])", re.IGNORECASE)
-            if pat.search(content):
-                unsupported.append(kw)
-
+    features = [
+        feature for feature in (*_ALL_CONSTRUCTS, "printout") if feature in detected_features
+    ]
+    unsupported = [
+        feature
+        for feature in (
+            *COOL_CONSTRUCTS,
+            *UNSUPPORTED_CONTROL,
+            *UNSUPPORTED_IO,
+            *INTERACTIVE_IO,
+            *LOADING_COMMANDS,
+        )
+        if feature in detected_unsupported
+    ]
     return features, unsupported
 
 

--- a/tools/ferric-tools/src/ferric_tools/compat/diff.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/diff.py
@@ -3,11 +3,20 @@
 from __future__ import annotations
 
 import csv
+import json
 from typing import Annotated
 
 import typer
 from rich.console import Console
 
+from ferric_tools._clips_parser import (
+    COOL_CONSTRUCTS,
+    INTERACTIVE_IO,
+    LOADING_COMMANDS,
+    SUPPORTED_CONSTRUCTS,
+    UNSUPPORTED_CONTROL,
+    UNSUPPORTED_IO,
+)
 from ferric_tools._manifest import load_manifest
 from ferric_tools.compat.diagnostics import result_diagnostic_view
 from ferric_tools.compat.report import compute_oracle_coverage, oracle_evidence_view
@@ -22,6 +31,39 @@ RANK = {"equivalent": 0, "divergent": 1, "pending": 2, "incompatible": 3}
 ORACLE_STATUS_RANK = {"invalid": 0, "missing": 1, "valid": 2}
 ORACLE_BOOLEAN_COVERAGE = ("selected", "declaration", "reached", "completed", "effect")
 STRUCTURED_ORACLE_MANIFEST_VERSION = 3
+SCANNER_DIFF_VERSION = 1
+FEATURE_SCAN_VERSION = 1
+SCANNER_FIELDS = (
+    "features",
+    "unsupported_features",
+    "classification",
+    "reason",
+    "runability",
+)
+FEATURE_SCAN_FIELDS = {"version", "status", "detections", "issues"}
+FEATURE_SCAN_DETECTION_FIELDS = {"feature", "category", "reason", "head_span", "form_span"}
+FEATURE_SCAN_ISSUE_FIELDS = {"kind", "reason", "span"}
+FEATURE_SCAN_SPAN_FIELDS = {
+    "start_byte",
+    "end_byte",
+    "start_line",
+    "start_column",
+    "end_line",
+    "end_column",
+}
+PROJECTED_FEATURES = frozenset((*SUPPORTED_CONSTRUCTS, *COOL_CONSTRUCTS, "printout"))
+PROJECTED_UNSUPPORTED_FEATURES = frozenset(
+    (*COOL_CONSTRUCTS, *UNSUPPORTED_CONTROL, *UNSUPPORTED_IO, *INTERACTIVE_IO, *LOADING_COMMANDS)
+)
+FEATURE_SCAN_SPECS = {
+    **{feature: ("supported-construct", "supported-form") for feature in SUPPORTED_CONSTRUCTS},
+    **{feature: ("cool-construct", "unsupported-form") for feature in COOL_CONSTRUCTS},
+    "printout": ("output", "supported-output"),
+    **{feature: ("unsupported-control", "unsupported-control") for feature in UNSUPPORTED_CONTROL},
+    **{feature: ("file-io", "unsupported-io") for feature in UNSUPPORTED_IO},
+    **{feature: ("interactive-io", "interactive") for feature in INTERACTIVE_IO},
+    **{feature: ("loading-command", "unsupported-command") for feature in LOADING_COMMANDS},
+}
 ABSENT_CLASSIFICATION = "absent"
 ABSENT_REASON = "not present"
 LEGACY_RUNNER_CLASSIFICATIONS = {
@@ -102,6 +144,503 @@ def fmt_delta(n: int) -> str:
     if n < 0:
         return str(n)
     return "0"
+
+
+def _scanner_string(value: object, *, label: str) -> str:
+    if type(value) is not str:
+        raise ValueError(f"{label} must be a string")
+    return value
+
+
+def _scanner_string_list(value: object, *, label: str) -> list[str]:
+    if type(value) is not list or any(type(item) is not str for item in value):
+        raise ValueError(f"{label} must be an array of strings")
+    return sorted(value)
+
+
+def _feature_scan_span(value: object, *, label: str) -> dict[str, int]:
+    if type(value) is not dict or set(value) != FEATURE_SCAN_SPAN_FIELDS:
+        raise ValueError(
+            f"{label} must contain exactly: {', '.join(sorted(FEATURE_SCAN_SPAN_FIELDS))}"
+        )
+
+    span: dict[str, int] = {}
+    for field in FEATURE_SCAN_SPAN_FIELDS:
+        coordinate = value[field]
+        minimum = 0 if field in {"start_byte", "end_byte"} else 1
+        if type(coordinate) is not int or coordinate < minimum:
+            qualifier = "non-negative" if minimum == 0 else "positive"
+            raise ValueError(f"{label}.{field} must be a {qualifier} integer")
+        span[field] = coordinate
+    if span["end_byte"] < span["start_byte"]:
+        raise ValueError(f"{label}.end_byte must not precede start_byte")
+    return span
+
+
+def _feature_scan_snapshot(value: object, *, label: str) -> dict:
+    if type(value) is not dict or set(value) != FEATURE_SCAN_FIELDS:
+        raise ValueError(f"{label} must contain exactly: {', '.join(sorted(FEATURE_SCAN_FIELDS))}")
+    if type(value["version"]) is not int or value["version"] != FEATURE_SCAN_VERSION:
+        raise ValueError(f"{label}.version must be {FEATURE_SCAN_VERSION}")
+    status = value["status"]
+    if type(status) is not str or status not in {"valid", "invalid"}:
+        raise ValueError(f"{label}.status must be 'valid' or 'invalid'")
+
+    raw_detections = value["detections"]
+    if type(raw_detections) is not list:
+        raise ValueError(f"{label}.detections must be an array")
+    detections: list[dict] = []
+    for index, raw_detection in enumerate(raw_detections):
+        detection_label = f"{label}.detections[{index}]"
+        if type(raw_detection) is not dict or set(raw_detection) != FEATURE_SCAN_DETECTION_FIELDS:
+            raise ValueError(
+                f"{detection_label} must contain exactly: "
+                f"{', '.join(sorted(FEATURE_SCAN_DETECTION_FIELDS))}"
+            )
+        detections.append(
+            {
+                "feature": _scanner_string(
+                    raw_detection["feature"], label=f"{detection_label}.feature"
+                ),
+                "category": _scanner_string(
+                    raw_detection["category"], label=f"{detection_label}.category"
+                ),
+                "reason": _scanner_string(
+                    raw_detection["reason"], label=f"{detection_label}.reason"
+                ),
+                "head_span": _feature_scan_span(
+                    raw_detection["head_span"], label=f"{detection_label}.head_span"
+                ),
+                "form_span": _feature_scan_span(
+                    raw_detection["form_span"], label=f"{detection_label}.form_span"
+                ),
+            }
+        )
+
+    raw_issues = value["issues"]
+    if type(raw_issues) is not list:
+        raise ValueError(f"{label}.issues must be an array")
+    issues: list[dict] = []
+    for index, raw_issue in enumerate(raw_issues):
+        issue_label = f"{label}.issues[{index}]"
+        if type(raw_issue) is not dict or set(raw_issue) != FEATURE_SCAN_ISSUE_FIELDS:
+            raise ValueError(
+                f"{issue_label} must contain exactly: "
+                f"{', '.join(sorted(FEATURE_SCAN_ISSUE_FIELDS))}"
+            )
+        issues.append(
+            {
+                "kind": _scanner_string(raw_issue["kind"], label=f"{issue_label}.kind"),
+                "reason": _scanner_string(raw_issue["reason"], label=f"{issue_label}.reason"),
+                "span": _feature_scan_span(raw_issue["span"], label=f"{issue_label}.span"),
+            }
+        )
+
+    if (status == "invalid") != bool(issues):
+        raise ValueError(f"{label}.status must be 'invalid' exactly when issues are present")
+
+    return {
+        "version": FEATURE_SCAN_VERSION,
+        "status": status,
+        "detections": detections,
+        "issues": issues,
+    }
+
+
+def _validate_scanner_snapshot(snapshot: dict, *, label: str) -> None:
+    scan = snapshot.get("feature_scan")
+    if scan is None:
+        return
+
+    detected_features = {detection["feature"] for detection in scan["detections"]}
+    unknown_detections = sorted(detected_features - FEATURE_SCAN_SPECS.keys())
+    if unknown_detections:
+        raise ValueError(
+            f"{label}.feature_scan contains unknown detections: {', '.join(unknown_detections)}"
+        )
+    for index, detection in enumerate(scan["detections"]):
+        expected_category, expected_reason = FEATURE_SCAN_SPECS[detection["feature"]]
+        if (detection["category"], detection["reason"]) != (
+            expected_category,
+            expected_reason,
+        ):
+            raise ValueError(
+                f"{label}.feature_scan.detections[{index}] category/reason must be "
+                f"{expected_category!r}/{expected_reason!r} for {detection['feature']!r}"
+            )
+
+    projected_features = sorted(detected_features & PROJECTED_FEATURES)
+    if snapshot["features"] != projected_features:
+        raise ValueError(
+            f"{label}.features must exactly project feature_scan detections: "
+            f"expected {projected_features!r}, got {snapshot['features']!r}"
+        )
+    projected_unsupported = sorted(detected_features & PROJECTED_UNSUPPORTED_FEATURES)
+    if snapshot["unsupported_features"] != projected_unsupported:
+        raise ValueError(
+            f"{label}.unsupported_features must exactly project feature_scan detections: "
+            f"expected {projected_unsupported!r}, got {snapshot['unsupported_features']!r}"
+        )
+
+    malformed_disposition = (
+        snapshot["classification"] == "incompatible"
+        and snapshot["reason"] == "malformed-source"
+        and snapshot["runability"] == "unknown"
+    )
+    if scan["status"] == "invalid" and not malformed_disposition:
+        raise ValueError(
+            f"{label}: invalid feature_scan requires "
+            "incompatible/malformed-source/unknown disposition"
+        )
+    if scan["status"] == "valid" and (
+        snapshot["reason"] == "malformed-source" or snapshot["runability"] == "unknown"
+    ):
+        raise ValueError(f"{label}: valid feature_scan cannot claim a malformed disposition")
+
+
+def _scanner_snapshot(value: object, *, label: str) -> dict:
+    if type(value) is not dict:
+        raise ValueError(f"{label} must be an object")
+    snapshot = {
+        "features": _scanner_string_list(value.get("features"), label=f"{label}.features"),
+        "unsupported_features": _scanner_string_list(
+            value.get("unsupported_features"), label=f"{label}.unsupported_features"
+        ),
+        "classification": _scanner_string(
+            value.get("classification"), label=f"{label}.classification"
+        ),
+        "reason": _scanner_string(value.get("reason"), label=f"{label}.reason"),
+        "runability": _scanner_string(value.get("runability"), label=f"{label}.runability"),
+    }
+    if "feature_scan" in value:
+        snapshot["feature_scan"] = _feature_scan_snapshot(
+            value["feature_scan"], label=f"{label}.feature_scan"
+        )
+    _validate_scanner_snapshot(snapshot, label=label)
+    return snapshot
+
+
+def _scanner_manifest_files(
+    manifest: object,
+    *,
+    label: str,
+    require_structured_evidence: bool = False,
+) -> dict[str, dict]:
+    if type(manifest) is not dict:
+        raise ValueError(f"{label} manifest must be an object")
+    raw_files = manifest.get("files")
+    if type(raw_files) is not dict:
+        raise ValueError(f"{label} manifest files must be an object")
+
+    files: dict[str, dict] = {}
+    for path, value in raw_files.items():
+        if type(path) is not str or not path:
+            raise ValueError(f"{label} manifest file paths must be non-empty strings")
+        entry_label = f"{label} manifest files[{path!r}]"
+        snapshot = _scanner_snapshot(value, label=entry_label)
+        read_error = (
+            snapshot["classification"] == "incompatible"
+            and snapshot["reason"] == "read-error"
+            and snapshot["runability"] == "unknown"
+        )
+        if read_error and (snapshot["features"] or snapshot["unsupported_features"]):
+            raise ValueError(f"{entry_label}: read-error entries cannot claim detected features")
+        if require_structured_evidence and "feature_scan" not in snapshot and not read_error:
+            raise ValueError(f"{entry_label}.feature_scan is required")
+        files[path] = snapshot
+    return files
+
+
+def _structured_evidence_change(base: dict | None, head: dict | None) -> str:
+    base_scan = base.get("feature_scan") if base is not None else None
+    head_scan = head.get("feature_scan") if head is not None else None
+    if base is None:
+        return "added" if head_scan is not None else "absent"
+    if head is None:
+        return "removed" if base_scan is not None else "absent"
+    if base_scan is None and head_scan is None:
+        return "absent"
+    if base_scan is None and head_scan is not None:
+        return "legacy-base"
+    if base_scan is not None and head_scan is None:
+        return "removed"
+    if base_scan != head_scan:
+        return "changed"
+    return "unchanged"
+
+
+def _head_scan_requires_retention(head: dict | None) -> bool:
+    if head is None or "feature_scan" not in head:
+        return False
+    scan = head["feature_scan"]
+    return scan["status"] != "valid" or bool(scan["issues"])
+
+
+def compute_scanner_diff(base: dict, head: dict) -> dict:
+    """Compare pre-run scanner-owned manifest evidence.
+
+    A base entry without the v1 ``feature_scan`` object is legacy evidence.
+    Adding that structured evidence on the head is deliberately neutral by
+    itself, while invalid head evidence is retained for review.
+    """
+    base_files = _scanner_manifest_files(base, label="base")
+    head_files = _scanner_manifest_files(head, label="head", require_structured_evidence=True)
+    common_paths = sorted(set(base_files) & set(head_files))
+    changes: list[dict] = []
+    changed_files = 0
+    added_files = 0
+    removed_files = 0
+    legacy_base_structured_evidence = 0
+    head_structured_evidence = sum("feature_scan" in snapshot for snapshot in head_files.values())
+    head_invalid_structured_evidence = sum(
+        snapshot.get("feature_scan", {}).get("status") == "invalid"
+        for snapshot in head_files.values()
+    )
+    head_scan_issues = sum(
+        len(snapshot.get("feature_scan", {}).get("issues", [])) for snapshot in head_files.values()
+    )
+
+    for path in sorted(set(base_files) | set(head_files)):
+        base_snapshot = base_files.get(path)
+        head_snapshot = head_files.get(path)
+        structured_change = _structured_evidence_change(base_snapshot, head_snapshot)
+
+        if base_snapshot is None:
+            added_files += 1
+            changes.append(
+                {
+                    "path": path,
+                    "change": "added",
+                    "changed_fields": list(SCANNER_FIELDS),
+                    "structured_evidence_change": structured_change,
+                    "base": None,
+                    "head": head_snapshot,
+                }
+            )
+            continue
+        if head_snapshot is None:
+            removed_files += 1
+            changes.append(
+                {
+                    "path": path,
+                    "change": "removed",
+                    "changed_fields": list(SCANNER_FIELDS),
+                    "structured_evidence_change": structured_change,
+                    "base": base_snapshot,
+                    "head": None,
+                }
+            )
+            continue
+
+        changed_fields = [
+            field for field in SCANNER_FIELDS if base_snapshot[field] != head_snapshot[field]
+        ]
+        if structured_change == "legacy-base":
+            legacy_base_structured_evidence += 1
+        elif structured_change in {"changed", "removed"}:
+            changed_fields.append("feature_scan")
+
+        retain_head_evidence = _head_scan_requires_retention(head_snapshot)
+        if changed_fields:
+            changed_files += 1
+            change = "changed"
+        elif retain_head_evidence:
+            change = "structured-evidence"
+        else:
+            continue
+        changes.append(
+            {
+                "path": path,
+                "change": change,
+                "changed_fields": changed_fields,
+                "structured_evidence_change": structured_change,
+                "base": base_snapshot,
+                "head": head_snapshot,
+            }
+        )
+
+    return {
+        "version": SCANNER_DIFF_VERSION,
+        "base_manifest_version": base.get("version"),
+        "head_manifest_version": head.get("version"),
+        "summary": {
+            "files_compared": len(common_paths),
+            "changed_files": changed_files,
+            "added_files": added_files,
+            "removed_files": removed_files,
+            "legacy_base_structured_evidence": legacy_base_structured_evidence,
+            "head_structured_evidence": head_structured_evidence,
+            "head_invalid_structured_evidence": head_invalid_structured_evidence,
+            "head_scan_issues": head_scan_issues,
+        },
+        "changes": changes,
+    }
+
+
+def _scanner_disposition(snapshot: dict | None) -> str:
+    if snapshot is None:
+        return "absent"
+    return " / ".join(str(snapshot[field]) for field in ("classification", "reason", "runability"))
+
+
+def _scanner_evidence_label(snapshot: dict | None) -> str:
+    if snapshot is None:
+        return "absent"
+    scan = snapshot.get("feature_scan")
+    if scan is None:
+        return "legacy"
+    issue_count = len(scan["issues"])
+    return f"{scan['status']} ({issue_count} issue{'s' if issue_count != 1 else ''})"
+
+
+def _markdown_cell(value: str) -> str:
+    return value.replace("|", "\\|").replace("\n", " ")
+
+
+def format_scanner_markdown(
+    scanner_diff: dict,
+    *,
+    repo: str | None = None,
+    base_sha: str | None = None,
+    head_sha: str | None = None,
+) -> list[str]:
+    """Build a concise retained scanner-evidence report."""
+    summary = scanner_diff["summary"]
+    lines = [
+        "## Static Compatibility Scanner Diff",
+        "",
+        "Compares scanner-owned fields from manifests captured before either compatibility run.",
+        "Observed changes are retained for review and do not fail the comparison job.",
+        "",
+    ]
+    if repo and base_sha and head_sha:
+        base_link = f"[`{base_sha[:10]}`](https://github.com/{repo}/commit/{base_sha})"
+        head_link = f"[`{head_sha[:10]}`](https://github.com/{repo}/commit/{head_sha})"
+        lines.extend([f"Base: {base_link} | Head: {head_link}", ""])
+
+    lines.extend(
+        [
+            "| Measure | Count |",
+            "|---|---:|",
+            f"| Files compared | {summary['files_compared']} |",
+            f"| Changed files | {summary['changed_files']} |",
+            f"| Added files | {summary['added_files']} |",
+            f"| Removed files | {summary['removed_files']} |",
+            f"| Head files with structured evidence | {summary['head_structured_evidence']} |",
+            f"| Head files with invalid scans | {summary['head_invalid_structured_evidence']} |",
+            f"| Head lexical issues | {summary['head_scan_issues']} |",
+        ]
+    )
+    legacy_count = summary["legacy_base_structured_evidence"]
+    if legacy_count:
+        lines.extend(
+            [
+                "",
+                f"The base lacks structured `feature_scan` evidence for {legacy_count} matched "
+                "file(s). This is treated as a legacy schema boundary, not as scanner changes.",
+            ]
+        )
+
+    changes = scanner_diff["changes"]
+    lines.extend(["", f"### Retained scanner observations ({len(changes)})", ""])
+    if not changes:
+        lines.append("None")
+        return lines
+
+    lines.extend(
+        [
+            f"<details><summary>Show {len(changes)} per-file observation(s)</summary>",
+            "",
+            "| File | Kind | Fields | Base disposition | Head disposition | Head evidence |",
+            "|---|---|---|---|---|---|",
+        ]
+    )
+    for change in changes:
+        fields = ", ".join(change["changed_fields"]) or "structured evidence"
+        lines.append(
+            "| "
+            f"`{_markdown_cell(change['path'])}` | "
+            f"{change['change']} | "
+            f"{_markdown_cell(fields)} | "
+            f"{_markdown_cell(_scanner_disposition(change['base']))} | "
+            f"{_markdown_cell(_scanner_disposition(change['head']))} | "
+            f"{_markdown_cell(_scanner_evidence_label(change['head']))} |"
+        )
+    lines.extend(
+        [
+            "",
+            "</details>",
+            "",
+            "The JSON artifact retains feature lists, unsupported-feature lists, structured "
+            "detections, issues, reasons, and exact spans for every observation above.",
+        ]
+    )
+    return lines
+
+
+def write_scanner_tsv(scanner_diff: dict, tsv_path: str) -> None:
+    """Write retained scanner observations as TSV."""
+    fieldnames = [
+        "path",
+        "change",
+        "changed_fields",
+        "structured_evidence_change",
+        "base_features",
+        "head_features",
+        "base_unsupported_features",
+        "head_unsupported_features",
+        "base_classification",
+        "head_classification",
+        "base_reason",
+        "head_reason",
+        "base_runability",
+        "head_runability",
+        "base_feature_scan_status",
+        "head_feature_scan_status",
+        "base_feature_scan_issues",
+        "head_feature_scan_issues",
+    ]
+
+    def side_fields(prefix: str, snapshot: dict | None) -> dict[str, str]:
+        if snapshot is None:
+            return {f"{prefix}_{field}": "" for field in SCANNER_FIELDS} | {
+                f"{prefix}_feature_scan_status": "",
+                f"{prefix}_feature_scan_issues": "",
+            }
+        scan = snapshot.get("feature_scan")
+        return {
+            f"{prefix}_features": ";".join(snapshot["features"]),
+            f"{prefix}_unsupported_features": ";".join(snapshot["unsupported_features"]),
+            f"{prefix}_classification": snapshot["classification"],
+            f"{prefix}_reason": snapshot["reason"],
+            f"{prefix}_runability": snapshot["runability"],
+            f"{prefix}_feature_scan_status": scan["status"] if scan else "",
+            f"{prefix}_feature_scan_issues": (
+                json.dumps(scan["issues"], sort_keys=True, separators=(",", ":")) if scan else ""
+            ),
+        }
+
+    with open(tsv_path, "w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        for change in scanner_diff["changes"]:
+            writer.writerow(
+                {
+                    "path": change["path"],
+                    "change": change["change"],
+                    "changed_fields": ";".join(change["changed_fields"]),
+                    "structured_evidence_change": change["structured_evidence_change"],
+                    **side_fields("base", change["base"]),
+                    **side_fields("head", change["head"]),
+                }
+            )
+
+
+def write_scanner_json(scanner_diff: dict, json_path: str) -> None:
+    """Write the complete retained scanner diff as deterministic JSON."""
+    with open(json_path, "w", encoding="utf-8") as stream:
+        json.dump(scanner_diff, stream, indent=2, ensure_ascii=False, sort_keys=True)
+        stream.write("\n")
 
 
 def _oracle_loss_details(
@@ -679,6 +1218,14 @@ def main(
     head_manifest: Annotated[str, typer.Argument(help="Head manifest JSON")],
     tsv: Annotated[str | None, typer.Option(help="Write per-file data as TSV")] = None,
     report: Annotated[str | None, typer.Option(help="Write self-contained Markdown report")] = None,
+    scanner_only: Annotated[
+        bool,
+        typer.Option(help="Compare retained pre-run scanner evidence instead of run results"),
+    ] = False,
+    json_output: Annotated[
+        str | None,
+        typer.Option("--json", help="Write the retained scanner diff as JSON"),
+    ] = None,
     repo: Annotated[str | None, typer.Option(help="GitHub repository for commit links")] = None,
     base_sha: Annotated[str | None, typer.Option(help="Base commit SHA")] = None,
     head_sha: Annotated[str | None, typer.Option(help="Head commit SHA")] = None,
@@ -686,6 +1233,33 @@ def main(
     """Compare two compat manifests."""
     base = load_manifest(base_manifest)
     head = load_manifest(head_manifest)
+
+    if scanner_only:
+        try:
+            scanner_diff = compute_scanner_diff(base, head)
+        except ValueError as error:
+            console.print(f"[red]error:[/] cannot generate scanner diff: {error}")
+            raise typer.Exit(2) from error
+        scanner_lines = format_scanner_markdown(
+            scanner_diff,
+            repo=repo,
+            base_sha=base_sha,
+            head_sha=head_sha,
+        )
+        print("\n".join(scanner_lines))
+        if report:
+            with open(report, "w", encoding="utf-8") as f:
+                f.write("\n".join(scanner_lines))
+                f.write("\n")
+        if tsv:
+            write_scanner_tsv(scanner_diff, tsv)
+        if json_output:
+            write_scanner_json(scanner_diff, json_output)
+        return
+
+    if json_output:
+        console.print("[red]error:[/] --json requires --scanner-only")
+        raise typer.Exit(2)
 
     base_counts, head_counts, regressions, real_improvements, reason_changes = compute_diff(
         base, head

--- a/tools/ferric-tools/src/ferric_tools/compat/run.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/run.py
@@ -1829,6 +1829,12 @@ def main(
             if rel_path != file:
                 continue
             file_was_found = True
+            if runability == "unknown":
+                console.print(
+                    f"[red]error:[/] {rel_path}: cannot explicitly run a file "
+                    "with unknown runability"
+                )
+                raise typer.Exit(1)
         elif only_pending:
             if info["classification"] != "pending":
                 continue

--- a/tools/ferric-tools/src/ferric_tools/compat/scan.py
+++ b/tools/ferric-tools/src/ferric_tools/compat/scan.py
@@ -20,8 +20,7 @@ from ferric_tools._clips_parser import (
     LOADING_COMMANDS,
     UNSUPPORTED_CONTROL,
     UNSUPPORTED_IO,
-    detect_features,
-    strip_comments,
+    scan_features,
 )
 from ferric_tools._harness import attach_harness_contracts, sha256_bytes
 from ferric_tools._manifest import save_manifest, utc_now_iso
@@ -321,6 +320,21 @@ def classify_file(path: Path, features: list[str], unsupported: list[str]) -> tu
     return "pending", "testable", "standalone"
 
 
+def _read_error_entry(source: str, error: OSError | UnicodeDecodeError) -> dict:
+    """Return the fail-closed manifest entry for unreadable UTF-8 source."""
+    return {
+        "source": source,
+        "classification": "incompatible",
+        "reason": "read-error",
+        "runability": "unknown",
+        "features": [],
+        "unsupported_features": [],
+        "ferric": None,
+        "clips": None,
+        "notes": str(error),
+    }
+
+
 def scan_examples(
     examples_path: Path,
     *,
@@ -337,24 +351,27 @@ def scan_examples(
         source = rel.parts[0] if len(rel.parts) > 1 else ""
 
         try:
-            raw_content = filepath.read_text(encoding="utf-8", errors="replace")
-        except OSError as e:
-            files[rel_str] = {
-                "source": source,
-                "classification": "incompatible",
-                "reason": "read-error",
-                "runability": "unknown",
-                "features": [],
-                "unsupported_features": [],
-                "ferric": None,
-                "clips": None,
-                "notes": str(e),
-            }
+            raw_bytes = filepath.read_bytes()
+        except OSError as error:
+            files[rel_str] = _read_error_entry(source, error)
+            continue
+        try:
+            raw_content = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError as error:
+            files[rel_str] = _read_error_entry(source, error)
             continue
 
-        cleaned = strip_comments(raw_content)
-        features, unsupported = detect_features(cleaned)
-        classification, reason, runability = classify_file(filepath, features, unsupported)
+        feature_scan = scan_features(raw_content)
+        features = list(feature_scan.feature_names)
+        unsupported = list(feature_scan.unsupported_feature_names)
+        if feature_scan.issues:
+            classification, reason, runability = (
+                "incompatible",
+                "malformed-source",
+                "unknown",
+            )
+        else:
+            classification, reason, runability = classify_file(filepath, features, unsupported)
 
         files[rel_str] = {
             "source": source,
@@ -363,6 +380,7 @@ def scan_examples(
             "runability": runability,
             "features": sorted(set(features)),
             "unsupported_features": sorted(set(unsupported)),
+            "feature_scan": feature_scan.to_dict(),
             "ferric": None,
             "clips": None,
             "notes": "",

--- a/tools/ferric-tools/tests/test_clips_parser.py
+++ b/tools/ferric-tools/tests/test_clips_parser.py
@@ -1,18 +1,26 @@
 """Tests for ferric_tools._clips_parser.
 
 Covers strip_comments(), extract_top_level_forms(), first_keyword(),
-detect_features(), and classify_keyword().
+scan_features(), detect_features(), and classify_keyword().
 """
 
 from __future__ import annotations
+
+import pytest
 
 from ferric_tools._clips_parser import (
     classify_keyword,
     detect_features,
     extract_top_level_forms,
     first_keyword,
+    scan_features,
     strip_comments,
 )
+
+
+def _span_text(source: str, span) -> str:
+    return source.encode("utf-8")[span.start_byte : span.end_byte].decode("utf-8")
+
 
 # ---------------------------------------------------------------------------
 # strip_comments
@@ -39,6 +47,12 @@ def test_strip_comments_does_not_strip_semicolon_inside_string():
     # not a comment delimiter.
     result = strip_comments('(assert (msg "hello; world"))')
     assert "hello; world" in result
+
+
+def test_strip_comments_does_not_strip_after_escaped_quote_inside_string():
+    source = '(printout t "escaped quote: \\"; still string" crlf) ; trailing comment'
+    result = strip_comments(source)
+    assert result == '(printout t "escaped quote: \\"; still string" crlf) '
 
 
 def test_strip_comments_multiline_preserves_line_count():
@@ -135,6 +149,397 @@ def test_first_keyword_mixed_case():
 
 
 # ---------------------------------------------------------------------------
+# scan_features
+# ---------------------------------------------------------------------------
+
+
+def test_scan_features_detects_real_form_heads_at_every_depth_case_insensitively():
+    source = """(DeFrUlE sample
+  (fact value)
+  =>
+  (PrInToUt t "hello" crlf)
+  (OpEn "out.txt" output "w"))
+(READ)
+(LoAd* "more.clp")"""
+
+    result = scan_features(source)
+
+    assert [detection.feature for detection in result.detections] == [
+        "defrule",
+        "printout",
+        "open",
+        "read",
+        "load*",
+    ]
+    assert [detection.category for detection in result.detections] == [
+        "supported-construct",
+        "output",
+        "file-io",
+        "interactive-io",
+        "loading-command",
+    ]
+    assert [detection.reason for detection in result.detections] == [
+        "supported-form",
+        "supported-output",
+        "unsupported-io",
+        "interactive",
+        "unsupported-command",
+    ]
+    assert result.feature_names == ("defrule", "printout")
+    assert result.unsupported_feature_names == ("open", "read", "load*")
+    assert result.issues == ()
+
+
+def test_scan_features_ignores_strings_comments_and_symbol_substrings():
+    source = r"""(defrule lexical
+  (message "plain (open x); escaped quote: \"(read)\"")
+  ; (batch "ignored.clp") and (close ignored)
+  (open-file yes)
+  (reader no)
+  (preload no)
+  (defrule-suffix no)
+  =>
+  (OpEn "real;name" logical "r"))"""
+
+    result = scan_features(source)
+
+    assert [detection.feature for detection in result.detections] == ["defrule", "open"]
+    assert result.feature_names == ("defrule",)
+    assert result.unsupported_feature_names == ("open",)
+    assert result.issues == ()
+
+
+def test_scan_features_allows_comments_before_a_form_head():
+    source = "(\n  ; the head follows on the next line\n  ClOsE logical)"
+
+    result = scan_features(source)
+
+    assert [detection.feature for detection in result.detections] == ["close"]
+    assert result.detections[0].head_span.start_line == 3
+    assert result.detections[0].head_span.start_column == 3
+
+
+def test_scan_features_uses_pinned_clips_symbol_terminators_after_form_heads():
+    source = (
+        '(OpEn&foo) (CLOSE|bar) (read~value) (LOAD<path) (batch"file") '
+        "(load*(nested)) (readline; comment\n)"
+    )
+
+    result = scan_features(source)
+
+    assert [detection.feature for detection in result.detections] == [
+        "open",
+        "close",
+        "read",
+        "load",
+        "batch",
+        "load*",
+        "readline",
+    ]
+    assert [_span_text(source, detection.head_span) for detection in result.detections] == [
+        "OpEn",
+        "CLOSE",
+        "read",
+        "LOAD",
+        "batch",
+        "load*",
+        "readline",
+    ]
+    assert result.issues == ()
+
+
+def test_scan_features_reports_nonprinting_ascii_terminators_and_retains_heads():
+    source = "(OpEn\x01argument) (read\x0bvalue) (close\x7fvalue)"
+
+    result = scan_features(source)
+
+    assert [detection.feature for detection in result.detections] == ["open", "read", "close"]
+    assert [_span_text(source, detection.head_span) for detection in result.detections] == [
+        "OpEn",
+        "read",
+        "close",
+    ]
+    assert [issue.kind for issue in result.issues] == [
+        "invalid-control-character",
+        "invalid-control-character",
+        "invalid-control-character",
+    ]
+    assert [_span_text(source, issue.span) for issue in result.issues] == [
+        "\x01",
+        "\x0b",
+        "\x7f",
+    ]
+    assert result.to_dict()["status"] == "invalid"
+
+
+@pytest.mark.parametrize("hard_stop", ["\x00", "\x03"])
+def test_scan_features_leading_nul_or_etx_stops_before_later_input(hard_stop):
+    source = f"{hard_stop}(OpEn)\x1f(ReAd))"
+
+    result = scan_features(source)
+
+    assert result.detections == ()
+    assert [issue.kind for issue in result.issues] == ["invalid-control-character"]
+    assert [_span_text(source, issue.span) for issue in result.issues] == [hard_stop]
+    assert result.issues[0].span.to_dict() == {
+        "start_byte": 0,
+        "end_byte": 1,
+        "start_line": 1,
+        "start_column": 1,
+        "end_line": 1,
+        "end_column": 2,
+    }
+
+
+@pytest.mark.parametrize("hard_stop", ["\x00", "\x03"])
+def test_scan_features_internal_nul_or_etx_retains_prefix_and_ends_open_forms_at_stop(
+    hard_stop,
+):
+    source = f"☃\r\n(DeFrUlE r => (OpEn{hard_stop}) (ReAd))\x1f(CLOSE)"
+    stop = source.index(hard_stop)
+    stop_byte = len(source[:stop].encode("utf-8"))
+    outer_form_start = source.index("(")
+
+    result = scan_features(source)
+
+    assert [detection.feature for detection in result.detections] == ["defrule", "open"]
+    assert [_span_text(source, detection.form_span) for detection in result.detections] == [
+        source[outer_form_start:stop],
+        "(OpEn",
+    ]
+    assert [issue.kind for issue in result.issues] == [
+        "unclosed-form",
+        "unclosed-form",
+        "invalid-control-character",
+    ]
+    assert [_span_text(source, issue.span) for issue in result.issues] == [
+        source[outer_form_start:stop],
+        "(OpEn",
+        hard_stop,
+    ]
+    assert all(detection.form_span.end_byte == stop_byte for detection in result.detections)
+    assert result.issues[-1].span.start_byte == stop_byte
+    assert result.issues[-1].span.end_byte == stop_byte + 1
+    assert result.issues[-1].span.start_line == 2
+
+
+def test_scan_features_invalid_control_as_first_form_token_prevents_false_head():
+    source = "(\x01open) (ReAd)"
+
+    result = scan_features(source)
+
+    assert [detection.feature for detection in result.detections] == ["read"]
+    assert [issue.kind for issue in result.issues] == ["invalid-control-character"]
+
+
+def test_scan_features_ignores_control_characters_inside_strings_and_comments():
+    source = '(defrule r => (printout t "\x00\x01\x03\x7f" crlf)) ; \x00\x03\x1f\n(ReAd)'
+
+    result = scan_features(source)
+
+    assert [detection.feature for detection in result.detections] == [
+        "defrule",
+        "printout",
+        "read",
+    ]
+    assert result.issues == ()
+
+
+def test_scan_features_does_not_treat_standalone_or_nonterminating_symbols_as_heads():
+    source = (
+        "(&open) (|read) (~load) (<close) (open>suffix) (read?field) "
+        "(open\u200bsuffix) (close\u00a0suffix) (load\u0085suffix)"
+    )
+
+    result = scan_features(source)
+
+    assert result.detections == ()
+    assert result.issues == ()
+
+
+def test_scan_features_returns_every_repeated_detection_in_source_order():
+    result = scan_features("(OPEN a b c) (open d e f) (CLOSE a)")
+
+    assert [detection.feature for detection in result.detections] == [
+        "open",
+        "open",
+        "close",
+    ]
+    assert result.unsupported_feature_names == ("open", "close")
+
+
+def test_scan_features_spans_use_utf8_bytes_and_one_based_character_locations():
+    source = '☃ (OpEn "é" data "r")'
+
+    result = scan_features(source)
+    detection = result.detections[0]
+
+    assert detection.feature == "open"
+    assert detection.head_span.to_dict() == {
+        "start_byte": 5,
+        "end_byte": 9,
+        "start_line": 1,
+        "start_column": 4,
+        "end_line": 1,
+        "end_column": 8,
+    }
+    assert detection.form_span.start_byte == 4
+    assert detection.form_span.end_byte == len(source.encode("utf-8"))
+    assert detection.form_span.start_line == 1
+    assert detection.form_span.start_column == 3
+    assert detection.form_span.end_line == 1
+    assert detection.form_span.end_column == len(source) + 1
+    assert _span_text(source, detection.head_span) == "OpEn"
+    assert _span_text(source, detection.form_span) == '(OpEn "é" data "r")'
+
+
+def test_scan_features_large_source_without_evidence_remains_empty():
+    source = "x" * 300_000 + '\r\n"(open ignored)" ; (read ignored)'
+
+    result = scan_features(source)
+
+    assert result.detections == ()
+    assert result.issues == ()
+    assert result.to_dict() == {
+        "version": 1,
+        "status": "valid",
+        "detections": [],
+        "issues": [],
+    }
+
+
+def test_scan_features_large_source_maps_few_boundaries_exactly():
+    prefix = "x" * 250_000 + "\r\né "
+    form = '(OpEn "é" data "r")'
+    source = prefix + form + "\n" + "y" * 250_000
+
+    result = scan_features(source)
+    detection = result.detections[0]
+
+    assert len(result.detections) == 1
+    assert result.issues == ()
+    assert detection.head_span.start_byte == len((prefix + "(").encode("utf-8"))
+    assert detection.head_span.end_byte == detection.head_span.start_byte + len("OpEn")
+    assert detection.head_span.start_line == 2
+    assert detection.head_span.start_column == 4
+    assert detection.head_span.end_line == 2
+    assert detection.head_span.end_column == 8
+    assert detection.form_span.start_byte == len(prefix.encode("utf-8"))
+    assert detection.form_span.end_byte == len((prefix + form).encode("utf-8"))
+    assert detection.form_span.start_line == 2
+    assert detection.form_span.start_column == 3
+    assert _span_text(source, detection.form_span) == form
+
+
+def test_scan_features_spans_cover_the_nested_form_not_its_parent():
+    source = '(defrule r => (open "x" data "r"))'
+
+    result = scan_features(source)
+
+    defrule, open_command = result.detections
+    assert _span_text(source, defrule.form_span) == source
+    assert _span_text(source, open_command.form_span) == '(open "x" data "r")'
+    assert _span_text(source, open_command.head_span) == "open"
+
+
+def test_scan_features_reports_unterminated_string_and_retains_prior_detection():
+    source = '(OpEn "unterminated ; (read)'
+
+    result = scan_features(source)
+
+    assert [detection.feature for detection in result.detections] == ["open"]
+    assert [issue.kind for issue in result.issues] == [
+        "unclosed-form",
+        "unterminated-string",
+    ]
+    assert _span_text(source, result.detections[0].form_span) == source
+    assert _span_text(source, result.issues[0].span) == source
+    assert _span_text(source, result.issues[1].span) == '"unterminated ; (read)'
+    assert result.to_dict()["status"] == "invalid"
+
+
+def test_scan_features_reports_each_unclosed_form_with_partial_detections():
+    source = "(defrule r => (OpEn"
+
+    result = scan_features(source)
+
+    assert [detection.feature for detection in result.detections] == ["defrule", "open"]
+    assert [issue.kind for issue in result.issues] == ["unclosed-form", "unclosed-form"]
+    assert [_span_text(source, issue.span) for issue in result.issues] == [
+        source,
+        "(OpEn",
+    ]
+    assert [_span_text(source, detection.form_span) for detection in result.detections] == [
+        source,
+        "(OpEn",
+    ]
+
+
+def test_scan_features_reports_unmatched_close_and_keeps_later_detections():
+    source = '(defrule r => (open "x" data "r")))\n(ReAd)'
+
+    result = scan_features(source)
+
+    assert [detection.feature for detection in result.detections] == [
+        "defrule",
+        "open",
+        "read",
+    ]
+    assert [issue.kind for issue in result.issues] == ["unmatched-close"]
+    assert _span_text(source, result.issues[0].span) == ")"
+    assert result.issues[0].span.start_line == 1
+    assert result.detections[-1].head_span.start_line == 2
+
+
+def test_scan_features_serializer_has_a_stable_complete_schema():
+    source = '(OpEn "x" data "r"))'
+
+    result = scan_features(source)
+
+    assert result.to_dict() == {
+        "version": 1,
+        "status": "invalid",
+        "detections": [
+            {
+                "feature": "open",
+                "category": "file-io",
+                "reason": "unsupported-io",
+                "head_span": {
+                    "start_byte": 1,
+                    "end_byte": 5,
+                    "start_line": 1,
+                    "start_column": 2,
+                    "end_line": 1,
+                    "end_column": 6,
+                },
+                "form_span": {
+                    "start_byte": 0,
+                    "end_byte": 19,
+                    "start_line": 1,
+                    "start_column": 1,
+                    "end_line": 1,
+                    "end_column": 20,
+                },
+            }
+        ],
+        "issues": [
+            {
+                "kind": "unmatched-close",
+                "reason": "unmatched-close",
+                "span": {
+                    "start_byte": 19,
+                    "end_byte": 20,
+                    "start_line": 1,
+                    "start_column": 20,
+                    "end_line": 1,
+                    "end_column": 21,
+                },
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
 # detect_features
 # ---------------------------------------------------------------------------
 
@@ -179,6 +584,28 @@ def test_detect_features_returns_two_lists():
     features, unsupported = detect_features("(defrule r => nil)")
     assert isinstance(features, list)
     assert isinstance(unsupported, list)
+
+
+def test_detect_features_uses_lexical_scanner_for_raw_source():
+    content = r"""(defrule r
+  (message "(open file logical r); \"(read)\"")
+  ; (load "ignored.clp")
+  (open-file value)
+  => nil)"""
+
+    features, unsupported = detect_features(content)
+
+    assert features == ["defrule"]
+    assert unsupported == []
+
+
+def test_detect_features_preserves_historical_keyword_order_and_deduplication():
+    content = "(printout t x) (DEFCLASS X) (defrule r) (open x y z) (deftemplate t)"
+
+    features, unsupported = detect_features(content)
+
+    assert features == ["defrule", "deftemplate", "defclass", "printout"]
+    assert unsupported == ["defclass", "open"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/ferric-tools/tests/test_compat_diff.py
+++ b/tools/ferric-tools/tests/test_compat_diff.py
@@ -6,9 +6,22 @@ Covers compute_diff() and format_markdown().
 from __future__ import annotations
 
 import csv
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
 
 from ferric_tools.compat.diagnostics import diagnostic
-from ferric_tools.compat.diff import compute_diff, format_markdown, write_tsv
+from ferric_tools.compat.diff import (
+    app,
+    compute_diff,
+    compute_scanner_diff,
+    format_markdown,
+    format_scanner_markdown,
+    write_scanner_json,
+    write_scanner_tsv,
+    write_tsv,
+)
 from ferric_tools.compat.report import compute_oracle_coverage
 
 # ---------------------------------------------------------------------------
@@ -72,6 +85,472 @@ def _engine_result(
         "diagnostic": diagnostic(phase, category, continued=continued),
         "termination": {"kind": "exit", "exit_code": exit_code, "signal": None},
     }
+
+
+def _span(start_byte: int = 0, end_byte: int = 4) -> dict:
+    return {
+        "start_byte": start_byte,
+        "end_byte": end_byte,
+        "start_line": 1,
+        "start_column": start_byte + 1,
+        "end_line": 1,
+        "end_column": end_byte + 1,
+    }
+
+
+def _detection(
+    feature: str = "defrule",
+    *,
+    category: str = "supported-construct",
+    reason: str = "supported-form",
+    head_span: dict | None = None,
+    form_span: dict | None = None,
+) -> dict:
+    return {
+        "feature": feature,
+        "category": category,
+        "reason": reason,
+        "head_span": head_span or _span(1, 8),
+        "form_span": form_span or _span(0, 20),
+    }
+
+
+def _feature_scan(
+    *,
+    status: str = "valid",
+    detections: list[dict] | None = None,
+    issues: list[dict] | None = None,
+) -> dict:
+    return {
+        "version": 1,
+        "status": status,
+        "detections": [_detection()] if detections is None else detections,
+        "issues": issues or [],
+    }
+
+
+def _scanner_entry(
+    *,
+    features: list[str] | None = None,
+    unsupported_features: list[str] | None = None,
+    classification: str = "pending",
+    reason: str = "testable",
+    runability: str = "standalone",
+    feature_scan: dict | None = None,
+) -> dict:
+    entry = {
+        "features": ["defrule"] if features is None else features,
+        "unsupported_features": [] if unsupported_features is None else unsupported_features,
+        "classification": classification,
+        "reason": reason,
+        "runability": runability,
+    }
+    if feature_scan is not None:
+        entry["feature_scan"] = feature_scan
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# scanner-only retained diff
+# ---------------------------------------------------------------------------
+
+
+def test_scanner_diff_treats_new_structured_evidence_as_legacy_neutral():
+    base = _manifest({"same.clp": _scanner_entry()})
+    head = _manifest({"same.clp": _scanner_entry(feature_scan=_feature_scan())})
+
+    result = compute_scanner_diff(base, head)
+
+    assert result["summary"] == {
+        "files_compared": 1,
+        "changed_files": 0,
+        "added_files": 0,
+        "removed_files": 0,
+        "legacy_base_structured_evidence": 1,
+        "head_structured_evidence": 1,
+        "head_invalid_structured_evidence": 0,
+        "head_scan_issues": 0,
+    }
+    assert result["changes"] == []
+
+
+def test_scanner_diff_retains_effective_field_changes_and_structured_spans():
+    base = _manifest({"string.clp": _scanner_entry()})
+    detection = {
+        "feature": "load",
+        "category": "loading-command",
+        "reason": "unsupported-command",
+        "head_span": _span(12, 16),
+        "form_span": _span(11, 24),
+    }
+    head = _manifest(
+        {
+            "string.clp": _scanner_entry(
+                features=["deffacts", "defrule"],
+                unsupported_features=["load"],
+                classification="incompatible",
+                reason="unsupported-command",
+                runability="batch",
+                feature_scan=_feature_scan(
+                    detections=[_detection(), _detection("deffacts"), detection]
+                ),
+            )
+        }
+    )
+
+    result = compute_scanner_diff(base, head)
+
+    assert result["summary"]["changed_files"] == 1
+    assert result["summary"]["legacy_base_structured_evidence"] == 1
+    assert len(result["changes"]) == 1
+    change = result["changes"][0]
+    assert change["change"] == "changed"
+    assert change["structured_evidence_change"] == "legacy-base"
+    assert change["changed_fields"] == [
+        "features",
+        "unsupported_features",
+        "classification",
+        "reason",
+        "runability",
+    ]
+    assert change["head"]["feature_scan"]["detections"][2]["head_span"] == _span(12, 16)
+
+
+def test_scanner_diff_retains_invalid_head_evidence_without_counting_legacy_as_change():
+    issue = {
+        "kind": "unterminated-string",
+        "reason": "string literal reaches end of input",
+        "span": _span(8, 19),
+    }
+    malformed_entry = {
+        "classification": "incompatible",
+        "reason": "malformed-source",
+        "runability": "unknown",
+    }
+    base = _manifest({"malformed.clp": _scanner_entry(**malformed_entry)})
+    head = _manifest(
+        {
+            "malformed.clp": _scanner_entry(
+                **malformed_entry,
+                feature_scan=_feature_scan(status="invalid", issues=[issue]),
+            )
+        }
+    )
+
+    result = compute_scanner_diff(base, head)
+
+    assert result["summary"]["changed_files"] == 0
+    assert result["summary"]["legacy_base_structured_evidence"] == 1
+    assert result["summary"]["head_invalid_structured_evidence"] == 1
+    assert result["summary"]["head_scan_issues"] == 1
+    assert result["changes"] == [
+        {
+            "path": "malformed.clp",
+            "change": "structured-evidence",
+            "changed_fields": [],
+            "structured_evidence_change": "legacy-base",
+            "base": _scanner_entry(**malformed_entry),
+            "head": _scanner_entry(
+                **malformed_entry,
+                feature_scan=_feature_scan(status="invalid", issues=[issue]),
+            ),
+        }
+    ]
+
+
+def test_scanner_diff_compares_structured_evidence_once_both_revisions_have_it():
+    base_scan = _feature_scan()
+    head_scan = _feature_scan(
+        detections=[
+            {
+                "feature": "defrule",
+                "category": "supported-construct",
+                "reason": "supported-form",
+                "head_span": _span(2, 9),
+                "form_span": _span(0, 20),
+            }
+        ]
+    )
+    base = _manifest({"evidence.clp": _scanner_entry(feature_scan=base_scan)})
+    head = _manifest({"evidence.clp": _scanner_entry(feature_scan=head_scan)})
+
+    result = compute_scanner_diff(base, head)
+
+    assert result["summary"]["changed_files"] == 1
+    assert result["summary"]["legacy_base_structured_evidence"] == 0
+    assert result["changes"][0]["changed_fields"] == ["feature_scan"]
+    assert result["changes"][0]["structured_evidence_change"] == "changed"
+
+
+def test_scanner_diff_does_not_label_a_new_file_as_legacy_structured_evidence():
+    result = compute_scanner_diff(
+        _manifest({}),
+        _manifest({"new.clp": _scanner_entry(feature_scan=_feature_scan())}),
+    )
+
+    assert result["summary"]["added_files"] == 1
+    assert result["summary"]["legacy_base_structured_evidence"] == 0
+    assert result["changes"][0]["structured_evidence_change"] == "added"
+
+
+def test_scanner_diff_machine_outputs_and_markdown_retain_review_evidence(tmp_path):
+    base = _manifest({"changed.clp": _scanner_entry()})
+    head = _manifest(
+        {
+            "changed.clp": _scanner_entry(
+                features=["deffacts", "defrule"],
+                unsupported_features=["load"],
+                feature_scan=_feature_scan(
+                    detections=[
+                        _detection(),
+                        _detection("deffacts"),
+                        _detection(
+                            "load",
+                            category="loading-command",
+                            reason="unsupported-command",
+                        ),
+                    ]
+                ),
+            )
+        }
+    )
+    result = compute_scanner_diff(base, head)
+    tsv_path = tmp_path / "scanner.tsv"
+    json_path = tmp_path / "scanner.json"
+
+    write_scanner_tsv(result, str(tsv_path))
+    write_scanner_json(result, str(json_path))
+    markdown = "\n".join(format_scanner_markdown(result))
+
+    with tsv_path.open(newline="", encoding="utf-8") as stream:
+        row = next(csv.DictReader(stream, delimiter="\t"))
+    assert row["changed_fields"] == "features;unsupported_features"
+    assert row["structured_evidence_change"] == "legacy-base"
+    assert row["head_feature_scan_status"] == "valid"
+    assert json.loads(json_path.read_text(encoding="utf-8")) == result
+    assert "Static Compatibility Scanner Diff" in markdown
+    assert "legacy schema boundary, not as scanner changes" in markdown
+    assert "`changed.clp`" in markdown
+
+
+def test_scanner_only_cli_exits_zero_for_observed_changes(tmp_path):
+    base_path = tmp_path / "base.json"
+    head_path = tmp_path / "head.json"
+    report_path = tmp_path / "scanner.md"
+    tsv_path = tmp_path / "scanner.tsv"
+    json_path = tmp_path / "scanner-diff.json"
+    base_path.write_text(json.dumps(_manifest({"changed.clp": _scanner_entry()})), encoding="utf-8")
+    head_path.write_text(
+        json.dumps(
+            _manifest(
+                {
+                    "changed.clp": _scanner_entry(
+                        classification="incompatible",
+                        reason="unsupported-command",
+                        runability="batch",
+                        feature_scan=_feature_scan(),
+                    )
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            str(base_path),
+            str(head_path),
+            "--scanner-only",
+            "--report",
+            str(report_path),
+            "--tsv",
+            str(tsv_path),
+            "--json",
+            str(json_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert report_path.is_file()
+    assert tsv_path.is_file()
+    assert json_path.is_file()
+
+
+def test_scanner_only_cli_fails_on_malformed_structured_evidence(tmp_path):
+    base_path = tmp_path / "base.json"
+    head_path = tmp_path / "head.json"
+    base_path.write_text(json.dumps(_manifest({"bad.clp": _scanner_entry()})), encoding="utf-8")
+    malformed = _feature_scan()
+    malformed["status"] = "maybe"
+    head_path.write_text(
+        json.dumps(_manifest({"bad.clp": _scanner_entry(feature_scan=malformed)})),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [str(base_path), str(head_path), "--scanner-only"],
+    )
+
+    assert result.exit_code == 2
+    assert "cannot generate scanner diff" in result.output
+
+
+def test_scanner_only_cli_fails_when_head_lacks_required_structured_evidence(tmp_path):
+    base_path = tmp_path / "base.json"
+    head_path = tmp_path / "head.json"
+    base_path.write_text(json.dumps(_manifest({"missing.clp": _scanner_entry()})), encoding="utf-8")
+    head_path.write_text(json.dumps(_manifest({"missing.clp": _scanner_entry()})), encoding="utf-8")
+
+    result = CliRunner().invoke(
+        app,
+        [str(base_path), str(head_path), "--scanner-only"],
+    )
+
+    assert result.exit_code == 2
+    assert "missing.clp" in result.output
+    assert "feature_scan is required" in result.output
+
+
+def test_scanner_only_cli_fails_when_head_aggregates_do_not_project_detections(tmp_path):
+    base_path = tmp_path / "base.json"
+    head_path = tmp_path / "head.json"
+    base_path.write_text(
+        json.dumps(_manifest({"mismatch.clp": _scanner_entry()})), encoding="utf-8"
+    )
+    head_path.write_text(
+        json.dumps(
+            _manifest(
+                {
+                    "mismatch.clp": _scanner_entry(
+                        features=[],
+                        feature_scan=_feature_scan(),
+                    )
+                }
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [str(base_path), str(head_path), "--scanner-only"],
+    )
+
+    assert result.exit_code == 2
+    assert "features must exactly project feature_scan detections" in result.output
+
+
+def test_scanner_only_cli_fails_when_detection_metadata_is_not_canonical(tmp_path):
+    base_path = tmp_path / "base.json"
+    head_path = tmp_path / "head.json"
+    base_path.write_text(json.dumps(_manifest({"bad.clp": _scanner_entry()})), encoding="utf-8")
+    bad_detection = _detection(reason="unsupported-form")
+    head_path.write_text(
+        json.dumps(
+            _manifest(
+                {"bad.clp": _scanner_entry(feature_scan=_feature_scan(detections=[bad_detection]))}
+            )
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [str(base_path), str(head_path), "--scanner-only"],
+    )
+
+    assert result.exit_code == 2
+    assert "category/reason must be" in result.output
+
+
+def test_scanner_diff_rejects_structured_status_disposition_mismatches():
+    issue = {
+        "kind": "unmatched-close",
+        "reason": "unmatched-close",
+        "span": _span(),
+    }
+    mismatched_entries = (
+        _scanner_entry(feature_scan=_feature_scan(status="invalid", issues=[issue])),
+        _scanner_entry(
+            classification="incompatible",
+            reason="malformed-source",
+            runability="unknown",
+            feature_scan=_feature_scan(),
+        ),
+    )
+
+    for entry in mismatched_entries:
+        try:
+            compute_scanner_diff(_manifest({}), _manifest({"bad.clp": entry}))
+        except ValueError as error:
+            assert "feature_scan" in str(error)
+        else:
+            raise AssertionError("feature_scan disposition mismatch must fail closed")
+
+
+def test_scanner_diff_allows_head_read_error_without_structured_evidence():
+    read_error = _scanner_entry(
+        features=[],
+        classification="incompatible",
+        reason="read-error",
+        runability="unknown",
+    )
+
+    result = compute_scanner_diff(
+        _manifest({"binary.clp": read_error}),
+        _manifest({"binary.clp": read_error}),
+    )
+
+    assert result["changes"] == []
+    assert result["summary"]["head_structured_evidence"] == 0
+
+
+def test_scanner_diff_rejects_head_read_error_with_feature_aggregates():
+    read_error = _scanner_entry(
+        classification="incompatible",
+        reason="read-error",
+        runability="unknown",
+    )
+
+    try:
+        compute_scanner_diff(_manifest({}), _manifest({"binary.clp": read_error}))
+    except ValueError as error:
+        assert "read-error entries cannot claim detected features" in str(error)
+    else:
+        raise AssertionError("read-error feature aggregates must fail closed")
+
+
+def test_compat_compare_workflow_retains_native_pre_run_scans_and_artifacts():
+    workflow_path = Path(__file__).parents[3] / ".github" / "workflows" / "compat-compare.yml"
+    workflow = workflow_path.read_text(encoding="utf-8")
+
+    base_capture = "cp tests/examples/compat-manifest.json /tmp/base-compat-scan-manifest.json"
+    head_overlay = "git checkout ${{ inputs.head_sha }} --"
+    head_capture = "cp tests/examples/compat-manifest.json /tmp/head-compat-scan-manifest.json"
+    head_run = "uv run --project tools/ferric-tools ferric-compat-run --workers 4 --timeout 30"
+    scanner_generation = workflow.index("- name: Generate retained scanner comparison")
+    assert workflow.index(base_capture) < workflow.index(head_overlay)
+    assert workflow.index(head_capture) < scanner_generation < workflow.rindex(head_run)
+    assert "--scanner-only" in workflow
+    assert "cat /tmp/compat-scanner-diff-report.md >> /tmp/compat-diff-report.md" in workflow
+    scanner_step = workflow.split("- name: Generate retained scanner comparison", maxsplit=1)[1]
+    scanner_step = scanner_step.split("- name: Run compat assessment", maxsplit=1)[0]
+    assert "continue-on-error" not in scanner_step
+    append_step = workflow.split("- name: Append retained scanner comparison", maxsplit=1)[1]
+    append_step = append_step.split("- name: Copy head manifest", maxsplit=1)[0]
+    assert "if: always()" in append_step
+    upload_step = workflow.split("- name: Upload artifacts", maxsplit=1)[1]
+    assert "if: always()" in upload_step
+    for artifact in (
+        "/tmp/compat-scanner-diff.tsv",
+        "/tmp/compat-scanner-diff.json",
+        "/tmp/compat-scanner-diff-report.md",
+        "/tmp/base-compat-scan-manifest.json",
+        "/tmp/head-compat-scan-manifest.json",
+    ):
+        assert artifact in workflow
 
 
 # ---------------------------------------------------------------------------

--- a/tools/ferric-tools/tests/test_compat_run.py
+++ b/tools/ferric-tools/tests/test_compat_run.py
@@ -21,6 +21,7 @@ from ferric_tools._paths import repo_root
 from ferric_tools.compat import run as run_module
 from ferric_tools.compat.clips_oracle import NATIVE_RECORD_PREFIX
 from ferric_tools.compat.oracle import canonical_scenario_plan
+from ferric_tools.compat.scan import build_summary, scan_examples
 
 
 def _resolved_harness(
@@ -1864,6 +1865,46 @@ def test_runner_persists_missing_oracle_state_without_engine_preflight(
     assert persisted["files"]["fixture.clp"]["oracle_evidence"]["status"] == "missing"
     assert persisted["files"]["fixture.clp"]["ferric"] is None
     assert persisted["files"]["fixture.clp"]["clips"] is None
+
+
+def test_runner_rejects_explicit_unknown_runability_before_oracle_or_engine_preflight(
+    tmp_path,
+    monkeypatch,
+):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "malformed.clp"
+    source.parent.mkdir(parents=True)
+    source.write_text('(defrule partial => (printout t "unterminated)\n', encoding="utf-8")
+    files = scan_examples(examples, root=root)
+    assert files["malformed.clp"]["reason"] == "malformed-source"
+    assert files["malformed.clp"]["runability"] == "unknown"
+    manifest_path = examples / "compat-manifest.json"
+    save_manifest(
+        manifest_path,
+        {
+            "version": 3,
+            "oracle_protocol_version": 1,
+            "summary": build_summary(files),
+            "files": files,
+        },
+    )
+    monkeypatch.setattr(run_module, "repo_root", lambda: root)
+    monkeypatch.setattr(run_module, "default_examples_dir", lambda: examples)
+
+    def fail_if_scheduled(*_args, **_kwargs):
+        raise AssertionError("engine work must not be scheduled")
+
+    monkeypatch.setattr(run_module, "parallel_run", fail_if_scheduled)
+
+    result = CliRunner().invoke(
+        run_module.app,
+        ["--manifest", str(manifest_path), "--file", "malformed.clp"],
+    )
+
+    assert result.exit_code == 1
+    assert "cannot explicitly run a file with unknown runability" in result.output
+    assert load_manifest(manifest_path)["files"]["malformed.clp"]["reason"] == ("malformed-source")
 
 
 def test_runner_persists_explicit_missing_oracle_before_nonzero_exit(

--- a/tools/ferric-tools/tests/test_compat_scan.py
+++ b/tools/ferric-tools/tests/test_compat_scan.py
@@ -49,6 +49,12 @@ def _clp(name: str = "example.clp") -> Path:
     return Path(name)
 
 
+def _span_text(source: str, span: dict) -> str:
+    """Slice source using one serialized byte-oriented feature-scan span."""
+    encoded = source.encode("utf-8")
+    return encoded[span["start_byte"] : span["end_byte"]].decode("utf-8")
+
+
 def _materialized_library_harness(tmp_path):
     root = tmp_path / "repo"
     examples = root / "tests" / "examples"
@@ -192,6 +198,105 @@ def test_classify_file_bat_extension_is_incompatible():
 
     assert classification == "incompatible"
     assert reason == "test-suite-batch"
+
+
+@pytest.mark.parametrize("suffix", [".clp", ".bat"])
+def test_scan_preserves_strict_utf8_read_errors_as_unknown(tmp_path, suffix):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / f"invalid-utf8{suffix}"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"(defrule visible =>)\r\n\xff")
+
+    entry = scan_examples(examples, root=root)[source.name]
+
+    assert entry["classification"] == "incompatible"
+    assert entry["reason"] == "read-error"
+    assert entry["runability"] == "unknown"
+    assert entry["features"] == []
+    assert entry["unsupported_features"] == []
+    assert "utf-8" in entry["notes"]
+
+
+def test_scan_attaches_string_aware_feature_evidence_and_legacy_aggregates(tmp_path):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / "string-aware.clp"
+    source.parent.mkdir(parents=True)
+    source_text = (
+        "; (read) in a comment must not count\r\n"
+        "(DeFrUlE safe\r\n"
+        "  =>\r\n"
+        '  (PrInToUt t "π ; \\"(open fake)\\"" crlf)\r\n'
+        "  (assert (batch-mode open-file readline-token)))\r\n"
+    )
+    source.write_bytes(source_text.encode("utf-8"))
+
+    entry = scan_examples(examples, root=root)[source.name]
+
+    assert entry["classification"] == "pending"
+    assert entry["reason"] == "testable"
+    assert entry["runability"] == "standalone"
+    assert entry["features"] == ["defrule", "printout"]
+    assert entry["unsupported_features"] == []
+    evidence = entry["feature_scan"]
+    assert evidence["version"] == 1
+    assert evidence["status"] == "valid"
+    assert evidence["issues"] == []
+    assert [detection["feature"] for detection in evidence["detections"]] == [
+        "defrule",
+        "printout",
+    ]
+    for detection in evidence["detections"]:
+        assert detection["category"] in {"supported-construct", "output"}
+        assert detection["reason"] in {"supported-form", "supported-output"}
+        assert _span_text(source_text, detection["head_span"]).lower() == detection["feature"]
+        assert _span_text(source_text, detection["form_span"]).startswith("(")
+
+
+@pytest.mark.parametrize("suffix", [".clp", ".bat"])
+def test_scan_marks_lexically_malformed_source_unknown_with_partial_evidence(
+    tmp_path,
+    suffix,
+):
+    root = tmp_path / "repo"
+    examples = root / "tests" / "examples"
+    source = examples / f"malformed{suffix}"
+    source.parent.mkdir(parents=True)
+    source_text = '(DeFrUlE seen => (PrInToUt t "ok" crlf))\r\n(OpEn "fixture" logical "r")\r\n)'
+    source.write_bytes(source_text.encode("utf-8"))
+
+    entry = scan_examples(examples, root=root)[source.name]
+
+    assert entry["classification"] == "incompatible"
+    assert entry["reason"] == "malformed-source"
+    assert entry["runability"] == "unknown"
+    assert entry["features"] == ["defrule", "printout"]
+    assert entry["unsupported_features"] == ["open"]
+    evidence = entry["feature_scan"]
+    assert evidence["status"] == "invalid"
+    assert [detection["feature"] for detection in evidence["detections"]] == [
+        "defrule",
+        "printout",
+        "open",
+    ]
+    assert evidence["detections"][2]["category"] == "file-io"
+    assert evidence["detections"][2]["reason"] == "unsupported-io"
+    assert _span_text(source_text, evidence["detections"][2]["head_span"]) == "OpEn"
+    assert evidence["issues"] == [
+        {
+            "kind": "unmatched-close",
+            "reason": "unmatched-close",
+            "span": {
+                "start_byte": len(source_text.encode("utf-8")) - 1,
+                "end_byte": len(source_text.encode("utf-8")),
+                "start_line": 3,
+                "start_column": 1,
+                "end_line": 3,
+                "end_column": 2,
+            },
+        }
+    ]
 
 
 @pytest.mark.parametrize(("input_version", "expected_version"), [(1, 2), (3, 3)])


### PR DESCRIPTION
## Summary

- replace regex feature matching with a CLIPS 6.30-aligned lexical form-head scanner that ignores strings, comments, and symbol substrings
- persist versioned detection and issue evidence with exact UTF-8 byte and source-coordinate spans
- fail closed on malformed or undecodable sources and refuse explicit runs with unknown runability
- retain native base/head scanner manifests plus Markdown, TSV, and JSON scanner diffs before compatibility execution in CI

## Retained corpus review

- compared all 1,229 corpus files with no added, removed, or source-digest changes
- retained 75 effective scanner changes: 19 corrected feature lists and 56 malformed-source dispositions containing 154 exact lexical issues
- all 365 removed legacy regex occurrences were inside string literals; no code, comment, or symbol-substring detection was incorrectly removed
- 19 files moved from pending to fail-closed incompatible; unsupported-feature aggregates did not change
- all 23 oracle-backed fixtures, including all 22 semantic scenarios, remain lexically valid

## Validation

- `just preflight-pr`
- `just compat-scan`
- `just compat-semantic-lane`
- full ferric-tools suite: 594 passed
- Python bindings: 222 passed, 3 skipped
- `actionlint .github/workflows/compat-compare.yml`

Closes #120