### PR TITLE
[FR-DIST-007] Publish and test Python wheel matrix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,4 @@ crates/ferric-rules-python/LICENSE-MIT text eol=lf
 crates/ferric-rules-python/LICENSE-APACHE text eol=lf
 crates/ferric-rules-python/wheel-targets.json text eol=lf
 docs/python-package-release.md text eol=lf
+scripts/musl_static_libgcc_linker.py text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,10 @@ packages/ferric/package.json text eol=lf
 packages/ferric/native/index.js text eol=lf
 packages/ferric/native/runtime-target.js text eol=lf
 packages/ferric/native/targets.json text eol=lf
+
+# Keep Python package metadata and files embedded in distributions stable.
+crates/ferric-rules-python/README.md text eol=lf
+crates/ferric-rules-python/LICENSE-MIT text eol=lf
+crates/ferric-rules-python/LICENSE-APACHE text eol=lf
+crates/ferric-rules-python/wheel-targets.json text eol=lf
+docs/python-package-release.md text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,8 @@ packages/ferric/native/runtime-target.js text eol=lf
 packages/ferric/native/targets.json text eol=lf
 
 # Keep Python package metadata and files embedded in distributions stable.
+LICENSE-MIT text eol=lf
+LICENSE-APACHE text eol=lf
 crates/ferric-rules-python/README.md text eol=lf
 crates/ferric-rules-python/LICENSE-MIT text eol=lf
 crates/ferric-rules-python/LICENSE-APACHE text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,56 +219,20 @@ jobs:
         uses: astral-sh/setup-uv@v5
       - name: Build and test Python bindings from source
         working-directory: crates/ferric-rules-python
-        run: |
-          python_path="$(command -v python)"
-          uv sync --locked --python "$python_path"
-          uv run --locked --python "$python_path" maturin develop --quiet
-          uv run --locked --python "$python_path" pytest tests/ -v
-      - name: Build and smoke-test an isolated wheel
-        working-directory: crates/ferric-rules-python
         env:
           EXPECTED_PYTHON: ${{ matrix.python-version }}
         run: |
           python_path="$(command -v python)"
-          smoke_dir="$(mktemp -d "$RUNNER_TEMP/ferric-python-wheel.XXXXXX")"
-          wheel_dir="$smoke_dir/wheels"
-          mkdir "$wheel_dir"
-          uv run --locked --python "$python_path" \
-            maturin build --release --locked --interpreter "$python_path" --out "$wheel_dir"
-          artifacts=()
-          while IFS= read -r artifact; do
-            artifacts+=("$artifact")
-          done < <(find "$wheel_dir" -mindepth 1 -maxdepth 1 -print)
-          if [[ "${#artifacts[@]}" -ne 1 || ! -f "${artifacts[0]:-}" \
-              || "${artifacts[0]}" != *.whl ]]; then
-            printf 'expected exactly one wheel, found %s artifact(s)\n' \
-              "${#artifacts[@]}" >&2
-            exit 1
-          fi
-          "$python_path" -m venv "$smoke_dir/venv"
-          "$smoke_dir/venv/bin/python" -m pip install --no-index --no-deps "${artifacts[0]}"
-          cd "$smoke_dir"
-          "$smoke_dir/venv/bin/python" - <<'PY'
-          import ferric
+          "$python_path" - <<'PY'
           import os
-          import pathlib
           import sys
 
           expected = tuple(int(part) for part in os.environ["EXPECTED_PYTHON"].split("."))
           assert sys.version_info[:2] == expected
-          module_path = pathlib.Path(ferric.__file__).resolve()
-          assert pathlib.Path(sys.prefix).resolve() in module_path.parents
-
-          engine = ferric.Engine()
-          engine.load(
-              "(deffacts startup (ready)) "
-              "(defrule smoke (ready) => (assert (complete)))"
-          )
-          engine.reset()
-          result = engine.run()
-          assert result.rules_fired == 1
-          engine.close()
           PY
+          uv sync --locked --python "$python_path"
+          uv run --locked --python "$python_path" maturin develop --quiet
+          uv run --locked --python "$python_path" pytest tests/ -v
 
   node-bindings:
     name: Node.js Bindings

--- a/.github/workflows/python-package-artifacts.yml
+++ b/.github/workflows/python-package-artifacts.yml
@@ -336,7 +336,31 @@ jobs:
             exit 1
           fi
           report="python-audit/audit-${{ matrix.target }}.txt"
-          trap 'status=$?; trap - EXIT; cat "$report" 2>/dev/null || true; exit "$status"' EXIT
+          print_audit_report() {
+            if [[ ! -f "$report" ]]; then
+              return
+            fi
+            report_bytes="$(wc -c <"$report" | tr -d '[:space:]')"
+            printf 'macOS audit report bytes=%s\n' "$report_bytes"
+            if [[ "$report_bytes" -gt 1048576 ]]; then
+              bounded_report="${report}.bounded"
+              {
+                printf 'audit output truncated; original_report_bytes=%s; retained_tail_bytes=1048576\n' \
+                  "$report_bytes"
+                tail -c 1048576 -- "$report"
+              } >"$bounded_report"
+              mv -- "$bounded_report" "$report"
+              printf 'stored only the final 1048576 report bytes\n'
+            fi
+            cat "$report"
+          }
+          trap 'status=$?; trap - EXIT; print_audit_report || true; exit "$status"' EXIT
+          # Bound every file created by the external audit tools to 512 MiB. The
+          # expected wheel is about 3 MiB; this prevents runaway diagnostics or
+          # repair output from exhausting the hosted runner before evidence is
+          # printed and uploaded.
+          ulimit -f 524288
+          printf 'starting delocate repair audit for %s\n' '${{ matrix.target }}'
           {
             printf 'target=%s\n' '${{ matrix.target }}'
             printf 'rust_target=%s\n' '${{ matrix.rust_target }}'
@@ -360,6 +384,7 @@ jobs:
               "${#repaired[@]}" >&2
             exit 1
           fi
+          printf 'delocate repair complete; starting strict wheel validation\n'
           {
             uvx --from "delocate==$DELOCATE_VERSION" \
               delocate-listdeps --all "${repaired[0]}"
@@ -370,7 +395,8 @@ jobs:
             uvx --from "abi3audit==$ABI3AUDIT_VERSION" \
               abi3audit --strict "${repaired[0]}"
           } >>"$report" 2>&1
-          cat "$report"
+          printf 'strict wheel and ABI validation complete\n'
+          print_audit_report
           trap - EXIT
       - name: Repair and audit Windows wheel
         id: windows-audit

--- a/.github/workflows/python-package-artifacts.yml
+++ b/.github/workflows/python-package-artifacts.yml
@@ -13,6 +13,7 @@ on:
       - "LICENSE-MIT"
       - "crates/ferric-*/**"
       - "scripts/python_package_lib.py"
+      - "scripts/musl_static_libgcc_linker.py"
       - "scripts/test-python-sdist-artifact.py"
       - "scripts/test-python-wheel-artifact.py"
       - "scripts/validate-python-package.py"
@@ -29,6 +30,7 @@ on:
       - "LICENSE-MIT"
       - "crates/ferric-*/**"
       - "scripts/python_package_lib.py"
+      - "scripts/musl_static_libgcc_linker.py"
       - "scripts/test-python-sdist-artifact.py"
       - "scripts/test-python-wheel-artifact.py"
       - "scripts/validate-python-package.py"
@@ -45,6 +47,7 @@ env:
   DELOCATE_VERSION: "0.13.0"
   DELVEWHEEL_VERSION: "1.13.0"
   MATURIN_VERSION: "1.12.6"
+  PYTHON_AUDIT_IMAGE: "python:3.12-alpine@sha256:6d43704baacd1bfbe7c295d7f13079d5d8104ed33568873133f8fc69980419df"
   RUSTFLAGS: "-D warnings"
   RUST_TOOLCHAIN: "1.93.0"
   UV_VERSION: "0.12.3"
@@ -90,6 +93,7 @@ jobs:
             runner: ubuntu-24.04
             rust_target: x86_64-unknown-linux-musl
             family: musllinux
+            container_image: ghcr.io/rust-cross/rust-musl-cross:x86_64-musl@sha256:ce75e9174325d4fbb3de85c309e2d7ca29f7500169bc4b5d2c611ff7e86d549a
             container_policy: musllinux_1_2
             compatibility: musllinux_1_2
             compatibility_args: ""
@@ -100,6 +104,7 @@ jobs:
             runner: ubuntu-24.04-arm
             rust_target: aarch64-unknown-linux-musl
             family: musllinux
+            container_image: ghcr.io/rust-cross/rust-musl-cross:aarch64-musl@sha256:ecae5dd62d1c938c14f8071d36c16fa699860aace03bfb5284fb1216474d2643
             container_policy: musllinux_1_2
             compatibility: musllinux_1_2
             compatibility_args: ""
@@ -141,6 +146,29 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
     steps:
       - uses: actions/checkout@v4
+      - name: Configure the pinned static musl unwind linker
+        if: matrix.family == 'musllinux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          case '${{ matrix.rust_target }}' in
+            x86_64-unknown-linux-musl)
+              cargo_linker_env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER
+              ;;
+            aarch64-unknown-linux-musl)
+              cargo_linker_env=CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER
+              ;;
+            *)
+              printf 'unsupported musl Rust target: %s\n' \
+                '${{ matrix.rust_target }}' >&2
+              exit 1
+              ;;
+          esac
+          wrapper="$GITHUB_WORKSPACE/scripts/musl_static_libgcc_linker.py"
+          test -x "$wrapper"
+          printf 'CARGO_FERRIC_MUSL_LINKER=%s\n' \
+            '/usr/local/musl/bin/${{ matrix.rust_target }}-gcc' >>"$GITHUB_ENV"
+          printf '%s=%s\n' "$cargo_linker_env" "$wrapper" >>"$GITHUB_ENV"
       - name: Install the abi3 baseline interpreter for Windows linking
         if: matrix.family == 'windows'
         uses: actions/setup-python@v5
@@ -160,6 +188,7 @@ jobs:
             --auditwheel ${{ matrix.auditwheel_mode }}
             --out python-wheel-staging
           manylinux: ${{ matrix.container_policy }}
+          container: ${{ matrix.container_image }}
           maturin-version: v${{ env.MATURIN_VERSION }}
           rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: ${{ matrix.rust_target }}
@@ -184,6 +213,7 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
       - name: Promote and audit repaired Linux wheel
+        id: linux-audit
         if: matrix.family == 'manylinux' || matrix.family == 'musllinux'
         shell: bash
         working-directory: crates/ferric-rules-python
@@ -203,17 +233,56 @@ jobs:
           cp -- "${staged[0]}" python-wheel-final/
           final="python-wheel-final/${staged[0]##*/}"
           report="python-audit/audit-${{ matrix.target }}.txt"
+          trap 'status=$?; trap - EXIT; cat "$report" 2>/dev/null || true; exit "$status"' EXIT
           {
             printf 'target=%s\n' '${{ matrix.target }}'
             printf 'rust_target=%s\n' '${{ matrix.rust_target }}'
             printf 'compatibility=%s\n' '${{ matrix.compatibility }}'
+            python3 ../../scripts/validate-python-package.py \
+              --wheel "$final" \
+              --target '${{ matrix.target }}'
             printf 'auditwheel=%s\n' "$AUDITWHEEL_VERSION"
-            uvx --from "auditwheel==$AUDITWHEEL_VERSION" auditwheel show "$final"
+            if [[ '${{ matrix.family }}' == musllinux ]]; then
+              auditwheel_root="$RUNNER_TEMP/auditwheel-${{ matrix.target }}"
+              uv pip install \
+                --target "$auditwheel_root" \
+                --python "$(command -v python3)" \
+                "auditwheel==$AUDITWHEEL_VERSION"
+              docker run --rm \
+                --network none \
+                --read-only \
+                --tmpfs /tmp:exec \
+                --env PYTHONDONTWRITEBYTECODE=1 \
+                --env PYTHONPATH=/opt/auditwheel \
+                --volume "$auditwheel_root:/opt/auditwheel:ro" \
+                --volume "$GITHUB_WORKSPACE:/workspace:ro" \
+                "$PYTHON_AUDIT_IMAGE" \
+                sh -ceu '
+                  output="$(python -m auditwheel show "$1")"
+                  printf "%s\n" "$output"
+                  normalized="$(printf "%s\n" "$output" | tr "\n" " " | tr -s " ")"
+                  expected="is consistent with the following platform tag: \"$2\"."
+                  case "$normalized" in
+                    *"$expected"*) ;;
+                    *)
+                      printf "auditwheel did not report exact policy %s\n" "$2" >&2
+                      exit 1
+                      ;;
+                  esac
+                ' audit-musllinux \
+                "/workspace/crates/ferric-rules-python/$final" \
+                'musllinux_1_2_${{ matrix.required_arch }}'
+            else
+              uvx --from "auditwheel==$AUDITWHEEL_VERSION" \
+                auditwheel show "$final"
+            fi
             printf '\nabi3audit=%s\n' "$ABI3AUDIT_VERSION"
             uvx --from "abi3audit==$ABI3AUDIT_VERSION" abi3audit --strict "$final"
           } >"$report" 2>&1
           cat "$report"
+          trap - EXIT
       - name: Repair and audit macOS wheel
+        id: macos-audit
         if: matrix.family == 'macos'
         shell: bash
         working-directory: crates/ferric-rules-python
@@ -231,6 +300,7 @@ jobs:
             exit 1
           fi
           report="python-audit/audit-${{ matrix.target }}.txt"
+          trap 'status=$?; trap - EXIT; cat "$report" 2>/dev/null || true; exit "$status"' EXIT
           {
             printf 'target=%s\n' '${{ matrix.target }}'
             printf 'rust_target=%s\n' '${{ matrix.rust_target }}'
@@ -257,12 +327,17 @@ jobs:
           {
             uvx --from "delocate==$DELOCATE_VERSION" \
               delocate-listdeps --all "${repaired[0]}"
+            python3 ../../scripts/validate-python-package.py \
+              --wheel "${repaired[0]}" \
+              --target '${{ matrix.target }}'
             printf '\nabi3audit=%s\n' "$ABI3AUDIT_VERSION"
             uvx --from "abi3audit==$ABI3AUDIT_VERSION" \
               abi3audit --strict "${repaired[0]}"
           } >>"$report" 2>&1
           cat "$report"
+          trap - EXIT
       - name: Repair and audit Windows wheel
+        id: windows-audit
         if: matrix.family == 'windows'
         shell: bash
         working-directory: crates/ferric-rules-python
@@ -280,6 +355,7 @@ jobs:
             exit 1
           fi
           report="python-audit/audit-${{ matrix.target }}.txt"
+          trap 'status=$?; trap - EXIT; cat "$report" 2>/dev/null || true; exit "$status"' EXIT
           {
             printf 'target=%s\n' '${{ matrix.target }}'
             printf 'rust_target=%s\n' '${{ matrix.rust_target }}'
@@ -304,11 +380,15 @@ jobs:
           {
             uvx --from "delvewheel==$DELVEWHEEL_VERSION" \
               delvewheel show "${repaired[0]}"
+            python ../../scripts/validate-python-package.py \
+              --wheel "${repaired[0]}" \
+              --target '${{ matrix.target }}'
             printf '\nabi3audit=%s\n' "$ABI3AUDIT_VERSION"
             uvx --from "abi3audit==$ABI3AUDIT_VERSION" \
               abi3audit --strict "${repaired[0]}"
           } >>"$report" 2>&1
           cat "$report"
+          trap - EXIT
       - name: Select the exact final wheel
         id: final-wheel
         shell: bash
@@ -342,6 +422,11 @@ jobs:
           if-no-files-found: error
           retention-days: 14
       - name: Upload exact repair and ABI audit report
+        if: >-
+          ${{ always() &&
+              (steps.linux-audit.outcome != 'skipped' ||
+               steps.macos-audit.outcome != 'skipped' ||
+               steps.windows-audit.outcome != 'skipped') }}
         uses: actions/upload-artifact@v4
         with:
           name: python-audit-${{ matrix.target }}

--- a/.github/workflows/python-package-artifacts.yml
+++ b/.github/workflows/python-package-artifacts.yml
@@ -208,6 +208,42 @@ jobs:
           rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: ${{ matrix.rust_target }}
           working-directory: crates/ferric-rules-python
+      - name: Reclaim macOS native build scratch before audit
+        if: matrix.family == 'macos'
+        shell: bash
+        run: |
+          set -euo pipefail
+          staged=()
+          while IFS= read -r -d '' wheel; do
+            staged+=("$wheel")
+          done < <(find \
+            "$GITHUB_WORKSPACE/crates/ferric-rules-python/python-wheel-staging" \
+            -mindepth 1 -maxdepth 1 -type f -name '*.whl' -print0)
+          if [[ "${#staged[@]}" -ne 1 ]]; then
+            printf 'refusing cleanup: expected one staged wheel, found %s\n' \
+              "${#staged[@]}" >&2
+            exit 1
+          fi
+          target_directory="$(
+            cargo metadata \
+              --format-version 1 \
+              --no-deps \
+              --locked \
+              --offline \
+              --manifest-path "$GITHUB_WORKSPACE/Cargo.toml" |
+              python3 -c \
+                'import json,sys; print(json.load(sys.stdin)["target_directory"])'
+          )"
+          if [[ "$target_directory" != "$GITHUB_WORKSPACE/target" ||
+                ! -d "$target_directory" || -L "$target_directory" ]]; then
+            printf 'refusing unexpected Cargo target cleanup: %s\n' \
+              "$target_directory" >&2
+            exit 1
+          fi
+          du -sh "$target_directory"
+          rm -rf -- "$target_directory"
+          test ! -e "$target_directory"
+          df -h "$GITHUB_WORKSPACE"
       - name: Install pinned packaging tools
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:

--- a/.github/workflows/python-package-artifacts.yml
+++ b/.github/workflows/python-package-artifacts.yml
@@ -1,0 +1,729 @@
+name: Python Package Artifacts
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".cargo/**"
+      - ".gitattributes"
+      - ".github/workflows/python-package-artifacts.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "LICENSE-APACHE"
+      - "LICENSE-MIT"
+      - "crates/ferric-*/**"
+      - "scripts/python_package_lib.py"
+      - "scripts/test-python-sdist-artifact.py"
+      - "scripts/test-python-wheel-artifact.py"
+      - "scripts/validate-python-package.py"
+      - "scripts/verify-python-package-artifacts.py"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".cargo/**"
+      - ".gitattributes"
+      - ".github/workflows/python-package-artifacts.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "LICENSE-APACHE"
+      - "LICENSE-MIT"
+      - "crates/ferric-*/**"
+      - "scripts/python_package_lib.py"
+      - "scripts/test-python-sdist-artifact.py"
+      - "scripts/test-python-wheel-artifact.py"
+      - "scripts/validate-python-package.py"
+      - "scripts/verify-python-package-artifacts.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  ABI3AUDIT_VERSION: "0.0.26"
+  AUDITWHEEL_VERSION: "6.7.0"
+  CARGO_TERM_COLOR: always
+  DELOCATE_VERSION: "0.13.0"
+  DELVEWHEEL_VERSION: "1.13.0"
+  MATURIN_VERSION: "1.12.6"
+  RUSTFLAGS: "-D warnings"
+  RUST_TOOLCHAIN: "1.93.0"
+  UV_VERSION: "0.12.3"
+
+jobs:
+  validate-artifact-contract:
+    name: Validate Python artifact contract
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate package metadata and release matrix
+        run: python3 scripts/validate-python-package.py
+
+  build-wheels:
+    name: Build and repair (${{ matrix.target }})
+    needs: validate-artifact-contract
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: manylinux2014-x86_64
+            runner: ubuntu-24.04
+            rust_target: x86_64-unknown-linux-gnu
+            family: manylinux
+            container_policy: "2014"
+            compatibility: manylinux2014
+            compatibility_args: ""
+            auditwheel_mode: repair
+            required_arch: x86_64
+            deployment_target: ""
+          - target: manylinux2014-aarch64
+            runner: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            family: manylinux
+            container_policy: "2014"
+            compatibility: manylinux2014
+            compatibility_args: ""
+            auditwheel_mode: repair
+            required_arch: aarch64
+            deployment_target: ""
+          - target: musllinux1_2-x86_64
+            runner: ubuntu-24.04
+            rust_target: x86_64-unknown-linux-musl
+            family: musllinux
+            container_policy: musllinux_1_2
+            compatibility: musllinux_1_2
+            compatibility_args: ""
+            auditwheel_mode: repair
+            required_arch: x86_64
+            deployment_target: ""
+          - target: musllinux1_2-aarch64
+            runner: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-musl
+            family: musllinux
+            container_policy: musllinux_1_2
+            compatibility: musllinux_1_2
+            compatibility_args: ""
+            auditwheel_mode: repair
+            required_arch: aarch64
+            deployment_target: ""
+          - target: macos-x86_64
+            runner: macos-15-intel
+            rust_target: x86_64-apple-darwin
+            family: macos
+            container_policy: auto
+            compatibility: pypi
+            compatibility_args: "--compatibility pypi"
+            auditwheel_mode: skip
+            required_arch: x86_64
+            deployment_target: "10.12"
+          - target: macos-arm64
+            runner: macos-15
+            rust_target: aarch64-apple-darwin
+            family: macos
+            container_policy: auto
+            compatibility: pypi
+            compatibility_args: "--compatibility pypi"
+            auditwheel_mode: skip
+            required_arch: arm64
+            deployment_target: "11.0"
+          - target: windows-x86_64
+            runner: windows-2025
+            rust_target: x86_64-pc-windows-msvc
+            family: windows
+            container_policy: auto
+            compatibility: pypi
+            compatibility_args: "--compatibility pypi"
+            auditwheel_mode: skip
+            required_arch: AMD64
+            deployment_target: ""
+    runs-on: ${{ matrix.runner }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install the abi3 baseline interpreter for Windows linking
+        if: matrix.family == 'windows'
+        uses: actions/setup-python@v5
+        with:
+          architecture: x64
+          python-version: "3.9"
+      - name: Build one staged Unix wheel with pinned maturin
+        if: matrix.family != 'windows'
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        env:
+          PYO3_NO_PYTHON: "1"
+        with:
+          args: >-
+            --release
+            --locked
+            ${{ matrix.compatibility_args }}
+            --auditwheel ${{ matrix.auditwheel_mode }}
+            --out python-wheel-staging
+          manylinux: ${{ matrix.container_policy }}
+          maturin-version: v${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+          target: ${{ matrix.rust_target }}
+          working-directory: crates/ferric-rules-python
+      - name: Build one staged Windows wheel with pinned maturin
+        if: matrix.family == 'windows'
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          args: >-
+            --release
+            --locked
+            ${{ matrix.compatibility_args }}
+            --auditwheel ${{ matrix.auditwheel_mode }}
+            --out python-wheel-staging
+          manylinux: ${{ matrix.container_policy }}
+          maturin-version: v${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+          target: ${{ matrix.rust_target }}
+          working-directory: crates/ferric-rules-python
+      - name: Install pinned packaging tools
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
+      - name: Promote and audit repaired Linux wheel
+        if: matrix.family == 'manylinux' || matrix.family == 'musllinux'
+        shell: bash
+        working-directory: crates/ferric-rules-python
+        run: |
+          set -euo pipefail
+          mkdir -p python-wheel-final python-audit
+          staged=()
+          while IFS= read -r -d '' wheel; do
+            staged+=("$wheel")
+          done < <(find python-wheel-staging -mindepth 1 -maxdepth 1 \
+            -type f -name '*.whl' -print0)
+          if [[ "${#staged[@]}" -ne 1 ]]; then
+            printf 'expected exactly one staged wheel, found %s\n' \
+              "${#staged[@]}" >&2
+            exit 1
+          fi
+          cp -- "${staged[0]}" python-wheel-final/
+          final="python-wheel-final/${staged[0]##*/}"
+          report="python-audit/audit-${{ matrix.target }}.txt"
+          {
+            printf 'target=%s\n' '${{ matrix.target }}'
+            printf 'rust_target=%s\n' '${{ matrix.rust_target }}'
+            printf 'compatibility=%s\n' '${{ matrix.compatibility }}'
+            printf 'auditwheel=%s\n' "$AUDITWHEEL_VERSION"
+            uvx --from "auditwheel==$AUDITWHEEL_VERSION" auditwheel show "$final"
+            printf '\nabi3audit=%s\n' "$ABI3AUDIT_VERSION"
+            uvx --from "abi3audit==$ABI3AUDIT_VERSION" abi3audit --strict "$final"
+          } >"$report" 2>&1
+          cat "$report"
+      - name: Repair and audit macOS wheel
+        if: matrix.family == 'macos'
+        shell: bash
+        working-directory: crates/ferric-rules-python
+        run: |
+          set -euo pipefail
+          mkdir -p python-wheel-final python-audit
+          staged=()
+          while IFS= read -r -d '' wheel; do
+            staged+=("$wheel")
+          done < <(find python-wheel-staging -mindepth 1 -maxdepth 1 \
+            -type f -name '*.whl' -print0)
+          if [[ "${#staged[@]}" -ne 1 ]]; then
+            printf 'expected exactly one staged wheel, found %s\n' \
+              "${#staged[@]}" >&2
+            exit 1
+          fi
+          report="python-audit/audit-${{ matrix.target }}.txt"
+          {
+            printf 'target=%s\n' '${{ matrix.target }}'
+            printf 'rust_target=%s\n' '${{ matrix.rust_target }}'
+            printf 'deployment_target=%s\n' "$MACOSX_DEPLOYMENT_TARGET"
+            printf 'delocate=%s\n' "$DELOCATE_VERSION"
+            uvx --from "delocate==$DELOCATE_VERSION" \
+              delocate-listdeps --all "${staged[0]}"
+            uvx --from "delocate==$DELOCATE_VERSION" \
+              delocate-wheel \
+              --require-archs '${{ matrix.required_arch }}' \
+              -w python-wheel-final \
+              "${staged[0]}"
+          } >"$report" 2>&1
+          repaired=()
+          while IFS= read -r -d '' wheel; do
+            repaired+=("$wheel")
+          done < <(find python-wheel-final -mindepth 1 -maxdepth 1 \
+            -type f -name '*.whl' -print0)
+          if [[ "${#repaired[@]}" -ne 1 ]]; then
+            printf 'expected exactly one repaired wheel, found %s\n' \
+              "${#repaired[@]}" >&2
+            exit 1
+          fi
+          {
+            uvx --from "delocate==$DELOCATE_VERSION" \
+              delocate-listdeps --all "${repaired[0]}"
+            printf '\nabi3audit=%s\n' "$ABI3AUDIT_VERSION"
+            uvx --from "abi3audit==$ABI3AUDIT_VERSION" \
+              abi3audit --strict "${repaired[0]}"
+          } >>"$report" 2>&1
+          cat "$report"
+      - name: Repair and audit Windows wheel
+        if: matrix.family == 'windows'
+        shell: bash
+        working-directory: crates/ferric-rules-python
+        run: |
+          set -euo pipefail
+          mkdir -p python-wheel-final python-audit
+          staged=()
+          while IFS= read -r -d '' wheel; do
+            staged+=("$wheel")
+          done < <(find python-wheel-staging -mindepth 1 -maxdepth 1 \
+            -type f -name '*.whl' -print0)
+          if [[ "${#staged[@]}" -ne 1 ]]; then
+            printf 'expected exactly one staged wheel, found %s\n' \
+              "${#staged[@]}" >&2
+            exit 1
+          fi
+          report="python-audit/audit-${{ matrix.target }}.txt"
+          {
+            printf 'target=%s\n' '${{ matrix.target }}'
+            printf 'rust_target=%s\n' '${{ matrix.rust_target }}'
+            printf 'delvewheel=%s\n' "$DELVEWHEEL_VERSION"
+            uvx --from "delvewheel==$DELVEWHEEL_VERSION" \
+              delvewheel show "${staged[0]}"
+            uvx --from "delvewheel==$DELVEWHEEL_VERSION" \
+              delvewheel repair \
+              --wheel-dir python-wheel-final \
+              "${staged[0]}"
+          } >"$report" 2>&1
+          repaired=()
+          while IFS= read -r -d '' wheel; do
+            repaired+=("$wheel")
+          done < <(find python-wheel-final -mindepth 1 -maxdepth 1 \
+            -type f -name '*.whl' -print0)
+          if [[ "${#repaired[@]}" -ne 1 ]]; then
+            printf 'expected exactly one repaired wheel, found %s\n' \
+              "${#repaired[@]}" >&2
+            exit 1
+          fi
+          {
+            uvx --from "delvewheel==$DELVEWHEEL_VERSION" \
+              delvewheel show "${repaired[0]}"
+            printf '\nabi3audit=%s\n' "$ABI3AUDIT_VERSION"
+            uvx --from "abi3audit==$ABI3AUDIT_VERSION" \
+              abi3audit --strict "${repaired[0]}"
+          } >>"$report" 2>&1
+          cat "$report"
+      - name: Select the exact final wheel
+        id: final-wheel
+        shell: bash
+        working-directory: crates/ferric-rules-python
+        run: |
+          set -euo pipefail
+          wheels=()
+          while IFS= read -r -d '' wheel; do
+            wheels+=("$wheel")
+          done < <(find python-wheel-final -mindepth 1 -maxdepth 1 \
+            -type f -name '*.whl' -print0)
+          if [[ "${#wheels[@]}" -ne 1 ]]; then
+            printf 'expected exactly one final wheel, found %s\n' \
+              "${#wheels[@]}" >&2
+            exit 1
+          fi
+          case "${wheels[0]##*/}" in
+            *-cp39-abi3-*.whl) ;;
+            *)
+              printf 'wheel is not tagged cp39-abi3: %s\n' "${wheels[0]}" >&2
+              exit 1
+              ;;
+          esac
+          printf 'path=%s\n' \
+            "crates/ferric-rules-python/${wheels[0]}" >>"$GITHUB_OUTPUT"
+      - name: Upload exact repaired wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-wheel-${{ matrix.target }}
+          path: ${{ steps.final-wheel.outputs.path }}
+          if-no-files-found: error
+          retention-days: 14
+      - name: Upload exact repair and ABI audit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-audit-${{ matrix.target }}
+          path: crates/ferric-rules-python/python-audit/audit-${{ matrix.target }}.txt
+          if-no-files-found: error
+          retention-days: 14
+
+  smoke-wheels:
+    name: Smoke (${{ matrix.target }}, CPython ${{ matrix.python_version }})
+    needs: build-wheels
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - manylinux2014-x86_64
+          - manylinux2014-aarch64
+          - musllinux1_2-x86_64
+          - musllinux1_2-aarch64
+          - macos-x86_64
+          - macos-arm64
+          - windows-x86_64
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - target: manylinux2014-x86_64
+            runner: ubuntu-24.04
+            family: manylinux
+          - target: manylinux2014-aarch64
+            runner: ubuntu-24.04-arm
+            family: manylinux
+          - target: musllinux1_2-x86_64
+            runner: ubuntu-24.04
+            family: musllinux
+          - target: musllinux1_2-aarch64
+            runner: ubuntu-24.04-arm
+            family: musllinux
+          - target: macos-x86_64
+            runner: macos-15-intel
+            family: macos
+          - target: macos-arm64
+            runner: macos-15
+            family: macos
+          - target: windows-x86_64
+            runner: windows-2025
+            family: windows
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download the exact repaired wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: python-wheel-${{ matrix.target }}
+          path: downloaded-python-wheel
+      - name: Select the downloaded wheel
+        id: downloaded-wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          wheels=()
+          while IFS= read -r -d '' wheel; do
+            wheels+=("$wheel")
+          done < <(find downloaded-python-wheel -type f -name '*.whl' -print0)
+          if [[ "${#wheels[@]}" -ne 1 ]]; then
+            printf 'expected exactly one downloaded wheel, found %s\n' \
+              "${#wheels[@]}" >&2
+            exit 1
+          fi
+          printf 'path=%s\n' "${wheels[0]}" >>"$GITHUB_OUTPUT"
+      - name: Install pinned uv
+        if: matrix.family != 'musllinux'
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
+      - name: Install managed CPython
+        if: matrix.family != 'musllinux'
+        shell: bash
+        run: uv python install '${{ matrix.python_version }}'
+      - name: Smoke exact wheel in a clean managed-Python environment
+        if: matrix.family != 'musllinux'
+        shell: bash
+        env:
+          PYTHON_VERSION: ${{ matrix.python_version }}
+          RECEIPT: python-receipts/wheel-smoke-${{ matrix.target }}-py${{ matrix.python_version }}.json
+          TARGET_ID: ${{ matrix.target }}
+          WHEEL: ${{ steps.downloaded-wheel.outputs.path }}
+        run: |
+          set -euo pipefail
+          mkdir -p python-receipts
+          uv_bin="$(command -v uv)"
+          case "$RUNNER_OS" in
+            Windows) clean_path='/c/Windows/System32:/c/Windows:/usr/bin:/bin' ;;
+            *) clean_path='/usr/bin:/bin:/usr/sbin:/sbin' ;;
+          esac
+          if PATH="$clean_path" command -v cargo >/dev/null \
+              || PATH="$clean_path" command -v rustc >/dev/null; then
+            printf 'Rust toolchain leaked into clean wheel smoke PATH\n' >&2
+            exit 1
+          fi
+          PATH="$clean_path" UV_OFFLINE=1 UV_PYTHON_DOWNLOADS=never \
+            "$uv_bin" run --isolated --no-project --python "$PYTHON_VERSION" -- \
+            python scripts/test-python-wheel-artifact.py \
+              --wheel "$WHEEL" \
+              --target "$TARGET_ID" \
+              --receipt "$RECEIPT"
+      - name: Smoke exact wheel in native matching-architecture Alpine
+        if: matrix.family == 'musllinux'
+        shell: bash
+        env:
+          PYTHON_VERSION: ${{ matrix.python_version }}
+          RECEIPT: python-receipts/wheel-smoke-${{ matrix.target }}-py${{ matrix.python_version }}.json
+          TARGET_ID: ${{ matrix.target }}
+          WHEEL: ${{ steps.downloaded-wheel.outputs.path }}
+        run: |
+          set -euo pipefail
+          mkdir -p python-receipts
+          docker run --rm \
+            --network none \
+            --read-only \
+            --tmpfs /tmp:exec \
+            --env PYTHONDONTWRITEBYTECODE=1 \
+            --env PYTHONNOUSERSITE=1 \
+            --volume "$GITHUB_WORKSPACE:/workspace" \
+            --workdir /tmp \
+            "python:$PYTHON_VERSION-alpine" \
+            python /workspace/scripts/test-python-wheel-artifact.py \
+              --wheel "/workspace/$WHEEL" \
+              --target "$TARGET_ID" \
+              --receipt "/workspace/$RECEIPT"
+      - name: Upload exact smoke receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-smoke-${{ matrix.target }}-py${{ matrix.python_version }}
+          path: python-receipts/wheel-smoke-${{ matrix.target }}-py${{ matrix.python_version }}.json
+          if-no-files-found: error
+          retention-days: 14
+
+  reject-python-314:
+    name: Reject CPython 3.14
+    needs: build-wheels
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download the exact manylinux x86-64 wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: python-wheel-manylinux2014-x86_64
+          path: downloaded-python-wheel
+      - name: Select the downloaded wheel
+        id: downloaded-wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          wheels=()
+          while IFS= read -r -d '' wheel; do
+            wheels+=("$wheel")
+          done < <(find downloaded-python-wheel -type f -name '*.whl' -print0)
+          if [[ "${#wheels[@]}" -ne 1 ]]; then
+            printf 'expected exactly one downloaded wheel, found %s\n' \
+              "${#wheels[@]}" >&2
+            exit 1
+          fi
+          printf 'path=%s\n' "${wheels[0]}" >>"$GITHUB_OUTPUT"
+      - name: Install pinned uv and managed CPython 3.14
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: "3.14"
+      - name: Materialize managed CPython 3.14 before offline rejection
+        run: uv python install 3.14
+      - name: Prove Requires-Python rejects the otherwise-compatible abi3 wheel
+        env:
+          WHEEL: ${{ steps.downloaded-wheel.outputs.path }}
+        run: |
+          mkdir -p python-receipts
+          uv_bin="$(command -v uv)"
+          clean_path='/usr/bin:/bin:/usr/sbin:/sbin'
+          if PATH="$clean_path" command -v cargo >/dev/null \
+              || PATH="$clean_path" command -v rustc >/dev/null; then
+            printf 'Rust toolchain leaked into rejection smoke PATH\n' >&2
+            exit 1
+          fi
+          PATH="$clean_path" UV_OFFLINE=1 UV_PYTHON_DOWNLOADS=never \
+            "$uv_bin" run --isolated --no-project --python 3.14 -- \
+            python scripts/test-python-wheel-artifact.py \
+              --wheel "$WHEEL" \
+              --target manylinux2014-x86_64 \
+              --receipt python-receipts/wheel-reject-py314.json \
+              --expect-python-rejection
+      - name: Upload exact rejection receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-rejection-py314
+          path: python-receipts/wheel-reject-py314.json
+          if-no-files-found: error
+          retention-days: 14
+
+  build-and-smoke-sdist:
+    name: Build and clean-test sdist
+    needs: validate-artifact-contract
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install the source-build interpreter
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
+      - name: Build exactly one sdist with pinned maturin
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        env:
+          PYO3_NO_PYTHON: "1"
+        with:
+          args: --out python-sdist-staging
+          command: sdist
+          manylinux: "off"
+          maturin-version: v${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+          target: x86_64-unknown-linux-gnu
+          working-directory: crates/ferric-rules-python
+      - name: Select the exact raw sdist and final output path
+        id: sdist
+        shell: bash
+        run: |
+          set -euo pipefail
+          sdists=()
+          while IFS= read -r -d '' sdist; do
+            sdists+=("$sdist")
+          done < <(find crates/ferric-rules-python/python-sdist-staging \
+            -mindepth 1 -maxdepth 1 -type f -name '*.tar.gz' -print0)
+          if [[ "${#sdists[@]}" -ne 1 ]]; then
+            printf 'expected exactly one sdist, found %s\n' \
+              "${#sdists[@]}" >&2
+            exit 1
+          fi
+          case "${sdists[0]##*/}" in
+            ferric-*.tar.gz) ;;
+            *)
+              printf 'unexpected sdist filename: %s\n' "${sdists[0]}" >&2
+              exit 1
+              ;;
+          esac
+          final_dir="crates/ferric-rules-python/python-sdist-final"
+          mkdir -p "$final_dir"
+          printf 'raw_path=%s\n' "${sdists[0]}" >>"$GITHUB_OUTPUT"
+          printf 'final_path=%s/%s\n' \
+            "$final_dir" "${sdists[0]##*/}" >>"$GITHUB_OUTPUT"
+      - name: Prefetch the locked Rust dependency graph
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo "+$RUST_TOOLCHAIN" fetch \
+            --locked --manifest-path Cargo.toml
+      - name: Normalize, locked-build, and smoke on native Linux
+        shell: bash
+        env:
+          FINAL_SDIST: ${{ steps.sdist.outputs.final_path }}
+          RAW_SDIST: ${{ steps.sdist.outputs.raw_path }}
+        run: |
+          set -euo pipefail
+          mkdir -p python-receipts
+          python_path="$(command -v python)"
+          cargo_path="$(command -v cargo)"
+          uv_path="$(command -v uv)"
+          "$uv_path" run \
+            --isolated --no-project \
+            --python "$python_path" \
+            --with "maturin==$MATURIN_VERSION" -- \
+            python scripts/test-python-sdist-artifact.py \
+              --sdist "$RAW_SDIST" \
+              --output "$FINAL_SDIST" \
+              --target manylinux2014-x86_64 \
+              --receipt python-receipts/sdist-smoke.json \
+              --cargo "$cargo_path" \
+              --uv "$uv_path"
+          test -f "$FINAL_SDIST"
+      - name: Upload exact tested sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-sdist
+          path: ${{ steps.sdist.outputs.final_path }}
+          if-no-files-found: error
+          retention-days: 14
+      - name: Upload exact sdist smoke receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-sdist-smoke
+          path: python-receipts/sdist-smoke.json
+          if-no-files-found: error
+          retention-days: 14
+
+  verify-artifact-set:
+    name: Verify deterministic Python release bundle
+    needs:
+      - smoke-wheels
+      - reject-python-314
+      - build-and-smoke-sdist
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download only final wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: python-wheel-*
+          merge-multiple: true
+          path: downloaded-python-artifacts
+      - name: Download the final sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: python-sdist
+          path: downloaded-python-artifacts
+      - name: Download all 35 wheel smoke receipts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: python-smoke-*
+          merge-multiple: true
+          path: downloaded-python-receipts
+      - name: Download the Python 3.14 rejection receipt
+        uses: actions/download-artifact@v4
+        with:
+          name: python-rejection-py314
+          path: downloaded-python-receipts
+      - name: Download the sdist smoke receipt
+        uses: actions/download-artifact@v4
+        with:
+          name: python-sdist-smoke
+          path: downloaded-python-receipts
+      - name: Download exact platform audit reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: python-audit-*
+          merge-multiple: true
+          path: downloaded-python-reports
+      - name: Verify artifact, receipt, tag, ABI, and architecture coverage
+        run: |
+          mkdir -p python-release-bundle
+          python3 scripts/verify-python-package-artifacts.py \
+            --artifacts-dir downloaded-python-artifacts \
+            --receipts-dir downloaded-python-receipts \
+            --manifest-out python-release-bundle/python-package-manifest.json
+      - name: Install pinned uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
+      - name: Dry-run publish the exact verified files without credentials
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish_files=()
+          while IFS= read -r -d '' artifact; do
+            publish_files+=("$artifact")
+          done < <(find downloaded-python-artifacts -type f \
+            \( -name '*.whl' -o -name '*.tar.gz' \) -print0 | sort -z)
+          if [[ "${#publish_files[@]}" -ne 8 ]]; then
+            printf 'expected exactly eight publish files, found %s\n' \
+              "${#publish_files[@]}" >&2
+            exit 1
+          fi
+          uv publish \
+            --dry-run \
+            --trusted-publishing never \
+            --no-attestations \
+            "${publish_files[@]}"
+          uv publish \
+            --dry-run \
+            --publish-url https://test.pypi.org/legacy/ \
+            --trusted-publishing never \
+            --no-attestations \
+            "${publish_files[@]}"
+      - name: Upload exact verified release bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-release-bundle
+          path: |
+            downloaded-python-artifacts
+            downloaded-python-receipts
+            downloaded-python-reports
+            python-release-bundle/python-package-manifest.json
+          if-no-files-found: error
+          retention-days: 14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,9 @@ rustc-hash = "2"
 # Bounded channels with cancel-aware and timeout-aware admission.
 crossbeam-channel = "0.5"
 
