### PR TITLE
feat(node): support complete native target matrix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,5 @@
 # Keep checked-in text shipped by the Node package byte-identical on Windows.
 packages/ferric/package.json text eol=lf
 packages/ferric/native/index.js text eol=lf
+packages/ferric/native/runtime-target.js text eol=lf
 packages/ferric/native/targets.json text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,12 +236,12 @@ jobs:
       - name: Build native addon
         working-directory: crates/ferric-rules-napi
         run: |
-          npm install
+          npm ci
           napi build --release
       - name: Build and lint TypeScript
         working-directory: packages/ferric
         run: |
-          npm install
+          npm ci
           npm run build
           npm run lint
       - name: Run TypeScript binding tests

--- a/.github/workflows/node-package-artifacts.yml
+++ b/.github/workflows/node-package-artifacts.yml
@@ -56,6 +56,7 @@ jobs:
         working-directory: packages/ferric
         run: |
           npm ci
+          npm run build
           ./node_modules/.bin/tsx --test \
             test/conformance/package/loader-paths.test.ts \
             test/conformance/package/node-target-matrix.test.ts

--- a/.github/workflows/node-package-artifacts.yml
+++ b/.github/workflows/node-package-artifacts.yml
@@ -42,27 +42,64 @@ env:
   RUST_TOOLCHAIN: "1.93.0"
 
 jobs:
+  validate-artifact-contract:
+    name: Validate Node artifact contract
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Validate package metadata
+        run: node scripts/validate-node-package.mjs
+      - name: Test packaged runtime target selection
+        working-directory: packages/ferric
+        run: |
+          npm ci
+          ./node_modules/.bin/tsx --test \
+            test/conformance/package/loader-paths.test.ts \
+            test/conformance/package/node-target-matrix.test.ts
+
   pack-and-smoke:
     name: Pack and smoke (${{ matrix.target }})
+    needs: validate-artifact-contract
     strategy:
       fail-fast: false
       matrix:
         include:
           - target: darwin-arm64
             runner: macos-15
+            rust_target: aarch64-apple-darwin
           - target: darwin-x64
             runner: macos-15-intel
+            rust_target: x86_64-apple-darwin
           - target: linux-x64-gnu
             runner: ubuntu-24.04
+            rust_target: x86_64-unknown-linux-gnu
+          - target: linux-arm64-gnu
+            runner: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+          - target: linux-x64-musl
+            runner: ubuntu-24.04
+            rust_target: x86_64-unknown-linux-musl
+            libc: musl
+          - target: linux-arm64-musl
+            runner: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-musl
+            libc: musl
           - target: win32-x64-msvc
             runner: windows-2025
+            rust_target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        if: matrix.libc != 'musl'
         with:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
+          targets: ${{ matrix.rust_target }}
       - uses: actions/setup-node@v4
+        if: matrix.libc != 'musl'
         with:
           node-version: "22"
           cache: npm
@@ -70,21 +107,57 @@ jobs:
             crates/ferric-rules-napi/package-lock.json
             packages/ferric/package-lock.json
       - name: Build native addon
+        if: matrix.libc != 'musl'
         working-directory: crates/ferric-rules-napi
         run: |
           npm ci
-          npm run build
+          npm run build -- --target ${{ matrix.rust_target }}
       - name: Install and build JavaScript package
+        if: matrix.libc != 'musl'
         working-directory: packages/ferric
         run: |
           npm ci --omit=optional
           npm run build
       - name: Pack and smoke exact release artifacts
+        if: matrix.libc != 'musl'
         run: >-
           node scripts/test-node-package-artifact.mjs
           --target ${{ matrix.target }}
           --binary crates/ferric-rules-napi/ferric-rules-napi.node
           --artifacts-dir node-release-artifacts
+      - name: Build, pack, and smoke in matching-architecture musl runtime
+        if: matrix.libc == 'musl'
+        shell: bash
+        run: |
+          docker run --rm \
+            --env CARGO_TERM_COLOR \
+            --env RUSTFLAGS \
+            --env RUST_TOOLCHAIN \
+            --env RUST_TARGET="${{ matrix.rust_target }}" \
+            --env TARGET_ID="${{ matrix.target }}" \
+            --volume "${{ github.workspace }}:/workspace" \
+            --workdir /workspace \
+            node:22-alpine \
+            sh -euxc '
+              apk add --no-cache build-base curl
+              curl --proto "=https" --tlsv1.2 -sSf \
+                https://sh.rustup.rs \
+                --output /tmp/rustup-init.sh
+              sh /tmp/rustup-init.sh -y --profile minimal \
+                --default-toolchain "$RUST_TOOLCHAIN"
+              export PATH="/root/.cargo/bin:$PATH"
+              cd crates/ferric-rules-napi
+              npm ci
+              npm run build -- --target "$RUST_TARGET"
+              cd ../../packages/ferric
+              npm ci --omit=optional
+              npm run build
+              cd ../..
+              node scripts/test-node-package-artifact.mjs \
+                --target "$TARGET_ID" \
+                --binary crates/ferric-rules-napi/ferric-rules-napi.node \
+                --artifacts-dir node-release-artifacts
+            '
       - uses: actions/upload-artifact@v4
         with:
           name: node-package-${{ matrix.target }}

--- a/docs/node-package-release.md
+++ b/docs/node-package-release.md
@@ -7,27 +7,35 @@ source checkout.
 ## Artifact contract
 
 The main tarball contains the compiled JavaScript/declarations plus
-`native/index.js` and `native/targets.json`. It never contains a host-specific
-`.node` file. Its optional dependencies are exact-version pins to the native
-packages below:
+`native/index.js`, `native/runtime-target.js`, and `native/targets.json`. It
+never contains a host-specific `.node` file. Its regular `detect-libc` runtime
+dependency is exactly pinned so Linux selection uses a tested detector, and its
+optional dependencies are exact-version pins to the native packages below:
 
 | Target ID | Native package | Runtime selector |
 | --- | --- | --- |
 | `darwin-arm64` | `@ferric-rules/napi-darwin-arm64` | macOS arm64 |
 | `darwin-x64` | `@ferric-rules/napi-darwin-x64` | macOS x64 |
 | `linux-x64-gnu` | `@ferric-rules/napi-linux-x64-gnu` | Linux x64 with glibc |
+| `linux-arm64-gnu` | `@ferric-rules/napi-linux-arm64-gnu` | Linux arm64 with glibc |
+| `linux-x64-musl` | `@ferric-rules/napi-linux-x64-musl` | Linux x64 with musl |
+| `linux-arm64-musl` | `@ferric-rules/napi-linux-arm64-musl` | Linux arm64 with musl |
 | `win32-x64-msvc` | `@ferric-rules/napi-win32-x64-msvc` | Windows x64 |
 
 Each native package contains only its package metadata, README, and
 `ferric-rules-napi.node`. `native/targets.json` is the source of truth used by both
-the loader and release assembly. FR-DIST-002 owns any expansion or refinement
-of this matrix.
+the loader and release assembly. Future matrix changes must preserve exact
+version alignment, unambiguous OS/architecture/libc detection, and an executable
+clean-install smoke for every declared target.
 
 The Rust addon exports `nativePackageVersion()`. Loading succeeds only when
 the main package version, selected native package version, and embedded addon
-version are identical. A missing package, unsupported target, load failure, or
-version mismatch fails before an engine is exposed and identifies the expected
-package in the error.
+version are identical. Linux selection includes the runtime C library, so a
+glibc process cannot select a musl package or vice versa. A missing package,
+unsupported target, inconclusive Linux C-library detection, load failure, or
+version mismatch fails before an engine is exposed and identifies the detected
+target, the expected package when one is declared, and the supported target
+alternatives for unsupported combinations.
 
 ## Local release dry run
 
@@ -38,13 +46,20 @@ just node-package-smoke
 ```
 
 This builds the release-profile N-API addon, builds the TypeScript package,
-packs the exact main and current-platform native tarballs, installs both
-tarballs offline into a temporary project outside the repository, then uses
-CommonJS and dynamic `import()` to create, run, and close engines. The smoke
+detects the current OS, architecture, and Linux C library, and packs the exact
+main and current-platform native tarballs. It also packs the installed,
+version-locked `detect-libc` dependency into temporary test storage so the
+consumer install uses no registry or pre-existing npm cache. It installs all
+three tarballs offline into a temporary project outside the repository, then
+uses CommonJS and dynamic `import()` to create, run, and close engines. The smoke
 also checks that the binary reports the same version as both package manifests.
 
-The `Node Package Artifacts` workflow repeats this operation natively on every
-declared target, uploads the exact tarballs, checks target coverage, and
-requires the independently packed main tarball to be byte-identical across the
-matrix. It stages artifacts only; publishing to npm remains subject to the
-production-readiness release checkpoint.
+The `Node Package Artifacts` workflow repeats this operation on every declared
+target. macOS, Windows, and Linux glibc jobs run on matching hosted
+architectures. Linux musl jobs build and execute inside `node:22-alpine` on a
+matching-architecture Linux host; they do not use CPU emulation. The workflow
+uploads the exact tarballs, checks target coverage, and requires the
+independently packed main tarball to be byte-identical across the matrix. It
+does not upload the temporary dependency tarball. It stages release artifacts
+only; publishing to npm remains subject to the production-readiness release
+checkpoint.

--- a/docs/typescript-binding-architecture.md
+++ b/docs/typescript-binding-architecture.md
@@ -63,6 +63,7 @@ packages/ferric/
 │   └── types.ts
 ├── native/
 │   ├── index.js
+│   ├── runtime-target.js
 │   └── targets.json
 └── dist/
 ```