-# PyO3 Python bindings
-pyo3 = { version = "0.23", features = ["extension-module"] }
+# PyO3 Python bindings. The Python distribution targets CPython's stable ABI
+# from 3.9 onward; keep this feature aligned with wheel-targets.json.
+pyo3 = { version = "0.23", features = ["extension-module", "abi3-py39"] }
 pyo3-build-config = "0.23"
 
 # napi-rs Node.js bindings
@@ -116,6 +117,13 @@ missing_panics_doc = "allow"
 lto = true
 codegen-units = 1
 strip = "symbols"
+
+# Stripping the abi3 extension during Cargo's link step can produce malformed
+# Mach-O string-table alignment with some Apple linkers. Maturin inspects and
+# packages this crate separately, so retain its symbols while leaving the
+# workspace release policy unchanged for every other package.
+[profile.release.package.ferric-rules-python]
+strip = "none"
 
 # FFI profile: development builds retain unwind so exported wrappers can
 # contain ordinary Rust panics before they reach the C ABI boundary.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2279,7 +2279,6 @@ Used by:
 - ferric-rules-napi 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
 - ferric-rules-parser 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
 - ferric-rules-pinned 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
-- ferric-rules-python 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
 - ferric-rules-runtime 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
 - users-guide-01-minimal-embedding 0.1.0 (`MIT OR Apache-2.0`)
 - users-guide-02-ordered-vs-template 0.1.0 (`MIT OR Apache-2.0`)
@@ -2360,6 +2359,37 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+
+## MIT License (`MIT`)
+
+Used by:
+
+- ferric-rules-python 0.1.0 (`MIT OR Apache-2.0`) - https://github.com/plx/ferric-rules
+
+```text
+MIT License
+
+Copyright (c) Ferric contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ```
 

--- a/crates/ferric-rules-python/Cargo.toml
+++ b/crates/ferric-rules-python/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+description = "Python bindings for the Ferric rules engine"
+readme = "README.md"
 publish = false
 
 [lib]