@@ -75,9 +76,11 @@ and the loader verifies both package metadata and the version embedded in the
 Rust addon before exposing it. No host-specific binary is committed to or
 packed inside the main package.
 
-The currently declared targets are macOS arm64, macOS x64, Linux x64 with
-glibc, and Windows x64 with MSVC. Expanding and refining this matrix is owned
-by FR-DIST-002 rather than by the base packaging mechanism.
+The declared targets are macOS arm64 and x64; Linux arm64 and x64 with glibc;
+Linux arm64 and x64 with musl; and Windows x64 with MSVC. Linux runtime
+selection includes libc as well as OS and architecture. Future matrix changes
+must extend the same target metadata, loader selection, package validation, and
+per-runtime artifact-smoke contract.
 
 ## Ownership Boundaries
 - Rust owns engine correctness and low-level conversion primitives.

--- a/docs/typescript-binding-normative-contract.md
+++ b/docs/typescript-binding-normative-contract.md
@@ -187,13 +187,20 @@ interface WorkerResponse {
 5. Every native addon `MUST` embed its Ferric package version. The loader
    `MUST` reject mismatched main-package metadata, native-package metadata, or
    embedded addon versions before exposing an engine.
-6. Unsupported targets and missing optional packages `MUST` fail with an
-   actionable error that names the detected target and expected package.
+6. Unsupported targets `MUST` fail with an actionable error that names the
+   detected OS and architecture, the detected libc on Linux, and the supported
+   target alternatives. A missing optional package `MUST` name the full
+   detected target and exact expected package.
 7. CI `MUST` pack, install, and execute the exact main and native tarballs from
    a clean consumer directory without a source checkout or native build.
 8. The declared target set is the versioned `native/targets.json` file.
    Extending the platform, architecture, or libc matrix requires the
-   FR-DIST-002 contract and its validation.
+   validation in this contract.
+9. Every declared Linux target `MUST` name exactly one npm libc selector. The
+   loader and release-artifact smoke `MUST` distinguish glibc from musl and
+   fail before loading a native package when libc detection is inconclusive.
+10. CI `MUST` build, pack, install, load, and run the exact artifact for every
+    declared OS, architecture, and libc combination on a matching runtime.
 
 ## 10. Required Test Gating
 

--- a/packages/ferric/native/index.js
+++ b/packages/ferric/native/index.js
@@ -5,12 +5,14 @@ const { resolve } = require("node:path");
 
 const targets = require("./targets.json");
 const packageMetadata = require("../package.json");
+const {
+  detectRuntimeTarget,
+  selectDeclaredTarget,
+} = require("./runtime-target");
 
 const expectedVersion = packageMetadata.version;
-const detectedTarget = targets.find(
-  (target) =>
-    target.platform === process.platform && target.arch === process.arch,
-);
+const detectedRuntime = detectRuntimeTarget();
+const detectedTarget = selectDeclaredTarget(targets, detectedRuntime);
 
 function formatCause(error) {
   return String(error);
@@ -39,16 +41,6 @@ function verifyBindingVersion(binding, source) {
 }
 
 function loadNativeBinding() {
-  if (!detectedTarget) {
-    const supported = targets
-      .map((target) => `${target.platform}-${target.arch} (${target.id})`)
-      .join(", ");
-    throw new Error(
-      `[ferric] Unsupported native target ${process.platform}-${process.arch}. ` +
-        `Supported targets: ${supported}.`,
-    );
-  }
-
   // A source checkout keeps the development binary in crates/ferric-rules-napi.
   // This path cannot exist in a normal npm consumer install.
   const developmentBinary = resolve(

--- a/packages/ferric/native/runtime-target.js
+++ b/packages/ferric/native/runtime-target.js
@@ -1,0 +1,107 @@
+"use strict";
+
+function formatCause(error) {
+  return String(error);
+}
+
+function detectLibcFamily() {
+  const detector = require("detect-libc");
+  if (typeof detector?.familySync !== "function") {
+    throw new Error("detect-libc familySync export is unavailable");
+  }
+  const family = detector.familySync();
+  if (family === "glibc") return "glibc";
+  if (family === "musl") return "musl";
+  return family;
+}
+
+function formatRuntimeTarget(runtime) {
+  if (runtime.platform === "linux") {
+    const abi =
+      runtime.libc === "glibc"
+        ? "gnu"
+        : runtime.libc === "musl"
+          ? "musl"
+          : "unknown";
+    return `${runtime.platform}-${runtime.arch}-${abi}`;
+  }
+
+  const abi = runtime.platform === "win32" ? "-msvc" : "";
+  return `${runtime.platform}-${runtime.arch}${abi}`;
+}
+
+function detectRuntimeTarget({
+  platform = process.platform,
+  arch = process.arch,
+  detectLibc = detectLibcFamily,
+} = {}) {
+  if (platform !== "linux") {
+    const runtime = { platform, arch, libc: undefined, error: undefined };
+    return { ...runtime, id: formatRuntimeTarget(runtime) };
+  }
+
+  let libc = null;
+  let error;
+  try {
+    const detected = detectLibc();
+    if (detected === "glibc" || detected === "musl") {
+      libc = detected;
+    } else if (detected !== null) {
+      error = new Error(
+        `detect-libc returned unsupported family ${String(detected)}`,
+      );
+    }
+  } catch (cause) {
+    error = cause;
+  }
+
+  const runtime = { platform, arch, libc, error };
+  return { ...runtime, id: formatRuntimeTarget(runtime) };
+}
+
+function targetMatchesRuntime(target, runtime) {
+  if (target.platform !== runtime.platform || target.arch !== runtime.arch) {
+    return false;
+  }
+  if (runtime.platform !== "linux") return target.libc === undefined;
+  return (
+    (runtime.libc === "glibc" || runtime.libc === "musl") &&
+    Array.isArray(target.libc) &&
+    target.libc.length === 1 &&
+    target.libc[0] === runtime.libc
+  );
+}
+
+function selectDeclaredTarget(targets, runtime) {
+  const detected = formatRuntimeTarget(runtime);
+  const supported = targets.map((target) => target.id).join(", ");
+  const matches = targets.filter((target) =>
+    targetMatchesRuntime(target, runtime),
+  );
+
+  if (matches.length === 0) {
+    const detectionContext = runtime.error
+      ? ` Libc detection cause: ${formatCause(runtime.error)}.`
+      : "";
+    throw new Error(
+      `[ferric] Unsupported native target ${detected}. ` +
+        `Supported targets: ${supported}.${detectionContext}`,
+      { cause: runtime.error },
+    );
+  }
+  if (matches.length !== 1) {
+    const matched = matches.map((target) => target.id).join(", ");
+    throw new Error(
+      `[ferric] Ambiguous native target ${detected}: matched ${matched}. ` +
+        `Supported targets: ${supported}.`,
+    );
+  }
+  return matches[0];
+}
+
+module.exports = {
+  detectRuntimeTarget,
+  formatRuntimeTarget,
+  selectDeclaredTarget,
+  targetMatchesRuntime,
+};

--- a/packages/ferric/native/targets.json
+++ b/packages/ferric/native/targets.json
@@ -25,6 +25,33 @@
     "libc": ["glibc"]
   },
   {
+    "id": "linux-arm64-gnu",
+    "packageName": "@ferric-rules/napi-linux-arm64-gnu",
+    "platform": "linux",
+    "arch": "arm64",
+    "os": ["linux"],
+    "cpu": ["arm64"],
+    "libc": ["glibc"]
+  },
+  {
+    "id": "linux-x64-musl",
+    "packageName": "@ferric-rules/napi-linux-x64-musl",
+    "platform": "linux",
+    "arch": "x64",
+    "os": ["linux"],
+    "cpu": ["x64"],
+    "libc": ["musl"]
+  },
+  {
+    "id": "linux-arm64-musl",
+    "packageName": "@ferric-rules/napi-linux-arm64-musl",
+    "platform": "linux",
+    "arch": "arm64",
+    "os": ["linux"],
+    "cpu": ["arm64"],
+    "libc": ["musl"]
+  },
+  {
     "id": "win32-x64-msvc",
     "packageName": "@ferric-rules/napi-win32-x64-msvc",
     "platform": "win32",

--- a/packages/ferric/package-lock.json
+++ b/packages/ferric/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@ferric-rules/node",
       "version": "0.1.0",
       "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "detect-libc": "2.1.2"
+      },
       "devDependencies": {
         "@types/node": "^22.0.0",
         "tsx": "^4.21.0",
@@ -20,6 +23,9 @@
         "@ferric-rules/napi-darwin-arm64": "0.1.0",
         "@ferric-rules/napi-darwin-x64": "0.1.0",
         "@ferric-rules/napi-linux-x64-gnu": "0.1.0",
+        "@ferric-rules/napi-linux-arm64-gnu": "0.1.0",
+        "@ferric-rules/napi-linux-x64-musl": "0.1.0",
+        "@ferric-rules/napi-linux-arm64-musl": "0.1.0",
         "@ferric-rules/napi-win32-x64-msvc": "0.1.0"
       }
     },
@@ -471,7 +477,16 @@
     "node_modules/@ferric-rules/napi-darwin-x64": {
       "optional": true
     },
+    "node_modules/@ferric-rules/napi-linux-arm64-gnu": {
+      "optional": true
+    },
+    "node_modules/@ferric-rules/napi-linux-arm64-musl": {
+      "optional": true
+    },
     "node_modules/@ferric-rules/napi-linux-x64-gnu": {
+      "optional": true
+    },
+    "node_modules/@ferric-rules/napi-linux-x64-musl": {
       "optional": true
     },
     "node_modules/@ferric-rules/napi-win32-x64-msvc": {
@@ -485,6 +500,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/esbuild": {

--- a/packages/ferric/package.json
+++ b/packages/ferric/package.json
@@ -30,10 +30,16 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "detect-libc": "2.1.2"
+  },
   "optionalDependencies": {
     "@ferric-rules/napi-darwin-arm64": "0.1.0",
     "@ferric-rules/napi-darwin-x64": "0.1.0",
     "@ferric-rules/napi-linux-x64-gnu": "0.1.0",
+    "@ferric-rules/napi-linux-arm64-gnu": "0.1.0",
+    "@ferric-rules/napi-linux-x64-musl": "0.1.0",
+    "@ferric-rules/napi-linux-arm64-musl": "0.1.0",
     "@ferric-rules/napi-win32-x64-msvc": "0.1.0"
   },
   "devDependencies": {

--- a/packages/ferric/test/conformance/coverage-entrypoint.test.ts
+++ b/packages/ferric/test/conformance/coverage-entrypoint.test.ts
@@ -15,6 +15,7 @@ import "./package/additional.test.ts";
 import "./package/coverage-entrypoint-manifest.test.ts";
 import "./package/loader-paths.test.ts";
 import "./package/node-package-text.test.ts";
+import "./package/node-target-matrix.test.ts";
 import "./package/npm-command.test.ts";
 import "./package/package-smoke.test.ts";
 import "./package/public-api-property.test.ts";

--- a/packages/ferric/test/conformance/package/loader-paths.test.ts
+++ b/packages/ferric/test/conformance/package/loader-paths.test.ts
@@ -9,13 +9,24 @@ import * as assert from "node:assert/strict";
 import { dirname, join, resolve } from "node:path";
 import { createRequire } from "node:module";
 
-import { FerricRuntimeError, FerricSerializationError } from "../../../dist/types";
+import {
+  FerricRuntimeError,
+  FerricSerializationError,
+} from "../../../dist/types";
 
 const requireFromHere = createRequire(__filename);
 const Module = requireFromHere("node:module") as any;
+const releaseNativeLoaderPath = resolve(__dirname, "../../../native/index.js");
+const runtimeTargetPath = resolve(
+  __dirname,
+  "../../../native/runtime-target.js",
+);
 
 function clearModule(path: string): void {
   delete requireFromHere.cache[requireFromHere.resolve(path)];
+  if (path === releaseNativeLoaderPath) {
+    delete requireFromHere.cache[requireFromHere.resolve(runtimeTargetPath)];
+  }
 }
 
 function withModuleLoad<T>(
@@ -23,7 +34,11 @@ function withModuleLoad<T>(
     request: string,
     parent: unknown,
     isMain: boolean,
-    originalLoad: (request: string, parent: unknown, isMain: boolean) => unknown,
+    originalLoad: (
+      request: string,
+      parent: unknown,
+      isMain: boolean,
+    ) => unknown,
   ) => unknown,
   fn: () => T,
 ): T {
@@ -42,7 +57,10 @@ function withModuleLoad<T>(
   }
 }
 
-function fakeNativeBinding(options?: { constructThrows?: boolean; snapshotFileThrows?: boolean }) {
+function fakeNativeBinding(options?: {
+  constructThrows?: boolean;
+  snapshotFileThrows?: boolean;
+}) {
   class FerricSymbol {
     constructor(readonly value: string) {}
   }
@@ -75,7 +93,10 @@ function fakeNativeBinding(options?: { constructThrows?: boolean; snapshotFileTh
       return fields;
     }
 
-    assertTemplate(_templateName: string, slots: Record<string, unknown>): Record<string, unknown> {
+    assertTemplate(
+      _templateName: string,
+      slots: Record<string, unknown>,
+    ): Record<string, unknown> {
       return slots;
     }
   }
@@ -85,6 +106,97 @@ function fakeNativeBinding(options?: { constructThrows?: boolean; snapshotFileTh
     FerricSymbol,
     nativePackageVersion: () => "0.1.0",
   };
+}
+
+interface NativeTargetFixture {
+  id: string;
+  packageName: string;
+  platform: string;
+  arch: string;
+  os: string[];
+  cpu: string[];
+  libc?: string[];
+}
+
+const declaredTargetFixtures: NativeTargetFixture[] = [
+  {
+    id: "darwin-arm64",
+    packageName: "@ferric-rules/napi-darwin-arm64",
+    platform: "darwin",
+    arch: "arm64",
+    os: ["darwin"],
+    cpu: ["arm64"],
+  },
+  {
+    id: "darwin-x64",
+    packageName: "@ferric-rules/napi-darwin-x64",
+    platform: "darwin",
+    arch: "x64",
+    os: ["darwin"],
+    cpu: ["x64"],
+  },
+  {
+    id: "linux-x64-gnu",
+    packageName: "@ferric-rules/napi-linux-x64-gnu",
+    platform: "linux",
+    arch: "x64",
+    os: ["linux"],
+    cpu: ["x64"],
+    libc: ["glibc"],
+  },
+  {
+    id: "linux-arm64-gnu",
+    packageName: "@ferric-rules/napi-linux-arm64-gnu",
+    platform: "linux",
+    arch: "arm64",
+    os: ["linux"],
+    cpu: ["arm64"],
+    libc: ["glibc"],
+  },
+  {
+    id: "linux-x64-musl",
+    packageName: "@ferric-rules/napi-linux-x64-musl",
+    platform: "linux",
+    arch: "x64",
+    os: ["linux"],
+    cpu: ["x64"],
+    libc: ["musl"],
+  },
+  {
+    id: "linux-arm64-musl",
+    packageName: "@ferric-rules/napi-linux-arm64-musl",
+    platform: "linux",
+    arch: "arm64",
+    os: ["linux"],
+    cpu: ["arm64"],
+    libc: ["musl"],
+  },
+  {
+    id: "win32-x64-msvc",
+    packageName: "@ferric-rules/napi-win32-x64-msvc",
+    platform: "win32",
+    arch: "x64",
+    os: ["win32"],
+    cpu: ["x64"],
+  },
+];
+
+function withProcessTarget<T>(platform: string, arch: string, fn: () => T): T {
+  const platformDescriptor = Object.getOwnPropertyDescriptor(
+    process,
+    "platform",
+  );
+  const archDescriptor = Object.getOwnPropertyDescriptor(process, "arch");
+  assert.ok(platformDescriptor);
+  assert.ok(archDescriptor);
+  Object.defineProperty(process, "platform", { value: platform });
+  Object.defineProperty(process, "arch", { value: arch });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, "platform", platformDescriptor);
+    Object.defineProperty(process, "arch", archDescriptor);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -177,18 +289,21 @@ test("G-002 package native wrapper converts mocked constructor and static errors
       () => {
         try {
           const mod = requireFromHere(nativePath);
-          assert.throws(() => exercise(mod), (err: unknown) => {
-            // The wrapper must CONVERT the raw napi-style error into the right
-            // FerricError subclass AND strip the "FerricXxxError:" prefix. A bare
-            // message substring would also match the unconverted error, so we
-            // pin both the class and the cleaned message to prove conversion ran.
-            assert.ok(
-              err instanceof ErrorClass,
-              `expected ${ErrorClass.name}, got ${(err as Error)?.constructor?.name}`,
-            );
-            assert.strictEqual((err as Error).message, strippedMessage);
-            return true;
-          });
+          assert.throws(
+            () => exercise(mod),
+            (err: unknown) => {
+              // The wrapper must CONVERT the raw napi-style error into the right
+              // FerricError subclass AND strip the "FerricXxxError:" prefix. A bare
+              // message substring would also match the unconverted error, so we
+              // pin both the class and the cleaned message to prove conversion ran.
+              assert.ok(
+                err instanceof ErrorClass,
+                `expected ${ErrorClass.name}, got ${(err as Error)?.constructor?.name}`,
+              );
+              assert.strictEqual((err as Error).message, strippedMessage);
+              return true;
+            },
+          );
         } finally {
           clearModule(nativePath);
         }
@@ -201,69 +316,412 @@ test("G-002 package native wrapper converts mocked constructor and static errors
 // G-002 manual napi loader: dev failure falls back to platform package
 // ---------------------------------------------------------------------------
 test("G-002 napi loader falls back from local node file to platform package", () => {
-  const napiPath = resolve(__dirname, "../../../../../crates/ferric-rules-napi/index.js");
-  const releaseLoaderPath = resolve(
+  const napiPath = resolve(
     __dirname,
-    "../../../native/index.js",
+    "../../../../../crates/ferric-rules-napi/index.js",
   );
+  const releaseLoaderPath = resolve(__dirname, "../../../native/index.js");
   const devPath = join(dirname(napiPath), "ferric-rules-napi.node");
-  const targets = requireFromHere("../../../native/targets.json") as Array<{
-    platform: string;
-    arch: string;
-    packageName: string;
-  }>;
-  const platformPackage = targets.find(
-    (target) =>
-      target.platform === process.platform &&
-      target.arch === process.arch,
-  )?.packageName;
-  assert.ok(platformPackage, "test host must be a declared native target");
+  const platformPackage = "@ferric-rules/napi-darwin-arm64";
   const fs = requireFromHere("node:fs") as typeof import("node:fs");
   const originalExistsSync = fs.existsSync;
 
   clearModule(napiPath);
   clearModule(releaseLoaderPath);
   fs.existsSync = (path) => path === devPath || originalExistsSync(path);
-  withModuleLoad(
-    (request, parent, isMain, originalLoad) => {
-      if (request === devPath) throw new Error("bad local binary");
-      if (request === `${platformPackage}/package.json`) {
-        return { version: "0.1.0" };
-      }
-      if (request === platformPackage || request.startsWith("@ferric-rules/napi-")) {
-        return fakeNativeBinding();
-      }
-      return originalLoad(request, parent, isMain);
-    },
-    () => {
-      try {
-        const mod = requireFromHere(napiPath);
-        const engine = new mod.Engine();
-        const sym = new mod.FerricSymbol("red");
-        const fields = engine.assertFact("color", sym, [sym], null, undefined, 7) as any[];
-        assert.deepStrictEqual(fields[0], { __ferric_symbol: true, value: "red" });
-        assert.deepStrictEqual(fields[1][0], { __ferric_symbol: true, value: "red" });
-        assert.strictEqual(fields[2], null);
-        assert.strictEqual(fields[3], undefined);
-        assert.strictEqual(fields[4], 7);
+  withProcessTarget("darwin", "arm64", () =>
+    withModuleLoad(
+      (request, parent, isMain, originalLoad) => {
+        if (request === devPath) throw new Error("bad local binary");
+        if (request === `${platformPackage}/package.json`) {
+          return { version: "0.1.0" };
+        }
+        if (
+          request === platformPackage ||
+          request.startsWith("@ferric-rules/napi-")
+        ) {
+          return fakeNativeBinding();
+        }
+        return originalLoad(request, parent, isMain);
+      },
+      () => {
+        try {
+          const mod = requireFromHere(napiPath);
+          const engine = new mod.Engine();
+          const sym = new mod.FerricSymbol("red");
+          const fields = engine.assertFact(
+            "color",
+            sym,
+            [sym],
+            null,
+            undefined,
+            7,
+          ) as any[];
+          assert.deepStrictEqual(fields[0], {
+            __ferric_symbol: true,
+            value: "red",
+          });
+          assert.deepStrictEqual(fields[1][0], {
+            __ferric_symbol: true,
+            value: "red",
+          });
+          assert.strictEqual(fields[2], null);
+          assert.strictEqual(fields[3], undefined);
+          assert.strictEqual(fields[4], 7);
 
-        // Slots can be absent in defensive/mocked calls; the loader should
-        // pass non-object slot values through instead of trying to enumerate.
-        assert.strictEqual(engine.assertTemplate("thing", null as any), null);
-      } finally {
-        fs.existsSync = originalExistsSync;
-        clearModule(napiPath);
-        clearModule(releaseLoaderPath);
-      }
-    },
+          // Slots can be absent in defensive/mocked calls; the loader should
+          // pass non-object slot values through instead of trying to enumerate.
+          assert.strictEqual(engine.assertTemplate("thing", null as any), null);
+        } finally {
+          fs.existsSync = originalExistsSync;
+          clearModule(napiPath);
+          clearModule(releaseLoaderPath);
+        }
+      },
+    ),
   );
+});
+
+// ---------------------------------------------------------------------------
+// FR-DIST-002: every declared OS/architecture/libc target is exact
+// ---------------------------------------------------------------------------
+test("FR-DIST-002 native loader selects exactly one compatible package", () => {
+  const releaseLoaderPath = resolve(__dirname, "../../../native/index.js");
+  const fs = requireFromHere("node:fs") as typeof import("node:fs");
+  const originalExistsSync = fs.existsSync;
+  const cases = declaredTargetFixtures.map((target) => ({
+    ...target,
+    family: target.libc?.[0],
+  }));
+
+  fs.existsSync = () => false;
+  try {
+    for (const item of cases) {
+      clearModule(releaseLoaderPath);
+      const nativeRequests: string[] = [];
+      let detectorCalls = 0;
+
+      withProcessTarget(item.platform, item.arch, () =>
+        withModuleLoad(
+          (request, parent, isMain, originalLoad) => {
+            if (request === "./targets.json") return declaredTargetFixtures;
+            if (request === "detect-libc") {
+              detectorCalls += 1;
+              return {
+                familySync: () => item.family,
+                GLIBC: "glibc",
+                MUSL: "musl",
+              };
+            }
+            if (request.startsWith("@ferric-rules/napi-")) {
+              nativeRequests.push(request);
+              if (request === `${item.packageName}/package.json`) {
+                return { version: "0.1.0" };
+              }
+              if (request === item.packageName) return fakeNativeBinding();
+              throw new Error(
+                `loader requested incompatible package ${request}`,
+              );
+            }
+            return originalLoad(request, parent, isMain);
+          },
+          () => {
+            const mod = requireFromHere(releaseLoaderPath);
+            assert.strictEqual(typeof mod.Engine, "function");
+          },
+        ),
+      );
+
+      assert.deepStrictEqual(
+        nativeRequests,
+        [`${item.packageName}/package.json`, item.packageName],
+        `${item.id} must not probe a sibling OS, architecture, or libc package`,
+      );
+      assert.strictEqual(
+        detectorCalls,
+        item.platform === "linux" ? 1 : 0,
+        `${item.id} must ${item.platform === "linux" ? "use" : "skip"} libc detection`,
+      );
+    }
+  } finally {
+    fs.existsSync = originalExistsSync;
+    clearModule(releaseLoaderPath);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// FR-DIST-002: unknown libc fails closed instead of guessing GNU or musl
+// ---------------------------------------------------------------------------
+test("FR-DIST-002 native loader fails closed when Linux libc is unknown", () => {
+  const releaseLoaderPath = resolve(__dirname, "../../../native/index.js");
+  const fs = requireFromHere("node:fs") as typeof import("node:fs");
+  const originalExistsSync = fs.existsSync;
+  const supported = declaredTargetFixtures
+    .map((target) => target.id)
+    .join(", ");
+  const cases = [
+    {
+      label: "null",
+      familySync: () => null,
+      expectedCause: undefined,
+    },
+    {
+      label: "detector exception",
+      familySync: () => {
+        throw new Error("detector exploded");
+      },
+      expectedCause: /detector exploded/,
+    },
+    {
+      label: "unrecognized family",
+      familySync: () => "bionic",
+      expectedCause: /detect-libc returned unsupported family bionic/,
+    },
+    {
+      label: "incomplete detector constants",
+      familySync: () => undefined,
+      omitConstants: true,
+      expectedCause: /detect-libc returned unsupported family undefined/,
+    },
+    {
+      label: "missing familySync export",
+      familySync: undefined,
+      omitConstants: true,
+      expectedCause: /detect-libc familySync export is unavailable/,
+    },
+  ];
+
+  fs.existsSync = () => true;
+  try {
+    for (const item of cases) {
+      clearModule(releaseLoaderPath);
+      const nativeRequests: string[] = [];
+      withProcessTarget("linux", "x64", () =>
+        withModuleLoad(
+          (request, parent, isMain, originalLoad) => {
+            if (request === "./targets.json") return declaredTargetFixtures;
+            if (request === "detect-libc") {
+              return item.omitConstants
+                ? { familySync: item.familySync }
+                : {
+                    familySync: item.familySync,
+                    GLIBC: "glibc",
+                    MUSL: "musl",
+                  };
+            }
+            if (
+              request.endsWith(".node") ||
+              request.startsWith("@ferric-rules/napi-")
+            ) {
+              nativeRequests.push(request);
+            }
+            return originalLoad(request, parent, isMain);
+          },
+          () => {
+            assert.throws(
+              () => requireFromHere(releaseLoaderPath),
+              (error: Error & { cause?: unknown }) => {
+                assert.match(
+                  error.message,
+                  /Unsupported native target linux-x64-unknown/,
+                  item.label,
+                );
+                assert.match(
+                  error.message,
+                  new RegExp(`Supported targets: ${supported}\\.`),
+                  item.label,
+                );
+                if (item.expectedCause) {
+                  assert.match(error.message, item.expectedCause, item.label);
+                  assert.ok(error.cause instanceof Error, item.label);
+                } else {
+                  assert.strictEqual(error.cause, undefined, item.label);
+                }
+                return true;
+              },
+            );
+          },
+        ),
+      );
+      assert.deepStrictEqual(
+        nativeRequests,
+        [],
+        `${item.label} must fail before requiring a development or platform addon`,
+      );
+    }
+  } finally {
+    fs.existsSync = originalExistsSync;
+    clearModule(releaseLoaderPath);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// FR-DIST-002: unsupported triples identify the complete detected target
+// ---------------------------------------------------------------------------
+test("FR-DIST-002 unsupported native targets fail before addon loading", () => {
+  const releaseLoaderPath = resolve(__dirname, "../../../native/index.js");
+  const fs = requireFromHere("node:fs") as typeof import("node:fs");
+  const originalExistsSync = fs.existsSync;
+  const supported = declaredTargetFixtures
+    .map((target) => target.id)
+    .join(", ");
+  const cases = [
+    {
+      platform: "linux",
+      arch: "riscv64",
+      family: "glibc",
+      detectedId: "linux-riscv64-gnu",
+    },
+    {
+      platform: "win32",
+      arch: "arm64",
+      family: undefined,
+      detectedId: "win32-arm64-msvc",
+    },
+    {
+      platform: "freebsd",
+      arch: "riscv64",
+      family: undefined,
+      detectedId: "freebsd-riscv64",
+    },
+  ];
+
+  fs.existsSync = () => true;
+  try {
+    for (const item of cases) {
+      clearModule(releaseLoaderPath);
+      const nativeRequests: string[] = [];
+      let detectorCalls = 0;
+      withProcessTarget(item.platform, item.arch, () =>
+        withModuleLoad(
+          (request, parent, isMain, originalLoad) => {
+            if (request === "./targets.json") return declaredTargetFixtures;
+            if (request === "detect-libc") {
+              detectorCalls += 1;
+              return {
+                familySync: () => item.family,
+                GLIBC: "glibc",
+                MUSL: "musl",
+              };
+            }
+            if (
+              request.endsWith(".node") ||
+              request.startsWith("@ferric-rules/napi-")
+            ) {
+              nativeRequests.push(request);
+            }
+            return originalLoad(request, parent, isMain);
+          },
+          () => {
+            assert.throws(
+              () => requireFromHere(releaseLoaderPath),
+              (error: Error) => {
+                assert.match(
+                  error.message,
+                  new RegExp(`Unsupported native target ${item.detectedId}\\.`),
+                );
+                assert.match(
+                  error.message,
+                  new RegExp(`Supported targets: ${supported}\\.`),
+                );
+                return true;
+              },
+            );
+          },
+        ),
+      );
+      assert.strictEqual(detectorCalls, item.platform === "linux" ? 1 : 0);
+      assert.deepStrictEqual(
+        nativeRequests,
+        [],
+        `${item.detectedId} must fail before requiring an addon`,
+      );
+    }
+  } finally {
+    fs.existsSync = originalExistsSync;
+    clearModule(releaseLoaderPath);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// FR-DIST-002: corrupt/ambiguous target manifests fail before addon loading
+// ---------------------------------------------------------------------------
+test("FR-DIST-002 ambiguous native targets fail before addon loading", () => {
+  const releaseLoaderPath = resolve(__dirname, "../../../native/index.js");
+  const fs = requireFromHere("node:fs") as typeof import("node:fs");
+  const originalExistsSync = fs.existsSync;
+  const duplicate = {
+    ...declaredTargetFixtures.find((target) => target.id === "linux-x64-gnu")!,
+    id: "linux-x64-gnu-duplicate",
+    packageName: "@ferric-rules/napi-linux-x64-gnu-duplicate",
+  };
+  const ambiguousTargets = [...declaredTargetFixtures, duplicate];
+  const supported = ambiguousTargets.map((target) => target.id).join(", ");
+  const nativeRequests: string[] = [];
+
+  fs.existsSync = () => true;
+  clearModule(releaseLoaderPath);
+  try {
+    withProcessTarget("linux", "x64", () =>
+      withModuleLoad(
+        (request, parent, isMain, originalLoad) => {
+          if (request === "./targets.json") return ambiguousTargets;
+          if (request === "detect-libc") {
+            return {
+              familySync: () => "glibc",
+              GLIBC: "glibc",
+              MUSL: "musl",
+            };
+          }
+          if (
+            request.endsWith(".node") ||
+            request.startsWith("@ferric-rules/napi-")
+          ) {
+            nativeRequests.push(request);
+          }
+          return originalLoad(request, parent, isMain);
+        },
+        () => {
+          assert.throws(
+            () => requireFromHere(releaseLoaderPath),
+            (error: Error) => {
+              assert.match(
+                error.message,
+                /Ambiguous native target linux-x64-gnu/,
+              );
+              assert.match(
+                error.message,
+                /matched linux-x64-gnu, linux-x64-gnu-duplicate/,
+              );
+              assert.match(
+                error.message,
+                new RegExp(`Supported targets: ${supported}\\.`),
+              );
+              return true;
+            },
+          );
+        },
+      ),
+    );
+    assert.deepStrictEqual(
+      nativeRequests,
+      [],
+      "ambiguous detection must fail before requiring an addon",
+    );
+  } finally {
+    fs.existsSync = originalExistsSync;
+    clearModule(releaseLoaderPath);
+  }
 });
 
 // ---------------------------------------------------------------------------
 // G-002 table-driven napi loader: package and binary versions must match
 // ---------------------------------------------------------------------------
 test("G-002 napi loader rejects native package version skew", () => {
-  const napiPath = resolve(__dirname, "../../../../../crates/ferric-rules-napi/index.js");
+  const napiPath = resolve(
+    __dirname,
+    "../../../../../crates/ferric-rules-napi/index.js",
+  );
   const releaseLoaderPath = resolve(__dirname, "../../../native/index.js");
   const platformPackage = "@ferric-rules/napi-darwin-arm64";
   const fs = requireFromHere("node:fs") as typeof import("node:fs");
@@ -331,11 +789,11 @@ test("G-002 napi loader rejects native package version skew", () => {
 // G-002 table-driven napi loader failures produce deterministic messages
 // ---------------------------------------------------------------------------
 test("G-002 table-driven napi loader failure cases are explicit", () => {
-  const napiPath = resolve(__dirname, "../../../../../crates/ferric-rules-napi/index.js");
-  const releaseLoaderPath = resolve(
+  const napiPath = resolve(
     __dirname,
-    "../../../native/index.js",
+    "../../../../../crates/ferric-rules-napi/index.js",
   );
+  const releaseLoaderPath = resolve(__dirname, "../../../native/index.js");
   const fs = requireFromHere("node:fs") as typeof import("node:fs");
   const originalExistsSync = fs.existsSync;
   const originalPlatform = process.platform;
@@ -373,7 +831,10 @@ test("G-002 table-driven napi loader failure cases are explicit", () => {
     try {
       withModuleLoad(
         (request, parent, isMain, originalLoad) => {
-          if (item.devReturnsNull && request === join(dirname(napiPath), "ferric-rules-napi.node")) {
+          if (
+            item.devReturnsNull &&
+            request === join(dirname(napiPath), "ferric-rules-napi.node")
+          ) {
             return null;
           }
           return originalLoad(request, parent, isMain);

--- a/packages/ferric/test/conformance/package/node-target-matrix.test.ts
+++ b/packages/ferric/test/conformance/package/node-target-matrix.test.ts
@@ -154,6 +154,23 @@ test("G-001 generated platform manifests preserve every canonical target selecto
 });
 
 test("G-001 Node artifact workflow covers the exact native target matrix", () => {
+  const contractJob = artifactWorkflow.match(
+    /\n  validate-artifact-contract:\n([\s\S]*?)\n  pack-and-smoke:/,
+  )?.[1];
+  assert.ok(contractJob, "Node artifact workflow must validate clean checkout state");
+  const installOffset = contractJob.indexOf("npm ci");
+  const buildOffset = contractJob.indexOf("npm run build");
+  const testOffset = contractJob.indexOf("./node_modules/.bin/tsx --test");
+  assert.ok(installOffset >= 0, "artifact contract job must install dependencies");
+  assert.ok(
+    buildOffset > installOffset,
+    "artifact contract job must build dist after installing dependencies",
+  );
+  assert.ok(
+    testOffset > buildOffset,
+    "artifact contract job must build dist before running loader tests",
+  );
+
   const rows = workflowTargetRows();
   assert.deepStrictEqual(rows, [
     {

--- a/packages/ferric/test/conformance/package/node-target-matrix.test.ts
+++ b/packages/ferric/test/conformance/package/node-target-matrix.test.ts
@@ -1,0 +1,290 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import * as assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  CANONICAL_NODE_TARGETS,
+  DETECT_LIBC_VERSION,
+  collectNodeTargetValidationErrors,
+  createPlatformManifest,
+  targetDetectionKey,
+} from "../../../../../scripts/node-package-lib.mjs";
+
+function readJson(relativePath: string): any {
+  return JSON.parse(readFileSync(resolve(__dirname, relativePath), "utf8"));
+}
+
+const mainPackage = readJson("../../../package.json");
+const mainLock = readJson("../../../package-lock.json");
+const declaredTargets = readJson("../../../native/targets.json");
+const artifactWorkflow = readFileSync(
+  resolve(
+    __dirname,
+    "../../../../../.github/workflows/node-package-artifacts.yml",
+  ),
+  "utf8",
+);
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function validConfiguration(overrides: Record<string, unknown> = {}): any {
+  return {
+    targets: clone(CANONICAL_NODE_TARGETS),
+    version: mainPackage.version,
+    dependencies: clone(mainPackage.dependencies),
+    optionalDependencies: clone(mainPackage.optionalDependencies),
+    lockedDependencies: clone(mainLock.packages[""].dependencies),
+    lockedOptionalDependencies: clone(
+      mainLock.packages[""].optionalDependencies,
+    ),
+    lockedPackages: clone(mainLock.packages),
+    ...overrides,
+  };
+}
+
+function assertHasError(errors: string[], expected: RegExp): void {
+  assert.ok(
+    errors.some((error) => expected.test(error)),
+    `expected ${expected} in:\n${errors.join("\n")}`,
+  );
+}
+
+function workflowTargetRows(): Array<Record<string, string>> {
+  const matrix = artifactWorkflow.match(
+    /\n\s+matrix:\n\s+include:\n([\s\S]*?)\n\s+runs-on:/,
+  )?.[1];
+  assert.ok(matrix, "Node artifact workflow must contain an include matrix");
+
+  return [
+    ...matrix.matchAll(/^\s+- target:\s*(\S+)\n((?:\s{12}.+\n?)*)/gm),
+  ].map(([, target, body]) => {
+    const row: Record<string, string> = { target };
+    for (const field of ["runner", "rust_target", "libc"]) {
+      const value = body.match(
+        new RegExp(`^\\s+${field}:\\s*(\\S+)`, "m"),
+      )?.[1];
+      if (value) row[field] = value;
+    }
+    return row;
+  });
+}
+
+test("G-001 Node target manifest is the exact canonical seven-target matrix", () => {
+  assert.deepStrictEqual(declaredTargets, CANONICAL_NODE_TARGETS);
+  assert.deepStrictEqual(declaredTargets.map(targetDetectionKey), [
+    "darwin/arm64/none",
+    "darwin/x64/none",
+    "linux/x64/glibc",
+    "linux/arm64/glibc",
+    "linux/x64/musl",
+    "linux/arm64/musl",
+    "win32/x64/none",
+  ]);
+  assert.deepStrictEqual(
+    collectNodeTargetValidationErrors(validConfiguration()),
+    [],
+  );
+});
+
+test("G-001 Node package and lock metadata pin every target and detect-libc", () => {
+  const packageNames = CANONICAL_NODE_TARGETS.map(
+    (target) => target.packageName,
+  );
+  assert.deepStrictEqual(
+    Object.keys(mainPackage.optionalDependencies),
+    packageNames,
+  );
+  assert.deepStrictEqual(
+    Object.keys(mainLock.packages[""].optionalDependencies),
+    packageNames,
+  );
+  assert.strictEqual(
+    mainPackage.dependencies["detect-libc"],
+    DETECT_LIBC_VERSION,
+  );
+  assert.strictEqual(
+    mainLock.packages[""].dependencies["detect-libc"],
+    DETECT_LIBC_VERSION,
+  );
+  assert.strictEqual(
+    mainLock.packages["node_modules/detect-libc"].version,
+    DETECT_LIBC_VERSION,
+  );
+
+  for (const packageName of packageNames) {
+    assert.strictEqual(
+      mainPackage.optionalDependencies[packageName],
+      mainPackage.version,
+    );
+    assert.strictEqual(
+      mainLock.packages[`node_modules/${packageName}`].optional,
+      true,
+    );
+  }
+});
+
+test("G-001 generated platform manifests preserve every canonical target selector", () => {
+  for (const target of CANONICAL_NODE_TARGETS) {
+    const manifest = createPlatformManifest({
+      target,
+      mainPackage,
+      version: mainPackage.version,
+    });
+    assert.deepStrictEqual(manifest, {
+      name: target.packageName,
+      version: mainPackage.version,
+      description: `Native Ferric addon for ${target.id}`,
+      main: "ferric-rules-napi.node",
+      files: ["ferric-rules-napi.node"],
+      os: target.os,
+      cpu: target.cpu,
+      ...(target.libc ? { libc: target.libc } : {}),
+      engines: mainPackage.engines,
+      repository: {
+        type: "git",
+        url: "git+https://github.com/plx/ferric-rules.git",
+      },
+      license: mainPackage.license,
+      publishConfig: { access: "public" },
+    });
+  }
+});
+
+test("G-001 Node artifact workflow covers the exact native target matrix", () => {
+  const rows = workflowTargetRows();
+  assert.deepStrictEqual(rows, [
+    {
+      target: "darwin-arm64",
+      runner: "macos-15",
+      rust_target: "aarch64-apple-darwin",
+    },
+    {
+      target: "darwin-x64",
+      runner: "macos-15-intel",
+      rust_target: "x86_64-apple-darwin",
+    },
+    {
+      target: "linux-x64-gnu",
+      runner: "ubuntu-24.04",
+      rust_target: "x86_64-unknown-linux-gnu",
+    },
+    {
+      target: "linux-arm64-gnu",
+      runner: "ubuntu-24.04-arm",
+      rust_target: "aarch64-unknown-linux-gnu",
+    },
+    {
+      target: "linux-x64-musl",
+      runner: "ubuntu-24.04",
+      rust_target: "x86_64-unknown-linux-musl",
+      libc: "musl",
+    },
+    {
+      target: "linux-arm64-musl",
+      runner: "ubuntu-24.04-arm",
+      rust_target: "aarch64-unknown-linux-musl",
+      libc: "musl",
+    },
+    {
+      target: "win32-x64-msvc",
+      runner: "windows-2025",
+      rust_target: "x86_64-pc-windows-msvc",
+    },
+  ]);
+  assert.strictEqual(new Set(rows.map((row) => row.target)).size, 7);
+
+  const muslRows = rows.filter((row) => row.libc === "musl");
+  assert.deepStrictEqual(
+    muslRows.map((row) => row.target),
+    ["linux-x64-musl", "linux-arm64-musl"],
+  );
+  for (const target of ["linux-arm64-gnu", "linux-arm64-musl"]) {
+    assert.strictEqual(
+      rows.find((row) => row.target === target)?.runner,
+      "ubuntu-24.04-arm",
+    );
+  }
+});
+
+test("G-001 musl artifact lanes build and smoke in matching Alpine runtimes", () => {
+  for (const requiredFragment of [
+    "if: matrix.libc == 'musl'",
+    "docker run --rm",
+    '--env RUST_TARGET="${{ matrix.rust_target }}"',
+    '--env TARGET_ID="${{ matrix.target }}"',
+    "node:22-alpine",
+    'npm run build -- --target "$RUST_TARGET"',
+    '--target "$TARGET_ID"',
+  ]) {
+    assert.ok(
+      artifactWorkflow.includes(requiredFragment),
+      `Node artifact workflow must contain ${requiredFragment}`,
+    );
+  }
+});
+
+test("G-001 target validation rejects reordered, malformed, and ambiguous rows", () => {
+  const reordered = clone(CANONICAL_NODE_TARGETS);
+  [reordered[2], reordered[3]] = [reordered[3], reordered[2]];
+  assertHasError(
+    collectNodeTargetValidationErrors(
+      validConfiguration({ targets: reordered }),
+    ),
+    /canonical order/,
+  );
+
+  const missingLibc = clone(CANONICAL_NODE_TARGETS);
+  delete missingLibc[2].libc;
+  const missingLibcErrors = collectNodeTargetValidationErrors(
+    validConfiguration({ targets: missingLibc }),
+  );
+  assertHasError(missingLibcErrors, /linux-x64-gnu.*fields/);
+  assertHasError(missingLibcErrors, /linux-x64-gnu\.libc/);
+
+  const ambiguous = clone(CANONICAL_NODE_TARGETS);
+  ambiguous[5].libc = ["glibc"];
+  assertHasError(
+    collectNodeTargetValidationErrors(
+      validConfiguration({ targets: ambiguous }),
+    ),
+    /ambiguous target detection key linux\/arm64\/glibc/,
+  );
+
+  const extraField = clone(CANONICAL_NODE_TARGETS);
+  extraField[0].abi = "napi8";
+  assertHasError(
+    collectNodeTargetValidationErrors(
+      validConfiguration({ targets: extraField }),
+    ),
+    /darwin-arm64.*exactly these fields/,
+  );
+});
+
+test("G-001 target validation rejects dependency and lock drift", () => {
+  const optionalDependencies = clone(mainPackage.optionalDependencies);
+  optionalDependencies["@ferric-rules/napi-linux-arm64-musl"] = "0.2.0";
+  optionalDependencies["@ferric-rules/napi-freebsd-x64"] = mainPackage.version;
+  const optionalErrors = collectNodeTargetValidationErrors(
+    validConfiguration({ optionalDependencies }),
+  );
+  assertHasError(optionalErrors, /linux-arm64-musl.*exact optional dependency/);
+  assertHasError(optionalErrors, /unexpected optional dependency.*freebsd/);
+
+  const lockedPackages = clone(mainLock.packages);
+  delete lockedPackages["node_modules/@ferric-rules/napi-linux-x64-musl"];
+  lockedPackages["node_modules/detect-libc"].dev = true;
+  const lockedErrors = collectNodeTargetValidationErrors(
+    validConfiguration({
+      dependencies: { "detect-libc": "^2.1.2" },
+      lockedDependencies: { "detect-libc": "2.0.0" },
+      lockedPackages,
+    }),
+  );
+  assertHasError(lockedErrors, /exact runtime dependency/);
+  assertHasError(lockedErrors, /version-locked/);
+  assertHasError(lockedErrors, /linux-x64-musl.*present and optional/);
+  assertHasError(lockedErrors, /regular runtime dependency/);
+});

--- a/packages/ferric/test/conformance/package/node-target-matrix.test.ts
+++ b/packages/ferric/test/conformance/package/node-target-matrix.test.ts
@@ -25,6 +25,10 @@ const artifactWorkflow = readFileSync(
   ),
   "utf8",
 );
+const ciWorkflow = readFileSync(
+  resolve(__dirname, "../../../../../.github/workflows/ci.yml"),
+  "utf8",
+);
 
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value));
@@ -224,6 +228,23 @@ test("G-001 Node artifact workflow covers the exact native target matrix", () =>
       "ubuntu-24.04-arm",
     );
   }
+});
+
+test("G-001 Node CI preserves the version-locked package metadata", () => {
+  const nodeBindingsJob = ciWorkflow.match(
+    /\n  node-bindings:\n([\s\S]*?)\n  bindings-conformance:/,
+  )?.[1];
+  assert.ok(nodeBindingsJob, "CI must contain the Node bindings job");
+  assert.strictEqual(
+    [...nodeBindingsJob.matchAll(/^\s+npm ci$/gm)].length,
+    2,
+    "Node binding installs must use the immutable lockfile path",
+  );
+  assert.strictEqual(
+    [...nodeBindingsJob.matchAll(/^\s+npm install$/gm)].length,
+    0,
+    "Node binding installs must not rewrite the locked native matrix",
+  );
 });
 
 test("G-001 musl artifact lanes build and smoke in matching Alpine runtimes", () => {

--- a/scripts/node-package-lib.mjs
+++ b/scripts/node-package-lib.mjs
@@ -24,6 +24,70 @@ export const nativeCrateDirectory = join(
   "ferric-rules-napi",
 );
 export const nativeBinaryName = "ferric-rules-napi.node";
+export const DETECT_LIBC_VERSION = "2.1.2";
+
+export const CANONICAL_NODE_TARGETS = Object.freeze([
+  {
+    id: "darwin-arm64",
+    packageName: "@ferric-rules/napi-darwin-arm64",
+    platform: "darwin",
+    arch: "arm64",
+    os: ["darwin"],
+    cpu: ["arm64"],
+  },
+  {
+    id: "darwin-x64",
+    packageName: "@ferric-rules/napi-darwin-x64",
+    platform: "darwin",
+    arch: "x64",
+    os: ["darwin"],
+    cpu: ["x64"],
+  },
+  {
+    id: "linux-x64-gnu",
+    packageName: "@ferric-rules/napi-linux-x64-gnu",
+    platform: "linux",
+    arch: "x64",
+    os: ["linux"],
+    cpu: ["x64"],
+    libc: ["glibc"],
+  },
+  {
+    id: "linux-arm64-gnu",
+    packageName: "@ferric-rules/napi-linux-arm64-gnu",
+    platform: "linux",
+    arch: "arm64",
+    os: ["linux"],
+    cpu: ["arm64"],
+    libc: ["glibc"],
+  },
+  {
+    id: "linux-x64-musl",
+    packageName: "@ferric-rules/napi-linux-x64-musl",
+    platform: "linux",
+    arch: "x64",
+    os: ["linux"],
+    cpu: ["x64"],
+    libc: ["musl"],
+  },
+  {
+    id: "linux-arm64-musl",
+    packageName: "@ferric-rules/napi-linux-arm64-musl",
+    platform: "linux",
+    arch: "arm64",
+    os: ["linux"],
+    cpu: ["arm64"],
+    libc: ["musl"],
+  },
+  {
+    id: "win32-x64-msvc",
+    packageName: "@ferric-rules/napi-win32-x64-msvc",
+    platform: "win32",
+    arch: "x64",
+    os: ["win32"],
+    cpu: ["x64"],
+  },
+]);
 
 const targetsPath = join(mainPackageDirectory, "native", "targets.json");
 
@@ -37,6 +101,196 @@ async function writeJson(path, value) {
 
 export async function loadTargets() {
   return readJson(targetsPath);
+}
+
+function sameSequence(actual, expected) {
+  return (
+    actual.length === expected.length &&
+    actual.every((value, index) => value === expected[index])
+  );
+}
+
+function formatValue(value) {
+  return JSON.stringify(value) ?? String(value);
+}
+
+export function targetDetectionKey(target) {
+  const libc =
+    Array.isArray(target.libc) && target.libc.length === 1
+      ? target.libc[0]
+      : "none";
+  return `${String(target.platform)}/${String(target.arch)}/${String(libc)}`;
+}
+
+function validateVersionMap({ errors, label, actual, expectedNames, version }) {
+  if (actual === null || typeof actual !== "object" || Array.isArray(actual)) {
+    errors.push(`${label} must be an object`);
+    return;
+  }
+
+  const actualNames = Object.keys(actual);
+  if (!sameSequence(actualNames, expectedNames)) {
+    errors.push(
+      `${label} must follow canonical target order: ${expectedNames.join(", ")}`,
+    );
+  }
+
+  for (const packageName of expectedNames) {
+    if (actual[packageName] !== version) {
+      errors.push(`${packageName} must be an exact ${label} at ${version}`);
+    }
+  }
+  for (const packageName of actualNames) {
+    if (!expectedNames.includes(packageName)) {
+      errors.push(`unexpected ${label} ${packageName}`);
+    }
+  }
+}
+
+export function collectNodeTargetValidationErrors({
+  targets,
+  version,
+  dependencies = {},
+  optionalDependencies = {},
+  lockedDependencies = {},
+  lockedOptionalDependencies = {},
+  lockedPackages = {},
+}) {
+  const errors = [];
+  const expectedIds = CANONICAL_NODE_TARGETS.map((target) => target.id);
+  const expectedPackageNames = CANONICAL_NODE_TARGETS.map(
+    (target) => target.packageName,
+  );
+  const canonicalById = new Map(
+    CANONICAL_NODE_TARGETS.map((target) => [target.id, target]),
+  );
+
+  if (!Array.isArray(targets)) {
+    return ["native/targets.json must contain an array"];
+  }
+
+  if (targets.length !== CANONICAL_NODE_TARGETS.length) {
+    errors.push(
+      `native/targets.json must declare exactly ${CANONICAL_NODE_TARGETS.length} targets, found ${targets.length}`,
+    );
+  }
+
+  const actualIds = targets.map((target) => target?.id);
+  if (!sameSequence(actualIds, expectedIds)) {
+    errors.push(
+      `native targets must follow canonical order: ${expectedIds.join(", ")}`,
+    );
+  }
+
+  const ids = new Set();
+  const packageNames = new Set();
+  const detectionKeys = new Set();
+  for (const target of targets) {
+    if (
+      target === null ||
+      typeof target !== "object" ||
+      Array.isArray(target)
+    ) {
+      errors.push(
+        `native target rows must be objects, found ${formatValue(target)}`,
+      );
+      continue;
+    }
+
+    const id = String(target.id);
+    const packageName = String(target.packageName);
+    const detectionKey = targetDetectionKey(target);
+    if (ids.has(id)) errors.push(`duplicate target id ${id}`);
+    if (packageNames.has(packageName)) {
+      errors.push(`duplicate native package ${packageName}`);
+    }
+    if (detectionKeys.has(detectionKey)) {
+      errors.push(`ambiguous target detection key ${detectionKey}`);
+    }
+    ids.add(id);
+    packageNames.add(packageName);
+    detectionKeys.add(detectionKey);
+
+    const canonical = canonicalById.get(id);
+    if (!canonical) {
+      errors.push(`unexpected native target id ${id}`);
+      continue;
+    }
+
+    const actualKeys = Object.keys(target).sort();
+    const expectedKeys = Object.keys(canonical).sort();
+    if (!sameSequence(actualKeys, expectedKeys)) {
+      errors.push(
+        `${id} must contain exactly these fields: ${expectedKeys.join(", ")}`,
+      );
+    }
+    for (const [field, expected] of Object.entries(canonical)) {
+      if (formatValue(target[field]) !== formatValue(expected)) {
+        errors.push(
+          `${id}.${field} must be ${formatValue(expected)}, found ${formatValue(target[field])}`,
+        );
+      }
+    }
+  }
+
+  for (const id of expectedIds) {
+    if (!ids.has(id)) errors.push(`missing native target ${id}`);
+  }
+
+  validateVersionMap({
+    errors,
+    label: "optional dependency",
+    actual: optionalDependencies,
+    expectedNames: expectedPackageNames,
+    version,
+  });
+  validateVersionMap({
+    errors,
+    label: "locked optional dependency",
+    actual: lockedOptionalDependencies,
+    expectedNames: expectedPackageNames,
+    version,
+  });
+
+  if (dependencies["detect-libc"] !== DETECT_LIBC_VERSION) {
+    errors.push(
+      `detect-libc must be an exact runtime dependency at ${DETECT_LIBC_VERSION}`,
+    );
+  }
+  if (lockedDependencies["detect-libc"] !== DETECT_LIBC_VERSION) {
+    errors.push(
+      `detect-libc must be version-locked at ${DETECT_LIBC_VERSION} in package-lock.json`,
+    );
+  }
+
+  const expectedLockedPackagePaths = new Set(
+    expectedPackageNames.map((name) => `node_modules/${name}`),
+  );
+  const lockedNativePackagePaths = Object.keys(lockedPackages).filter((path) =>
+    path.startsWith("node_modules/@ferric-rules/napi-"),
+  );
+  for (const path of expectedLockedPackagePaths) {
+    if (lockedPackages[path]?.optional !== true) {
+      errors.push(`${path} must be present and optional in package-lock.json`);
+    }
+  }
+  for (const path of lockedNativePackagePaths) {
+    if (!expectedLockedPackagePaths.has(path)) {
+      errors.push(`unexpected locked native package ${path}`);
+    }
+  }
+
+  const lockedDetectLibc = lockedPackages["node_modules/detect-libc"];
+  if (lockedDetectLibc?.version !== DETECT_LIBC_VERSION) {
+    errors.push(
+      `node_modules/detect-libc must be locked at ${DETECT_LIBC_VERSION}`,
+    );
+  }
+  if (lockedDetectLibc?.dev === true || lockedDetectLibc?.optional === true) {
+    errors.push("detect-libc must be a regular runtime dependency");
+  }
+
+  return errors;
 }
 
 export function npmArchiveName(packageName, version) {
@@ -63,6 +317,7 @@ export async function validateNodePackage() {
     nativeEntries,
     mainPackageText,
     nativeLoaderText,
+    runtimeTargetText,
     targetsText,
   ] = await Promise.all([
     readJson(join(mainPackageDirectory, "package.json")),
@@ -73,13 +328,16 @@ export async function validateNodePackage() {
     readdir(join(mainPackageDirectory, "native")),
     readFile(join(mainPackageDirectory, "package.json"), "utf8"),
     readFile(join(mainPackageDirectory, "native", "index.js"), "utf8"),
+    readFile(join(mainPackageDirectory, "native", "runtime-target.js"), "utf8"),
     readFile(targetsPath, "utf8"),
   ]);
 
   const errors = [];
   const version = mainPackage.version;
   const cargoVersion = workspaceVersion(cargoManifest);
+  const dependencies = mainPackage.dependencies ?? {};
   const optionalDependencies = mainPackage.optionalDependencies ?? {};
+  const lockedDependencies = mainLock.packages?.[""]?.dependencies ?? {};
   const lockedOptionalDependencies =
     mainLock.packages?.[""]?.optionalDependencies ?? {};
 
@@ -114,6 +372,10 @@ export async function validateNodePackage() {
       contents: nativeLoaderText,
     },
     {
+      path: "packages/ferric/native/runtime-target.js",
+      contents: runtimeTargetText,
+    },
+    {
       path: "packages/ferric/native/targets.json",
       contents: targetsText,
     },
@@ -133,44 +395,17 @@ export async function validateNodePackage() {
     );
   }
 
-  const ids = new Set();
-  const packageNames = new Set();
-  const detectionKeys = new Set();
-  for (const target of targets) {
-    const detectionKey = `${target.platform}-${target.arch}`;
-    if (ids.has(target.id)) errors.push(`duplicate target id ${target.id}`);
-    if (packageNames.has(target.packageName)) {
-      errors.push(`duplicate native package ${target.packageName}`);
-    }
-    if (detectionKeys.has(detectionKey)) {
-      errors.push(`ambiguous target detection key ${detectionKey}`);
-    }
-    ids.add(target.id);
-    packageNames.add(target.packageName);
-    detectionKeys.add(detectionKey);
-
-    if (optionalDependencies[target.packageName] !== version) {
-      errors.push(
-        `${target.packageName} must be an exact optional dependency at ${version}`,
-      );
-    }
-    if (lockedOptionalDependencies[target.packageName] !== version) {
-      errors.push(
-        `${target.packageName} must be version-locked in package-lock.json`,
-      );
-    }
-  }
-
-  for (const packageName of Object.keys(optionalDependencies)) {
-    if (!packageNames.has(packageName)) {
-      errors.push(`unexpected optional dependency ${packageName}`);
-    }
-  }
-  for (const packageName of Object.keys(lockedOptionalDependencies)) {
-    if (!packageNames.has(packageName)) {
-      errors.push(`unexpected locked optional dependency ${packageName}`);
-    }
-  }
+  errors.push(
+    ...collectNodeTargetValidationErrors({
+      targets,
+      version,
+      dependencies,
+      optionalDependencies,
+      lockedDependencies,
+      lockedOptionalDependencies,
+      lockedPackages: mainLock.packages ?? {},
+    }),
+  );
 
   if (errors.length !== 0) {
     throw new Error(
@@ -181,6 +416,28 @@ export async function validateNodePackage() {
   }
 
   return { mainPackage, targets, version };
+}
+
+export function createPlatformManifest({ target, mainPackage, version }) {
+  return {
+    name: target.packageName,
+    version,
+    description: `Native Ferric addon for ${target.id}`,
+    main: nativeBinaryName,
+    files: [nativeBinaryName],
+    os: target.os,
+    cpu: target.cpu,
+    ...(target.libc ? { libc: target.libc } : {}),
+    engines: mainPackage.engines,
+    repository: {
+      type: "git",
+      url: "git+https://github.com/plx/ferric-rules.git",
+    },
+    license: mainPackage.license,
+    publishConfig: {
+      access: "public",
+    },
+  };
 }
 
 export async function stagePlatformPackage({
@@ -211,25 +468,11 @@ export async function stagePlatformPackage({
     );
   }
 
-  const platformManifest = {
-    name: target.packageName,
+  const platformManifest = createPlatformManifest({
+    target,
+    mainPackage,
     version,
-    description: `Native Ferric addon for ${target.id}`,
-    main: nativeBinaryName,
-    files: [nativeBinaryName],
-    os: target.os,
-    cpu: target.cpu,
-    ...(target.libc ? { libc: target.libc } : {}),
-    engines: mainPackage.engines,
-    repository: {
-      type: "git",
-      url: "git+https://github.com/plx/ferric-rules.git",
-    },
-    license: mainPackage.license,
-    publishConfig: {
-      access: "public",
-    },
-  };
+  });
 
   await Promise.all([
     copyFile(binaryPath, join(outputDirectory, nativeBinaryName)),

--- a/scripts/test-node-package-artifact.mjs
+++ b/scripts/test-node-package-artifact.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import {
   mainPackageDirectory,
@@ -14,6 +15,16 @@ import {
   stagePlatformPackage,
   validateNodePackage,
 } from "./node-package-lib.mjs";
+
+const requireFromMainPackage = createRequire(
+  join(mainPackageDirectory, "package.json"),
+);
+const {
+  detectRuntimeTarget,
+  formatRuntimeTarget,
+  selectDeclaredTarget,
+  targetMatchesRuntime,
+} = requireFromMainPackage("./native/runtime-target.js");
 
 function parseArguments(argv) {
   const options = {};
@@ -30,31 +41,16 @@ function parseArguments(argv) {
   return options;
 }
 
-function currentTargetId() {
-  const key = `${process.platform}-${process.arch}`;
-  const targets = {
-    "darwin-arm64": "darwin-arm64",
-    "darwin-x64": "darwin-x64",
-    "linux-x64": "linux-x64-gnu",
-    "win32-x64": "win32-x64-msvc",
-  };
-  return targets[key];
-}
-
 const options = parseArguments(process.argv.slice(2));
-const targetId = options.target ?? currentTargetId();
-if (!targetId) {
-  throw new Error(
-    `No declared native package target for ${process.platform}-${process.arch}`,
-  );
-}
-
-const { targets } = await validateNodePackage();
+const { mainPackage, targets } = await validateNodePackage();
+const runtime = detectRuntimeTarget();
+const detectedTarget = selectDeclaredTarget(targets, runtime);
+const targetId = options.target ?? detectedTarget.id;
 const target = targets.find((candidate) => candidate.id === targetId);
 if (!target) throw new Error(`Unknown target ${targetId}`);
-if (target.platform !== process.platform || target.arch !== process.arch) {
+if (!targetMatchesRuntime(target, runtime)) {
   throw new Error(
-    `Cannot smoke-test ${targetId} on ${process.platform}-${process.arch}`,
+    `Cannot smoke-test ${targetId} on ${formatRuntimeTarget(runtime)}`,
   );
 }
 
@@ -62,6 +58,10 @@ const workDirectory = await mkdtemp(join(tmpdir(), "ferric-node-package-"));
 const artifactsDirectory = options.artifactsDirectory
   ? resolve(options.artifactsDirectory)
   : join(workDirectory, "artifacts");
+const dependencyArtifactsDirectory = join(
+  workDirectory,
+  "dependency-artifacts",
+);
 const platformStage = join(workDirectory, "platform-package");
 const consumerDirectory = join(workDirectory, "consumer");
 const binaryPath = resolve(
@@ -81,6 +81,23 @@ try {
     artifactsDirectory,
     runScripts: false,
   });
+  const detectLibcDirectory = dirname(
+    requireFromMainPackage.resolve("detect-libc/package.json"),
+  );
+  const detectLibcPack = await packPackage({
+    packageDirectory: detectLibcDirectory,
+    artifactsDirectory: dependencyArtifactsDirectory,
+    runScripts: false,
+  });
+  if (
+    detectLibcPack.record.name !== "detect-libc" ||
+    detectLibcPack.record.version !== mainPackage.dependencies?.["detect-libc"]
+  ) {
+    throw new Error(
+      `Packed detect-libc ${String(detectLibcPack.record.version)}, expected ` +
+        String(mainPackage.dependencies?.["detect-libc"]),
+    );
+  }
   const mainPack = await packPackage({
     packageDirectory: mainPackageDirectory,
     artifactsDirectory,
@@ -90,7 +107,11 @@ try {
   const mainNativeFiles = mainPack.files
     .filter((path) => path.startsWith("native/"))
     .sort();
-  const expectedMainNativeFiles = ["native/index.js", "native/targets.json"];
+  const expectedMainNativeFiles = [
+    "native/index.js",
+    "native/runtime-target.js",
+    "native/targets.json",
+  ];
   if (
     JSON.stringify(mainNativeFiles) !== JSON.stringify(expectedMainNativeFiles)
   ) {
@@ -129,6 +150,7 @@ try {
       "--no-audit",
       "--no-fund",
       "--package-lock=false",
+      detectLibcPack.archivePath,
       platformPack.archivePath,
       mainPack.archivePath,
     ],


### PR DESCRIPTION
## Summary

- add one fail-closed runtime target detector for OS, architecture, and Linux libc
- declare and validate the exact seven-package native matrix for macOS, Linux GNU/musl, and Windows
- build, pack, install, load, and execute every declared target in matching hosted runtimes
- harden offline artifact verification and document the expanded release contract

## Why

The release loader previously selected a native package from only `process.platform` and `process.arch`. It could not distinguish glibc from musl, Linux arm64 was undeclared, and CI exercised only four native rows. That left compatible targets unsupported and made libc confusion possible as the matrix expanded.

The new detector uses the exact pinned `detect-libc` synchronous API and treats null, malformed, throwing, or unrecognized results as `linux-<arch>-unknown`. Unsupported, ambiguous, and inconclusive targets fail before any native addon is required.

## Validation

- `just preflight-pr`
- `npm test` in `packages/ferric` (all type/runtime/package suites)
- `npm run build -- --target aarch64-apple-darwin` in `crates/ferric-rules-napi`
- clean offline CJS, ESM, worker, and engine artifact smoke for `darwin-arm64`
- `actionlint .github/workflows/node-package-artifacts.yml`
- `node scripts/validate-node-package.mjs`

The PR workflow supplies the remaining executable acceptance evidence through all seven `Pack and smoke` lanes, including native x64/arm64 Alpine jobs for musl.

Closes #121