--- a/crates/ferric-rules-python/LICENSE-APACHE
+++ b/crates/ferric-rules-python/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but not
+      limited to compiled object code, generated documentation, and
+      conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!) The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a file
+      or class name and description of purpose be included on the same
+      "printed page" as the copyright notice for easier identification
+      within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/ferric-rules-python/LICENSE-MIT
+++ b/crates/ferric-rules-python/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Ferric contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/ferric-rules-python/README.md
+++ b/crates/ferric-rules-python/README.md
@@ -1,0 +1,86 @@
+# Ferric for Python
+
+`ferric` is the CPython interface to the Ferric rules engine, an
+almost-drop-in replacement for CLIPS implemented in Rust. The extension exposes
+engine construction, rule loading and execution, typed fact inspection, output
+capture, and snapshot serialization.
+
+## Release status
+
+The repository builds and verifies Python release artifacts, but stable PyPI
+publication is gated on the independent production-readiness audit in
+[issue #223](https://github.com/plx/ferric-rules/issues/223). The presence of
+package metadata or CI artifacts does not mean that a stable registry release
+has been authorized.
+
+## Supported Python and platforms
+
+The release contract supports GIL-enabled CPython 3.9 through 3.13. Wheels use
+PyO3's stable ABI with a Python/ABI tag of `cp39-abi3`, so one wheel per native
+target covers every supported minor.
+
+Verified wheel targets are:
+
+- glibc 2.17+ Linux on x86-64 and AArch64 (`manylinux2014`);
+- musl 1.2+ Linux on x86-64 and AArch64 (`musllinux_1_2`);
+- macOS 10.12+ on x86-64;
+- macOS 11.0+ on Apple silicon; and
+- 64-bit Windows on x86-64.
+
+Python 3.14, PyPy, GraalPy, free-threaded CPython, macOS universal2, Windows on
+Arm, and every unlisted platform or architecture are outside this contract.
+The machine-readable source of truth is
+[`wheel-targets.json`](https://github.com/plx/ferric-rules/blob/main/crates/ferric-rules-python/wheel-targets.json).
+
+## Example
+
+```python
+import ferric
+
+source = """
+(deffacts startup (ready))
+(defrule complete (ready) => (assert (complete)))
+"""
+
+with ferric.Engine.from_source(source) as engine:
+    engine.reset()
+    result = engine.run()
+    assert result.rules_fired == 1
+
+    snapshot = engine.serialize(format=ferric.Format.JSON)
+
+with ferric.Engine.from_snapshot(snapshot, format=ferric.Format.JSON) as restored:
+    assert restored.fact_count == 2
+```
+
+## Building from source
+
+A source build requires a supported CPython, Rust 1.75 or newer, Maturin 1.x,
+and the platform's native compiler and linker. Resolving build dependencies
+also requires network access or pre-populated Python and Cargo caches.
+
+From a repository checkout:
+
+```sh
+cd crates/ferric-rules-python
+uv sync --locked
+uv run --locked maturin develop --release
+uv run --locked pytest tests/ -v
+```
+
+Release source distributions carry the required Rust workspace subset and a
+lockfile normalized for that relocated workspace. The exact final archive is
+built into a wheel and smoke-tested before it may join the verified dry-run
+bundle; publishing Maturin's raw intermediate or any untested sdist is not
+allowed.
+
+See the repository's
+[Python package release contract](https://github.com/plx/ferric-rules/blob/main/docs/python-package-release.md)
+for the complete ABI, target, verification, and publication policy.
+
+## License
+
+Ferric is available under either the
+[Apache License 2.0](https://github.com/plx/ferric-rules/blob/main/LICENSE-APACHE)
+or the [MIT License](https://github.com/plx/ferric-rules/blob/main/LICENSE-MIT),
+at your option. Both license texts are included in every distribution.

--- a/crates/ferric-rules-python/pyproject.toml
+++ b/crates/ferric-rules-python/pyproject.toml
@@ -4,11 +4,22 @@ build-backend = "maturin"
 
 [project]
 name = "ferric"
-version = "0.1.0"
+dynamic = ["version"]
+description = "A CLIPS-inspired rules engine for Python, implemented in Rust"
+readme = { file = "README.md", content-type = "text/markdown" }
 license = "MIT OR Apache-2.0"
+license-files = ["LICENSE-MIT", "LICENSE-APACHE"]
+authors = [{ name = "Ferric contributors" }]
 requires-python = ">=3.9,<3.14"
+keywords = ["clips", "expert-system", "rete", "rules-engine"]
 classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
     "Programming Language :: Rust",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -17,6 +28,12 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 
+[project.urls]
+Homepage = "https://github.com/plx/ferric-rules"
+Documentation = "https://github.com/plx/ferric-rules/blob/main/docs/users-guide.md"
+Repository = "https://github.com/plx/ferric-rules"
+Issues = "https://github.com/plx/ferric-rules/issues"
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",
@@ -24,4 +41,7 @@ dev = [
 ]
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "pyo3/abi3-py39"]
+include = [{ path = "README.md", format = "sdist" }]
+locked = true
+strip = false

--- a/crates/ferric-rules-python/tests/test_package_artifact_workflow.py
+++ b/crates/ferric-rules-python/tests/test_package_artifact_workflow.py
@@ -163,6 +163,25 @@ def test_builds_are_pinned_repaired_audited_and_uploaded_exactly_once():
     assert "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER" in job
     assert "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER" in job
     assert "scripts/musl_static_libgcc_linker.py" in job
+    cleanup = "Reclaim macOS native build scratch before audit"
+    assert cleanup in job
+    assert job.index(cleanup) > job.index("Build one staged Unix wheel")
+    assert job.index(cleanup) < job.index("Install pinned packaging tools")
+    cleanup_block = job[
+        job.index(cleanup) : job.index("Install pinned packaging tools")
+    ]
+    assert "if: matrix.family == 'macos'" in cleanup_block
+    assert "expected one staged wheel" in cleanup_block
+    for metadata_guard in [
+        "--no-deps",
+        "--locked",
+        "--offline",
+        '--manifest-path "$GITHUB_WORKSPACE/Cargo.toml"',
+    ]:
+        assert metadata_guard in cleanup_block
+    assert '"$target_directory" != "$GITHUB_WORKSPACE/target"' in cleanup_block
+    assert '! -d "$target_directory" || -L "$target_directory"' in cleanup_block
+    assert 'rm -rf -- "$target_directory"' in cleanup_block
     assert "--auditwheel ${{ matrix.auditwheel_mode }}" in job
     assert job.count("auditwheel_mode: repair") == 4
     assert "auditwheel show" in job

--- a/crates/ferric-rules-python/tests/test_package_artifact_workflow.py
+++ b/crates/ferric-rules-python/tests/test_package_artifact_workflow.py
@@ -1,0 +1,265 @@
+"""Keep the Python release-artifact workflow fail-closed and matrix-complete."""
+
+import json
+import pathlib
+import re
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "python-package-artifacts.yml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+TARGETS = REPO_ROOT / "crates" / "ferric-rules-python" / "wheel-targets.json"
+
+MATURIN_ACTION = "PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b"
+SETUP_UV_ACTION = "astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9"
+
+
+def _job(workflow: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n(?P<job>.*?)(?=^  [a-z][a-z0-9-]+:\n|\Z)",
+        workflow,
+    )
+    assert match is not None, f"workflow must define the {name} job"
+    return match.group("job")
+
+
+def _producer_matrix(job: str) -> dict[str, dict[str, str]]:
+    matrix = re.search(
+        r"(?ms)^      matrix:\n        include:\n(?P<rows>.*?)(?=^    runs-on:)",
+        job,
+    )
+    assert matrix is not None, "build-wheels must use an explicit include matrix"
+    rows: dict[str, dict[str, str]] = {}
+    for match in re.finditer(
+        r"(?ms)^          - target: (?P<target>[^\n]+)\n"
+        r"(?P<body>.*?)(?=^          - target:|\Z)",
+        matrix.group("rows"),
+    ):
+        values = {
+            key: value.strip('"')
+            for key, value in re.findall(
+                r"(?m)^            ([a-z_]+): ([^\n]+)$", match.group("body")
+            )
+        }
+        rows[match.group("target")] = values
+    return rows
+
+
+def test_build_matrix_exactly_matches_the_checked_in_contract():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    contract = json.loads(TARGETS.read_text(encoding="utf-8"))
+    rows = _producer_matrix(_job(workflow, "build-wheels"))
+    wheels = {wheel["id"]: wheel for wheel in contract["wheels"]}
+
+    assert len(rows) == 7
+    assert rows.keys() == wheels.keys()
+    for target, wheel in wheels.items():
+        row = rows[target]
+        assert row["runner"] == wheel["runner"]
+        assert row["rust_target"] == wheel["rust_target"]
+        assert row["family"] == wheel["compatibility"]["family"]
+        assert row["compatibility"] == wheel["compatibility"]["maturin"]
+        expected_cli = (
+            ""
+            if row["family"] in {"manylinux", "musllinux"}
+            else "--compatibility pypi"
+        )
+        assert row["compatibility_args"] == expected_cli
+        expected_deployment = wheel["compatibility"].get("deployment_target", "")
+        assert row["deployment_target"] == expected_deployment
+
+
+def test_path_filters_cover_every_artifact_contract_input():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    # These appear once under push and once under pull_request. The crate glob
+    # covers pyproject, wheel-targets, package assets, and both contract tests.
+    for path_filter in [
+        '      - ".cargo/**"',
+        '      - ".gitattributes"',
+        '      - ".github/workflows/python-package-artifacts.yml"',
+        '      - "Cargo.lock"',
+        '      - "Cargo.toml"',
+        '      - "LICENSE-APACHE"',
+        '      - "LICENSE-MIT"',
+        '      - "crates/ferric-*/**"',
+        '      - "scripts/python_package_lib.py"',
+        '      - "scripts/test-python-sdist-artifact.py"',
+        '      - "scripts/test-python-wheel-artifact.py"',
+        '      - "scripts/validate-python-package.py"',
+        '      - "scripts/verify-python-package-artifacts.py"',
+    ]:
+        assert workflow.count(path_filter) == 2, f"path filter drifted: {path_filter}"
+
+
+def test_smoke_matrix_is_the_full_seven_by_five_cross_product():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    contract = json.loads(TARGETS.read_text(encoding="utf-8"))
+    job = _job(workflow, "smoke-wheels")
+
+    target_block = re.search(
+        r"(?ms)^        target:\n(?P<targets>.*?)(?=^        python_version:)", job
+    )
+    assert target_block is not None
+    targets = re.findall(r"(?m)^          - ([^\n]+)$", target_block.group("targets"))
+    expected_targets = [wheel["id"] for wheel in contract["wheels"]]
+    assert targets == expected_targets
+
+    minor_block = re.search(r"python_version: \[([^]]+)]", job)
+    assert minor_block is not None
+    minors = re.findall(r'"(\d+\.\d+)"', minor_block.group(1))
+    assert minors == contract["python"]["supported_minors"]
+    assert len(targets) * len(minors) == 35
+
+    # Each include row only enriches one original target dimension. GitHub's
+    # matrix include semantics therefore apply its runner/family to all five
+    # original target x python_version combinations rather than adding jobs.
+    include = re.search(r"(?ms)^        include:\n(?P<rows>.*?)(?=^    runs-on:)", job)
+    assert include is not None
+    included_targets = re.findall(
+        r"(?m)^          - target: ([^\n]+)$", include.group("rows")
+    )
+    assert included_targets == expected_targets
+    assert "python_version:" not in include.group("rows")
+
+
+def test_builds_are_pinned_repaired_audited_and_uploaded_exactly_once():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    job = _job(workflow, "build-wheels")
+
+    assert workflow.count(f"uses: {MATURIN_ACTION}") == 3
+    assert f"uses: {SETUP_UV_ACTION}" in workflow
+    for pinned_version in [
+        'ABI3AUDIT_VERSION: "0.0.26"',
+        'AUDITWHEEL_VERSION: "6.7.0"',
+        'DELOCATE_VERSION: "0.13.0"',
+        'DELVEWHEEL_VERSION: "1.13.0"',
+        'MATURIN_VERSION: "1.12.6"',
+        'RUST_TOOLCHAIN: "1.93.0"',
+        'UV_VERSION: "0.12.3"',
+    ]:
+        assert pinned_version in workflow
+
+    assert "--release" in job
+    assert "--locked" in job
+    assert "${{ matrix.compatibility_args }}" in job
+    assert job.count('compatibility_args: ""') == 4
+    assert job.count('compatibility_args: "--compatibility pypi"') == 3
+    assert "manylinux: ${{ matrix.container_policy }}" in job
+    assert "Install the abi3 baseline interpreter for Windows linking" in job
+    assert "uses: actions/setup-python@v5" in job
+    assert 'python-version: "3.9"' in job
+    assert job.count('PYO3_NO_PYTHON: "1"') == 1
+    assert "--auditwheel ${{ matrix.auditwheel_mode }}" in job
+    assert job.count("auditwheel_mode: repair") == 4
+    assert "auditwheel show" in job
+    assert "delocate-wheel" in job
+    assert "delvewheel repair" in job
+    assert job.count("abi3audit") >= 4
+    assert job.count("abi3audit --strict") == 3
+    assert 'deployment_target: "10.12"' in job
+    assert 'deployment_target: "11.0"' in job
+    assert "*-cp39-abi3-*.whl" in job
+    assert "name: python-wheel-${{ matrix.target }}" in job
+    assert "name: python-audit-${{ matrix.target }}" in job
+    assert "if-no-files-found: error" in job
+
+
+def test_each_smoke_uses_only_the_downloaded_repaired_wheel():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    job = _job(workflow, "smoke-wheels")
+
+    assert "needs: build-wheels" in job
+    assert "name: python-wheel-${{ matrix.target }}" in job
+    assert "maturin build" not in job
+    assert "test-python-wheel-artifact.py" in job
+    assert '--wheel "$WHEEL"' in job
+    assert '--target "$TARGET_ID"' in job
+    assert '--receipt "$RECEIPT"' in job
+    assert "--network none" in job
+    assert '"python:$PYTHON_VERSION-alpine"' in job
+    assert "ubuntu-24.04-arm" in job
+    assert "--read-only" in job
+    assert "Rust toolchain leaked into clean wheel smoke PATH" in job
+    assert "UV_OFFLINE=1" in job
+    assert "UV_PYTHON_DOWNLOADS=never" in job
+    assert "if-no-files-found: error" in job
+
+
+def test_python_314_rejection_and_clean_sdist_build_are_required():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    rejection = _job(workflow, "reject-python-314")
+    sdist = _job(workflow, "build-and-smoke-sdist")
+
+    assert "needs: build-wheels" in rejection
+    assert 'python-version: "3.14"' in rejection
+    assert "uv python install 3.14" in rejection
+    assert rejection.index("uv python install 3.14") < rejection.index("UV_OFFLINE=1")
+    assert "--expect-python-rejection" in rejection
+    assert "wheel-reject-py314.json" in rejection
+
+    assert "needs: validate-artifact-contract" in sdist
+    assert "runs-on: ubuntu-24.04" in sdist
+    assert "Install the source-build interpreter" in sdist
+    assert 'python-version: "3.12"' in sdist
+    assert "command: sdist" in sdist
+    assert "args: --out python-sdist-staging" in sdist
+    assert "args: --locked" not in sdist
+    assert 'cargo "+$RUST_TOOLCHAIN" fetch' in sdist
+    assert "--locked --manifest-path Cargo.toml" in sdist
+    assert "test-python-sdist-artifact.py" in sdist
+    assert '--with "maturin==$MATURIN_VERSION"' in sdist
+    assert "python-sdist-final" in sdist
+    assert "path: ${{ steps.sdist.outputs.final_path }}" in sdist
+    assert "Normalize, locked-build, and smoke on native Linux" in sdist
+    assert "docker run" not in sdist
+    assert "quay.io/pypa" not in sdist
+    assert '--sdist "$RAW_SDIST"' in sdist
+    assert '--output "$FINAL_SDIST"' in sdist
+    assert "--target manylinux2014-x86_64" in sdist
+    assert sdist.count('PYO3_NO_PYTHON: "1"') == 1
+    assert "sdist-smoke.json" in sdist
+    assert "name: python-sdist" in sdist
+
+
+def test_aggregate_verifies_every_receipt_and_only_dry_runs_publication():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    job = _job(workflow, "verify-artifact-set")
+
+    for dependency in [
+        "smoke-wheels",
+        "reject-python-314",
+        "build-and-smoke-sdist",
+    ]:
+        assert f"- {dependency}" in job
+    assert "pattern: python-wheel-*" in job
+    assert "pattern: python-smoke-*" in job
+    assert "pattern: python-audit-*" in job
+    assert "verify-python-package-artifacts.py" in job
+    assert "--artifacts-dir downloaded-python-artifacts" in job
+    assert "--receipts-dir downloaded-python-receipts" in job
+    assert "python-package-manifest.json" in job
+    assert "expected exactly eight publish files" in job
+
+    assert workflow.count("uv publish") == 2
+    assert workflow.count("--dry-run") == 2
+    assert workflow.count("--trusted-publishing never") == 2
+    assert workflow.count("--no-attestations") == 2
+    assert workflow.count('"${publish_files[@]}"') == 2
+    assert "--publish-url https://test.pypi.org/legacy/" in workflow
+    assert "name: python-package-release-bundle" in job
+    assert "downloaded-python-reports" in job
+
+    assert "continue-on-error" not in workflow
+    assert "id-token: write" not in workflow
+    assert "permissions:\n  contents: read" in workflow
+
+
+def test_fast_ci_retains_source_tests_without_rebuilding_release_wheels():
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    job = _job(workflow, "python-bindings")
+
+    assert "maturin develop" in job
+    assert "pytest tests/" in job
+    assert "maturin build" not in job
+    assert "pip install" not in job

--- a/crates/ferric-rules-python/tests/test_package_artifact_workflow.py
+++ b/crates/ferric-rules-python/tests/test_package_artifact_workflow.py
@@ -194,6 +194,20 @@ def test_builds_are_pinned_repaired_audited_and_uploaded_exactly_once():
     assert "--network none" in job
     assert "--read-only" in job
     assert "delocate-wheel" in job
+    mac_audit = job[job.index("Repair and audit macOS wheel") :]
+    mac_audit = mac_audit[: mac_audit.index("Repair and audit Windows wheel")]
+    assert "ulimit -f 524288" in mac_audit
+    assert "print_audit_report" in mac_audit
+    assert "tail -c 1048576" in mac_audit
+    assert "audit output truncated; original_report_bytes=" in mac_audit
+    assert "retained_tail_bytes=1048576" in mac_audit
+    assert 'mv -- "$bounded_report" "$report"' in mac_audit
+    assert "stored only the final 1048576 report bytes" in mac_audit
+    assert 'cat "$report"' in mac_audit
+    assert "trap 'status=$?; trap - EXIT; print_audit_report" in mac_audit
+    assert "starting delocate repair audit" in mac_audit
+    assert "delocate repair complete; starting strict wheel validation" in mac_audit
+    assert "strict wheel and ABI validation complete" in mac_audit
     assert "delvewheel repair" in job
     assert job.count("abi3audit") >= 4
     assert job.count("abi3audit --strict") == 3

--- a/crates/ferric-rules-python/tests/test_package_artifact_workflow.py
+++ b/crates/ferric-rules-python/tests/test_package_artifact_workflow.py
@@ -50,6 +50,10 @@ def test_build_matrix_exactly_matches_the_checked_in_contract():
     contract = json.loads(TARGETS.read_text(encoding="utf-8"))
     rows = _producer_matrix(_job(workflow, "build-wheels"))
     wheels = {wheel["id"]: wheel for wheel in contract["wheels"]}
+    pinned_containers = {
+        "musllinux1_2-x86_64": "ghcr.io/rust-cross/rust-musl-cross:x86_64-musl@sha256:ce75e9174325d4fbb3de85c309e2d7ca29f7500169bc4b5d2c611ff7e86d549a",
+        "musllinux1_2-aarch64": "ghcr.io/rust-cross/rust-musl-cross:aarch64-musl@sha256:ecae5dd62d1c938c14f8071d36c16fa699860aace03bfb5284fb1216474d2643",
+    }
 
     assert len(rows) == 7
     assert rows.keys() == wheels.keys()
@@ -59,6 +63,7 @@ def test_build_matrix_exactly_matches_the_checked_in_contract():
         assert row["rust_target"] == wheel["rust_target"]
         assert row["family"] == wheel["compatibility"]["family"]
         assert row["compatibility"] == wheel["compatibility"]["maturin"]
+        assert row.get("container_image", "") == pinned_containers.get(target, "")
         expected_cli = (
             ""
             if row["family"] in {"manylinux", "musllinux"}
@@ -84,6 +89,7 @@ def test_path_filters_cover_every_artifact_contract_input():
         '      - "LICENSE-MIT"',
         '      - "crates/ferric-*/**"',
         '      - "scripts/python_package_lib.py"',
+        '      - "scripts/musl_static_libgcc_linker.py"',
         '      - "scripts/test-python-sdist-artifact.py"',
         '      - "scripts/test-python-wheel-artifact.py"',
         '      - "scripts/validate-python-package.py"',
@@ -135,6 +141,7 @@ def test_builds_are_pinned_repaired_audited_and_uploaded_exactly_once():
         'DELOCATE_VERSION: "0.13.0"',
         'DELVEWHEEL_VERSION: "1.13.0"',
         'MATURIN_VERSION: "1.12.6"',
+        'PYTHON_AUDIT_IMAGE: "python:3.12-alpine@sha256:6d43704baacd1bfbe7c295d7f13079d5d8104ed33568873133f8fc69980419df"',
         'RUST_TOOLCHAIN: "1.93.0"',
         'UV_VERSION: "0.12.3"',
     ]:
@@ -146,17 +153,36 @@ def test_builds_are_pinned_repaired_audited_and_uploaded_exactly_once():
     assert job.count('compatibility_args: ""') == 4
     assert job.count('compatibility_args: "--compatibility pypi"') == 3
     assert "manylinux: ${{ matrix.container_policy }}" in job
+    assert "container: ${{ matrix.container_image }}" in job
     assert "Install the abi3 baseline interpreter for Windows linking" in job
     assert "uses: actions/setup-python@v5" in job
     assert 'python-version: "3.9"' in job
     assert job.count('PYO3_NO_PYTHON: "1"') == 1
+    assert "Configure the pinned static musl unwind linker" in job
+    assert "CARGO_FERRIC_MUSL_LINKER" in job
+    assert "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER" in job
+    assert "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER" in job
+    assert "scripts/musl_static_libgcc_linker.py" in job
     assert "--auditwheel ${{ matrix.auditwheel_mode }}" in job
     assert job.count("auditwheel_mode: repair") == 4
     assert "auditwheel show" in job
+    assert "uv pip install" in job
+    assert '--target "$auditwheel_root"' in job
+    assert '"$PYTHON_AUDIT_IMAGE"' in job
+    assert "python -m auditwheel show" in job
+    assert "auditwheel did not report exact policy" in job
+    assert "musllinux_1_2_${{ matrix.required_arch }}" in job
+    assert "--network none" in job
+    assert "--read-only" in job
     assert "delocate-wheel" in job
     assert "delvewheel repair" in job
     assert job.count("abi3audit") >= 4
     assert job.count("abi3audit --strict") == 3
+    assert job.count("scripts/validate-python-package.py") == 3
+    assert job.count("trap 'status=$?") == 3
+    assert "steps.linux-audit.outcome != 'skipped'" in job
+    assert "steps.macos-audit.outcome != 'skipped'" in job
+    assert "steps.windows-audit.outcome != 'skipped'" in job
     assert 'deployment_target: "10.12"' in job
     assert 'deployment_target: "11.0"' in job
     assert "*-cp39-abi3-*.whl" in job

--- a/crates/ferric-rules-python/tests/test_python_package_artifacts.py
+++ b/crates/ferric-rules-python/tests/test_python_package_artifacts.py
@@ -1,0 +1,732 @@
+"""Adversarial tests for the Python package artifact verification tooling."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import csv
+import hashlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_ROOT = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_ROOT))
+
+import python_package_lib as package_lib  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def contract():
+    return package_lib.load_contract()
+
+
+@pytest.fixture(scope="module")
+def version(contract):
+    return package_lib.package_version(contract)
+
+
+def _metadata(
+    version, *, requires_python=">=3.9,<3.14", dependency=None, metadata_version=None
+):
+    classifiers = [
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: Implementation :: CPython",
+        *(
+            f"Programming Language :: Python :: {minor}"
+            for minor in package_lib.EXPECTED_SUPPORTED_MINORS
+        ),
+    ]
+    headers = [
+        "Metadata-Version: 2.4",
+        "Name: ferric",
+        f"Version: {metadata_version or version}",
+        f"Summary: {package_lib.EXPECTED_SUMMARY}",
+        "License-Expression: MIT OR Apache-2.0",
+        "License-File: LICENSE-MIT",
+        "License-File: LICENSE-APACHE",
+        f"Requires-Python: {requires_python}",
+        "Description-Content-Type: text/markdown",
+        *(f"Classifier: {classifier}" for classifier in classifiers),
+        *(
+            f"Project-URL: {project_url}"
+            for project_url in sorted(package_lib.EXPECTED_PROJECT_URLS)
+        ),
+    ]
+    if dependency is not None:
+        headers.append(f"Requires-Dist: {dependency}")
+    readme = (package_lib.PACKAGE_ROOT / "README.md").read_text(encoding="utf-8")
+    return ("\n".join(headers) + "\n\n" + readme).encode()
+
+
+def _native_binary(target, *, architecture=None, truncated=False, wrong_format=False):
+    family = target["compatibility"]["family"]
+    architecture = architecture or target["runtime"]["architecture"]
+    if wrong_format:
+        return b"not-a-native-library".ljust(128, b"\0")
+    if family in {"manylinux", "musllinux"}:
+        data = bytearray(64)
+        data[:6] = b"\x7fELF\x02\x01"
+        data[18:20] = {"x86_64": 62, "aarch64": 183}[architecture].to_bytes(2, "little")
+    elif family == "macos":
+        data = bytearray(32)
+        data[:4] = b"\xcf\xfa\xed\xfe"
+        data[4:8] = {"x86_64": 0x01000007, "aarch64": 0x0100000C}[
+            architecture
+        ].to_bytes(4, "little")
+    else:
+        data = bytearray(256)
+        data[:2] = b"MZ"
+        data[0x3C:0x40] = (0x80).to_bytes(4, "little")
+        data[0x80:0x84] = b"PE\0\0"
+        data[0x84:0x86] = {"x86_64": 0x8664, "aarch64": 0xAA64}[architecture].to_bytes(
+            2, "little"
+        )
+        data[0x98:0x9A] = (0x20B).to_bytes(2, "little")
+    return bytes(data[:8] if truncated else data)
+
+
+def _sbom(version):
+    return json.dumps(
+        {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "version": 1,
+            "metadata": {
+                "component": {
+                    "type": "library",
+                    "name": "ferric-rules-python",
+                    "version": version,
+                }
+            },
+            "components": [],
+            "dependencies": [],
+        },
+        sort_keys=True,
+    ).encode()
+
+
+def _record_bytes(members, *, bad_hash=False, omit_path=None):
+    rows = []
+    for name, data in members.items():
+        if name == omit_path:
+            continue
+        digest = (
+            base64.urlsafe_b64encode(hashlib.sha256(data).digest())
+            .rstrip(b"=")
+            .decode()
+        )
+        if bad_hash and not rows:
+            digest = "A" * 43
+        rows.append([name, f"sha256={digest}", str(len(data))])
+    output = io.StringIO(newline="")
+    writer = csv.writer(output, lineterminator="\n")
+    writer.writerows(rows)
+    return output.getvalue().encode()
+
+
+def _write_wheel(
+    directory,
+    contract,
+    version,
+    target,
+    *,
+    platform_tags=None,
+    wheel_tags=None,
+    metadata_version=None,
+    metadata_override=None,
+    requires_python=">=3.9,<3.14",
+    dependency=None,
+    extra_members=None,
+    omit_members=(),
+    bad_record=False,
+    omit_record_path=None,
+    native_architecture=None,
+    native_truncated=False,
+    native_wrong_format=False,
+    license_drift=False,
+    sbom_override=None,
+):
+    platform_tags = platform_tags or target["platform_tags"]
+    wheel_tags = wheel_tags or platform_tags
+    filename = package_lib.wheel_filename_for_platform_tags(
+        contract, platform_tags, version
+    )
+    path = directory / filename
+    dist_info = f"ferric-{version}.dist-info"
+    native_name = (
+        "ferric/ferric.pyd"
+        if target["runtime"]["os"] == "windows"
+        else "ferric/ferric.abi3.so"
+    )
+    members = {
+        "ferric/__init__.py": b"from .ferric import *\n",
+        native_name: _native_binary(
+            target,
+            architecture=native_architecture,
+            truncated=native_truncated,
+            wrong_format=native_wrong_format,
+        ),
+        f"{dist_info}/METADATA": (
+            metadata_override
+            if metadata_override is not None
+            else _metadata(
+                version,
+                requires_python=requires_python,
+                dependency=dependency,
+                metadata_version=metadata_version,
+            )
+        ),
+        f"{dist_info}/WHEEL": (
+            "Wheel-Version: 1.0\n"
+            "Generator: synthetic-test\n"
+            "Root-Is-Purelib: false\n"
+            + "".join(f"Tag: cp39-abi3-{tag}\n" for tag in wheel_tags)
+        ).encode(),
+        f"{dist_info}/licenses/LICENSE-MIT": (
+            package_lib.PACKAGE_ROOT / "LICENSE-MIT"
+        ).read_bytes(),
+        f"{dist_info}/licenses/LICENSE-APACHE": (
+            b"drift"
+            if license_drift
+            else (package_lib.PACKAGE_ROOT / "LICENSE-APACHE").read_bytes()
+        ),
+        f"{dist_info}/sboms/ferric-rules-python.cyclonedx.json": (
+            _sbom(version) if sbom_override is None else sbom_override
+        ),
+    }
+    members.update(extra_members or {})
+    for name in omit_members:
+        members.pop(name, None)
+    record_path = f"{dist_info}/RECORD"
+    record = _record_bytes(members, bad_hash=bad_record, omit_path=omit_record_path)
+    record += f"{record_path},,\n".encode()
+    members[record_path] = record
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, data in members.items():
+            info = zipfile.ZipInfo(name, date_time=(2020, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = 0o100644 << 16
+            archive.writestr(info, data)
+    return path
+
+
+def _sdist_files(version, *, locked=True):
+    readme = (package_lib.PACKAGE_ROOT / "README.md").read_bytes()
+    mit = (package_lib.PACKAGE_ROOT / "LICENSE-MIT").read_bytes()
+    apache = (package_lib.PACKAGE_ROOT / "LICENSE-APACHE").read_bytes()
+    files = {
+        "PKG-INFO": _metadata(version),
+        "Cargo.lock": b"# synthetic lock\nversion = 4\n",
+        "Cargo.toml": b"[workspace]\nmembers = []\n",
+        "pyproject.toml": f"[tool.maturin]\nlocked = {'true' if locked else 'false'}\n".encode(),
+        "README.md": readme,
+        "LICENSE-MIT": mit,
+        "LICENSE-APACHE": apache,
+        "crates/ferric-rules-python/Cargo.toml": b"[package]\nname='ferric-rules-python'\n",
+        "crates/ferric-rules-python/README.md": readme,
+        "crates/ferric-rules-python/LICENSE-MIT": mit,
+        "crates/ferric-rules-python/LICENSE-APACHE": apache,
+        "crates/ferric-rules-python/build.rs": b"fn main() {}\n",
+        "crates/ferric-rules-python/src/lib.rs": b"pub fn synthetic() {}\n",
+        "crates/ferric-rules-core/Cargo.toml": b"[package]\nname='ferric-rules-core'\n",
+        "crates/ferric-rules-core/README.md": b"core\n",
+        "crates/ferric-rules-core/src/lib.rs": b"pub fn synthetic() {}\n",
+        "crates/ferric-rules-parser/Cargo.toml": b"[package]\nname='ferric-rules-parser'\n",
+        "crates/ferric-rules-parser/README.md": b"parser\n",
+        "crates/ferric-rules-parser/src/lib.rs": b"pub fn synthetic() {}\n",
+        "crates/ferric-rules-runtime/Cargo.toml": b"[package]\nname='ferric-rules-runtime'\n",
+        "crates/ferric-rules-runtime/README.md": b"runtime\n",
+        "crates/ferric-rules-runtime/src/lib.rs": b"pub fn synthetic() {}\n",
+    }
+    return files
+
+
+def _write_sdist(
+    directory, contract, version, *, extra_files=None, omit=(), locked=True
+):
+    path = directory / package_lib.expected_sdist_filename(contract, version)
+    root = path.name[: -len(".tar.gz")]
+    files = _sdist_files(version, locked=locked)
+    files.update(extra_files or {})
+    for name in omit:
+        files.pop(name, None)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(path, "w:gz") as archive:
+        for relative, data in files.items():
+            info = tarfile.TarInfo(f"{root}/{relative}")
+            info.size = len(data)
+            info.mode = 0o644
+            archive.addfile(info, io.BytesIO(data))
+    return path
+
+
+def _runtime_receipt(target):
+    runtime = target["runtime"]
+    return {
+        "os": runtime["os"],
+        "architecture": runtime["architecture"],
+        "libc": runtime.get("libc"),
+        "libc_version": runtime.get("libc_minimum"),
+        "os_version": runtime.get("minimum_os_version"),
+    }
+
+
+def _smoke_payload(target, minor):
+    prefix = "Lib" if target["runtime"]["os"] == "windows" else f"lib/python{minor}"
+    native = "ferric.pyd" if target["runtime"]["os"] == "windows" else "ferric.abi3.so"
+    return {
+        "checks": list(package_lib.EXPECTED_SMOKE_CHECKS),
+        "import_path_relative_to_venv": f"{prefix}/site-packages/ferric/__init__.py",
+        "native_path_relative_to_venv": f"{prefix}/site-packages/ferric/{native}",
+    }
+
+
+def _wheel_receipt(inspection, target, minor):
+    return {
+        "schema_version": 1,
+        "kind": "wheel-smoke",
+        "status": "passed",
+        "distribution": "ferric",
+        "version": inspection.version,
+        "target_id": target["id"],
+        "python": {
+            "implementation": "CPython",
+            "version": f"{minor}.1",
+            "minor": minor,
+            "gil_enabled": True,
+        },
+        "runtime": _runtime_receipt(target),
+        "wheel": {"filename": inspection.filename, "sha256": inspection.sha256},
+        "smoke": _smoke_payload(target, minor),
+    }
+
+
+def _write_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, sort_keys=True), encoding="utf-8")
+
+
+def _complete_artifact_set(root, contract, version):
+    artifacts = root / "artifacts"
+    receipts = root / "receipts"
+    inspections = {}
+    targets = {target["id"]: target for target in contract["wheels"]}
+    for target in contract["wheels"]:
+        wheel = _write_wheel(artifacts, contract, version, target)
+        inspections[target["id"]] = package_lib.validate_wheel(wheel, contract, version)
+    sdist_path = _write_sdist(artifacts, contract, version)
+    sdist = package_lib.validate_sdist(sdist_path, contract, version)
+    for target_id, inspection in inspections.items():
+        target = targets[target_id]
+        for minor in package_lib.EXPECTED_SUPPORTED_MINORS:
+            _write_json(
+                receipts / f"wheel-{target_id}-py{minor.replace('.', '')}.json",
+                _wheel_receipt(inspection, target, minor),
+            )
+    rejection_target = targets["manylinux2014-x86_64"]
+    rejection_inspection = inspections[rejection_target["id"]]
+    rejection = _wheel_receipt(rejection_inspection, rejection_target, "3.14")
+    rejection["kind"] = "python-rejection"
+    rejection.pop("smoke")
+    rejection["rejection"] = {
+        "reason": "Requires-Python",
+        "requires_python": ">=3.9,<3.14",
+        "installer_exit_code": 1,
+        "module_importable": False,
+    }
+    _write_json(receipts / "python-rejection.json", rejection)
+    source_smoke = _wheel_receipt(rejection_inspection, rejection_target, "3.12")
+    source_smoke["kind"] = "source-built-wheel"
+    source_smoke["wheel"] = {
+        "filename": package_lib.wheel_filename_for_platform_tags(
+            contract,
+            package_lib.source_built_wheel_platform_tags(rejection_target),
+            version,
+        ),
+        "sha256": "a" * 64,
+    }
+    sdist_receipt = {
+        "schema_version": 1,
+        "kind": "sdist-smoke",
+        "status": "passed",
+        "distribution": "ferric",
+        "version": version,
+        "target_id": rejection_target["id"],
+        "sdist": {
+            "filename": sdist.filename,
+            "sha256": sdist.sha256,
+            "safe_archive_paths": True,
+            "cargo_lock_locked_offline": True,
+            "deterministic_repack": True,
+            "pep517_built_from_exact_archive": True,
+        },
+        "wheel_smoke": source_smoke,
+    }
+    _write_json(receipts / "sdist-smoke.json", sdist_receipt)
+    return artifacts, receipts
+
+
+def test_repository_metadata_and_abi_contract_is_valid():
+    assert package_lib.validate_repository_contract() == "0.1.0"
+
+
+def test_clean_venv_uses_platform_safe_python_layout(tmp_path):
+    venv_root = package_lib._new_clean_venv(tmp_path)  # noqa: SLF001
+    python = package_lib.find_python_executable(venv_root)
+    result = subprocess.run(
+        [str(python), "-I", "-c", "import pip,sys; print(sys.prefix)"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert Path(result.stdout.strip()).resolve() == venv_root.resolve()
+    if os.name != "nt":
+        assert python.is_symlink()
+
+
+@pytest.mark.parametrize("target_id", list(package_lib.EXPECTED_TARGETS))
+def test_each_exact_wheel_shape_is_accepted(tmp_path, contract, version, target_id):
+    target = package_lib.contract_target(contract, target_id)
+    wheel = _write_wheel(tmp_path, contract, version, target)
+    inspection = package_lib.validate_wheel(wheel, contract, version)
+    assert inspection.target_id == target_id
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        ({"metadata_version": "9.9.9"}, "Version differs"),
+        ({"requires_python": ">=3.9"}, "Requires-Python"),
+        ({"dependency": "requests"}, "runtime dependencies"),
+        ({"bad_record": True}, "RECORD hash mismatch"),
+        ({"omit_record_path": "ferric/__init__.py"}, "RECORD paths"),
+        ({"extra_members": {"../escape": b"secret"}}, "traverses upward"),
+        ({"extra_members": {"ferric.libs/libsecret.so": b"ELF"}}, "exactly one native"),
+        ({"native_architecture": "aarch64"}, "e_machine"),
+        ({"native_truncated": True}, "truncated ELF"),
+        ({"native_wrong_format": True}, "not an ELF"),
+        ({"license_drift": True}, "checked-in license"),
+        ({"sbom_override": b"not-json"}, "CycloneDX JSON"),
+    ],
+)
+def test_wheel_adversarial_mutations_are_rejected(
+    tmp_path, contract, version, mutation, message
+):
+    target = package_lib.contract_target(contract, "manylinux2014-x86_64")
+    wheel = _write_wheel(tmp_path, contract, version, target, **mutation)
+    with pytest.raises(package_lib.PackageValidationError, match=message):
+        package_lib.validate_wheel(wheel, contract, version)
+
+
+@pytest.mark.parametrize(
+    ("target_id", "mutation", "message"),
+    [
+        ("macos-arm64", {"native_architecture": "x86_64"}, "CPU type"),
+        ("macos-arm64", {"native_truncated": True}, "truncated Mach-O"),
+        ("macos-arm64", {"native_wrong_format": True}, "not a little-endian"),
+        ("windows-x86_64", {"native_architecture": "aarch64"}, "PE machine"),
+        ("windows-x86_64", {"native_truncated": True}, "truncated PE"),
+        ("windows-x86_64", {"native_wrong_format": True}, "not a PE"),
+    ],
+)
+def test_native_header_format_and_architecture_must_match_target(
+    tmp_path, contract, version, target_id, mutation, message
+):
+    target = package_lib.contract_target(contract, target_id)
+    wheel = _write_wheel(tmp_path, contract, version, target, **mutation)
+    with pytest.raises(package_lib.PackageValidationError, match=message):
+        package_lib.validate_wheel(wheel, contract, version)
+
+
+def test_bad_filename_platform_tag_is_rejected(tmp_path, contract, version):
+    target = package_lib.contract_target(contract, "manylinux2014-x86_64")
+    wheel = _write_wheel(tmp_path, contract, version, target)
+    bad = wheel.with_name(wheel.name.replace("manylinux_2_17_x86_64", "linux_x86_64"))
+    wheel.rename(bad)
+    with pytest.raises(
+        package_lib.PackageValidationError, match="not one exact contracted artifact"
+    ):
+        package_lib.validate_wheel(bad, contract, version)
+
+
+def test_wheel_tag_metadata_must_match_filename(tmp_path, contract, version):
+    target = package_lib.contract_target(contract, "manylinux2014-x86_64")
+    wheel = _write_wheel(
+        tmp_path, contract, version, target, wheel_tags=["linux_x86_64"]
+    )
+    with pytest.raises(package_lib.PackageValidationError, match="WHEEL tags"):
+        package_lib.validate_wheel(wheel, contract, version)
+
+
+def test_wheel_requires_both_license_payloads(tmp_path, contract, version):
+    target = package_lib.contract_target(contract, "manylinux2014-x86_64")
+    dist_info = f"ferric-{version}.dist-info"
+    wheel = _write_wheel(
+        tmp_path,
+        contract,
+        version,
+        target,
+        omit_members=(f"{dist_info}/licenses/LICENSE-MIT",),
+    )
+    with pytest.raises(
+        package_lib.PackageValidationError, match="missing required members"
+    ):
+        package_lib.validate_wheel(wheel, contract, version)
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "message"),
+    [
+        (package_lib.EXPECTED_SUMMARY.encode(), b"Wrong summary", "Summary drifted"),
+        (b"License-File: LICENSE-MIT\n", b"", "License-File headers"),
+        (
+            b"License-Expression: MIT OR Apache-2.0",
+            b"License-Expression: MIT",
+            "license expression",
+        ),
+        (
+            b"Project-URL: Homepage, https://github.com/plx/ferric-rules\n",
+            b"",
+            "project URLs",
+        ),
+        (b"# Ferric for Python", b"# Wrong README", "README body"),
+    ],
+)
+def test_publish_metadata_deletion_or_drift_is_rejected(
+    tmp_path, contract, version, old, new, message
+):
+    target = package_lib.contract_target(contract, "manylinux2014-x86_64")
+    metadata = _metadata(version)
+    assert old in metadata
+    wheel = _write_wheel(
+        tmp_path,
+        contract,
+        version,
+        target,
+        metadata_override=metadata.replace(old, new, 1),
+    )
+    with pytest.raises(package_lib.PackageValidationError, match=message):
+        package_lib.validate_wheel(wheel, contract, version)
+
+
+def test_sbom_rejects_an_unexpected_native_component(tmp_path, contract, version):
+    target = package_lib.contract_target(contract, "manylinux2014-x86_64")
+    sbom = json.loads(_sbom(version))
+    sbom["components"] = [{"type": "file", "name": "vendored-secret.so"}]
+    wheel = _write_wheel(
+        tmp_path,
+        contract,
+        version,
+        target,
+        sbom_override=json.dumps(sbom).encode(),
+    )
+    with pytest.raises(
+        package_lib.PackageValidationError, match="bundled native components"
+    ):
+        package_lib.validate_wheel(wheel, contract, version)
+
+
+@pytest.mark.parametrize(
+    ("options", "message"),
+    [
+        ({"extra_files": {"../escape": b"secret"}}, "traverses upward"),
+        (
+            {"extra_files": {"credentials.env": b"TOKEN=secret"}},
+            "unexpected publish payload",
+        ),
+        (
+            {"extra_files": {"crates/unlisted/src/lib.rs": b"secret"}},
+            "unexpected publish payload",
+        ),
+        ({"omit": ("LICENSE-MIT",)}, "missing members"),
+        ({"extra_files": {"README.md": b"drift"}}, "copies of README.md differ"),
+        ({"locked": False}, "locked = true"),
+    ],
+)
+def test_sdist_adversarial_mutations_are_rejected(
+    tmp_path, contract, version, options, message
+):
+    sdist = _write_sdist(tmp_path, contract, version, **options)
+    with pytest.raises(package_lib.PackageValidationError, match=message):
+        package_lib.validate_sdist(sdist, contract, version)
+
+
+def test_complete_artifact_and_receipt_matrix_produces_deterministic_manifest(
+    tmp_path, contract, version
+):
+    artifacts, receipts = _complete_artifact_set(tmp_path, contract, version)
+    first = package_lib.verify_artifact_set(artifacts, receipts, contract, version)
+    second = package_lib.verify_artifact_set(artifacts, receipts, contract, version)
+    assert first == second
+    assert len(first["artifacts"]) == 8
+    assert first["receipt_coverage"] == {
+        "wheel_smokes": 35,
+        "python_314_rejections": 1,
+        "sdist_smokes": 1,
+    }
+
+
+def test_artifact_set_rejects_missing_and_duplicate_wheels(tmp_path, contract, version):
+    missing_root = tmp_path / "missing"
+    artifacts, receipts = _complete_artifact_set(missing_root, contract, version)
+    next(artifacts.glob("*.whl")).unlink()
+    with pytest.raises(
+        package_lib.PackageValidationError, match="exactly seven wheels"
+    ):
+        package_lib.verify_artifact_set(artifacts, receipts, contract, version)
+
+    duplicate_root = tmp_path / "duplicate"
+    artifacts, receipts = _complete_artifact_set(duplicate_root, contract, version)
+    wheel = next(artifacts.glob("*.whl"))
+    duplicate = artifacts / "nested" / wheel.name
+    duplicate.parent.mkdir()
+    shutil.copyfile(wheel, duplicate)
+    with pytest.raises(
+        package_lib.PackageValidationError, match="exactly seven wheels"
+    ):
+        package_lib.verify_artifact_set(artifacts, receipts, contract, version)
+
+
+def test_receipt_matrix_rejects_missing_duplicate_and_bad_identity(
+    tmp_path, contract, version
+):
+    missing_root = tmp_path / "missing"
+    artifacts, receipts = _complete_artifact_set(missing_root, contract, version)
+    next(receipts.glob("wheel-*.json")).unlink()
+    with pytest.raises(
+        package_lib.PackageValidationError, match="expected 37 receipts"
+    ):
+        package_lib.verify_artifact_set(artifacts, receipts, contract, version)
+
+    duplicate_root = tmp_path / "duplicate"
+    artifacts, receipts = _complete_artifact_set(duplicate_root, contract, version)
+    receipt = next(receipts.glob("wheel-*.json"))
+    shutil.copyfile(receipt, receipts / f"duplicate-{receipt.name}")
+    with pytest.raises(
+        package_lib.PackageValidationError, match="expected 37 receipts"
+    ):
+        package_lib.verify_artifact_set(artifacts, receipts, contract, version)
+
+    identity_root = tmp_path / "identity"
+    artifacts, receipts = _complete_artifact_set(identity_root, contract, version)
+    receipt = next(receipts.glob("wheel-*.json"))
+    value = json.loads(receipt.read_text())
+    value["wheel"]["sha256"] = "0" * 64
+    _write_json(receipt, value)
+    with pytest.raises(package_lib.PackageValidationError, match="final wheel"):
+        package_lib.verify_artifact_set(artifacts, receipts, contract, version)
+
+
+def test_receipt_rejects_boolean_schema_version(tmp_path, contract, version):
+    artifacts, receipts = _complete_artifact_set(tmp_path, contract, version)
+    receipt = next(receipts.glob("wheel-*.json"))
+    value = json.loads(receipt.read_text())
+    value["schema_version"] = True
+    _write_json(receipt, value)
+    with pytest.raises(package_lib.PackageValidationError, match="integer 1"):
+        package_lib.verify_artifact_set(artifacts, receipts, contract, version)
+
+
+def test_receipt_rejects_an_unsupported_python_minor(tmp_path, contract, version):
+    artifacts, receipts = _complete_artifact_set(tmp_path, contract, version)
+    receipt = next(receipts.glob("wheel-*.json"))
+    value = json.loads(receipt.read_text())
+    value["python"]["minor"] = "3.8"
+    value["python"]["version"] = "3.8.20"
+    _write_json(receipt, value)
+    with pytest.raises(package_lib.PackageValidationError, match="supported-minor"):
+        package_lib.verify_artifact_set(artifacts, receipts, contract, version)
+
+
+def test_contract_rejects_boolean_schema_version(contract):
+    invalid = copy.deepcopy(contract)
+    invalid["schema_version"] = True
+    with pytest.raises(package_lib.PackageValidationError, match="integer 1"):
+        package_lib.validate_contract(invalid)
+
+    invalid = copy.deepcopy(contract)
+    invalid["sdist"]["artifact_count"] = True
+    with pytest.raises(package_lib.PackageValidationError, match="exactly one sdist"):
+        package_lib.validate_contract(invalid)
+
+
+def _maturin_executable():
+    executable = Path(sys.executable).with_name(
+        "maturin.exe" if os.name == "nt" else "maturin"
+    )
+    if executable.is_file():
+        return str(executable)
+    return shutil.which("maturin")
+
+
+@pytest.mark.skipif(_maturin_executable() is None, reason="Maturin is unavailable")
+def test_real_sdist_stale_lock_is_normalized_and_repacked_deterministically(
+    tmp_path, contract, version
+):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    subprocess.run(
+        [
+            _maturin_executable(),
+            "sdist",
+            "--manifest-path",
+            str(package_lib.PYTHON_CARGO_PATH),
+            "--out",
+            str(raw_dir),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    raw = raw_dir / package_lib.expected_sdist_filename(contract, version)
+    source = package_lib.safe_extract_sdist(
+        raw, tmp_path / "raw-extracted", contract, version
+    )
+    stale = subprocess.run(
+        [
+            "cargo",
+            "metadata",
+            "--format-version",
+            "1",
+            "--offline",
+            "--locked",
+            "--manifest-path",
+            str(source / "Cargo.toml"),
+        ],
+        cwd=source,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert stale.returncode != 0
+    assert "lock file" in stale.stderr
+    assert "--locked" in stale.stderr
+
+    first = package_lib.normalize_sdist(
+        raw,
+        tmp_path / "first" / raw.name,
+        contract,
+        version,
+    )
+    second = package_lib.normalize_sdist(
+        raw,
+        tmp_path / "second" / raw.name,
+        contract,
+        version,
+    )
+    assert first.sha256 == second.sha256
+    assert first.size == second.size

--- a/crates/ferric-rules-python/tests/test_python_package_artifacts.py
+++ b/crates/ferric-rules-python/tests/test_python_package_artifacts.py
@@ -10,6 +10,7 @@ import io
 import json
 import os
 import shutil
+import stat
 import subprocess
 import sys
 import tarfile
@@ -157,6 +158,8 @@ def _write_wheel(
     native_wrong_format=False,
     license_drift=False,
     sbom_override=None,
+    directory_entries=None,
+    member_modes=None,
 ):
     platform_tags = platform_tags or target["platform_tags"]
     wheel_tags = wheel_tags or platform_tags
@@ -215,10 +218,15 @@ def _write_wheel(
     members[record_path] = record
     path.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for name, data in (directory_entries or {}).items():
+            info = zipfile.ZipInfo(name, date_time=(2020, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_STORED
+            info.external_attr = (stat.S_IFDIR | 0o755) << 16
+            archive.writestr(info, data)
         for name, data in members.items():
             info = zipfile.ZipInfo(name, date_time=(2020, 1, 1, 0, 0, 0))
             info.compress_type = zipfile.ZIP_DEFLATED
-            info.external_attr = 0o100644 << 16
+            info.external_attr = (member_modes or {}).get(name, 0o100644) << 16
             archive.writestr(info, data)
     return path
 
@@ -447,6 +455,48 @@ def test_each_exact_wheel_shape_is_accepted(tmp_path, contract, version, target_
     assert inspection.target_id == target_id
 
 
+def test_canonical_empty_wheel_directory_entries_are_accepted(
+    tmp_path, contract, version
+):
+    target = package_lib.contract_target(contract, "macos-arm64")
+    dist_info = f"ferric-{version}.dist-info"
+    wheel = _write_wheel(
+        tmp_path,
+        contract,
+        version,
+        target,
+        directory_entries={
+            "ferric/": b"",
+            f"{dist_info}/": b"",
+            f"{dist_info}/licenses/": b"",
+            f"{dist_info}/sboms/": b"",
+        },
+    )
+
+    inspection = package_lib.validate_wheel(wheel, contract, version)
+
+    assert inspection.target_id == "macos-arm64"
+
+
+@pytest.mark.parametrize(
+    ("directory_entries", "message"),
+    [
+        ({"unreferenced/": b""}, "not canonical parents"),
+        ({"ferric/": b"not empty"}, "directory entry is not empty"),
+    ],
+)
+def test_noncanonical_wheel_directory_entries_are_rejected(
+    tmp_path, contract, version, directory_entries, message
+):
+    target = package_lib.contract_target(contract, "macos-arm64")
+    wheel = _write_wheel(
+        tmp_path, contract, version, target, directory_entries=directory_entries
+    )
+
+    with pytest.raises(package_lib.PackageValidationError, match=message):
+        package_lib.validate_wheel(wheel, contract, version)
+
+
 @pytest.mark.parametrize(
     ("mutation", "message"),
     [
@@ -462,6 +512,10 @@ def test_each_exact_wheel_shape_is_accepted(tmp_path, contract, version, target_
         ({"native_wrong_format": True}, "not an ELF"),
         ({"license_drift": True}, "checked-in license"),
         ({"sbom_override": b"not-json"}, "CycloneDX JSON"),
+        (
+            {"member_modes": {"ferric/__init__.py": stat.S_IFIFO | 0o644}},
+            "not a regular file",
+        ),
     ],
 )
 def test_wheel_adversarial_mutations_are_rejected(

--- a/crates/ferric-rules-python/tests/test_python_package_artifacts.py
+++ b/crates/ferric-rules-python/tests/test_python_package_artifacts.py
@@ -23,6 +23,7 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 SCRIPTS_ROOT = REPO_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_ROOT))
 
+import musl_static_libgcc_linker as musl_linker  # noqa: E402
 import python_package_lib as package_lib  # noqa: E402
 
 
@@ -380,6 +381,40 @@ def _complete_artifact_set(root, contract, version):
 
 def test_repository_metadata_and_abi_contract_is_valid():
     assert package_lib.validate_repository_contract() == "0.1.0"
+
+
+def test_musl_linker_replaces_only_the_dynamic_gcc_runtime_and_libc_name(
+    tmp_path,
+):
+    original = ["-shared", "input.o", "-lgcc_s", "-lc", "-o", "ferric.so"]
+    assert musl_linker.rewrite_linker_arguments(
+        original,
+        alias_dir=tmp_path,
+        canonical_libc="libc.musl-x86_64.so.1",
+    ) == [
+        "-shared",
+        "input.o",
+        "-Wl,-Bstatic",
+        "-lgcc_eh",
+        "-Wl,-Bdynamic",
+        f"-L{tmp_path}",
+        "-l:libc.musl-x86_64.so.1",
+        "-o",
+        "ferric.so",
+    ]
+
+
+@pytest.mark.parametrize(
+    "dynamic_arguments",
+    [[], ["-lgcc_s", "-lgcc_s", "-lc"], ["-lgcc_s", "-lc", "-lc"]],
+)
+def test_musl_linker_rejects_toolchain_argument_drift(dynamic_arguments, tmp_path):
+    with pytest.raises(ValueError, match="exactly one dynamic -lgcc_s and one -lc"):
+        musl_linker.rewrite_linker_arguments(
+            dynamic_arguments,
+            alias_dir=tmp_path,
+            canonical_libc="libc.musl-x86_64.so.1",
+        )
 
 
 def test_clean_venv_uses_platform_safe_python_layout(tmp_path):

--- a/crates/ferric-rules-python/tests/test_python_package_artifacts.py
+++ b/crates/ferric-rules-python/tests/test_python_package_artifacts.py
@@ -383,6 +383,13 @@ def test_repository_metadata_and_abi_contract_is_valid():
     assert package_lib.validate_repository_contract() == "0.1.0"
 
 
+def test_distribution_license_copies_have_stable_checkout_bytes():
+    attributes = (REPO_ROOT / ".gitattributes").read_text(encoding="utf-8")
+    for filename in package_lib.EXPECTED_LICENSE_FILES:
+        assert f"{filename} text eol=lf" in attributes
+        assert f"crates/ferric-rules-python/{filename} text eol=lf" in attributes
+
+
 def test_musl_linker_replaces_only_the_dynamic_gcc_runtime_and_libc_name(
     tmp_path,
 ):

--- a/crates/ferric-rules-python/tests/test_support_contract.py
+++ b/crates/ferric-rules-python/tests/test_support_contract.py
@@ -42,13 +42,12 @@ def test_python_metadata_matches_ci_matrix():
     workflow = CI_WORKFLOW.read_text(encoding="utf-8")
     job = _python_bindings_job(workflow)
 
-    requires_python = re.search(r'^requires-python\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+    requires_python = re.search(
+        r'^requires-python\s*=\s*"([^"]+)"', pyproject, re.MULTILINE
+    )
     assert requires_python is not None
     assert requires_python.group(1) == REQUIRES_PYTHON
-    assert (
-        '"Programming Language :: Python :: Implementation :: CPython"'
-        in pyproject
-    )
+    assert '"Programming Language :: Python :: Implementation :: CPython"' in pyproject
 
     classifiers = re.findall(
         r'"Programming Language :: Python :: (\d+\.\d+)"',
@@ -83,37 +82,31 @@ def test_lockfile_carries_the_same_python_range_without_314_artifacts():
     pyproject = PYPROJECT.read_text(encoding="utf-8")
     lockfile = UV_LOCK.read_text(encoding="utf-8")
 
-    project_range = re.search(r'^requires-python\s*=\s*"([^"]+)"', pyproject, re.MULTILINE)
+    project_range = re.search(
+        r'^requires-python\s*=\s*"([^"]+)"', pyproject, re.MULTILINE
+    )
     lock_range = re.search(r'^requires-python\s*=\s*"([^"]+)"', lockfile, re.MULTILINE)
     assert project_range is not None
     assert lock_range is not None
     assert lock_range.group(1) == LOCK_REQUIRES_PYTHON
-    assert "".join(lock_range.group(1).split()) == "".join(project_range.group(1).split())
+    assert "".join(lock_range.group(1).split()) == "".join(
+        project_range.group(1).split()
+    )
     assert re.search(r"(?i)(?:cp|cpython[-_])314", lockfile) is None
 
 
-def test_every_matrix_lane_builds_tests_and_smokes_a_wheel():
+def test_every_fast_ci_matrix_lane_builds_and_tests_from_source():
     workflow = CI_WORKFLOW.read_text(encoding="utf-8")
     job = _python_bindings_job(workflow)
 
     required_commands = [
         "maturin develop",
         "pytest tests/",
-        "maturin build",
-        "$RUNNER_TEMP",
-        "${#artifacts[@]}",
-        "-m venv",
-        "pip install",
-        'cd "$smoke_dir"',
-        "import ferric",
         "sys.version_info[:2]",
-        "ferric.__file__",
-        "engine.load(",
-        "engine.run()",
-        "engine.close()",
     ]
     missing = [command for command in required_commands if command not in job]
     assert not missing, f"python-bindings job is missing coverage: {missing}"
+    assert "maturin build" not in job
 
 
 def test_supported_builds_do_not_use_pyo3_forward_compatibility_escape_hatch():

--- a/crates/ferric-rules-python/uv.lock
+++ b/crates/ferric-rules-python/uv.lock
@@ -29,7 +29,6 @@ wheels = [
 
 [[package]]
 name = "ferric"
-version = "0.1.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/crates/ferric-rules-python/wheel-targets.json
+++ b/crates/ferric-rules-python/wheel-targets.json
@@ -1,0 +1,195 @@
+{
+  "schema_version": 1,
+  "distribution": {
+    "name": "ferric",
+    "import_name": "ferric",
+    "version_source": {
+      "path": "../../Cargo.toml",
+      "toml_key": "workspace.package.version"
+    }
+  },
+  "python": {
+    "implementation": "CPython",
+    "gil": "enabled",
+    "requires_python": ">=3.9,<3.14",
+    "supported_minors": [
+      "3.9",
+      "3.10",
+      "3.11",
+      "3.12",
+      "3.13"
+    ],
+    "abi": {
+      "kind": "abi3",
+      "pyo3_feature": "abi3-py39",
+      "minimum_python": "3.9",
+      "python_tag": "cp39",
+      "abi_tag": "abi3"
+    },
+    "exclusions": {
+      "python_versions": [
+        "<3.9",
+        ">=3.14"
+      ],
+      "implementations": [
+        "PyPy",
+        "GraalPy"
+      ],
+      "cpython_builds": [
+        "free-threaded"
+      ],
+      "wheel_targets": [
+        "macos-universal2",
+        "windows-arm64",
+        "unlisted-platforms-and-architectures"
+      ]
+    }
+  },
+  "wheels": [
+    {
+      "id": "manylinux2014-x86_64",
+      "runner": "ubuntu-24.04",
+      "rust_target": "x86_64-unknown-linux-gnu",
+      "platform_tags": [
+        "manylinux_2_17_x86_64",
+        "manylinux2014_x86_64"
+      ],
+      "runtime": {
+        "os": "linux",
+        "architecture": "x86_64",
+        "libc": "glibc",
+        "libc_minimum": "2.17"
+      },
+      "compatibility": {
+        "family": "manylinux",
+        "maturin": "manylinux2014"
+      }
+    },
+    {
+      "id": "manylinux2014-aarch64",
+      "runner": "ubuntu-24.04-arm",
+      "rust_target": "aarch64-unknown-linux-gnu",
+      "platform_tags": [
+        "manylinux_2_17_aarch64",
+        "manylinux2014_aarch64"
+      ],
+      "runtime": {
+        "os": "linux",
+        "architecture": "aarch64",
+        "libc": "glibc",
+        "libc_minimum": "2.17"
+      },
+      "compatibility": {
+        "family": "manylinux",
+        "maturin": "manylinux2014"
+      }
+    },
+    {
+      "id": "musllinux1_2-x86_64",
+      "runner": "ubuntu-24.04",
+      "rust_target": "x86_64-unknown-linux-musl",
+      "platform_tags": [
+        "musllinux_1_2_x86_64"
+      ],
+      "runtime": {
+        "os": "linux",
+        "architecture": "x86_64",
+        "libc": "musl",
+        "libc_minimum": "1.2"
+      },
+      "compatibility": {
+        "family": "musllinux",
+        "maturin": "musllinux_1_2"
+      }
+    },
+    {
+      "id": "musllinux1_2-aarch64",
+      "runner": "ubuntu-24.04-arm",
+      "rust_target": "aarch64-unknown-linux-musl",
+      "platform_tags": [
+        "musllinux_1_2_aarch64"
+      ],
+      "runtime": {
+        "os": "linux",
+        "architecture": "aarch64",
+        "libc": "musl",
+        "libc_minimum": "1.2"
+      },
+      "compatibility": {
+        "family": "musllinux",
+        "maturin": "musllinux_1_2"
+      }
+    },
+    {
+      "id": "macos-x86_64",
+      "runner": "macos-15-intel",
+      "rust_target": "x86_64-apple-darwin",
+      "platform_tags": [
+        "macosx_10_12_x86_64"
+      ],
+      "runtime": {
+        "os": "macos",
+        "architecture": "x86_64",
+        "minimum_os_version": "10.12"
+      },
+      "compatibility": {
+        "family": "macos",
+        "maturin": "pypi",
+        "deployment_target": "10.12"
+      }
+    },
+    {
+      "id": "macos-arm64",
+      "runner": "macos-15",
+      "rust_target": "aarch64-apple-darwin",
+      "platform_tags": [
+        "macosx_11_0_arm64"
+      ],
+      "runtime": {
+        "os": "macos",
+        "architecture": "aarch64",
+        "minimum_os_version": "11.0"
+      },
+      "compatibility": {
+        "family": "macos",
+        "maturin": "pypi",
+        "deployment_target": "11.0"
+      }
+    },
+    {
+      "id": "windows-x86_64",
+      "runner": "windows-2025",
+      "rust_target": "x86_64-pc-windows-msvc",
+      "platform_tags": [
+        "win_amd64"
+      ],
+      "runtime": {
+        "os": "windows",
+        "architecture": "x86_64"
+      },
+      "compatibility": {
+        "family": "windows",
+        "maturin": "pypi"
+      }
+    }
+  ],
+  "sdist": {
+    "included": true,
+    "artifact_count": 1,
+    "format": "tar.gz",
+    "build_and_test": true,
+    "include_in_publish_dry_run": true,
+    "cargo_lock": {
+      "required": true,
+      "relocated_workspace": "normalize-offline-then-verify-locked",
+      "final_artifact": "deterministically-repacked-and-tested"
+    },
+    "requirements": {
+      "python": ">=3.9,<3.14",
+      "rust": ">=1.75",
+      "maturin": ">=1.0,<2.0",
+      "native_toolchain": true,
+      "dependency_resolution": "network access or pre-populated Python and Cargo caches"
+    }
+  }
+}

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -138,8 +138,10 @@ implementation. It is published only so registry builds of
 
 ### `ferric-rules-python`
 
-PyO3 extension module (`ferric`) built via `maturin`. Located in
-`crates/ferric-rules-python/`; tests in `tests/*.py`.
+PyO3 extension module (`ferric`) built via `maturin`. Its `abi3-py39` release
+contract covers GIL-enabled CPython 3.9 through 3.13 across seven native wheel
+targets; see [`python-package-release.md`](python-package-release.md). Located
+in `crates/ferric-rules-python/`; tests are in `tests/*.py`.
 
 - `engine.rs` — `PyEngine`.
 - `fact.rs` — `Fact`, `FactType`.

--- a/docs/python-package-release.md
+++ b/docs/python-package-release.md
@@ -1,0 +1,154 @@
+# Python package release contract
+
+This document defines the release surface for the `ferric` Python distribution
+and import package. It is the human-readable companion to the versioned
+machine contract in
+[`wheel-targets.json`](../crates/ferric-rules-python/wheel-targets.json).
+Changes to either document must keep package metadata, CI, validators, and
+consumer smoke tests in agreement.
+
+This contract is limited to Python distribution artifacts. The broader
+cross-binding minimum-runtime, sanitizer, stress, and clean-consumer CI program
+remains tracked in
+[#124](https://github.com/plx/ferric-rules/issues/124); this matrix does not
+claim to complete that work.
+
+## Package identity and support boundary
+
+- Distribution name: `ferric`.
+- Import name: `ferric`.
+- Version source: `[workspace.package].version` in the root `Cargo.toml`;
+  `pyproject.toml` declares its version dynamically so Maturin reads that
+  source rather than maintaining a second literal.
+- Python: GIL-enabled CPython 3.9, 3.10, 3.11, 3.12, and 3.13.
+- Packaging range: `Requires-Python: >=3.9,<3.14`.
+- ABI: PyO3 `abi3-py39`, producing `cp39-abi3` wheels.
+
+Python 3.14 is not admitted merely because the stable ABI may be loadable on a
+newer interpreter. PyPy, GraalPy, free-threaded CPython, macOS universal2,
+Windows Arm64, and unlisted platforms and architectures are unsupported. Their
+absence is intentional, not missing CI coverage.
+
+## ABI decision
+
+The project uses `abi3-py39` instead of per-minor CPython wheels. The baseline
+matches the package's minimum Python version and reduces the release set from
+35 platform/minor wheels to seven platform wheels. Every one of those wheels is
+still installed and exercised separately on each supported Python minor.
+
+The stable ABI restricts PyO3 to CPython's limited API and may forgo
+version-specific boundary optimizations. No performance improvement is claimed
+from this choice. Free-threaded CPython has a distinct ABI and is not covered by
+`abi3`.
+
+Cargo's workspace release profile strips symbols by default. The Python package
+overrides that setting with `strip = "none"`, and Maturin also has
+`strip = false`, because link-time stripping of an abi3 extension produced
+malformed Mach-O string-table alignment with an Apple linker. Native import and
+dependency inspection remain mandatory on both macOS architectures.
+
+Maturin's package configuration sets `locked = true`. This makes every Cargo
+invocation reject dependency drift even though Maturin's standalone `sdist`
+command has no `--locked` CLI option. Because Maturin relocates and prunes the
+workspace manifest when it creates an sdist, its raw archive is only an
+intermediate: the release tooling normalizes that relocated workspace's
+`Cargo.lock` offline, proves it with `cargo metadata --locked --offline`, and
+then deterministically repacks the candidate before any build or smoke test.
+
+## Wheel matrix
+
+The release set contains exactly seven wheels:
+
+| Contract ID | Native runner | Rust target | Required platform tag or tags | Compatibility floor |
+| --- | --- | --- | --- | --- |
+| `manylinux2014-x86_64` | `ubuntu-24.04` | `x86_64-unknown-linux-gnu` | `manylinux_2_17_x86_64`, `manylinux2014_x86_64` | glibc 2.17 |
+| `manylinux2014-aarch64` | `ubuntu-24.04-arm` | `aarch64-unknown-linux-gnu` | `manylinux_2_17_aarch64`, `manylinux2014_aarch64` | glibc 2.17 |
+| `musllinux1_2-x86_64` | `ubuntu-24.04` | `x86_64-unknown-linux-musl` | `musllinux_1_2_x86_64` | musl 1.2 |
+| `musllinux1_2-aarch64` | `ubuntu-24.04-arm` | `aarch64-unknown-linux-musl` | `musllinux_1_2_aarch64` | musl 1.2 |
+| `macos-x86_64` | `macos-15-intel` | `x86_64-apple-darwin` | `macosx_10_12_x86_64` | macOS 10.12 |
+| `macos-arm64` | `macos-15` | `aarch64-apple-darwin` | `macosx_11_0_arm64` | macOS 11.0 |
+| `windows-x86_64` | `windows-2025` | `x86_64-pc-windows-msvc` | `win_amd64` | 64-bit Windows |
+
+Every filename and internal `WHEEL` record must combine the declared platform
+tag set with `cp39-abi3`. The two manylinux spellings are equivalent tags on a
+single wheel, not separate artifacts.
+
+## Source distribution policy
+
+Each verified bundle also contains exactly one `.tar.gz` source distribution.
+The sdist must include the Python crate, its required Rust workspace crates, a
+lockfile normalized for the relocated workspace, the package README, and both
+license texts. The raw Maturin output is never the release candidate. A job
+safe-extracts it, updates only the relocated lockfile without network access,
+checks the result with locked and offline Cargo metadata, and deterministically
+repacks it. A clean job then builds a wheel from those exact final bytes and
+runs the same package smoke before the sdist can enter the bundle.
+
+An sdist consumer needs:
+
+- CPython `>=3.9,<3.14`;
+- Rust 1.75 or newer;
+- Maturin `>=1.0,<2.0`;
+- the target's native compiler, linker, and platform development tools; and
+- network access or pre-populated Python and Cargo caches for dependency
+  resolution.
+
+Supported users should receive a wheel and therefore should not need any of
+these source-build tools. The sdist is not a substitute for a missing declared
+wheel.
+
+## Artifact verification
+
+The Python artifact workflow must fail closed through this sequence:
+
+1. Build each wheel with locked Cargo and Maturin inputs on its declared native
+   runner. Package-level `locked = true` must remain active for the sdist and
+   PEP 517 paths. Apply the declared manylinux, musllinux, or macOS
+   compatibility floor.
+2. Repair or audit the wheel with the platform-native equivalent of
+   `auditwheel`, `delocate`, or `delvewheel`. Only the final inspected wheel may
+   be uploaded as a workflow artifact.
+3. Verify the archive layout, distribution metadata, license files, ABI and
+   platform tags, native dependencies, and `RECORD` hashes. Record its SHA-256
+   digest in the release manifest.
+4. Download that exact artifact into clean consumer jobs for CPython 3.9 through
+   3.13. Install with `pip --no-index --no-deps --only-binary=:all:` from a
+   directory outside the checkout, then import, load and run rules,
+   serialize/restore, and close all engines.
+5. Normalize and deterministically repack Maturin's raw workspace sdist as
+   described above. Re-extract the exact final archive, require locked and
+   offline Cargo metadata, build its wheel through PEP 517, and run the package
+   smoke. Aggregate exactly seven verified wheels and that one verified sdist;
+   reject missing, duplicate, or extra files.
+6. Run a non-mutating registry check against the downloaded aggregate, for
+   example:
+
+   ```sh
+   uv publish --dry-run --trusted-publishing never --no-attestations \
+     <each-explicitly-verified-distribution>
+   ```
+
+The publish dry run must use explicit verified paths. A permissive glob, an
+artifact built again in the promotion job, a network-backed `pip` fallback, or
+smoke testing only before artifact upload does not satisfy the contract.
+
+## Publication boundary
+
+Artifact building, repair, inspection, clean installation, attestation, and a
+non-mutating registry dry run are permitted staging steps. Stable publication
+to PyPI is an irreversible action and is not authorized by this contract or by
+the existence of a successful workflow run.
+
+No stable Python distribution may be published until the independent audit in
+[#223](https://github.com/plx/ferric-rules/issues/223) has approved the exact
+candidate and the maintainer has authorized the exact artifacts under the
+[staged-artifact and publication policy](audits/production-readiness-remediation-goal.md#staged-artifacts-and-irreversible-publication).
+The eventual promotion job must download the already verified bytes, recheck
+their manifest, and must not rebuild them.
+
+## Updating the contract
+
+Treat `wheel-targets.json` as a versioned interface. A change to a Python minor,
+ABI baseline, target, runner, Rust triple, compatibility floor, exclusion, or
+sdist rule requires an intentional schema/contract update and matching
+validation. Do not infer support from whatever a build host happens to provide.

--- a/docs/python-package-release.md
+++ b/docs/python-package-release.md
@@ -47,6 +47,26 @@ overrides that setting with `strip = "none"`, and Maturin also has
 malformed Mach-O string-table alignment with an Apple linker. Native import and
 dependency inspection remain mandatory on both macOS architectures.
 
+Rust's dynamically loaded musl target normally requests `libgcc_s.so.1`. The
+release workflow pins each architecture's `rust-musl-cross` image index by
+digest, then replaces that toolchain's single dynamic linker argument with its
+static `libgcc_eh` archive. It also links the same pinned musl libc through its
+architecture-canonical runtime name (`libc.musl-*.so.1`) instead of the sysroot
+file's bare `libc.so` name. This keeps each musllinux wheel self-contained apart
+from musl itself, makes the runtime dependency portable and auditable, and
+preserves the exact one-native-module archive contract. The wrapper fails if
+Rust stops emitting exactly one `-lgcc_s` or one `-lc` argument, so toolchain
+drift cannot silently change this linkage policy.
+
+The repaired musllinux wheel is audited inside a digest-pinned,
+matching-architecture Alpine container. Running `auditwheel show` directly on
+the glibc host can mistake musl's `libc.so` linker script for an ELF object.
+The container receives a read-only wheel and a pinned, host-prepared
+`auditwheel` environment, runs without network access, and writes only to a
+temporary filesystem. The workflow requires `auditwheel` to report the exact
+contracted `musllinux_1_2` architecture tag; its exit status alone is not
+accepted because the tool can successfully report a weaker generic Linux tag.
+
 Maturin's package configuration sets `locked = true`. This makes every Cargo
 invocation reject dependency drift even though Maturin's standalone `sdist`
 command has no `--locked` CLI option. Because Maturin relocates and prunes the

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -871,9 +871,10 @@ Ferric's engine core is reachable from other languages via `ferric-rules-ffi`
   §16.13 for the C contract.
 - **Go**: `bindings/go` provides an idiomatic façade (`Engine`,
   `Coordinator`, `Manager`) plus a Temporal activity wrapper.
-- **Python**: `crates/ferric-rules-python` ships a PyO3 extension module for
-  CPython 3.9 through 3.13; build it with `maturin` and `import ferric` from
-  Python. Python 3.14 is not currently supported.
+- **Python**: `crates/ferric-rules-python` exposes `import ferric` through
+  `cp39-abi3` wheels for GIL-enabled CPython 3.9 through 3.13. Python 3.14,
+  free-threaded CPython, and other interpreters are not currently supported;
+  see the [Python package release contract](python-package-release.md).
 - **CLI**: the `ferric` binary (`crates/ferric-rules-cli`) runs `.clp` files
   batch-style or drops you into a REPL. `ferric check [--json] file.clp`
   validates without running; `ferric run` executes.

--- a/justfile
+++ b/justfile
@@ -150,6 +150,22 @@ py-test:
 py-bindings-test:
     cd crates/ferric-rules-python && uv run maturin develop --quiet && .venv/bin/python -m pytest tests/
 
+# Validate Python publish metadata, stable ABI, strip policy, and artifact targets
+python-package-validate:
+    python3 scripts/validate-python-package.py
+
+# Smoke one exact local Python wheel and write a machine-verifiable receipt
+python-wheel-artifact-smoke wheel target receipt *args:
+    python3 scripts/test-python-wheel-artifact.py --wheel {{wheel}} --target {{target}} --receipt {{receipt}} {{args}}
+
+# Normalize, PEP 517-build, and smoke one exact Python source distribution
+python-sdist-artifact-test raw_sdist final_sdist target receipt:
+    uv run --project crates/ferric-rules-python --locked python scripts/test-python-sdist-artifact.py --sdist {{raw_sdist}} --output {{final_sdist}} --target {{target}} --receipt {{receipt}}
+
+# Verify seven final wheels, one tested sdist, and their complete receipt matrix
+python-package-artifacts-verify artifacts receipts manifest:
+    python3 scripts/verify-python-package-artifacts.py --artifacts-dir {{artifacts}} --receipts-dir {{receipts}} --manifest-out {{manifest}}
+
 # Run one language-neutral semantic corpus through Rust, C, Go, Node, and Python.
 bindings-conformance:
     just build-go-ffi

--- a/scripts/musl_static_libgcc_linker.py
+++ b/scripts/musl_static_libgcc_linker.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Link musl extension modules with GCC's unwind runtime statically."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+REAL_LINKER_ENV = "CARGO_FERRIC_MUSL_LINKER"
+LINKER_CONFIGS = {
+    "/usr/local/musl/bin/aarch64-unknown-linux-musl-gcc": (
+        Path("/usr/local/musl/aarch64-unknown-linux-musl/lib/libc.so"),
+        "libc.musl-aarch64.so.1",
+    ),
+    "/usr/local/musl/bin/x86_64-unknown-linux-musl-gcc": (
+        Path("/usr/local/musl/x86_64-unknown-linux-musl/lib/libc.so"),
+        "libc.musl-x86_64.so.1",
+    ),
+}
+
+
+def rewrite_linker_arguments(
+    arguments: Sequence[str], *, alias_dir: Path, canonical_libc: str
+) -> list[str]:
+    """Make the GCC unwind runtime static and the musl libc name canonical."""
+
+    rewritten: list[str] = []
+    gcc_runtime_replacements = 0
+    libc_replacements = 0
+    for argument in arguments:
+        if argument == "-lgcc_s":
+            rewritten.extend(("-Wl,-Bstatic", "-lgcc_eh", "-Wl,-Bdynamic"))
+            gcc_runtime_replacements += 1
+        elif argument == "-lc":
+            rewritten.extend((f"-L{alias_dir}", f"-l:{canonical_libc}"))
+            libc_replacements += 1
+        else:
+            rewritten.append(argument)
+    if gcc_runtime_replacements != 1 or libc_replacements != 1:
+        raise ValueError(
+            "expected exactly one dynamic -lgcc_s and one -lc linker argument, "
+            f"found {gcc_runtime_replacements} and {libc_replacements}"
+        )
+    return rewritten
+
+
+def main() -> None:
+    real_linker = os.environ.get(REAL_LINKER_ENV)
+    if real_linker not in LINKER_CONFIGS:
+        allowed = ", ".join(sorted(LINKER_CONFIGS))
+        raise SystemExit(
+            f"{REAL_LINKER_ENV} must name one pinned musl linker ({allowed})"
+        )
+    real_libc, canonical_libc = LINKER_CONFIGS[real_linker]
+    if not real_libc.is_file():
+        raise SystemExit(f"pinned musl libc does not exist: {real_libc}")
+
+    with TemporaryDirectory(prefix="ferric-musl-libc-", dir="/tmp") as temporary:
+        alias_dir = Path(temporary)
+        (alias_dir / canonical_libc).symlink_to(real_libc)
+        try:
+            arguments = rewrite_linker_arguments(
+                sys.argv[1:], alias_dir=alias_dir, canonical_libc=canonical_libc
+            )
+        except ValueError as error:
+            raise SystemExit(str(error)) from error
+        completed = subprocess.run([real_linker, *arguments], check=False)
+        raise SystemExit(completed.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/python_package_lib.py
+++ b/scripts/python_package_lib.py
@@ -1105,13 +1105,12 @@ def validate_wheel(
     with archive:
         infos = archive.infolist()
         _require(infos, f"wheel is empty: {path.name}")
+        archive_names: list[str] = []
+        directory_names: list[str] = []
+        regular_infos: list[zipfile.ZipInfo] = []
         names: list[str] = []
         for info in infos:
             _safe_archive_name(info.filename, f"wheel {path.name}")
-            _require(
-                not info.is_dir(),
-                f"wheel contains an unexpected directory entry: {info.filename}",
-            )
             _require(
                 not (info.flag_bits & 0x1),
                 f"wheel contains an encrypted member: {info.filename}",
@@ -1121,13 +1120,52 @@ def validate_wheel(
                 not stat.S_ISLNK(mode),
                 f"wheel contains a symbolic link: {info.filename}",
             )
+            archive_names.append(info.filename)
+            if info.is_dir():
+                _require(
+                    mode == (stat.S_IFDIR | 0o755),
+                    f"wheel directory mode is not canonical: {info.filename}",
+                )
+                _require(
+                    info.compress_type == zipfile.ZIP_STORED
+                    and info.file_size == 0
+                    and info.compress_size == 0
+                    and info.CRC == 0
+                    and info.flag_bits == 0
+                    and info.create_system == 3
+                    and not info.extra
+                    and not info.comment,
+                    f"wheel directory entry is not empty: {info.filename}",
+                )
+                try:
+                    directory_payload = archive.read(info)
+                except (
+                    OSError,
+                    RuntimeError,
+                    NotImplementedError,
+                    zipfile.BadZipFile,
+                ) as exc:
+                    raise _error(
+                        f"cannot verify wheel directory entry {info.filename}: {exc}"
+                    ) from exc
+                _require(
+                    directory_payload == b"",
+                    f"wheel directory entry is not empty: {info.filename}",
+                )
+                directory_names.append(info.filename)
+                continue
+            _require(
+                stat.S_ISREG(mode),
+                f"wheel member is not a regular file: {info.filename}",
+            )
             _require(
                 info.file_size <= 256 * 1024 * 1024,
                 f"wheel member is unreasonably large: {info.filename}",
             )
+            regular_infos.append(info)
             names.append(info.filename)
         _require(
-            len(names) == len(set(names)),
+            len(archive_names) == len(set(archive_names)),
             f"wheel contains duplicate archive paths: {path.name}",
         )
 
@@ -1180,6 +1218,18 @@ def validate_wheel(
         allowed = set(required)
         unexpected = sorted(set(names) - allowed)
         _require(not unexpected, f"wheel contains unexpected members: {unexpected}")
+        allowed_directories = {
+            f"{parent.as_posix()}/"
+            for name in allowed
+            for parent in PurePosixPath(name).parents
+            if parent != PurePosixPath(".")
+        }
+        unexpected_directories = sorted(set(directory_names) - allowed_directories)
+        _require(
+            not unexpected_directories,
+            "wheel contains directory entries that are not canonical parents of "
+            f"allowed members: {unexpected_directories}",
+        )
 
         _metadata_contract(
             archive.read(metadata_path), contract, version, metadata_path
@@ -1235,7 +1285,7 @@ def validate_wheel(
             by_name[record_path] == ["", ""],
             "RECORD must leave its own hash and size empty",
         )
-        for info in infos:
+        for info in regular_infos:
             if info.filename == record_path:
                 continue
             digest_text, size_text = by_name[info.filename]

--- a/scripts/python_package_lib.py
+++ b/scripts/python_package_lib.py
@@ -1,0 +1,2621 @@
+#!/usr/bin/env python3
+"""Shared validation primitives for Ferric's Python release artifacts.
+
+This module intentionally uses only the Python standard library so release
+jobs can inspect artifacts before installing anything from them.
+"""
+
+from __future__ import annotations
+
+import base64
+import csv
+import gzip
+import hashlib
+import io
+import json
+import os
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import sysconfig
+import tarfile
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = REPO_ROOT / "crates" / "ferric-rules-python"
+CONTRACT_PATH = PACKAGE_ROOT / "wheel-targets.json"
+PYPROJECT_PATH = PACKAGE_ROOT / "pyproject.toml"
+PYTHON_CARGO_PATH = PACKAGE_ROOT / "Cargo.toml"
+ROOT_CARGO_PATH = REPO_ROOT / "Cargo.toml"
+
+EXPECTED_SUPPORTED_MINORS = ("3.9", "3.10", "3.11", "3.12", "3.13")
+EXPECTED_REQUIRES_PYTHON = ">=3.9,<3.14"
+EXPECTED_PYTHON_TAG = "cp39"
+EXPECTED_ABI_TAG = "abi3"
+EXPECTED_SUMMARY = "A CLIPS-inspired rules engine for Python, implemented in Rust"
+EXPECTED_LICENSE_EXPRESSION = "MIT OR Apache-2.0"
+EXPECTED_LICENSE_FILES = ("LICENSE-MIT", "LICENSE-APACHE")
+EXPECTED_PROJECT_URLS = {
+    "Documentation, https://github.com/plx/ferric-rules/blob/main/docs/users-guide.md",
+    "Homepage, https://github.com/plx/ferric-rules",
+    "Issues, https://github.com/plx/ferric-rules/issues",
+    "Repository, https://github.com/plx/ferric-rules",
+}
+EXPECTED_SMOKE_CHECKS = (
+    "rust-toolchain-absent",
+    "wheel-metadata-record-and-native-header",
+    "offline-no-deps-only-binary-install",
+    "import-path-within-clean-venv",
+    "load-reset-run",
+    "unicode-roundtrip",
+    "typed-parse-error",
+    "serialize-restore",
+    "close-lifecycle",
+)
+
+WHEEL_SMOKE_PROGRAM = r"""\
+import importlib
+import json
+from pathlib import Path
+import shutil
+import sys
+
+venv_root = Path(sys.argv[1]).resolve()
+assert shutil.which("cargo") is None, "cargo is available in wheel consumer"
+assert shutil.which("rustc") is None, "rustc is available in wheel consumer"
+
+def relative_to_venv(value):
+    path = Path(value).resolve()
+    try:
+        relative = path.relative_to(venv_root)
+    except ValueError as exc:
+        raise AssertionError(f"import escaped clean venv: {path}") from exc
+    assert "site-packages" in relative.parts, relative
+    return relative.as_posix()
+
+import ferric
+native = importlib.import_module("ferric.ferric")
+import_relative = relative_to_venv(ferric.__file__)
+native_relative = relative_to_venv(native.__file__)
+
+unicode_value = "Grüße 東京 🦀"
+engine = ferric.Engine()
+engine.load(
+    '(deffacts package-smoke-startup (package-input ready)) '
+    '(defrule package-smoke (package-input ready) '
+    f'=> (assert (package-result "{unicode_value}")))'
+)
+engine.reset()
+result = engine.run()
+assert result.rules_fired == 1, result.rules_fired
+result_facts = engine.find_facts("package-result")
+assert len(result_facts) == 1, result_facts
+assert str(result_facts[0].fields[0]) == unicode_value
+
+snapshot = engine.serialize()
+assert isinstance(snapshot, bytes) and snapshot
+restored = ferric.Engine.from_snapshot(snapshot)
+restored_facts = restored.find_facts("package-result")
+assert len(restored_facts) == 1
+assert str(restored_facts[0].fields[0]) == unicode_value
+
+broken = ferric.Engine()
+try:
+    broken.load("(defrule incomplete")
+except ferric.FerricParseError:
+    pass
+else:
+    raise AssertionError("invalid source did not raise FerricParseError")
+
+broken.close()
+restored.close()
+engine.close()
+engine.close()
+try:
+    engine.fact_count
+except ferric.FerricRuntimeError:
+    pass
+else:
+    raise AssertionError("closed engine remained usable")
+
+print(json.dumps({
+    "import_path_relative_to_venv": import_relative,
+    "native_path_relative_to_venv": native_relative,
+}, sort_keys=True))
+"""
+
+EXPECTED_TARGETS = {
+    "manylinux2014-x86_64": {
+        "runner": "ubuntu-24.04",
+        "rust_target": "x86_64-unknown-linux-gnu",
+        "platform_tags": ["manylinux_2_17_x86_64", "manylinux2014_x86_64"],
+        "runtime": {
+            "os": "linux",
+            "architecture": "x86_64",
+            "libc": "glibc",
+            "libc_minimum": "2.17",
+        },
+        "compatibility": {"family": "manylinux", "maturin": "manylinux2014"},
+    },
+    "manylinux2014-aarch64": {
+        "runner": "ubuntu-24.04-arm",
+        "rust_target": "aarch64-unknown-linux-gnu",
+        "platform_tags": ["manylinux_2_17_aarch64", "manylinux2014_aarch64"],
+        "runtime": {
+            "os": "linux",
+            "architecture": "aarch64",
+            "libc": "glibc",
+            "libc_minimum": "2.17",
+        },
+        "compatibility": {"family": "manylinux", "maturin": "manylinux2014"},
+    },
+    "musllinux1_2-x86_64": {
+        "runner": "ubuntu-24.04",
+        "rust_target": "x86_64-unknown-linux-musl",
+        "platform_tags": ["musllinux_1_2_x86_64"],
+        "runtime": {
+            "os": "linux",
+            "architecture": "x86_64",
+            "libc": "musl",
+            "libc_minimum": "1.2",
+        },
+        "compatibility": {"family": "musllinux", "maturin": "musllinux_1_2"},
+    },
+    "musllinux1_2-aarch64": {
+        "runner": "ubuntu-24.04-arm",
+        "rust_target": "aarch64-unknown-linux-musl",
+        "platform_tags": ["musllinux_1_2_aarch64"],
+        "runtime": {
+            "os": "linux",
+            "architecture": "aarch64",
+            "libc": "musl",
+            "libc_minimum": "1.2",
+        },
+        "compatibility": {"family": "musllinux", "maturin": "musllinux_1_2"},
+    },
+    "macos-x86_64": {
+        "runner": "macos-15-intel",
+        "rust_target": "x86_64-apple-darwin",
+        "platform_tags": ["macosx_10_12_x86_64"],
+        "runtime": {
+            "os": "macos",
+            "architecture": "x86_64",
+            "minimum_os_version": "10.12",
+        },
+        "compatibility": {
+            "family": "macos",
+            "maturin": "pypi",
+            "deployment_target": "10.12",
+        },
+    },
+    "macos-arm64": {
+        "runner": "macos-15",
+        "rust_target": "aarch64-apple-darwin",
+        "platform_tags": ["macosx_11_0_arm64"],
+        "runtime": {
+            "os": "macos",
+            "architecture": "aarch64",
+            "minimum_os_version": "11.0",
+        },
+        "compatibility": {
+            "family": "macos",
+            "maturin": "pypi",
+            "deployment_target": "11.0",
+        },
+    },
+    "windows-x86_64": {
+        "runner": "windows-2025",
+        "rust_target": "x86_64-pc-windows-msvc",
+        "platform_tags": ["win_amd64"],
+        "runtime": {"os": "windows", "architecture": "x86_64"},
+        "compatibility": {"family": "windows", "maturin": "pypi"},
+    },
+}
+
+
+class PackageValidationError(ValueError):
+    """Raised when release policy or an artifact is invalid."""
+
+
+@dataclass(frozen=True)
+class WheelInspection:
+    """Verified identity and digest of one wheel."""
+
+    path: Path
+    filename: str
+    sha256: str
+    size: int
+    target_id: str
+    version: str
+    platform_tags: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SdistInspection:
+    """Verified identity and digest of one source distribution."""
+
+    path: Path
+    filename: str
+    sha256: str
+    size: int
+    version: str
+
+
+def _error(message: str) -> PackageValidationError:
+    return PackageValidationError(message)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise _error(message)
+
+
+def _require_exact_keys(
+    value: Mapping[str, Any], expected: set[str], context: str
+) -> None:
+    actual = set(value)
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    _require(
+        not missing and not unexpected,
+        f"{context} keys differ: missing={missing}, unexpected={unexpected}",
+    )
+
+
+def _require_dict(value: Any, context: str) -> dict[str, Any]:
+    _require(isinstance(value, dict), f"{context} must be an object")
+    return value
+
+
+def _require_string(value: Any, context: str) -> str:
+    _require(
+        isinstance(value, str) and bool(value), f"{context} must be a non-empty string"
+    )
+    return value
+
+
+def _require_string_list(value: Any, context: str) -> list[str]:
+    _require(isinstance(value, list), f"{context} must be an array")
+    _require(
+        all(isinstance(item, str) and item for item in value),
+        f"{context} must contain only non-empty strings",
+    )
+    return value
+
+
+def load_json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise _error(f"cannot read JSON object {path}: {exc}") from exc
+    return _require_dict(value, str(path))
+
+
+def load_contract(
+    path: Path = CONTRACT_PATH, *, validate: bool = True
+) -> dict[str, Any]:
+    contract = load_json_object(path)
+    if validate:
+        validate_contract(contract)
+    return contract
+
+
+def validate_contract(contract: Mapping[str, Any]) -> None:
+    """Validate the exact v1 release policy, not merely its JSON shape."""
+
+    _require_exact_keys(
+        contract,
+        {"schema_version", "distribution", "python", "wheels", "sdist"},
+        "wheel-targets.json",
+    )
+    _require(
+        type(contract["schema_version"]) is int and contract["schema_version"] == 1,
+        "wheel-targets.json schema_version must be integer 1",
+    )
+
+    distribution = _require_dict(contract["distribution"], "distribution")
+    _require_exact_keys(
+        distribution, {"name", "import_name", "version_source"}, "distribution"
+    )
+    _require(distribution["name"] == "ferric", "distribution.name must be ferric")
+    _require(
+        distribution["import_name"] == "ferric",
+        "distribution.import_name must be ferric",
+    )
+    version_source = _require_dict(
+        distribution["version_source"], "distribution.version_source"
+    )
+    _require_exact_keys(
+        version_source, {"path", "toml_key"}, "distribution.version_source"
+    )
+    _require(
+        version_source["path"] == "../../Cargo.toml",
+        "version source must be ../../Cargo.toml",
+    )
+    _require(
+        version_source["toml_key"] == "workspace.package.version",
+        "version source must be workspace.package.version",
+    )
+
+    python = _require_dict(contract["python"], "python")
+    _require_exact_keys(
+        python,
+        {
+            "implementation",
+            "gil",
+            "requires_python",
+            "supported_minors",
+            "abi",
+            "exclusions",
+        },
+        "python",
+    )
+    _require(python["implementation"] == "CPython", "only CPython may be claimed")
+    _require(python["gil"] == "enabled", "only GIL-enabled CPython may be claimed")
+    _require(
+        canonical_requires_python(python["requires_python"])
+        == EXPECTED_REQUIRES_PYTHON,
+        f"requires_python must be {EXPECTED_REQUIRES_PYTHON}",
+    )
+    _require(
+        tuple(
+            _require_string_list(python["supported_minors"], "python.supported_minors")
+        )
+        == EXPECTED_SUPPORTED_MINORS,
+        f"supported_minors must be {list(EXPECTED_SUPPORTED_MINORS)}",
+    )
+
+    abi = _require_dict(python["abi"], "python.abi")
+    _require_exact_keys(
+        abi,
+        {"kind", "pyo3_feature", "minimum_python", "python_tag", "abi_tag"},
+        "python.abi",
+    )
+    _require(
+        abi
+        == {
+            "kind": "abi3",
+            "pyo3_feature": "abi3-py39",
+            "minimum_python": "3.9",
+            "python_tag": EXPECTED_PYTHON_TAG,
+            "abi_tag": EXPECTED_ABI_TAG,
+        },
+        "python.abi must declare the cp39 abi3 baseline",
+    )
+
+    exclusions = _require_dict(python["exclusions"], "python.exclusions")
+    _require_exact_keys(
+        exclusions,
+        {"python_versions", "implementations", "cpython_builds", "wheel_targets"},
+        "python.exclusions",
+    )
+    _require(
+        exclusions["python_versions"] == ["<3.9", ">=3.14"], "Python exclusions drifted"
+    )
+    _require(
+        exclusions["implementations"] == ["PyPy", "GraalPy"],
+        "implementation exclusions drifted",
+    )
+    _require(
+        exclusions["cpython_builds"] == ["free-threaded"],
+        "CPython build exclusions drifted",
+    )
+    _require(
+        exclusions["wheel_targets"]
+        == [
+            "macos-universal2",
+            "windows-arm64",
+            "unlisted-platforms-and-architectures",
+        ],
+        "wheel target exclusions drifted",
+    )
+
+    wheels = contract["wheels"]
+    _require(isinstance(wheels, list), "wheels must be an array")
+    _require(len(wheels) == 7, "wheel contract must contain exactly seven targets")
+    by_id: dict[str, dict[str, Any]] = {}
+    for index, raw_target in enumerate(wheels):
+        target = _require_dict(raw_target, f"wheels[{index}]")
+        _require_exact_keys(
+            target,
+            {
+                "id",
+                "runner",
+                "rust_target",
+                "platform_tags",
+                "runtime",
+                "compatibility",
+            },
+            f"wheels[{index}]",
+        )
+        target_id = _require_string(target["id"], f"wheels[{index}].id")
+        _require(target_id not in by_id, f"duplicate wheel target id {target_id}")
+        by_id[target_id] = target
+
+    _require(
+        set(by_id) == set(EXPECTED_TARGETS),
+        "wheel target IDs differ from the seven-target policy",
+    )
+    for target_id, expected in EXPECTED_TARGETS.items():
+        target = dict(by_id[target_id])
+        target.pop("id")
+        _require(
+            target == expected,
+            f"wheel target {target_id} differs from the release policy",
+        )
+
+    sdist = _require_dict(contract["sdist"], "sdist")
+    _require_exact_keys(
+        sdist,
+        {
+            "included",
+            "artifact_count",
+            "format",
+            "build_and_test",
+            "include_in_publish_dry_run",
+            "cargo_lock",
+            "requirements",
+        },
+        "sdist",
+    )
+    _require(sdist["included"] is True, "sdist must be included")
+    _require(
+        type(sdist["artifact_count"]) is int and sdist["artifact_count"] == 1,
+        "exactly one sdist is required",
+    )
+    _require(sdist["format"] == "tar.gz", "sdist must use tar.gz")
+    _require(sdist["build_and_test"] is True, "sdist must be built and tested")
+    _require(
+        sdist["include_in_publish_dry_run"] is True, "sdist must be in publish dry runs"
+    )
+    cargo_lock = _require_dict(sdist["cargo_lock"], "sdist.cargo_lock")
+    _require_exact_keys(
+        cargo_lock,
+        {"required", "relocated_workspace", "final_artifact"},
+        "sdist.cargo_lock",
+    )
+    _require(cargo_lock["required"] is True, "the final sdist must contain Cargo.lock")
+    _require(
+        cargo_lock["relocated_workspace"] == "normalize-offline-then-verify-locked",
+        "sdist relocated-workspace lock policy drifted",
+    )
+    _require(
+        cargo_lock["final_artifact"] == "deterministically-repacked-and-tested",
+        "sdist final-artifact policy drifted",
+    )
+    requirements = _require_dict(sdist["requirements"], "sdist.requirements")
+    _require_exact_keys(
+        requirements,
+        {"python", "rust", "maturin", "native_toolchain", "dependency_resolution"},
+        "sdist.requirements",
+    )
+    _require(
+        canonical_requires_python(requirements["python"]) == EXPECTED_REQUIRES_PYTHON,
+        "sdist Python requirement must match wheel metadata",
+    )
+    _require(requirements["rust"] == ">=1.75", "sdist Rust requirement must be >=1.75")
+    _require(
+        requirements["maturin"] == ">=1.0,<2.0", "sdist Maturin requirement drifted"
+    )
+    _require(
+        requirements["native_toolchain"] is True,
+        "sdist must require a native toolchain",
+    )
+    _require(
+        requirements["dependency_resolution"]
+        == "network access or pre-populated Python and Cargo caches",
+        "sdist dependency-resolution requirement drifted",
+    )
+
+
+def contract_target(contract: Mapping[str, Any], target_id: str) -> dict[str, Any]:
+    for raw_target in contract["wheels"]:
+        if raw_target["id"] == target_id:
+            return raw_target
+    raise _error(f"unknown wheel target {target_id}")
+
+
+def package_version(
+    contract: Mapping[str, Any], package_root: Path = PACKAGE_ROOT
+) -> str:
+    source = contract["distribution"]["version_source"]
+    path = (package_root / source["path"]).resolve()
+    _require(
+        path == ROOT_CARGO_PATH.resolve(),
+        f"version source resolves outside root Cargo.toml: {path}",
+    )
+    text = path.read_text(encoding="utf-8")
+    return toml_string(text, "workspace.package", "version")
+
+
+def toml_section(text: str, section: str) -> str:
+    match = re.search(
+        rf"(?ms)^\[{re.escape(section)}\]\s*\n(?P<body>.*?)(?=^\[|\Z)",
+        text,
+    )
+    _require(match is not None, f"TOML section [{section}] is missing")
+    return match.group("body")
+
+
+def toml_string(text: str, section: str, key: str) -> str:
+    body = toml_section(text, section)
+    match = re.search(rf'(?m)^{re.escape(key)}\s*=\s*"([^"]+)"\s*(?:#.*)?$', body)
+    _require(match is not None, f"TOML key [{section}].{key} must be a string")
+    return match.group(1)
+
+
+def toml_bool(text: str, section: str, key: str) -> bool:
+    body = toml_section(text, section)
+    match = re.search(rf"(?m)^{re.escape(key)}\s*=\s*(true|false)\s*(?:#.*)?$", body)
+    _require(match is not None, f"TOML key [{section}].{key} must be a boolean")
+    return match.group(1) == "true"
+
+
+def toml_string_array(text: str, section: str, key: str) -> list[str]:
+    body = toml_section(text, section)
+    match = re.search(rf"(?ms)^{re.escape(key)}\s*=\s*\[(?P<items>.*?)]", body)
+    _require(match is not None, f"TOML key [{section}].{key} must be an array")
+    items = re.findall(r'"([^"]+)"', match.group("items"))
+    _require(
+        items or not match.group("items").strip(),
+        f"[{section}].{key} has invalid items",
+    )
+    return items
+
+
+def canonical_requires_python(value: Any) -> str:
+    _require(isinstance(value, str), "Requires-Python must be a string")
+    return "".join(value.split())
+
+
+def accepts_python_minor(specifier: str, minor: str) -> bool:
+    version = tuple(int(part) for part in minor.split("."))
+    for clause in specifier.split(","):
+        match = re.fullmatch(r"\s*(>=|<)\s*(\d+)\.(\d+)\s*", clause)
+        _require(match is not None, f"unsupported Requires-Python clause {clause!r}")
+        boundary = (int(match.group(2)), int(match.group(3)))
+        if match.group(1) == ">=" and version < boundary:
+            return False
+        if match.group(1) == "<" and version >= boundary:
+            return False
+    return True
+
+
+def validate_repository_contract(contract: Optional[Mapping[str, Any]] = None) -> str:
+    """Cross-check repository metadata, ABI features, and strip policy."""
+
+    contract = contract or load_contract()
+    validate_contract(contract)
+    version = package_version(contract)
+
+    root_cargo = ROOT_CARGO_PATH.read_text(encoding="utf-8")
+    python_cargo = PYTHON_CARGO_PATH.read_text(encoding="utf-8")
+    pyproject = PYPROJECT_PATH.read_text(encoding="utf-8")
+
+    _require(
+        toml_string(root_cargo, "workspace.package", "rust-version") == "1.75",
+        "workspace MSRV must match the sdist Rust requirement",
+    )
+    pyo3_line = re.search(r"(?m)^pyo3\s*=\s*\{(?P<body>[^\n]+)}\s*$", root_cargo)
+    _require(pyo3_line is not None, "workspace pyo3 dependency must be an inline table")
+    pyo3_features = re.findall(r'"([^"]+)"', pyo3_line.group("body"))
+    _require(
+        "extension-module" in pyo3_features,
+        "workspace PyO3 must enable extension-module",
+    )
+    _require("abi3-py39" in pyo3_features, "workspace PyO3 must enable abi3-py39")
+    abi_features = [
+        feature for feature in pyo3_features if feature.startswith("abi3-py")
+    ]
+    _require(
+        abi_features == ["abi3-py39"], f"unexpected PyO3 ABI features: {abi_features}"
+    )
+
+    release = toml_section(root_cargo, "profile.release")
+    _require(
+        re.search(r'(?m)^strip\s*=\s*"symbols"\s*$', release) is not None,
+        "release strip policy drifted",
+    )
+    python_release = toml_section(
+        root_cargo, "profile.release.package.ferric-rules-python"
+    )
+    _require(
+        re.search(r'(?m)^strip\s*=\s*"none"\s*$', python_release) is not None,
+        "Python release package must disable Cargo symbol stripping",
+    )
+
+    dependencies = toml_section(python_cargo, "dependencies")
+    _require(
+        re.search(r"(?m)^pyo3\s*=\s*\{\s*workspace\s*=\s*true\s*}\s*$", dependencies)
+        is not None,
+        "Python crate must inherit the workspace PyO3 ABI policy",
+    )
+    package = toml_section(python_cargo, "package")
+    _require(
+        re.search(r"(?m)^version\.workspace\s*=\s*true\s*$", package) is not None,
+        "Python crate version must come from the workspace",
+    )
+    _require(
+        re.search(
+            r'(?m)^description\s*=\s*"Python bindings for the Ferric rules engine"\s*$',
+            package,
+        )
+        is not None,
+        "Python Cargo package description drifted",
+    )
+    _require(
+        re.search(r'(?m)^readme\s*=\s*"README\.md"\s*$', package) is not None,
+        "Python Cargo package readme must be README.md",
+    )
+
+    _require(
+        toml_string(pyproject, "project", "name") == "ferric",
+        "pyproject name must be ferric",
+    )
+    _require(
+        canonical_requires_python(toml_string(pyproject, "project", "requires-python"))
+        == EXPECTED_REQUIRES_PYTHON,
+        "pyproject Requires-Python differs from the artifact contract",
+    )
+    _require(
+        toml_string_array(pyproject, "project", "dynamic") == ["version"],
+        "pyproject version must be dynamic",
+    )
+    project_body = toml_section(pyproject, "project")
+    _require(
+        re.search(r"(?m)^version\s*=", project_body) is None,
+        "pyproject must not duplicate a literal version",
+    )
+    _require(
+        re.search(r"(?m)^dependencies\s*=", project_body) is None,
+        "ferric wheel must not declare runtime dependencies",
+    )
+    _require(
+        toml_string(pyproject, "project", "description") == EXPECTED_SUMMARY,
+        "pyproject description drifted",
+    )
+    _require(
+        re.search(
+            r'(?m)^readme\s*=\s*\{\s*file\s*=\s*"README\.md",\s*content-type\s*=\s*"text/markdown"\s*}\s*$',
+            project_body,
+        )
+        is not None,
+        "pyproject readme must bind README.md as text/markdown",
+    )
+    _require(
+        toml_string(pyproject, "project", "license") == EXPECTED_LICENSE_EXPRESSION,
+        "pyproject license expression drifted",
+    )
+    _require(
+        toml_string_array(pyproject, "project", "license-files")
+        == list(EXPECTED_LICENSE_FILES),
+        "pyproject license-files drifted",
+    )
+    _require(
+        re.search(
+            r'(?m)^authors\s*=\s*\[\{\s*name\s*=\s*"Ferric contributors"\s*}]\s*$',
+            project_body,
+        )
+        is not None,
+        "pyproject authors drifted",
+    )
+    _require(
+        toml_string_array(pyproject, "project", "keywords")
+        == ["clips", "expert-system", "rete", "rules-engine"],
+        "pyproject keywords drifted",
+    )
+    classifiers = toml_string_array(pyproject, "project", "classifiers")
+    classified_minors = [
+        match.group(1)
+        for classifier in classifiers
+        if (
+            match := re.fullmatch(
+                r"Programming Language :: Python :: (\d+\.\d+)", classifier
+            )
+        )
+    ]
+    _require(
+        tuple(classified_minors) == EXPECTED_SUPPORTED_MINORS,
+        "pyproject Python classifiers differ from supported_minors",
+    )
+    _require(
+        "Programming Language :: Python :: Implementation :: CPython" in classifiers,
+        "pyproject must claim CPython only",
+    )
+    _require(
+        "Programming Language :: Python :: 3 :: Only" in classifiers,
+        "pyproject must exclude Python 2",
+    )
+    project_urls = {
+        f"{name}, {toml_string(pyproject, 'project.urls', name)}"
+        for name in ("Homepage", "Documentation", "Repository", "Issues")
+    }
+    _require(project_urls == EXPECTED_PROJECT_URLS, "pyproject project URLs drifted")
+    _require(
+        toml_bool(pyproject, "tool.maturin", "strip") is False,
+        "Maturin stripping must be disabled",
+    )
+    _require(
+        toml_bool(pyproject, "tool.maturin", "locked") is True,
+        "Maturin Cargo builds must be locked",
+    )
+    maturin_features = toml_string_array(pyproject, "tool.maturin", "features")
+    _require(
+        maturin_features == ["pyo3/extension-module", "pyo3/abi3-py39"],
+        "Maturin features must explicitly select extension-module and abi3-py39",
+    )
+    maturin_body = toml_section(pyproject, "tool.maturin")
+    _require(
+        re.search(
+            r'(?m)^include\s*=\s*\[\{\s*path\s*=\s*"README\.md",\s*format\s*=\s*"sdist"\s*}]\s*$',
+            maturin_body,
+        )
+        is not None,
+        "Maturin must copy the package README to the relocated sdist root",
+    )
+    build_requirements = toml_string_array(pyproject, "build-system", "requires")
+    _require(
+        build_requirements == ["maturin>=1.0,<2.0"],
+        "build-system Maturin range must match the sdist contract",
+    )
+    _require(
+        toml_string(pyproject, "build-system", "build-backend") == "maturin",
+        "build backend must be maturin",
+    )
+
+    required_files = [
+        PACKAGE_ROOT / "README.md",
+        PACKAGE_ROOT / "LICENSE-MIT",
+        PACKAGE_ROOT / "LICENSE-APACHE",
+    ]
+    missing_files = [
+        str(path.relative_to(REPO_ROOT))
+        for path in required_files
+        if not path.is_file()
+    ]
+    _require(
+        not missing_files, f"Python package metadata files are missing: {missing_files}"
+    )
+    for filename in EXPECTED_LICENSE_FILES:
+        _require(
+            (PACKAGE_ROOT / filename).read_bytes()
+            == (REPO_ROOT / filename).read_bytes(),
+            f"Python package {filename} differs from the repository license",
+        )
+    return version
+
+
+def normalized_distribution_component(name: str) -> str:
+    return re.sub(r"[-_.]+", "_", name).strip("_")
+
+
+def expected_wheel_filename(
+    contract: Mapping[str, Any], target: Mapping[str, Any], version: str
+) -> str:
+    return wheel_filename_for_platform_tags(contract, target["platform_tags"], version)
+
+
+def wheel_filename_for_platform_tags(
+    contract: Mapping[str, Any],
+    platform_tags: Sequence[str],
+    version: str,
+) -> str:
+    distribution = normalized_distribution_component(contract["distribution"]["name"])
+    abi = contract["python"]["abi"]
+    platforms = ".".join(platform_tags)
+    return (
+        f"{distribution}-{version}-{abi['python_tag']}-{abi['abi_tag']}-{platforms}.whl"
+    )
+
+
+def source_built_wheel_platform_tags(target: Mapping[str, Any]) -> list[str]:
+    if target["runtime"]["os"] == "linux":
+        architecture = target["runtime"]["architecture"]
+        return [f"linux_{architecture}"]
+    return list(target["platform_tags"])
+
+
+def expected_sdist_filename(contract: Mapping[str, Any], version: str) -> str:
+    distribution = re.sub(r"[-_.]+", "-", contract["distribution"]["name"])
+    return f"{distribution}-{version}.tar.gz"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _safe_archive_name(name: str, context: str) -> PurePosixPath:
+    _require(name and "\x00" not in name, f"{context} contains an empty or NUL path")
+    _require("\\" not in name, f"{context} path uses a backslash: {name!r}")
+    path = PurePosixPath(name)
+    _require(not path.is_absolute(), f"{context} path is absolute: {name!r}")
+    _require(".." not in path.parts, f"{context} path traverses upward: {name!r}")
+    _require("." not in path.parts, f"{context} path is not normalized: {name!r}")
+    _require(
+        str(path) == name.rstrip("/"), f"{context} path is not normalized: {name!r}"
+    )
+    _require(
+        not (path.parts and ":" in path.parts[0]),
+        f"{context} path has a drive prefix: {name!r}",
+    )
+    return path
+
+
+def _parse_email_metadata(data: bytes, context: str) -> Any:
+    try:
+        message = BytesParser(policy=policy.default).parsebytes(data)
+    except Exception as exc:
+        raise _error(f"cannot parse {context}: {exc}") from exc
+    _require(
+        not message.defects,
+        f"{context} contains email-parser defects: {message.defects}",
+    )
+    return message
+
+
+def _one_header(message: Any, name: str, context: str) -> str:
+    values = message.get_all(name, [])
+    _require(len(values) == 1, f"{context} must contain exactly one {name} header")
+    return str(values[0])
+
+
+def _metadata_contract(
+    data: bytes, contract: Mapping[str, Any], version: str, context: str
+) -> Any:
+    metadata = _parse_email_metadata(data, context)
+    name = _one_header(metadata, "Name", context)
+    _require(
+        normalized_distribution_component(name)
+        == normalized_distribution_component(contract["distribution"]["name"]),
+        f"{context} Name is {name!r}",
+    )
+    _require(
+        _one_header(metadata, "Version", context) == version,
+        f"{context} Version differs",
+    )
+    requires_python = canonical_requires_python(
+        _one_header(metadata, "Requires-Python", context)
+    )
+    _require(
+        requires_python == EXPECTED_REQUIRES_PYTHON,
+        f"{context} Requires-Python is {requires_python!r}",
+    )
+    dependencies = metadata.get_all("Requires-Dist", [])
+    _require(
+        not dependencies,
+        f"{context} unexpectedly declares runtime dependencies: {dependencies}",
+    )
+    _require(
+        _one_header(metadata, "Summary", context) == EXPECTED_SUMMARY,
+        f"{context} Summary drifted",
+    )
+    _require(
+        _one_header(metadata, "License-Expression", context)
+        == EXPECTED_LICENSE_EXPRESSION,
+        f"{context} license expression drifted",
+    )
+    license_files = metadata.get_all("License-File", [])
+    _require(
+        license_files == list(EXPECTED_LICENSE_FILES),
+        f"{context} License-File headers drifted",
+    )
+    _require(
+        _one_header(metadata, "Description-Content-Type", context) == "text/markdown",
+        f"{context} description content type drifted",
+    )
+    project_urls = set(metadata.get_all("Project-URL", []))
+    _require(project_urls == EXPECTED_PROJECT_URLS, f"{context} project URLs drifted")
+    classifiers = metadata.get_all("Classifier", [])
+    expected_python_classifiers = {
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: Implementation :: CPython",
+        *(
+            f"Programming Language :: Python :: {minor}"
+            for minor in EXPECTED_SUPPORTED_MINORS
+        ),
+    }
+    actual_python_classifiers = {
+        classifier
+        for classifier in classifiers
+        if classifier.startswith("Programming Language :: Python ::")
+    }
+    _require(
+        actual_python_classifiers == expected_python_classifiers,
+        f"{context} Python classifiers drifted",
+    )
+    payload = metadata.get_payload()
+    _require(
+        isinstance(payload, str) and payload.strip(), f"{context} has no README body"
+    )
+    expected_readme = (PACKAGE_ROOT / "README.md").read_text(encoding="utf-8").strip()
+    _require(
+        payload.strip() == expected_readme,
+        f"{context} README body differs from package README.md",
+    )
+    return metadata
+
+
+def _wheel_target_for_filename(
+    filename: str,
+    contract: Mapping[str, Any],
+    version: str,
+) -> dict[str, Any]:
+    matches = [
+        target
+        for target in contract["wheels"]
+        if expected_wheel_filename(contract, target, version) == filename
+    ]
+    _require(
+        len(matches) == 1,
+        f"wheel filename is not one exact contracted artifact: {filename}",
+    )
+    return matches[0]
+
+
+def _validate_native_binary(
+    data: bytes, target: Mapping[str, Any], context: str
+) -> None:
+    family = target["compatibility"]["family"]
+    architecture = target["runtime"]["architecture"]
+    if family in {"manylinux", "musllinux"}:
+        _require(len(data) >= 64, f"{context} has a truncated ELF header")
+        _require(data[:4] == b"\x7fELF", f"{context} is not an ELF binary")
+        _require(data[4] == 2, f"{context} is not ELF64")
+        _require(data[5] == 1, f"{context} is not little-endian ELF")
+        machine = int.from_bytes(data[18:20], "little")
+        expected_machine = {"x86_64": 62, "aarch64": 183}[architecture]
+        _require(
+            machine == expected_machine,
+            f"{context} ELF e_machine is {machine}, expected {expected_machine}",
+        )
+        return
+    if family == "macos":
+        _require(len(data) >= 32, f"{context} has a truncated Mach-O header")
+        _require(
+            data[:4]
+            not in {
+                b"\xca\xfe\xba\xbe",
+                b"\xbe\xba\xfe\xca",
+                b"\xca\xfe\xba\xbf",
+                b"\xbf\xba\xfe\xca",
+            },
+            f"{context} is a fat/universal Mach-O binary",
+        )
+        _require(
+            data[:4] == b"\xcf\xfa\xed\xfe",
+            f"{context} is not a little-endian 64-bit Mach-O binary",
+        )
+        cpu_type = int.from_bytes(data[4:8], "little")
+        expected_cpu = {"x86_64": 0x01000007, "aarch64": 0x0100000C}[architecture]
+        _require(
+            cpu_type == expected_cpu,
+            f"{context} Mach-O CPU type is {cpu_type:#x}, expected {expected_cpu:#x}",
+        )
+        return
+    if family == "windows":
+        _require(len(data) >= 64, f"{context} has a truncated PE header")
+        _require(data[:2] == b"MZ", f"{context} is not a PE binary")
+        pe_offset = int.from_bytes(data[0x3C:0x40], "little")
+        _require(
+            pe_offset >= 0x40 and pe_offset + 26 <= len(data),
+            f"{context} has an invalid PE header offset",
+        )
+        _require(
+            data[pe_offset : pe_offset + 4] == b"PE\x00\x00",
+            f"{context} lacks a PE signature",
+        )
+        machine = int.from_bytes(data[pe_offset + 4 : pe_offset + 6], "little")
+        _require(
+            machine == 0x8664, f"{context} PE machine is {machine:#x}, expected AMD64"
+        )
+        optional_magic = int.from_bytes(data[pe_offset + 24 : pe_offset + 26], "little")
+        _require(optional_magic == 0x20B, f"{context} is not PE32+")
+        return
+    raise _error(f"{context} has unsupported platform family {family!r}")
+
+
+def _validate_sbom(data: bytes, version: str, context: str) -> None:
+    try:
+        sbom = json.loads(data.decode("utf-8", errors="strict"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise _error(f"{context} is not valid UTF-8 CycloneDX JSON: {exc}") from exc
+    sbom = _require_dict(sbom, context)
+    _require(sbom.get("bomFormat") == "CycloneDX", f"{context} is not CycloneDX")
+    _require(isinstance(sbom.get("specVersion"), str), f"{context} lacks a specVersion")
+    metadata = _require_dict(sbom.get("metadata"), f"{context}.metadata")
+    component = _require_dict(
+        metadata.get("component"), f"{context}.metadata.component"
+    )
+    _require(
+        component.get("name") == "ferric-rules-python",
+        f"{context} component name drifted",
+    )
+    _require(
+        component.get("version") == version, f"{context} component version drifted"
+    )
+    components = sbom.get("components")
+    _require(isinstance(components, list), f"{context}.components must be an array")
+    unexpected_native = []
+    for raw_component in components:
+        child = _require_dict(raw_component, f"{context}.components[]")
+        name = str(child.get("name", ""))
+        component_type = child.get("type")
+        if component_type == "file" or name.endswith((".so", ".pyd", ".dylib", ".dll")):
+            unexpected_native.append(name)
+    _require(
+        not unexpected_native,
+        f"{context} declares unexpected bundled native components: {unexpected_native}",
+    )
+
+
+def validate_wheel(
+    path: Path,
+    contract: Mapping[str, Any],
+    version: str,
+    *,
+    expected_target_id: Optional[str] = None,
+    expected_platform_tags: Optional[Sequence[str]] = None,
+) -> WheelInspection:
+    path = Path(path)
+    _require(
+        path.is_file() and not path.is_symlink(), f"wheel is not a regular file: {path}"
+    )
+    if expected_platform_tags is None:
+        target = _wheel_target_for_filename(path.name, contract, version)
+        target_platform_tags = list(target["platform_tags"])
+        if expected_target_id is not None:
+            _require(
+                target["id"] == expected_target_id,
+                f"wheel is for {target['id']}, expected {expected_target_id}",
+            )
+    else:
+        _require(
+            expected_target_id is not None,
+            "custom wheel tags require an explicit target ID",
+        )
+        target = contract_target(contract, expected_target_id)
+        target_platform_tags = list(expected_platform_tags)
+        _require(
+            path.name
+            == wheel_filename_for_platform_tags(
+                contract, target_platform_tags, version
+            ),
+            f"source-built wheel filename is not exact: {path.name}",
+        )
+
+    try:
+        archive = zipfile.ZipFile(path)
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise _error(f"cannot open wheel {path}: {exc}") from exc
+
+    with archive:
+        infos = archive.infolist()
+        _require(infos, f"wheel is empty: {path.name}")
+        names: list[str] = []
+        for info in infos:
+            _safe_archive_name(info.filename, f"wheel {path.name}")
+            _require(
+                not info.is_dir(),
+                f"wheel contains an unexpected directory entry: {info.filename}",
+            )
+            _require(
+                not (info.flag_bits & 0x1),
+                f"wheel contains an encrypted member: {info.filename}",
+            )
+            mode = (info.external_attr >> 16) & 0xFFFF
+            _require(
+                not stat.S_ISLNK(mode),
+                f"wheel contains a symbolic link: {info.filename}",
+            )
+            _require(
+                info.file_size <= 256 * 1024 * 1024,
+                f"wheel member is unreasonably large: {info.filename}",
+            )
+            names.append(info.filename)
+        _require(
+            len(names) == len(set(names)),
+            f"wheel contains duplicate archive paths: {path.name}",
+        )
+
+        distribution = normalized_distribution_component(
+            contract["distribution"]["name"]
+        )
+        dist_info = f"{distribution}-{version}.dist-info"
+        metadata_path = f"{dist_info}/METADATA"
+        wheel_path = f"{dist_info}/WHEEL"
+        record_path = f"{dist_info}/RECORD"
+        import_name = contract["distribution"]["import_name"]
+        init_path = f"{import_name}/__init__.py"
+        sbom_path = f"{dist_info}/sboms/ferric-rules-python.cyclonedx.json"
+
+        platform_family = target["compatibility"]["family"]
+        if platform_family == "windows":
+            native_candidates = {
+                f"{import_name}/{import_name}.pyd",
+                f"{import_name}/{import_name}.abi3.pyd",
+            }
+        else:
+            native_candidates = {f"{import_name}/{import_name}.abi3.so"}
+        native_members = [
+            name for name in names if name.endswith((".so", ".pyd", ".dylib", ".dll"))
+        ]
+        _require(
+            len(native_members) == 1,
+            f"wheel must contain exactly one native module, found {native_members}",
+        )
+        _require(
+            native_members[0] in native_candidates,
+            f"unexpected native module path {native_members[0]}",
+        )
+
+        license_paths = {
+            f"{dist_info}/licenses/LICENSE-MIT",
+            f"{dist_info}/licenses/LICENSE-APACHE",
+        }
+        required = {
+            init_path,
+            native_members[0],
+            metadata_path,
+            wheel_path,
+            record_path,
+            sbom_path,
+            *license_paths,
+        }
+        missing = sorted(required - set(names))
+        _require(not missing, f"wheel is missing required members: {missing}")
+        allowed = set(required)
+        unexpected = sorted(set(names) - allowed)
+        _require(not unexpected, f"wheel contains unexpected members: {unexpected}")
+
+        _metadata_contract(
+            archive.read(metadata_path), contract, version, metadata_path
+        )
+        for filename in EXPECTED_LICENSE_FILES:
+            wheel_license = archive.read(f"{dist_info}/licenses/{filename}")
+            _require(
+                wheel_license == (PACKAGE_ROOT / filename).read_bytes(),
+                f"wheel {filename} differs from the checked-in license",
+            )
+        _validate_native_binary(
+            archive.read(native_members[0]), target, native_members[0]
+        )
+        _validate_sbom(archive.read(sbom_path), version, sbom_path)
+        wheel_metadata = _parse_email_metadata(archive.read(wheel_path), wheel_path)
+        _require(
+            _one_header(wheel_metadata, "Wheel-Version", wheel_path) == "1.0",
+            "unsupported Wheel-Version",
+        )
+        _require(
+            _one_header(wheel_metadata, "Root-Is-Purelib", wheel_path).lower()
+            == "false",
+            "native wheel claims purelib",
+        )
+        tags = wheel_metadata.get_all("Tag", [])
+        expected_tags = [
+            f"{EXPECTED_PYTHON_TAG}-{EXPECTED_ABI_TAG}-{platform_tag}"
+            for platform_tag in target_platform_tags
+        ]
+        _require(
+            tags == expected_tags, f"WHEEL tags are {tags}, expected {expected_tags}"
+        )
+
+        record_data = archive.read(record_path).decode("utf-8", errors="strict")
+        rows = list(csv.reader(io.StringIO(record_data, newline="")))
+        _require(
+            all(len(row) == 3 for row in rows),
+            "RECORD rows must have exactly three columns",
+        )
+        record_names = [row[0] for row in rows]
+        for record_name in record_names:
+            _safe_archive_name(record_name, "wheel RECORD")
+        _require(
+            len(record_names) == len(set(record_names)),
+            "RECORD contains duplicate paths",
+        )
+        _require(
+            set(record_names) == set(names),
+            "RECORD paths do not exactly match wheel members",
+        )
+        by_name = {row[0]: row[1:] for row in rows}
+        _require(
+            by_name[record_path] == ["", ""],
+            "RECORD must leave its own hash and size empty",
+        )
+        for info in infos:
+            if info.filename == record_path:
+                continue
+            digest_text, size_text = by_name[info.filename]
+            _require(
+                digest_text.startswith("sha256="),
+                f"RECORD hash is not sha256 for {info.filename}",
+            )
+            encoded_digest = digest_text.removeprefix("sha256=")
+            expected_digest = (
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(archive.read(info.filename)).digest()
+                )
+                .rstrip(b"=")
+                .decode("ascii")
+            )
+            _require(
+                encoded_digest == expected_digest,
+                f"RECORD hash mismatch for {info.filename}",
+            )
+            _require(
+                size_text == str(info.file_size),
+                f"RECORD size mismatch for {info.filename}",
+            )
+
+    return WheelInspection(
+        path=path,
+        filename=path.name,
+        sha256=sha256_file(path),
+        size=path.stat().st_size,
+        target_id=target["id"],
+        version=version,
+        platform_tags=tuple(target_platform_tags),
+    )
+
+
+def _allowed_sdist_relative_path(relative: PurePosixPath) -> bool:
+    top_level_files = {
+        "PKG-INFO",
+        "Cargo.lock",
+        "Cargo.toml",
+        "pyproject.toml",
+        "README.md",
+        "LICENSE-MIT",
+        "LICENSE-APACHE",
+    }
+    if len(relative.parts) == 1:
+        return relative.name in top_level_files
+    if len(relative.parts) < 3 or relative.parts[0] != "crates":
+        return False
+    crate = relative.parts[1]
+    tail = PurePosixPath(*relative.parts[2:])
+    if crate not in {
+        "ferric-rules-core",
+        "ferric-rules-parser",
+        "ferric-rules-runtime",
+        "ferric-rules-python",
+    }:
+        return False
+    if any(part.startswith(".") for part in tail.parts):
+        return False
+    common_files = {"Cargo.toml", "README.md"}
+    if str(tail) in common_files:
+        return True
+    if tail.parts[0] == "src":
+        return tail.suffix == ".rs"
+    if crate == "ferric-rules-python":
+        if str(tail) in {
+            "LICENSE-MIT",
+            "LICENSE-APACHE",
+            "build.rs",
+            "uv.lock",
+            "wheel-targets.json",
+        }:
+            return True
+        return tail.parts[0] == "tests" and tail.suffix == ".py"
+    if crate == "ferric-rules-parser":
+        return False
+    if tail.parts[0] == "benches":
+        return tail.suffix == ".rs"
+    if crate == "ferric-rules-core" and tail.parts[0] == "proptest-regressions":
+        return tail.suffix == ".txt"
+    if crate == "ferric-rules-runtime" and tail.parts[:2] == ("tests", "fixtures"):
+        return tail.suffix == ".clp"
+    return False
+
+
+def validate_sdist(
+    path: Path, contract: Mapping[str, Any], version: str
+) -> SdistInspection:
+    path = Path(path)
+    _require(
+        path.is_file() and not path.is_symlink(), f"sdist is not a regular file: {path}"
+    )
+    _require(
+        path.name == expected_sdist_filename(contract, version),
+        f"sdist filename is {path.name}, expected {expected_sdist_filename(contract, version)}",
+    )
+    try:
+        archive = tarfile.open(path, mode="r:gz")
+    except (OSError, tarfile.TarError) as exc:
+        raise _error(f"cannot open sdist {path}: {exc}") from exc
+
+    root = path.name[: -len(".tar.gz")]
+    with archive:
+        members = archive.getmembers()
+        _require(members, "sdist is empty")
+        names: list[str] = []
+        regular_files: set[str] = set()
+        for member in members:
+            archive_path = _safe_archive_name(member.name, f"sdist {path.name}")
+            _require(
+                member.name == root or member.name.startswith(f"{root}/"),
+                f"sdist member escapes the single {root}/ root: {member.name}",
+            )
+            _require(
+                member.isfile(),
+                f"sdist contains a directory, link, or special file: {member.name}",
+            )
+            _require(
+                member.size <= 256 * 1024 * 1024,
+                f"sdist member is unreasonably large: {member.name}",
+            )
+            relative = PurePosixPath(*archive_path.parts[1:])
+            _require(
+                _allowed_sdist_relative_path(relative),
+                f"sdist contains an unexpected publish payload: {relative}",
+            )
+            names.append(member.name.rstrip("/"))
+            if member.isfile():
+                regular_files.add(member.name)
+        _require(
+            len(names) == len(set(names)), "sdist contains duplicate archive paths"
+        )
+
+        required_relative = {
+            "PKG-INFO",
+            "Cargo.lock",
+            "Cargo.toml",
+            "pyproject.toml",
+            "README.md",
+            "LICENSE-MIT",
+            "LICENSE-APACHE",
+            "crates/ferric-rules-python/Cargo.toml",
+            "crates/ferric-rules-python/README.md",
+            "crates/ferric-rules-python/LICENSE-MIT",
+            "crates/ferric-rules-python/LICENSE-APACHE",
+            "crates/ferric-rules-python/build.rs",
+            "crates/ferric-rules-python/src/lib.rs",
+            "crates/ferric-rules-core/Cargo.toml",
+            "crates/ferric-rules-core/src/lib.rs",
+            "crates/ferric-rules-parser/Cargo.toml",
+            "crates/ferric-rules-parser/src/lib.rs",
+            "crates/ferric-rules-runtime/Cargo.toml",
+            "crates/ferric-rules-runtime/src/lib.rs",
+        }
+        required = {f"{root}/{relative}" for relative in required_relative}
+        missing = sorted(required - regular_files)
+        _require(not missing, f"sdist is incomplete; missing members: {missing}")
+        pkg_info_member = archive.getmember(f"{root}/PKG-INFO")
+        pkg_info = archive.extractfile(pkg_info_member)
+        _require(pkg_info is not None, "cannot read sdist PKG-INFO")
+        _metadata_contract(pkg_info.read(), contract, version, "sdist PKG-INFO")
+        embedded_pyproject = archive.extractfile(
+            archive.getmember(f"{root}/pyproject.toml")
+        )
+        _require(embedded_pyproject is not None, "cannot read sdist pyproject.toml")
+        try:
+            embedded_pyproject_text = embedded_pyproject.read().decode(
+                "utf-8", errors="strict"
+            )
+        except UnicodeError as exc:
+            raise _error(f"sdist pyproject.toml is not UTF-8: {exc}") from exc
+        _require(
+            toml_bool(embedded_pyproject_text, "tool.maturin", "locked") is True,
+            "sdist pyproject.toml must retain locked = true",
+        )
+        for filename in ("README.md", "LICENSE-MIT", "LICENSE-APACHE"):
+            root_file = archive.extractfile(archive.getmember(f"{root}/{filename}"))
+            nested_file = archive.extractfile(
+                archive.getmember(f"{root}/crates/ferric-rules-python/{filename}")
+            )
+            _require(
+                root_file is not None and nested_file is not None,
+                f"cannot read sdist {filename}",
+            )
+            _require(
+                root_file.read() == nested_file.read(),
+                f"sdist root and package copies of {filename} differ",
+            )
+
+    return SdistInspection(
+        path=path,
+        filename=path.name,
+        sha256=sha256_file(path),
+        size=path.stat().st_size,
+        version=version,
+    )
+
+
+def safe_extract_sdist(
+    path: Path, destination: Path, contract: Mapping[str, Any], version: str
+) -> Path:
+    """Validate and extract an sdist without trusting tarfile.extractall."""
+
+    validate_sdist(path, contract, version)
+    destination.mkdir(parents=True, exist_ok=True)
+    root = path.name[: -len(".tar.gz")]
+    with tarfile.open(path, mode="r:gz") as archive:
+        for member in archive.getmembers():
+            relative = _safe_archive_name(member.name, f"sdist {path.name}")
+            output = destination.joinpath(*relative.parts)
+            if member.isdir():
+                output.mkdir(parents=True, exist_ok=True)
+                continue
+            output.parent.mkdir(parents=True, exist_ok=True)
+            source = archive.extractfile(member)
+            _require(source is not None, f"cannot extract sdist member {member.name}")
+            with source, output.open("wb") as handle:
+                while True:
+                    chunk = source.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    handle.write(chunk)
+            mode = member.mode & 0o777
+            output.chmod(mode & ~0o022)
+    return destination / root
+
+
+def _source_file_hashes(source_root: Path) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    for path in sorted(source_root.rglob("*")):
+        _require(not path.is_symlink(), f"source tree contains a symbolic link: {path}")
+        if path.is_file():
+            hashes[path.relative_to(source_root).as_posix()] = sha256_file(path)
+        else:
+            _require(path.is_dir(), f"source tree contains a special file: {path}")
+    return hashes
+
+
+def normalize_extracted_sdist_lock(
+    source_root: Path, cargo: str, work_root: Path
+) -> None:
+    """Prune Maturin's stale full-workspace lock and prove the result is locked."""
+
+    before = _source_file_hashes(source_root)
+    _require("Cargo.lock" in before, "extracted sdist has no Cargo.lock")
+    environment = dict(os.environ)
+    environment["CARGO_TARGET_DIR"] = str((work_root / "cargo-target").resolve())
+    environment["CARGO_NET_OFFLINE"] = "true"
+    base_command = [
+        cargo,
+        "metadata",
+        "--format-version",
+        "1",
+        "--offline",
+        "--manifest-path",
+        str((source_root / "Cargo.toml").resolve()),
+    ]
+    run_checked(
+        base_command,
+        cwd=source_root,
+        environment=environment,
+        context="sdist Cargo.lock normalization",
+    )
+    after = _source_file_hashes(source_root)
+    changed = {
+        name for name in set(before) | set(after) if before.get(name) != after.get(name)
+    }
+    _require(
+        changed <= {"Cargo.lock"},
+        f"Cargo metadata changed files other than Cargo.lock: {sorted(changed)}",
+    )
+    run_checked(
+        [*base_command, "--locked"],
+        cwd=source_root,
+        environment=environment,
+        context="normalized sdist locked Cargo metadata",
+    )
+
+
+def verify_extracted_sdist_lock(source_root: Path, cargo: str, work_root: Path) -> None:
+    environment = dict(os.environ)
+    environment["CARGO_TARGET_DIR"] = str((work_root / "cargo-verify-target").resolve())
+    environment["CARGO_NET_OFFLINE"] = "true"
+    run_checked(
+        [
+            cargo,
+            "metadata",
+            "--format-version",
+            "1",
+            "--offline",
+            "--locked",
+            "--manifest-path",
+            str((source_root / "Cargo.toml").resolve()),
+        ],
+        cwd=source_root,
+        environment=environment,
+        context="final sdist locked Cargo metadata",
+    )
+
+
+def deterministic_sdist_repack(source_root: Path, output: Path) -> SdistInspection:
+    """Pack a normalized source tree with stable ordering and archive metadata."""
+
+    output = Path(output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    files: list[tuple[str, Path, int]] = []
+    for path in sorted(
+        source_root.rglob("*"),
+        key=lambda item: item.relative_to(source_root).as_posix(),
+    ):
+        _require(not path.is_symlink(), f"cannot repack symbolic link {path}")
+        if path.is_dir():
+            continue
+        _require(path.is_file(), f"cannot repack special file {path}")
+        relative = path.relative_to(source_root).as_posix()
+        _safe_archive_name(relative, "sdist repack")
+        mode = 0o755 if path.stat().st_mode & 0o111 else 0o644
+        files.append((relative, path, mode))
+    _require(files, "cannot repack an empty sdist source tree")
+
+    temporary = output.with_name(f".{output.name}.tmp")
+    try:
+        with temporary.open("wb") as raw_output:
+            with gzip.GzipFile(
+                filename="", mode="wb", fileobj=raw_output, compresslevel=9, mtime=0
+            ) as compressed:
+                with tarfile.open(
+                    fileobj=compressed, mode="w", format=tarfile.PAX_FORMAT
+                ) as archive:
+                    for relative, path, mode in files:
+                        data = path.read_bytes()
+                        info = tarfile.TarInfo(name=f"{source_root.name}/{relative}")
+                        info.size = len(data)
+                        info.mode = mode
+                        info.uid = 0
+                        info.gid = 0
+                        info.uname = ""
+                        info.gname = ""
+                        info.mtime = 0
+                        archive.addfile(info, io.BytesIO(data))
+        temporary.replace(output)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+    return SdistInspection(
+        path=output,
+        filename=output.name,
+        sha256=sha256_file(output),
+        size=output.stat().st_size,
+        version=source_root.name.rsplit("-", 1)[-1],
+    )
+
+
+def normalize_sdist(
+    raw_sdist: Path,
+    output: Path,
+    contract: Mapping[str, Any],
+    version: str,
+    *,
+    cargo: str = "cargo",
+) -> SdistInspection:
+    """Create the deterministic, lock-consistent sdist that may be published."""
+
+    raw_sdist = Path(raw_sdist).resolve()
+    output = Path(output).resolve()
+    _require(raw_sdist != output, "raw and normalized sdist paths must differ")
+    validate_sdist(raw_sdist, contract, version)
+    _require(
+        output.name == expected_sdist_filename(contract, version),
+        f"normalized sdist output must be named {expected_sdist_filename(contract, version)}",
+    )
+    with tempfile.TemporaryDirectory(
+        prefix="ferric-python-sdist-normalize-"
+    ) as temporary:
+        work_root = Path(temporary)
+        source_root = safe_extract_sdist(
+            raw_sdist, work_root / "source", contract, version
+        )
+        normalize_extracted_sdist_lock(source_root, cargo, work_root)
+        first = deterministic_sdist_repack(source_root, output)
+        reproducibility_probe = work_root / "reproducibility" / output.name
+        second = deterministic_sdist_repack(source_root, reproducibility_probe)
+        _require(
+            first.sha256 == second.sha256 and first.size == second.size,
+            "normalized sdist repack is not deterministic",
+        )
+    final = validate_sdist(output, contract, version)
+    with tempfile.TemporaryDirectory(prefix="ferric-python-sdist-locked-") as temporary:
+        work_root = Path(temporary)
+        source_root = safe_extract_sdist(
+            output, work_root / "source", contract, version
+        )
+        verify_extracted_sdist_lock(source_root, cargo, work_root)
+    return final
+
+
+def normalized_architecture(machine: str) -> str:
+    normalized = machine.lower().replace(" ", "_")
+    aliases = {
+        "amd64": "x86_64",
+        "x64": "x86_64",
+        "arm64": "aarch64",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def runtime_os() -> str:
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "macos"
+    if sys.platform in {"win32", "cygwin"}:
+        return "windows"
+    return sys.platform
+
+
+def _version_tuple(value: str) -> tuple[int, ...]:
+    numbers = re.findall(r"\d+", value)
+    _require(bool(numbers), f"cannot parse runtime version {value!r}")
+    return tuple(int(number) for number in numbers)
+
+
+def detect_libc() -> tuple[Optional[str], Optional[str]]:
+    if runtime_os() != "linux":
+        return None, None
+    family, version = platform.libc_ver()
+    lowered = family.lower()
+    if "musl" in lowered:
+        return "musl", version or None
+    if lowered in {"glibc", "gnu libc", "libc"} and version:
+        return "glibc", version
+    try:
+        gnu = os.confstr("CS_GNU_LIBC_VERSION")
+    except (AttributeError, OSError, ValueError):
+        gnu = None
+    if gnu:
+        match = re.search(r"glibc\s+([0-9.]+)", gnu, re.IGNORECASE)
+        if match:
+            return "glibc", match.group(1)
+    try:
+        result = subprocess.run(
+            ["ldd", "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        result = None
+    if result is not None:
+        output = f"{result.stdout}\n{result.stderr}"
+        musl = re.search(r"musl[^\n]*\n?Version\s+([0-9.]+)", output, re.IGNORECASE)
+        if musl:
+            return "musl", musl.group(1)
+        glibc = re.search(
+            r"(?:glibc|GNU C Library)[^\n]*?([0-9]+\.[0-9]+)", output, re.IGNORECASE
+        )
+        if glibc:
+            return "glibc", glibc.group(1)
+    return None, None
+
+
+def runtime_facts() -> dict[str, Any]:
+    libc, libc_version = detect_libc()
+    return {
+        "os": runtime_os(),
+        "architecture": normalized_architecture(platform.machine()),
+        "libc": libc,
+        "libc_version": libc_version,
+    }
+
+
+def verify_runtime_for_target(target: Mapping[str, Any]) -> dict[str, Any]:
+    facts = runtime_facts()
+    expected = target["runtime"]
+    _require(
+        facts["os"] == expected["os"],
+        f"runtime OS is {facts['os']}, expected {expected['os']}",
+    )
+    _require(
+        facts["architecture"] == expected["architecture"],
+        f"runtime architecture is {facts['architecture']}, expected {expected['architecture']}",
+    )
+    expected_libc = expected.get("libc")
+    _require(
+        facts["libc"] == expected_libc,
+        f"runtime libc is {facts['libc']}, expected {expected_libc}",
+    )
+    if expected_libc is not None:
+        _require(
+            facts["libc_version"] is not None,
+            "runtime libc version could not be detected",
+        )
+        _require(
+            _version_tuple(facts["libc_version"])
+            >= _version_tuple(expected["libc_minimum"]),
+            f"runtime libc {facts['libc_version']} is older than {expected['libc_minimum']}",
+        )
+    if expected["os"] == "macos":
+        macos_version = platform.mac_ver()[0]
+        _require(macos_version, "macOS version could not be detected")
+        _require(
+            _version_tuple(macos_version)
+            >= _version_tuple(expected["minimum_os_version"]),
+            f"macOS {macos_version} is older than {expected['minimum_os_version']}",
+        )
+        facts["os_version"] = macos_version
+    else:
+        facts["os_version"] = None
+    return facts
+
+
+def python_facts() -> dict[str, Any]:
+    gil_disabled = sysconfig.get_config_var("Py_GIL_DISABLED")
+    return {
+        "implementation": platform.python_implementation(),
+        "version": platform.python_version(),
+        "minor": f"{sys.version_info.major}.{sys.version_info.minor}",
+        "gil_enabled": not bool(gil_disabled),
+    }
+
+
+def verify_python_runtime(
+    contract: Mapping[str, Any], *, rejection: bool = False
+) -> dict[str, Any]:
+    facts = python_facts()
+    _require(facts["implementation"] == "CPython", "wheel smoke requires CPython")
+    _require(
+        facts["gil_enabled"] is True,
+        "free-threaded CPython is outside the wheel contract",
+    )
+    expected_minors = ("3.14",) if rejection else EXPECTED_SUPPORTED_MINORS
+    _require(
+        facts["minor"] in expected_minors,
+        f"Python {facts['minor']} is invalid for {'rejection' if rejection else 'smoke'} coverage",
+    )
+    if rejection:
+        _require(
+            not accepts_python_minor(
+                contract["python"]["requires_python"], facts["minor"]
+            ),
+            "rejection interpreter unexpectedly satisfies Requires-Python",
+        )
+    else:
+        _require(
+            accepts_python_minor(contract["python"]["requires_python"], facts["minor"]),
+            "smoke interpreter does not satisfy Requires-Python",
+        )
+    return facts
+
+
+def clean_subprocess_environment() -> dict[str, str]:
+    environment = dict(os.environ)
+    for name in (
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "VIRTUAL_ENV",
+        "PIP_INDEX_URL",
+        "PIP_EXTRA_INDEX_URL",
+    ):
+        environment.pop(name, None)
+    environment.update(
+        {
+            "PIP_CONFIG_FILE": os.devnull,
+            "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+            "PIP_NO_INDEX": "1",
+            "PIP_REQUIRE_VIRTUALENV": "1",
+            "PYTHONNOUSERSITE": "1",
+        }
+    )
+    return environment
+
+
+def path_without_commands(path_value: Optional[str], commands: Sequence[str]) -> str:
+    """Remove PATH entries that expose any named command."""
+
+    kept: list[str] = []
+    for entry in (path_value or os.defpath).split(os.pathsep):
+        if not entry:
+            continue
+        if any(shutil.which(command, path=entry) is not None for command in commands):
+            continue
+        kept.append(entry)
+    result = os.pathsep.join(kept)
+    for command in commands:
+        _require(
+            shutil.which(command, path=result) is None,
+            f"could not remove {command} from PATH",
+        )
+    return result
+
+
+def receipt_wheel_identity(inspection: WheelInspection) -> dict[str, Any]:
+    return {"filename": inspection.filename, "sha256": inspection.sha256}
+
+
+def write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    temporary.replace(path)
+
+
+def _new_clean_venv(root: Path) -> Path:
+    venv_root = root / "venv"
+    environment = dict(os.environ)
+    for name in ("PYTHONHOME", "PYTHONPATH", "VIRTUAL_ENV"):
+        environment.pop(name, None)
+    environment.update(
+        {
+            "PIP_CONFIG_FILE": os.devnull,
+            "PIP_DISABLE_PIP_VERSION_CHECK": "1",
+            "PIP_NO_INDEX": "1",
+            "PYTHONNOUSERSITE": "1",
+        }
+    )
+    attempts: list[subprocess.CompletedProcess[str]] = []
+    venv_mode = ["--copies"] if os.name == "nt" else ["--symlinks"]
+    for _attempt in range(2):
+        if venv_root.exists():
+            shutil.rmtree(venv_root)
+        result = subprocess.run(
+            [sys.executable, "-I", "-m", "venv", "--clear", *venv_mode, str(venv_root)],
+            cwd=root,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        attempts.append(result)
+        if result.returncode == 0:
+            break
+    else:
+        diagnostics = "\n\n".join(
+            f"attempt {index} exit={result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+            for index, result in enumerate(attempts, start=1)
+        )
+        raise _error(
+            f"cannot create clean wheel-smoke venv with bundled ensurepip:\n{diagnostics}"
+        )
+    python = find_python_executable(venv_root)
+    _require(python.is_file(), f"clean venv did not create {python}")
+    return venv_root
+
+
+def execute_wheel_smoke(
+    wheel_path: Path,
+    target_id: str,
+    contract: Mapping[str, Any],
+    version: str,
+    *,
+    expect_python_rejection: bool = False,
+    rust_free_path: Optional[str] = None,
+    expected_platform_tags: Optional[Sequence[str]] = None,
+    receipt_kind: str = "wheel-smoke",
+) -> dict[str, Any]:
+    """Install one exact wheel in a disposable venv and return its receipt."""
+
+    inspection = validate_wheel(
+        Path(wheel_path),
+        contract,
+        version,
+        expected_target_id=target_id,
+        expected_platform_tags=expected_platform_tags,
+    )
+    _require(
+        receipt_kind in {"wheel-smoke", "source-built-wheel"},
+        f"invalid wheel smoke receipt kind {receipt_kind}",
+    )
+    _require(
+        not expect_python_rejection or receipt_kind == "wheel-smoke",
+        "Python rejection receipts must refer to contracted release wheels",
+    )
+    target = contract_target(contract, target_id)
+    python = verify_python_runtime(contract, rejection=expect_python_rejection)
+    runtime = verify_runtime_for_target(target)
+
+    with tempfile.TemporaryDirectory(prefix="ferric-python-wheel-") as temporary:
+        work_root = Path(temporary).resolve()
+        try:
+            work_root.relative_to(REPO_ROOT.resolve())
+        except ValueError:
+            pass
+        else:
+            raise _error(
+                f"wheel smoke temporary directory is inside the repository: {work_root}"
+            )
+        consumer = work_root / "consumer"
+        consumer.mkdir()
+        venv_root = _new_clean_venv(work_root)
+        venv_python = find_python_executable(venv_root)
+        environment = clean_subprocess_environment()
+        if rust_free_path is not None:
+            environment["PATH"] = rust_free_path
+        effective_path = environment.get("PATH", os.defpath)
+        _require(
+            shutil.which("cargo", path=effective_path) is None,
+            "cargo must be absent from the clean wheel consumer PATH",
+        )
+        _require(
+            shutil.which("rustc", path=effective_path) is None,
+            "rustc must be absent from the clean wheel consumer PATH",
+        )
+        install_command = [
+            str(venv_python),
+            "-I",
+            "-m",
+            "pip",
+            "install",
+            "--no-index",
+            "--no-deps",
+            "--only-binary=:all:",
+            "--no-cache-dir",
+            str(inspection.path.resolve()),
+        ]
+        try:
+            install = subprocess.run(
+                install_command,
+                cwd=consumer,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except OSError as exc:
+            raise _error(f"cannot run clean wheel install: {exc}") from exc
+
+        if expect_python_rejection:
+            _require(
+                install.returncode != 0, "Python 3.14 unexpectedly installed the wheel"
+            )
+            installer_output = f"{install.stdout}\n{install.stderr}".lower()
+            _require(
+                "requires a different python" in installer_output
+                and "3.14" in installer_output,
+                "wheel install failed for a reason other than Requires-Python",
+            )
+            probe = subprocess.run(
+                [
+                    str(venv_python),
+                    "-I",
+                    "-c",
+                    "import importlib.util,sys; sys.exit(importlib.util.find_spec('ferric') is not None)",
+                ],
+                cwd=consumer,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            _require(
+                probe.returncode == 0,
+                "ferric remained importable after rejected installation",
+            )
+            return {
+                "schema_version": 1,
+                "kind": "python-rejection",
+                "status": "passed",
+                "distribution": contract["distribution"]["name"],
+                "version": version,
+                "target_id": target_id,
+                "python": python,
+                "runtime": runtime,
+                "wheel": receipt_wheel_identity(inspection),
+                "rejection": {
+                    "reason": "Requires-Python",
+                    "requires_python": contract["python"]["requires_python"],
+                    "installer_exit_code": install.returncode,
+                    "module_importable": False,
+                },
+            }
+
+        if install.returncode != 0:
+            raise _error(
+                "offline exact-wheel install failed:\n"
+                f"stdout:\n{install.stdout}\nstderr:\n{install.stderr}"
+            )
+        smoke = run_checked(
+            [str(venv_python), "-I", "-c", WHEEL_SMOKE_PROGRAM, str(venv_root)],
+            cwd=consumer,
+            environment=environment,
+            context="installed-wheel lifecycle smoke",
+        )
+        try:
+            smoke_paths = json.loads(smoke.stdout)
+        except json.JSONDecodeError as exc:
+            raise _error(f"wheel smoke emitted invalid JSON: {smoke.stdout!r}") from exc
+        payload = {
+            "checks": list(EXPECTED_SMOKE_CHECKS),
+            "import_path_relative_to_venv": smoke_paths.get(
+                "import_path_relative_to_venv"
+            ),
+            "native_path_relative_to_venv": smoke_paths.get(
+                "native_path_relative_to_venv"
+            ),
+        }
+        validate_smoke_payload(payload, "generated wheel smoke")
+        return {
+            "schema_version": 1,
+            "kind": receipt_kind,
+            "status": "passed",
+            "distribution": contract["distribution"]["name"],
+            "version": version,
+            "target_id": target_id,
+            "python": python,
+            "runtime": runtime,
+            "wheel": receipt_wheel_identity(inspection),
+            "smoke": payload,
+        }
+
+
+def collect_files(root: Path) -> list[Path]:
+    _require(root.is_dir(), f"directory does not exist: {root}")
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise _error(f"artifact input contains a symbolic link: {path}")
+        if path.is_file():
+            files.append(path)
+    return sorted(files, key=lambda item: item.relative_to(root).as_posix())
+
+
+def validate_smoke_payload(value: Any, context: str) -> dict[str, Any]:
+    smoke = _require_dict(value, context)
+    _require_exact_keys(
+        smoke,
+        {"checks", "import_path_relative_to_venv", "native_path_relative_to_venv"},
+        context,
+    )
+    _require(
+        smoke["checks"] == list(EXPECTED_SMOKE_CHECKS),
+        f"{context} checks are incomplete",
+    )
+    import_path = _require_string(
+        smoke["import_path_relative_to_venv"], f"{context}.import_path"
+    )
+    native_path = _require_string(
+        smoke["native_path_relative_to_venv"], f"{context}.native_path"
+    )
+    for relative in (import_path, native_path):
+        safe = _safe_archive_name(relative, context)
+        _require(
+            "site-packages" in safe.parts,
+            f"{context} import did not come from site-packages",
+        )
+    _require(
+        import_path.endswith("/ferric/__init__.py"),
+        f"{context} imported the wrong Python package",
+    )
+    _require(
+        native_path.endswith(
+            ("/ferric/ferric.abi3.so", "/ferric/ferric.pyd", "/ferric/ferric.abi3.pyd")
+        ),
+        f"{context} imported an unexpected native module",
+    )
+    return smoke
+
+
+def _validate_python_receipt(
+    value: Any, context: str, expected_minor: Optional[str] = None
+) -> dict[str, Any]:
+    python = _require_dict(value, f"{context}.python")
+    _require_exact_keys(
+        python,
+        {"implementation", "version", "minor", "gil_enabled"},
+        f"{context}.python",
+    )
+    _require(python["implementation"] == "CPython", f"{context} did not use CPython")
+    _require(python["gil_enabled"] is True, f"{context} used free-threaded CPython")
+    minor = _require_string(python["minor"], f"{context}.python.minor")
+    if expected_minor is not None:
+        _require(
+            minor == expected_minor,
+            f"{context} Python minor is {minor}, expected {expected_minor}",
+        )
+    version = _require_string(python["version"], f"{context}.python.version")
+    _require(
+        version == minor or version.startswith(f"{minor}."),
+        f"{context} Python version/minor disagree",
+    )
+    return python
+
+
+def _validate_runtime_receipt(
+    value: Any, target: Mapping[str, Any], context: str
+) -> dict[str, Any]:
+    runtime = _require_dict(value, f"{context}.runtime")
+    _require_exact_keys(
+        runtime,
+        {"os", "architecture", "libc", "libc_version", "os_version"},
+        f"{context}.runtime",
+    )
+    expected = target["runtime"]
+    _require(
+        runtime["os"] == expected["os"], f"{context} runtime OS differs from target"
+    )
+    _require(
+        runtime["architecture"] == expected["architecture"],
+        f"{context} runtime architecture differs from target",
+    )
+    _require(
+        runtime["libc"] == expected.get("libc"),
+        f"{context} runtime libc differs from target",
+    )
+    if expected.get("libc"):
+        version = _require_string(
+            runtime["libc_version"], f"{context}.runtime.libc_version"
+        )
+        _require(
+            _version_tuple(version) >= _version_tuple(expected["libc_minimum"]),
+            f"{context} runtime libc is below the target minimum",
+        )
+    else:
+        _require(
+            runtime["libc_version"] is None, f"{context} has an unexpected libc version"
+        )
+    if expected["os"] == "macos":
+        version = _require_string(
+            runtime["os_version"], f"{context}.runtime.os_version"
+        )
+        _require(
+            _version_tuple(version) >= _version_tuple(expected["minimum_os_version"]),
+            f"{context} macOS version is below the target minimum",
+        )
+    else:
+        _require(
+            runtime["os_version"] is None, f"{context} has an unexpected OS version"
+        )
+    return runtime
+
+
+def validate_wheel_smoke_receipt(
+    receipt: Mapping[str, Any],
+    contract: Mapping[str, Any],
+    version: str,
+    wheels_by_target: Mapping[str, WheelInspection],
+    context: str,
+    *,
+    expected_minor: Optional[str] = None,
+) -> tuple[str, str]:
+    _require_exact_keys(
+        receipt,
+        {
+            "schema_version",
+            "kind",
+            "status",
+            "distribution",
+            "version",
+            "target_id",
+            "python",
+            "runtime",
+            "wheel",
+            "smoke",
+        },
+        context,
+    )
+    _require(
+        type(receipt["schema_version"]) is int and receipt["schema_version"] == 1,
+        f"{context} schema_version must be integer 1",
+    )
+    _require(receipt["kind"] == "wheel-smoke", f"{context} has the wrong kind")
+    _require(receipt["status"] == "passed", f"{context} did not pass")
+    _require(
+        receipt["distribution"] == contract["distribution"]["name"],
+        f"{context} distribution differs",
+    )
+    _require(receipt["version"] == version, f"{context} version differs")
+    target_id = _require_string(receipt["target_id"], f"{context}.target_id")
+    _require(
+        target_id in wheels_by_target, f"{context} names unknown target {target_id}"
+    )
+    target = contract_target(contract, target_id)
+    python = _validate_python_receipt(receipt["python"], context, expected_minor)
+    _require(
+        python["minor"] in EXPECTED_SUPPORTED_MINORS,
+        f"{context} is not a supported-minor smoke receipt",
+    )
+    _validate_runtime_receipt(receipt["runtime"], target, context)
+    wheel = _require_dict(receipt["wheel"], f"{context}.wheel")
+    _require_exact_keys(wheel, {"filename", "sha256"}, f"{context}.wheel")
+    inspection = wheels_by_target[target_id]
+    _require(
+        wheel == receipt_wheel_identity(inspection),
+        f"{context} does not identify the final wheel",
+    )
+    validate_smoke_payload(receipt["smoke"], f"{context}.smoke")
+    return target_id, python["minor"]
+
+
+def validate_rejection_receipt(
+    receipt: Mapping[str, Any],
+    contract: Mapping[str, Any],
+    version: str,
+    wheels_by_target: Mapping[str, WheelInspection],
+    context: str,
+) -> None:
+    _require_exact_keys(
+        receipt,
+        {
+            "schema_version",
+            "kind",
+            "status",
+            "distribution",
+            "version",
+            "target_id",
+            "python",
+            "runtime",
+            "wheel",
+            "rejection",
+        },
+        context,
+    )
+    _require(
+        type(receipt["schema_version"]) is int and receipt["schema_version"] == 1,
+        f"{context} schema_version must be integer 1",
+    )
+    _require(receipt["kind"] == "python-rejection", f"{context} has the wrong kind")
+    _require(receipt["status"] == "passed", f"{context} did not pass")
+    _require(
+        receipt["distribution"] == contract["distribution"]["name"],
+        f"{context} distribution differs",
+    )
+    _require(receipt["version"] == version, f"{context} version differs")
+    target_id = _require_string(receipt["target_id"], f"{context}.target_id")
+    _require(
+        target_id in wheels_by_target, f"{context} names unknown target {target_id}"
+    )
+    _validate_python_receipt(receipt["python"], context, "3.14")
+    _validate_runtime_receipt(
+        receipt["runtime"], contract_target(contract, target_id), context
+    )
+    wheel = _require_dict(receipt["wheel"], f"{context}.wheel")
+    _require_exact_keys(wheel, {"filename", "sha256"}, f"{context}.wheel")
+    _require(
+        wheel == receipt_wheel_identity(wheels_by_target[target_id]),
+        f"{context} does not identify the final wheel",
+    )
+    rejection = _require_dict(receipt["rejection"], f"{context}.rejection")
+    _require_exact_keys(
+        rejection,
+        {"reason", "requires_python", "installer_exit_code", "module_importable"},
+        f"{context}.rejection",
+    )
+    _require(
+        rejection["reason"] == "Requires-Python", f"{context} rejection reason differs"
+    )
+    _require(
+        canonical_requires_python(rejection["requires_python"])
+        == EXPECTED_REQUIRES_PYTHON,
+        f"{context} rejected a different Python range",
+    )
+    _require(
+        type(rejection["installer_exit_code"]) is int
+        and rejection["installer_exit_code"] > 0,
+        f"{context} installer unexpectedly succeeded",
+    )
+    _require(
+        rejection["module_importable"] is False, f"{context} left ferric importable"
+    )
+
+
+def validate_sdist_receipt(
+    receipt: Mapping[str, Any],
+    contract: Mapping[str, Any],
+    version: str,
+    sdist: SdistInspection,
+    context: str,
+) -> None:
+    _require_exact_keys(
+        receipt,
+        {
+            "schema_version",
+            "kind",
+            "status",
+            "distribution",
+            "version",
+            "target_id",
+            "sdist",
+            "wheel_smoke",
+        },
+        context,
+    )
+    _require(
+        type(receipt["schema_version"]) is int and receipt["schema_version"] == 1,
+        f"{context} schema_version must be integer 1",
+    )
+    _require(receipt["kind"] == "sdist-smoke", f"{context} has the wrong kind")
+    _require(receipt["status"] == "passed", f"{context} did not pass")
+    _require(
+        receipt["distribution"] == contract["distribution"]["name"],
+        f"{context} distribution differs",
+    )
+    _require(receipt["version"] == version, f"{context} version differs")
+    target_id = _require_string(receipt["target_id"], f"{context}.target_id")
+    _require(
+        target_id == "manylinux2014-x86_64",
+        f"{context} final sdist proof must use the pinned Linux x86-64 source-build lane",
+    )
+    contract_target(contract, target_id)
+    sdist_identity = _require_dict(receipt["sdist"], f"{context}.sdist")
+    _require_exact_keys(
+        sdist_identity,
+        {
+            "filename",
+            "sha256",
+            "safe_archive_paths",
+            "cargo_lock_locked_offline",
+            "deterministic_repack",
+            "pep517_built_from_exact_archive",
+        },
+        f"{context}.sdist",
+    )
+    _require(
+        sdist_identity
+        == {
+            "filename": sdist.filename,
+            "sha256": sdist.sha256,
+            "safe_archive_paths": True,
+            "cargo_lock_locked_offline": True,
+            "deterministic_repack": True,
+            "pep517_built_from_exact_archive": True,
+        },
+        f"{context} does not identify the verified sdist",
+    )
+    nested = _require_dict(receipt["wheel_smoke"], f"{context}.wheel_smoke")
+    _require_exact_keys(
+        nested,
+        {
+            "schema_version",
+            "kind",
+            "status",
+            "distribution",
+            "version",
+            "target_id",
+            "python",
+            "runtime",
+            "wheel",
+            "smoke",
+        },
+        f"{context}.wheel_smoke",
+    )
+    _require(
+        type(nested.get("schema_version")) is int and nested.get("schema_version") == 1,
+        f"{context} nested schema_version differs",
+    )
+    _require(
+        nested.get("kind") == "source-built-wheel",
+        f"{context} must distinguish the source-built wheel from release wheels",
+    )
+    _require(
+        nested.get("status") == "passed", f"{context} built-wheel smoke did not pass"
+    )
+    _require(
+        nested.get("target_id") == target_id,
+        f"{context} target differs from built-wheel smoke",
+    )
+    _require(
+        nested.get("distribution") == contract["distribution"]["name"],
+        f"{context} nested distribution differs",
+    )
+    _require(nested.get("version") == version, f"{context} nested version differs")
+    nested_python = _validate_python_receipt(
+        nested.get("python"), f"{context}.wheel_smoke"
+    )
+    _require(
+        nested_python["minor"] in EXPECTED_SUPPORTED_MINORS,
+        f"{context} source-built wheel used an unsupported Python minor",
+    )
+    _validate_runtime_receipt(
+        nested.get("runtime"),
+        contract_target(contract, target_id),
+        f"{context}.wheel_smoke",
+    )
+    built_wheel = _require_dict(nested.get("wheel"), f"{context}.wheel_smoke.wheel")
+    _require_exact_keys(
+        built_wheel, {"filename", "sha256"}, f"{context}.wheel_smoke.wheel"
+    )
+    target = contract_target(contract, target_id)
+    _require(
+        built_wheel["filename"]
+        == wheel_filename_for_platform_tags(
+            contract,
+            source_built_wheel_platform_tags(target),
+            version,
+        ),
+        f"{context} source-built wheel must be exact cp39-abi3-linux_x86_64",
+    )
+    _require(
+        re.fullmatch(r"[0-9a-f]{64}", str(built_wheel["sha256"])) is not None,
+        f"{context} built wheel hash is invalid",
+    )
+    validate_smoke_payload(nested.get("smoke"), f"{context}.wheel_smoke.smoke")
+
+
+def verify_artifact_set(
+    artifacts_dir: Path,
+    receipts_dir: Path,
+    contract: Mapping[str, Any],
+    version: str,
+) -> dict[str, Any]:
+    artifact_files = collect_files(Path(artifacts_dir))
+    unexpected_artifacts = [
+        path.name
+        for path in artifact_files
+        if not (path.name.endswith(".whl") or path.name.endswith(".tar.gz"))
+    ]
+    _require(
+        not unexpected_artifacts,
+        f"unexpected release artifacts: {unexpected_artifacts}",
+    )
+    wheel_paths = [path for path in artifact_files if path.name.endswith(".whl")]
+    sdist_paths = [path for path in artifact_files if path.name.endswith(".tar.gz")]
+    _require(
+        len(wheel_paths) == 7,
+        f"expected exactly seven wheels, found {len(wheel_paths)}",
+    )
+    _require(
+        len(sdist_paths) == 1, f"expected exactly one sdist, found {len(sdist_paths)}"
+    )
+    artifact_names = [path.name for path in artifact_files]
+    _require(
+        len(artifact_names) == len(set(artifact_names)),
+        "duplicate artifact filenames are forbidden",
+    )
+
+    wheel_inspections = [
+        validate_wheel(path, contract, version) for path in wheel_paths
+    ]
+    wheels_by_target = {
+        inspection.target_id: inspection for inspection in wheel_inspections
+    }
+    _require(
+        len(wheels_by_target) == 7,
+        "each contracted target must contribute exactly one wheel",
+    )
+    _require(
+        set(wheels_by_target) == set(EXPECTED_TARGETS),
+        "final wheel target set is incomplete",
+    )
+    sdist = validate_sdist(sdist_paths[0], contract, version)
+
+    receipt_files = collect_files(Path(receipts_dir))
+    unexpected_receipts = [
+        path.name for path in receipt_files if path.suffix != ".json"
+    ]
+    _require(
+        not unexpected_receipts, f"unexpected receipt artifacts: {unexpected_receipts}"
+    )
+    receipts = [(path, load_json_object(path)) for path in receipt_files]
+    _require(
+        len(receipts) == 37,
+        f"expected 37 receipts (35 smoke, one rejection, one sdist), found {len(receipts)}",
+    )
+    smoke_keys: set[tuple[str, str]] = set()
+    rejection_count = 0
+    sdist_count = 0
+    for path, receipt in receipts:
+        context = f"receipt {path.name}"
+        kind = receipt.get("kind")
+        if kind == "wheel-smoke":
+            key = validate_wheel_smoke_receipt(
+                receipt, contract, version, wheels_by_target, context
+            )
+            _require(
+                key not in smoke_keys,
+                f"duplicate smoke receipt for {key[0]} Python {key[1]}",
+            )
+            smoke_keys.add(key)
+        elif kind == "python-rejection":
+            rejection_count += 1
+            validate_rejection_receipt(
+                receipt, contract, version, wheels_by_target, context
+            )
+        elif kind == "sdist-smoke":
+            sdist_count += 1
+            validate_sdist_receipt(receipt, contract, version, sdist, context)
+        else:
+            raise _error(f"{context} has unknown kind {kind!r}")
+
+    expected_smoke_keys = {
+        (target_id, minor)
+        for target_id in EXPECTED_TARGETS
+        for minor in EXPECTED_SUPPORTED_MINORS
+    }
+    missing_smokes = sorted(expected_smoke_keys - smoke_keys)
+    unexpected_smokes = sorted(smoke_keys - expected_smoke_keys)
+    _require(
+        not missing_smokes and not unexpected_smokes,
+        f"smoke receipt matrix differs: missing={missing_smokes}, unexpected={unexpected_smokes}",
+    )
+    _require(
+        rejection_count == 1,
+        f"expected one Python 3.14 rejection receipt, found {rejection_count}",
+    )
+    _require(sdist_count == 1, f"expected one sdist smoke receipt, found {sdist_count}")
+
+    artifacts = [
+        {
+            "filename": inspection.filename,
+            "kind": "wheel",
+            "sha256": inspection.sha256,
+            "size": inspection.size,
+            "target_id": inspection.target_id,
+        }
+        for inspection in wheel_inspections
+    ]
+    artifacts.append(
+        {
+            "filename": sdist.filename,
+            "kind": "sdist",
+            "sha256": sdist.sha256,
+            "size": sdist.size,
+        }
+    )
+    artifacts.sort(key=lambda item: item["filename"])
+    return {
+        "schema_version": 1,
+        "distribution": contract["distribution"]["name"],
+        "version": version,
+        "artifacts": artifacts,
+        "receipt_coverage": {
+            "wheel_smokes": len(smoke_keys),
+            "python_314_rejections": rejection_count,
+            "sdist_smokes": sdist_count,
+        },
+    }
+
+
+def command_text(command: Sequence[str]) -> str:
+    return " ".join(str(part) for part in command)
+
+
+def run_checked(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    environment: Optional[Mapping[str, str]] = None,
+    context: str,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            list(command),
+            cwd=cwd,
+            env=None if environment is None else dict(environment),
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as exc:
+        raise _error(f"cannot run {context}: {exc}") from exc
+    if result.returncode != 0:
+        raise _error(
+            f"{context} failed ({command_text(command)}):\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def find_python_executable(venv_root: Path) -> Path:
+    if os.name == "nt":
+        return venv_root / "Scripts" / "python.exe"
+    return venv_root / "bin" / "python"
+
+
+def relative_to_root(path: Path, root: Path, context: str) -> str:
+    resolved = path.resolve()
+    root_resolved = root.resolve()
+    try:
+        relative = resolved.relative_to(root_resolved)
+    except ValueError as exc:
+        raise _error(f"{context} is outside the clean venv: {resolved}") from exc
+    return relative.as_posix()
+
+
+def exact_unique_paths(paths: Iterable[Path], context: str) -> list[Path]:
+    values = list(paths)
+    names = [path.name for path in values]
+    _require(len(names) == len(set(names)), f"{context} contains duplicate filenames")
+    return values

--- a/scripts/test-python-sdist-artifact.py
+++ b/scripts/test-python-sdist-artifact.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Normalize, PEP 517-build, and smoke the exact final Ferric sdist."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+from python_package_lib import (
+    CONTRACT_PATH,
+    PackageValidationError,
+    contract_target,
+    execute_wheel_smoke,
+    load_contract,
+    normalize_sdist,
+    package_version,
+    path_without_commands,
+    run_checked,
+    source_built_wheel_platform_tags,
+    validate_wheel,
+    write_json,
+)
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sdist", type=Path, required=True, help="raw Maturin sdist intermediate"
+    )
+    parser.add_argument(
+        "--output", type=Path, required=True, help="normalized final sdist output"
+    )
+    parser.add_argument(
+        "--target", required=True, help="native wheel target ID for the build smoke"
+    )
+    parser.add_argument(
+        "--receipt", type=Path, required=True, help="JSON receipt output"
+    )
+    parser.add_argument("--cargo", default="cargo", help="Cargo executable")
+    parser.add_argument(
+        "--uv", default="uv", help="uv executable used for the PEP 517 build"
+    )
+    parser.add_argument("--contract", type=Path, default=CONTRACT_PATH)
+    return parser.parse_args()
+
+
+def require_executable(command: str, description: str) -> str:
+    resolved = shutil.which(command)
+    if resolved is None:
+        raise PackageValidationError(f"{description} is not available: {command}")
+    return resolved
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    contract = load_contract(arguments.contract)
+    version = package_version(contract)
+    target = contract_target(contract, arguments.target)
+    source_platform_tags = source_built_wheel_platform_tags(target)
+    source_compatibility = "linux" if target["runtime"]["os"] == "linux" else "pypi"
+    cargo = require_executable(arguments.cargo, "Cargo")
+    uv = require_executable(arguments.uv, "uv")
+
+    final_sdist = normalize_sdist(
+        arguments.sdist,
+        arguments.output,
+        contract,
+        version,
+        cargo=cargo,
+    )
+
+    with tempfile.TemporaryDirectory(prefix="ferric-python-sdist-build-") as temporary:
+        work_root = Path(temporary)
+        wheels = work_root / "wheels"
+        environment = dict(os.environ)
+        environment.update(
+            {
+                "CARGO_BUILD_TARGET": target["rust_target"],
+                "CARGO_NET_OFFLINE": "true",
+                "CARGO_TARGET_DIR": str((work_root / "cargo-target").resolve()),
+                "MATURIN_COMPATIBILITY": source_compatibility,
+                "MATURIN_STRIP": "false",
+                "PYO3_PYTHON": sys.executable,
+                "UV_NO_PROGRESS": "1",
+                "UV_PYTHON_DOWNLOADS": "never",
+            }
+        )
+        deployment_target = target["compatibility"].get("deployment_target")
+        if deployment_target is not None:
+            environment["MACOSX_DEPLOYMENT_TARGET"] = deployment_target
+        run_checked(
+            [
+                uv,
+                "build",
+                "--wheel",
+                "--force-pep517",
+                "--no-build-isolation",
+                "--no-sources",
+                "--no-config",
+                "--no-create-gitignore",
+                "--offline",
+                "--python",
+                sys.executable,
+                "--out-dir",
+                str(wheels),
+                str(final_sdist.path.resolve()),
+            ],
+            cwd=work_root,
+            environment=environment,
+            context="PEP 517 wheel build from exact normalized sdist",
+        )
+        built_wheels = sorted(wheels.glob("*.whl"))
+        if len(built_wheels) != 1:
+            raise PackageValidationError(
+                f"exact sdist build produced {len(built_wheels)} wheels, expected one"
+            )
+        validate_wheel(
+            built_wheels[0],
+            contract,
+            version,
+            expected_target_id=arguments.target,
+            expected_platform_tags=source_platform_tags,
+        )
+        rust_free_path = path_without_commands(
+            environment.get("PATH"), ("cargo", "rustc")
+        )
+        wheel_smoke = execute_wheel_smoke(
+            built_wheels[0],
+            arguments.target,
+            contract,
+            version,
+            rust_free_path=rust_free_path,
+            expected_platform_tags=source_platform_tags,
+            receipt_kind="source-built-wheel",
+        )
+
+    receipt = {
+        "schema_version": 1,
+        "kind": "sdist-smoke",
+        "status": "passed",
+        "distribution": contract["distribution"]["name"],
+        "version": version,
+        "target_id": arguments.target,
+        "sdist": {
+            "filename": final_sdist.filename,
+            "sha256": final_sdist.sha256,
+            "safe_archive_paths": True,
+            "cargo_lock_locked_offline": True,
+            "deterministic_repack": True,
+            "pep517_built_from_exact_archive": True,
+        },
+        "wheel_smoke": wheel_smoke,
+    }
+    write_json(arguments.receipt, receipt)
+    print(
+        f"normalized and tested {final_sdist.filename} sha256={final_sdist.sha256}; "
+        f"built {wheel_smoke['wheel']['filename']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-python-wheel-artifact.py
+++ b/scripts/test-python-wheel-artifact.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Install and smoke one exact local Ferric wheel in a clean environment."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from python_package_lib import (
+    CONTRACT_PATH,
+    execute_wheel_smoke,
+    load_contract,
+    package_version,
+    write_json,
+)
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--wheel", type=Path, required=True, help="exact local wheel to install"
+    )
+    parser.add_argument(
+        "--target", required=True, help="wheel target ID from wheel-targets.json"
+    )
+    parser.add_argument(
+        "--receipt", type=Path, required=True, help="JSON receipt output"
+    )
+    parser.add_argument(
+        "--expect-python-rejection",
+        action="store_true",
+        help="require Python 3.14 installation to fail because of Requires-Python",
+    )
+    parser.add_argument("--contract", type=Path, default=CONTRACT_PATH)
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    contract = load_contract(arguments.contract)
+    version = package_version(contract)
+    receipt = execute_wheel_smoke(
+        arguments.wheel,
+        arguments.target,
+        contract,
+        version,
+        expect_python_rejection=arguments.expect_python_rejection,
+    )
+    write_json(arguments.receipt, receipt)
+    print(
+        f"{receipt['kind']} passed for {arguments.target} on "
+        f"CPython {receipt['python']['minor']}: {arguments.wheel.name}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate-python-package.py
+++ b/scripts/validate-python-package.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Validate Ferric's Python package metadata and binary-release contract."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from python_package_lib import (
+    CONTRACT_PATH,
+    load_contract,
+    validate_repository_contract,
+)
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=CONTRACT_PATH,
+        help="wheel target contract (default: package wheel-targets.json)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    contract = load_contract(arguments.contract)
+    version = validate_repository_contract(contract)
+    print(
+        f"validated {contract['distribution']['name']}@{version}: "
+        f"cp39-abi3, {len(contract['wheels'])} wheels, one tested sdist"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate-python-package.py
+++ b/scripts/validate-python-package.py
@@ -10,6 +10,7 @@ from python_package_lib import (
     CONTRACT_PATH,
     load_contract,
     validate_repository_contract,
+    validate_wheel,
 )
 
 
@@ -21,13 +22,29 @@ def parse_arguments() -> argparse.Namespace:
         default=CONTRACT_PATH,
         help="wheel target contract (default: package wheel-targets.json)",
     )
-    return parser.parse_args()
+    parser.add_argument("--wheel", type=Path, help="exact built wheel to validate")
+    parser.add_argument("--target", help="expected wheel target ID")
+    arguments = parser.parse_args()
+    if (arguments.wheel is None) != (arguments.target is None):
+        parser.error("--wheel and --target must be provided together")
+    return arguments
 
 
 def main() -> None:
     arguments = parse_arguments()
     contract = load_contract(arguments.contract)
     version = validate_repository_contract(contract)
+    if arguments.wheel is not None:
+        inspection = validate_wheel(
+            arguments.wheel,
+            contract,
+            version,
+            expected_target_id=arguments.target,
+        )
+        print(
+            f"validated wheel {arguments.wheel.name}: "
+            f"{inspection.target_id}, sha256={inspection.sha256}"
+        )
     print(
         f"validated {contract['distribution']['name']}@{version}: "
         f"cp39-abi3, {len(contract['wheels'])} wheels, one tested sdist"

--- a/scripts/verify-python-package-artifacts.py
+++ b/scripts/verify-python-package-artifacts.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Verify the complete Ferric Python release set and write its SHA256 manifest."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from python_package_lib import (
+    CONTRACT_PATH,
+    load_contract,
+    package_version,
+    verify_artifact_set,
+    write_json,
+)
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifacts-dir", type=Path, required=True)
+    parser.add_argument("--receipts-dir", type=Path, required=True)
+    parser.add_argument("--manifest-out", type=Path, required=True)
+    parser.add_argument("--contract", type=Path, default=CONTRACT_PATH)
+    return parser.parse_args()
+
+
+def main() -> None:
+    arguments = parse_arguments()
+    contract = load_contract(arguments.contract)
+    version = package_version(contract)
+    manifest = verify_artifact_set(
+        arguments.artifacts_dir,
+        arguments.receipts_dir,
+        contract,
+        version,
+    )
+    write_json(arguments.manifest_out, manifest)
+    print(
+        f"verified {len(manifest['artifacts'])} Python package artifacts and "
+        f"{manifest['receipt_coverage']['wheel_smokes']} exact-wheel smokes; "
+        f"manifest: {arguments.manifest_out}"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- adopt PyO3 `abi3-py39` for GIL-enabled CPython 3.9–3.13 and declare the exact seven-wheel native target contract
- build, repair, strictly audit, and upload only the final wheel bytes, then smoke those exact artifacts across all 35 target/interpreter combinations
- reject CPython 3.14, normalize and independently build the exact source distribution, and verify the complete eight-file artifact set before credentialless PyPI/TestPyPI dry runs
- add fail-closed archive, metadata, RECORD, binary-architecture, receipt, and deterministic-sdist validation plus maintainer documentation

## Why

The Python package previously had truthful interpreter metadata but no explicit ABI decision or release-grade cross-platform artifact contract. This makes the stable-ABI baseline, supported native targets, repair/audit requirements, consumer validation, and source-distribution behavior reviewable and mechanically enforced.

The workflow performs no live registry publication. Stable PyPI promotion remains gated by the production-readiness approval tracked in #223.

## Validation

- `just preflight-pr`
- 61 focused artifact, workflow, and support-contract tests
- `actionlint -shellcheck shellcheck .github/workflows/*.yml`
- local `cp39-abi3` macOS wheel validation and clean installs on CPython 3.9–3.13
- exact normalized-sdist offline PEP 517 build and Rust-free lifecycle smoke
- independent workflow, security, and final acceptance audits

Closes #123
