### PR TITLE
[FR-GO-003] Track Go engine-option presence

### DIFF
--- a/bindings/go/cmd/bindings-conformance/main.go
+++ b/bindings/go/cmd/bindings-conformance/main.go
@@ -203,6 +203,102 @@ func configurationCustom() (any, error) {
 	}, nil
 }
 
+func configurationObservation(source string, options ...ferric.EngineOption) (map[string]any, error) {
+	options = append([]ferric.EngineOption{ferric.WithSource(source)}, options...)
+	engine, err := withEngine(options...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = engine.Close() }()
+
+	_, unicodeErr := engine.AssertFact("unicode", "é")
+	unicode := "accepted"
+	if unicodeErr != nil {
+		unicode = "rejected"
+	}
+	run, err := engine.Run(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"halt_reason": reason(run.HaltReason),
+		"unicode":     unicode,
+	}, nil
+}
+
+func configurationStrategyFired(source string) (int, error) {
+	engine, err := withEngine(
+		ferric.WithSource(source),
+		ferric.WithStrategy(ferric.StrategyBreadth),
+	)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = engine.Close() }()
+
+	run, err := engine.Run(context.Background())
+	if err != nil {
+		return 0, err
+	}
+	return run.RulesFired, nil
+}
+
+func configurationIsolation() (any, error) {
+	defaultDepthSource, err := fixture("configuration-default-depth.clp")
+	if err != nil {
+		return nil, err
+	}
+	customDepthSource, err := fixture("custom-config.clp")
+	if err != nil {
+		return nil, err
+	}
+	strategySource, err := fixture("configuration-strategy-order.clp")
+	if err != nil {
+		return nil, err
+	}
+
+	encodingASCII, err := configurationObservation(
+		defaultDepthSource,
+		ferric.WithEncoding(ferric.EncodingASCII),
+	)
+	if err != nil {
+		return nil, err
+	}
+	strategyBreadth, err := configurationObservation(
+		defaultDepthSource,
+		ferric.WithStrategy(ferric.StrategyBreadth),
+	)
+	if err != nil {
+		return nil, err
+	}
+	strategyFired, err := configurationStrategyFired(strategySource)
+	if err != nil {
+		return nil, err
+	}
+	strategyBreadth["strategy_fired"] = strategyFired
+	depthOne, err := configurationObservation(
+		customDepthSource,
+		ferric.WithMaxCallDepth(1),
+	)
+	if err != nil {
+		return nil, err
+	}
+	depth256, err := configurationObservation(
+		defaultDepthSource,
+		ferric.WithMaxCallDepth(256),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]any{
+		"depth_1_only":          depthOne,
+		"depth_256_only":        depth256,
+		"encoding_ascii_only":   encodingASCII,
+		"strategy_breadth_only": strategyBreadth,
+	}, nil
+}
+
 func errorCase(caseID string) (any, error) {
 	engine, err := withEngine()
 	if err != nil {
@@ -501,6 +597,8 @@ func runCase(caseID string) (any, error) {
 		return configurationDefault()
 	case "configuration.custom":
 		return configurationCustom()
+	case "configuration.isolation":
+		return configurationIsolation()
 	case "fact.lifecycle":
 		return factLifecycle()
 	case "execution.run-limits":

--- a/bindings/go/engine.go
+++ b/bindings/go/engine.go
@@ -31,16 +31,22 @@ type Engine struct {
 // The caller is responsible for ensuring thread affinity
 // (e.g., via runtime.LockOSThread).
 func NewEngine(opts ...EngineOption) (*Engine, error) {
-	cfg := engineConfig{
-		maxCallDepth: 256,
-	}
+	cfg := defaultEngineConfig()
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
+	// Build and validate the complete effective configuration before invoking
+	// any native constructor. Snapshot restoration does not currently apply
+	// these overrides, but explicitly supplied values must still be validated.
+	config, err := makeConfig(&cfg)
+	if err != nil {
+		return nil, err
+	}
+
 	var h ffi.EngineHandle
 
-	if cfg.snapshot != nil {
+	if cfg.hasSnapshot() {
 		// Deserialize from snapshot — skips parse/compile.
 		ffiFormat, err := formatToFFI(cfg.snapshotFormat)
 		if err != nil {
@@ -55,13 +61,8 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 			return nil, &FerricError{Message: "failed to create engine from snapshot"}
 		}
 	} else {
-		config, err := makeConfig(&cfg)
-		if err != nil {
-			return nil, err
-		}
-
-		if cfg.source != "" {
-			if cfg.strategy != 0 || cfg.encoding != 0 || cfg.maxCallDepth != 256 {
+		if cfg.hasSource() {
+			if cfg.hasEngineConfig() {
 				h = ffiEngineNewWithSourceConfig(cfg.source, config)
 			} else {
 				h = ffiEngineNewWithSource(cfg.source)
@@ -74,7 +75,7 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 				return nil, &ParseError{FerricError{Message: msg}}
 			}
 		} else {
-			if cfg.strategy != 0 || cfg.encoding != 0 || cfg.maxCallDepth != 256 {
+			if cfg.hasEngineConfig() {
 				h = ffiEngineNewWithConfig(config)
 			} else {
 				h = ffiEngineNew()

--- a/bindings/go/engine_options.go
+++ b/bindings/go/engine_options.go
@@ -10,32 +10,69 @@ import (
 type EngineOption func(*engineConfig)
 
 type engineConfig struct {
-	strategy       Strategy
-	encoding       Encoding
-	maxCallDepth   int
-	source         string // if non-empty, load+reset at creation
-	snapshot       []byte // if non-nil, deserialize instead of creating fresh
-	snapshotFormat Format // format of snapshot data
+	strategy        Strategy
+	strategySet     bool
+	encoding        Encoding
+	encodingSet     bool
+	maxCallDepth    int
+	maxCallDepthSet bool
+	source          string // if non-empty, load+reset at creation
+	sourceSet       bool
+	snapshot        []byte // if non-nil, deserialize instead of creating fresh
+	snapshotSet     bool
+	snapshotFormat  Format // format of snapshot data
+}
+
+func defaultEngineConfig() engineConfig {
+	return engineConfig{
+		strategy:     StrategyDepth,
+		encoding:     EncodingUTF8,
+		maxCallDepth: 64,
+	}
+}
+
+func (c *engineConfig) hasEngineConfig() bool {
+	return c.strategySet || c.encodingSet || c.maxCallDepthSet
+}
+
+func (c *engineConfig) hasSource() bool {
+	return c.sourceSet && c.source != ""
+}
+
+func (c *engineConfig) hasSnapshot() bool {
+	return c.snapshotSet && c.snapshot != nil
 }
 
 // WithStrategy sets the conflict resolution strategy.
 func WithStrategy(s Strategy) EngineOption {
-	return func(c *engineConfig) { c.strategy = s }
+	return func(c *engineConfig) {
+		c.strategy = s
+		c.strategySet = true
+	}
 }
 
 // WithEncoding sets the string encoding mode.
 func WithEncoding(e Encoding) EngineOption {
-	return func(c *engineConfig) { c.encoding = e }
+	return func(c *engineConfig) {
+		c.encoding = e
+		c.encodingSet = true
+	}
 }
 
 // WithMaxCallDepth sets the maximum call depth.
 func WithMaxCallDepth(n int) EngineOption {
-	return func(c *engineConfig) { c.maxCallDepth = n }
+	return func(c *engineConfig) {
+		c.maxCallDepth = n
+		c.maxCallDepthSet = true
+	}
 }
 
 // WithSource loads CLIPS source and resets the engine at creation time.
 func WithSource(clips string) EngineOption {
-	return func(c *engineConfig) { c.source = clips }
+	return func(c *engineConfig) {
+		c.source = clips
+		c.sourceSet = true
+	}
 }
 
 // WithSnapshot creates the engine by deserializing a snapshot previously
@@ -45,6 +82,7 @@ func WithSource(clips string) EngineOption {
 func WithSnapshot(data []byte, format Format) EngineOption {
 	return func(c *engineConfig) {
 		c.snapshot = data
+		c.snapshotSet = true
 		c.snapshotFormat = format
 	}
 }

--- a/bindings/go/engine_options_presence_test.go
+++ b/bindings/go/engine_options_presence_test.go
@@ -1,0 +1,374 @@
+package ferric
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
+)
+
+func TestEngineOptionDefaultsMatchRuntimeDefaults(t *testing.T) {
+	got := defaultEngineConfig()
+	want := engineConfig{
+		strategy:     StrategyDepth,
+		encoding:     EncodingUTF8,
+		maxCallDepth: 64,
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("default engine config = %+v, want %+v", got, want)
+	}
+	if got.hasEngineConfig() || got.hasSource() || got.hasSnapshot() {
+		t.Fatalf("default config reports an explicitly supplied option: %+v", got)
+	}
+	if constructor := observeEngineConstructor(t); constructor != "default" {
+		t.Fatalf("NewEngine() constructor = %q, want default", constructor)
+	}
+}
+
+func TestEngineOptionsTrackPresenceIndependentlyFromValues(t *testing.T) {
+	strategies := []Strategy{StrategyDepth, StrategyBreadth, StrategyLEX, StrategyMEA}
+	for _, strategy := range strategies {
+		t.Run("strategy-"+strategyName(strategy), func(t *testing.T) {
+			got := applyEngineOptions(WithStrategy(strategy))
+			want := defaultEngineConfig()
+			want.strategy = strategy
+			want.strategySet = true
+			assertEngineConfigEqual(t, got, want)
+			if !got.hasEngineConfig() {
+				t.Fatal("explicit strategy was not recorded as present")
+			}
+		})
+	}
+
+	encodings := []Encoding{EncodingASCII, EncodingUTF8, EncodingASCIISymbolsUTF8Strings}
+	for _, encoding := range encodings {
+		t.Run("encoding-"+encodingName(encoding), func(t *testing.T) {
+			got := applyEngineOptions(WithEncoding(encoding))
+			want := defaultEngineConfig()
+			want.encoding = encoding
+			want.encodingSet = true
+			assertEngineConfigEqual(t, got, want)
+			if !got.hasEngineConfig() {
+				t.Fatal("explicit encoding was not recorded as present")
+			}
+		})
+	}
+
+	for _, depth := range []int{0, 64, 255, 256, 257} {
+		t.Run("max-call-depth-"+depthName(depth), func(t *testing.T) {
+			got := applyEngineOptions(WithMaxCallDepth(depth))
+			want := defaultEngineConfig()
+			want.maxCallDepth = depth
+			want.maxCallDepthSet = true
+			assertEngineConfigEqual(t, got, want)
+			if !got.hasEngineConfig() {
+				t.Fatal("explicit max call depth was not recorded as present")
+			}
+		})
+	}
+}
+
+func TestSourceAndSnapshotOptionsTrackPresenceIndependentlyFromValues(t *testing.T) {
+	t.Run("empty-source", func(t *testing.T) {
+		got := applyEngineOptions(WithSource(""))
+		want := defaultEngineConfig()
+		want.sourceSet = true
+		assertEngineConfigEqual(t, got, want)
+		if !got.sourceSet {
+			t.Fatal("explicit empty source lost its presence bit")
+		}
+	})
+
+	t.Run("nil-snapshot", func(t *testing.T) {
+		got := applyEngineOptions(WithSnapshot(nil, FormatBincode))
+		want := defaultEngineConfig()
+		want.snapshotSet = true
+		assertEngineConfigEqual(t, got, want)
+		if !got.snapshotSet {
+			t.Fatal("explicit nil snapshot lost its presence bit")
+		}
+	})
+
+	t.Run("non-empty-source", func(t *testing.T) {
+		const source = "(deffacts startup (ready))"
+		got := applyEngineOptions(WithSource(source))
+		want := defaultEngineConfig()
+		want.source = source
+		want.sourceSet = true
+		assertEngineConfigEqual(t, got, want)
+		if !got.hasSource() {
+			t.Fatal("non-empty source was not recognized")
+		}
+	})
+
+	t.Run("non-nil-snapshot", func(t *testing.T) {
+		data := []byte("snapshot")
+		got := applyEngineOptions(WithSnapshot(data, FormatCBOR))
+		want := defaultEngineConfig()
+		want.snapshot = data
+		want.snapshotSet = true
+		want.snapshotFormat = FormatCBOR
+		assertEngineConfigEqual(t, got, want)
+		if !got.hasSnapshot() {
+			t.Fatal("non-nil snapshot was not recognized")
+		}
+	})
+}
+
+func TestEngineOptionConstructorSelection(t *testing.T) {
+	tests := []struct {
+		name string
+		opt  EngineOption
+	}{
+		{"strategy-depth-zero", WithStrategy(StrategyDepth)},
+		{"strategy-breadth", WithStrategy(StrategyBreadth)},
+		{"strategy-lex", WithStrategy(StrategyLEX)},
+		{"strategy-mea", WithStrategy(StrategyMEA)},
+		{"encoding-ascii-zero", WithEncoding(EncodingASCII)},
+		{"encoding-utf8-default", WithEncoding(EncodingUTF8)},
+		{"encoding-mixed", WithEncoding(EncodingASCIISymbolsUTF8Strings)},
+		{"depth-zero", WithMaxCallDepth(0)},
+		{"depth-runtime-default", WithMaxCallDepth(64)},
+		{"depth-255", WithMaxCallDepth(255)},
+		{"depth-former-sentinel-256", WithMaxCallDepth(256)},
+		{"depth-257", WithMaxCallDepth(257)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name+"-fresh", func(t *testing.T) {
+			if got := observeEngineConstructor(t, tc.opt); got != "configured" {
+				t.Fatalf("constructor = %q, want configured", got)
+			}
+		})
+		t.Run(tc.name+"-source", func(t *testing.T) {
+			if got := observeEngineConstructor(t, WithSource("(deffacts startup (ready))"), tc.opt); got != "source-configured" {
+				t.Fatalf("source constructor = %q, want source-configured", got)
+			}
+		})
+	}
+
+	t.Run("source-alone", func(t *testing.T) {
+		if got := observeEngineConstructor(t, WithSource("(deffacts startup (ready))")); got != "source" {
+			t.Fatalf("constructor = %q, want source", got)
+		}
+	})
+
+	t.Run("snapshot-alone", func(t *testing.T) {
+		if got := observeEngineConstructor(t, WithSnapshot([]byte("snapshot"), FormatBincode)); got != "snapshot" {
+			t.Fatalf("constructor = %q, want snapshot", got)
+		}
+	})
+}
+
+func TestEngineOptionPairsAreOrderIndependent(t *testing.T) {
+	options := []struct {
+		name string
+		opt  EngineOption
+	}{
+		{"strategy", WithStrategy(StrategyMEA)},
+		{"encoding", WithEncoding(EncodingASCIISymbolsUTF8Strings)},
+		{"max-call-depth", WithMaxCallDepth(257)},
+		{"source", WithSource("(deffacts startup (ready))")},
+		{"snapshot", WithSnapshot([]byte("snapshot"), FormatMessagePack)},
+	}
+
+	for i := range options {
+		for j := i + 1; j < len(options); j++ {
+			left, right := options[i], options[j]
+			t.Run(left.name+"-then-"+right.name, func(t *testing.T) {
+				forward := applyEngineOptions(left.opt, right.opt)
+				reverse := applyEngineOptions(right.opt, left.opt)
+				assertEngineConfigEqual(t, forward, reverse)
+			})
+		}
+	}
+}
+
+func TestInvalidEngineOptionsFailBeforeNativeConstruction(t *testing.T) {
+	snapshotPath := t.TempDir() + "/snapshot.bin"
+	if err := os.WriteFile(snapshotPath, []byte("file snapshot"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	invalid := []struct {
+		name string
+		opt  EngineOption
+	}{
+		{"strategy", WithStrategy(Strategy(99))},
+		{"encoding", WithEncoding(Encoding(99))},
+		{"max-call-depth", WithMaxCallDepth(-1)},
+	}
+	contexts := []struct {
+		name string
+		new  func(EngineOption) error
+	}{
+		{"fresh", func(opt EngineOption) error {
+			_, err := NewEngine(opt)
+			return err
+		}},
+		{"source", func(opt EngineOption) error {
+			_, err := NewEngine(WithSource("(deffacts startup (ready))"), opt)
+			return err
+		}},
+		{"snapshot", func(opt EngineOption) error {
+			_, err := NewEngine(WithSnapshot([]byte("snapshot"), FormatBincode), opt)
+			return err
+		}},
+		{"snapshot-file", func(opt EngineOption) error {
+			_, err := NewEngineFromFile(snapshotPath, FormatBincode, opt)
+			return err
+		}},
+	}
+
+	for _, bad := range invalid {
+		for _, context := range contexts {
+			t.Run(bad.name+"-"+context.name, func(t *testing.T) {
+				calls := recordEngineConstructors(t)
+				err := context.new(bad.opt)
+				if !errors.Is(err, ErrInvalidArgument) {
+					t.Fatalf("error = %v, want ErrInvalidArgument", err)
+				}
+				if len(*calls) != 0 {
+					t.Fatalf("native constructors called before validation: %v", *calls)
+				}
+			})
+		}
+	}
+
+	t.Run("snapshot-format", func(t *testing.T) {
+		calls := recordEngineConstructors(t)
+		_, err := NewEngine(WithSnapshot([]byte("snapshot"), Format(99)))
+		if !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("error = %v, want ErrInvalidArgument", err)
+		}
+		if len(*calls) != 0 {
+			t.Fatalf("native constructors called before format validation: %v", *calls)
+		}
+	})
+}
+
+func TestSnapshotInputsReachDeserializerUnchanged(t *testing.T) {
+	directData := []byte("direct snapshot")
+	assertSnapshotInput(t, directData, FormatMessagePack, func() error {
+		_, err := NewEngine(WithSnapshot(directData, FormatMessagePack))
+		return err
+	})
+
+	fileData := []byte("file snapshot")
+	path := t.TempDir() + "/snapshot.cbor"
+	if err := os.WriteFile(path, fileData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	assertSnapshotInput(t, fileData, FormatCBOR, func() error {
+		_, err := NewEngineFromFile(path, FormatCBOR)
+		return err
+	})
+}
+
+func applyEngineOptions(opts ...EngineOption) engineConfig {
+	cfg := defaultEngineConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}
+
+func assertEngineConfigEqual(t *testing.T, got, want engineConfig) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("engine config = %+v, want %+v", got, want)
+	}
+}
+
+func observeEngineConstructor(t *testing.T, opts ...EngineOption) string {
+	t.Helper()
+	calls := recordEngineConstructors(t)
+	_, _ = NewEngine(opts...)
+	if len(*calls) != 1 {
+		t.Fatalf("native constructor calls = %v, want exactly one", *calls)
+	}
+	return (*calls)[0]
+}
+
+func recordEngineConstructors(t *testing.T) *[]string {
+	t.Helper()
+	withFFIHooks(t)
+	calls := make([]string, 0, 1)
+	ffiEngineNew = func() ffi.EngineHandle {
+		calls = append(calls, "default")
+		return nil
+	}
+	ffiEngineNewWithConfig = func(*ffi.Config) ffi.EngineHandle {
+		calls = append(calls, "configured")
+		return nil
+	}
+	ffiEngineNewWithSource = func(string) ffi.EngineHandle {
+		calls = append(calls, "source")
+		return nil
+	}
+	ffiEngineNewWithSourceConfig = func(string, *ffi.Config) ffi.EngineHandle {
+		calls = append(calls, "source-configured")
+		return nil
+	}
+	ffiEngineDeserializeAs = func([]byte, ffi.SerializationFormat) (ffi.EngineHandle, ffi.ErrorCode) {
+		calls = append(calls, "snapshot")
+		return nil, ffi.ErrOK
+	}
+	ffiLastErrorGlobal = func() string { return "" }
+	return &calls
+}
+
+func assertSnapshotInput(t *testing.T, wantData []byte, wantFormat Format, construct func() error) {
+	t.Helper()
+	withFFIHooks(t)
+	var gotData []byte
+	var gotFormat ffi.SerializationFormat
+	ffiEngineDeserializeAs = func(data []byte, format ffi.SerializationFormat) (ffi.EngineHandle, ffi.ErrorCode) {
+		gotData = append([]byte(nil), data...)
+		gotFormat = format
+		return nil, ffi.ErrOK
+	}
+
+	if err := construct(); err == nil {
+		t.Fatal("nil deserializer handle unexpectedly produced a valid engine")
+	}
+	if !bytes.Equal(gotData, wantData) {
+		t.Fatalf("snapshot data = %q, want %q", gotData, wantData)
+	}
+	wantFFIFormat, err := formatToFFI(wantFormat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotFormat != wantFFIFormat {
+		t.Fatalf("snapshot format = %d, want %d", gotFormat, wantFFIFormat)
+	}
+}
+
+func strategyName(strategy Strategy) string {
+	return []string{"depth", "breadth", "lex", "mea"}[strategy]
+}
+
+func encodingName(encoding Encoding) string {
+	return []string{"ascii", "utf8", "mixed"}[encoding]
+}
+
+func depthName(depth int) string {
+	switch depth {
+	case 0:
+		return "zero"
+	case 64:
+		return "runtime-default"
+	case 255:
+		return "255"
+	case 256:
+		return "former-sentinel-256"
+	case 257:
+		return "257"
+	default:
+		return "other"
+	}
+}

--- a/crates/ferric-rules-python/tests/bindings_conformance_adapter.py
+++ b/crates/ferric-rules-python/tests/bindings_conformance_adapter.py
@@ -130,6 +130,52 @@ def configuration_custom() -> Any:
     }
 
 
+def configuration_observation(
+    source: str,
+    *,
+    encoding: ferric.Encoding | None = None,
+    strategy: ferric.Strategy | None = None,
+) -> Any:
+    engine = ferric.Engine.from_source(source, encoding=encoding, strategy=strategy)
+    unicode = "accepted"
+    try:
+        try:
+            engine.assert_fact("unicode", ferric.String("é"))
+        except ferric.FerricEncodingError:
+            unicode = "rejected"
+        run = engine.run()
+        return {"halt_reason": reason(run.halt_reason), "unicode": unicode}
+    finally:
+        engine.close()
+
+
+def configuration_strategy_fired(source: str) -> int:
+    engine = ferric.Engine.from_source(source, strategy=ferric.Strategy.BREADTH)
+    try:
+        return engine.run().rules_fired
+    finally:
+        engine.close()
+
+
+def configuration_isolation() -> Any:
+    default_depth_source = fixture("configuration-default-depth.clp")
+    strategy_source = fixture("configuration-strategy-order.clp")
+    unavailable = {"halt_reason": "unavailable", "unicode": "unavailable"}
+    return {
+        "depth_1_only": unavailable,
+        "depth_256_only": unavailable,
+        "encoding_ascii_only": configuration_observation(
+            default_depth_source, encoding=ferric.Encoding.ASCII
+        ),
+        "strategy_breadth_only": {
+            **configuration_observation(
+                default_depth_source, strategy=ferric.Strategy.BREADTH
+            ),
+            "strategy_fired": configuration_strategy_fired(strategy_source),
+        },
+    }
+
+
 def error_case(case_id: str) -> Any:
     engine = ferric.Engine()
     family = ""
@@ -305,6 +351,8 @@ def run_case(case_id: str) -> Any:
         return configuration_default()
     if case_id == "configuration.custom":
         return configuration_custom()
+    if case_id == "configuration.isolation":
+        return configuration_isolation()
     if case_id == "fact.lifecycle":
         return fact_lifecycle()
     if case_id == "execution.run-limits":

--- a/packages/ferric/test/bindings-conformance/adapter.ts
+++ b/packages/ferric/test/bindings-conformance/adapter.ts
@@ -152,6 +152,57 @@ function configurationCustom(): unknown {
   }
 }
 
+function configurationObservation(
+  source: string,
+  options: { encoding?: Encoding; strategy?: Strategy; maxCallDepth?: number },
+): Record<string, string> {
+  const engine = Engine.fromSource(source, options);
+  let unicode = "accepted";
+  try {
+    try {
+      engine.assertFact("unicode", "é");
+    } catch {
+      unicode = "rejected";
+    }
+    const run = engine.run();
+    return { halt_reason: reason(run.haltReason), unicode };
+  } finally {
+    engine.close();
+  }
+}
+
+function configurationStrategyFired(source: string): number {
+  const engine = Engine.fromSource(source, { strategy: Strategy.Breadth });
+  try {
+    return engine.run().rulesFired;
+  } finally {
+    engine.close();
+  }
+}
+
+function configurationIsolation(): unknown {
+  const defaultDepthSource = fixture("configuration-default-depth.clp");
+  const customDepthSource = fixture("custom-config.clp");
+  const strategySource = fixture("configuration-strategy-order.clp");
+  return {
+    depth_1_only: configurationObservation(customDepthSource, {
+      maxCallDepth: 1,
+    }),
+    depth_256_only: configurationObservation(defaultDepthSource, {
+      maxCallDepth: 256,
+    }),
+    encoding_ascii_only: configurationObservation(defaultDepthSource, {
+      encoding: Encoding.Ascii,
+    }),
+    strategy_breadth_only: {
+      ...configurationObservation(defaultDepthSource, {
+        strategy: Strategy.Breadth,
+      }),
+      strategy_fired: configurationStrategyFired(strategySource),
+    },
+  };
+}
+
 function errorCase(caseId: string): unknown {
   const engine = new Engine();
   let family = "";
@@ -380,6 +431,8 @@ async function runCase(caseId: string): Promise<unknown> {
       return configurationDefault();
     case "configuration.custom":
       return configurationCustom();
+    case "configuration.isolation":
+      return configurationIsolation();
     case "fact.lifecycle":
       return factLifecycle();
     case "execution.run-limits":

--- a/tests/bindings-conformance/adapters/c/adapter.c
+++ b/tests/bindings-conformance/adapters/c/adapter.c
@@ -9,6 +9,8 @@
 
 #define HIGH_ID_ITERATIONS 1048577U
 
+static const char *halt_reason_name(enum FerricHaltReason reason);
+
 static char *read_fixture(const char *name) {
     const char *root = getenv("FERRIC_BINDINGS_CONFORMANCE_ROOT");
     char path[4096];
@@ -326,6 +328,123 @@ static bool configuration_custom(void) {
     return true;
 }
 
+struct ConfigurationObservation {
+    const char *halt_reason;
+    const char *unicode;
+};
+
+static bool observe_configuration(const char *fixture_name,
+                                  const struct FerricConfig *config,
+                                  struct ConfigurationObservation *observation) {
+    char *source = read_fixture(fixture_name);
+    struct FerricEngine *engine;
+    struct FerricValue value;
+    uint64_t fact_id = 0;
+    uint64_t fired = 0;
+    enum FerricHaltReason reason = FERRIC_HALT_REASON_AGENDA_EMPTY;
+    enum FerricError unicode_code;
+    enum FerricError run_code;
+
+    if (source == NULL) {
+        return false;
+    }
+    engine = ferric_engine_new_with_source_config(source, config);
+    free(source);
+    if (engine == NULL) {
+        return false;
+    }
+
+    value = ferric_value_string("é");
+    unicode_code =
+        ferric_engine_assert_ordered(engine, "unicode", &value, 1U, &fact_id);
+    ferric_value_free(&value);
+    run_code = ferric_engine_run_ex(engine, -1, &fired, &reason);
+    ferric_engine_free(engine);
+    if (run_code != FERRIC_ERROR_OK || halt_reason_name(reason) == NULL) {
+        return false;
+    }
+
+    observation->halt_reason = halt_reason_name(reason);
+    observation->unicode =
+        unicode_code == FERRIC_ERROR_OK ? "accepted" : "rejected";
+    return true;
+}
+
+static void print_configuration_observation(
+    const struct ConfigurationObservation *observation) {
+    printf("{\"halt_reason\":\"%s\",\"unicode\":\"%s\"}",
+           observation->halt_reason,
+           observation->unicode);
+}
+
+static bool observe_strategy_breadth_fired(const struct FerricConfig *config,
+                                           uint64_t *fired) {
+    char *source = read_fixture("configuration-strategy-order.clp");
+    struct FerricEngine *engine;
+    enum FerricHaltReason reason = FERRIC_HALT_REASON_AGENDA_EMPTY;
+
+    if (source == NULL) {
+        return false;
+    }
+    engine = ferric_engine_new_with_source_config(source, config);
+    free(source);
+    if (engine == NULL) {
+        return false;
+    }
+    if (ferric_engine_run_ex(engine, -1, fired, &reason) != FERRIC_ERROR_OK ||
+        reason != FERRIC_HALT_REASON_AGENDA_EMPTY) {
+        ferric_engine_free(engine);
+        return false;
+    }
+    ferric_engine_free(engine);
+    return true;
+}
+
+static bool configuration_isolation(void) {
+    struct FerricConfig encoding_ascii = {
+        FERRIC_STRING_ENCODING_ASCII, FERRIC_CONFLICT_STRATEGY_DEPTH, 64U};
+    struct FerricConfig strategy_breadth = {
+        FERRIC_STRING_ENCODING_UTF8, FERRIC_CONFLICT_STRATEGY_BREADTH, 64U};
+    struct FerricConfig depth_one = {
+        FERRIC_STRING_ENCODING_UTF8, FERRIC_CONFLICT_STRATEGY_DEPTH, 1U};
+    struct FerricConfig depth_256 = {
+        FERRIC_STRING_ENCODING_UTF8, FERRIC_CONFLICT_STRATEGY_DEPTH, 256U};
+    struct ConfigurationObservation encoding_ascii_observation;
+    struct ConfigurationObservation strategy_breadth_observation;
+    struct ConfigurationObservation depth_one_observation;
+    struct ConfigurationObservation depth_256_observation;
+    uint64_t strategy_fired = 0;
+
+    if (!observe_configuration("configuration-default-depth.clp",
+                               &encoding_ascii,
+                               &encoding_ascii_observation) ||
+        !observe_configuration("configuration-default-depth.clp",
+                               &strategy_breadth,
+                               &strategy_breadth_observation) ||
+        !observe_configuration(
+            "custom-config.clp", &depth_one, &depth_one_observation) ||
+        !observe_configuration("configuration-default-depth.clp",
+                               &depth_256,
+                               &depth_256_observation) ||
+        !observe_strategy_breadth_fired(&strategy_breadth, &strategy_fired)) {
+        return false;
+    }
+
+    fputs("{\"depth_1_only\":", stdout);
+    print_configuration_observation(&depth_one_observation);
+    fputs(",\"depth_256_only\":", stdout);
+    print_configuration_observation(&depth_256_observation);
+    fputs(",\"encoding_ascii_only\":", stdout);
+    print_configuration_observation(&encoding_ascii_observation);
+    printf(",\"strategy_breadth_only\":{\"halt_reason\":\"%s\","
+           "\"strategy_fired\":%" PRIu64 ",\"unicode\":\"%s\"}",
+           strategy_breadth_observation.halt_reason,
+           strategy_fired,
+           strategy_breadth_observation.unicode);
+    putchar('}');
+    return true;
+}
+
 static bool error_case(const char *case_id) {
     struct FerricEngine *engine = ferric_engine_new();
     enum FerricError code;
@@ -623,6 +742,9 @@ static bool run_case(const char *case_id) {
     }
     if (strcmp(case_id, "configuration.custom") == 0) {
         return configuration_custom();
+    }
+    if (strcmp(case_id, "configuration.isolation") == 0) {
+        return configuration_isolation();
     }
     if (strcmp(case_id, "fact.lifecycle") == 0) {
         return fact_lifecycle();

--- a/tests/bindings-conformance/corpus.json
+++ b/tests/bindings-conformance/corpus.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "suite_version": "1.0.0",
+  "suite_version": "1.1.0",
   "bindings": ["rust", "c", "go", "node", "python"],
   "cases": [
     {
@@ -134,6 +134,55 @@
           },
           "rationale": "Python construction does not yet expose max_call_depth.",
           "since": "1.0.0",
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/187"
+        }
+      }
+    },
+    {
+      "id": "configuration.isolation",
+      "semantic": "configuration.isolation",
+      "canonical": {
+        "depth_1_only": {
+          "halt_reason": "action_error",
+          "unicode": "accepted"
+        },
+        "depth_256_only": {
+          "halt_reason": "agenda_empty",
+          "unicode": "accepted"
+        },
+        "encoding_ascii_only": {
+          "halt_reason": "action_error",
+          "unicode": "rejected"
+        },
+        "strategy_breadth_only": {
+          "halt_reason": "action_error",
+          "strategy_fired": 2,
+          "unicode": "accepted"
+        }
+      },
+      "deviations": {
+        "python": {
+          "expected": {
+            "depth_1_only": {
+              "halt_reason": "unavailable",
+              "unicode": "unavailable"
+            },
+            "depth_256_only": {
+              "halt_reason": "unavailable",
+              "unicode": "unavailable"
+            },
+            "encoding_ascii_only": {
+              "halt_reason": "action_error",
+              "unicode": "rejected"
+            },
+            "strategy_breadth_only": {
+              "halt_reason": "action_error",
+              "strategy_fired": 2,
+              "unicode": "accepted"
+            }
+          },
+          "rationale": "Python construction does not yet expose max_call_depth, so it cannot run the two depth-only isolation probes.",
+          "since": "1.1.0",
           "tracking_issue": "https://github.com/plx/ferric-rules/issues/187"
         }
       }

--- a/tests/bindings-conformance/fixtures/configuration-default-depth.clp
+++ b/tests/bindings-conformance/fixtures/configuration-default-depth.clp
@@ -1,0 +1,8 @@
+(deffunction recurse (?remaining)
+    (if (= ?remaining 0) then
+        (return 0))
+    (return (recurse (- ?remaining 1))))
+
+(defrule exercise-default-depth-boundary
+    =>
+    (recurse 64))

--- a/tests/bindings-conformance/fixtures/configuration-strategy-order.clp
+++ b/tests/bindings-conformance/fixtures/configuration-strategy-order.clp
@@ -1,0 +1,20 @@
+(deffacts startup
+    (candidate old)
+    (candidate new))
+
+(defrule choose-old
+    (candidate old)
+    (not (winner ?))
+    =>
+    (assert (winner old))
+    (assert (extra)))
+
+(defrule choose-new
+    (candidate new)
+    (not (winner ?))
+    =>
+    (assert (winner new)))
+
+(defrule observe-extra
+    (extra)
+    =>)

--- a/tools/bindings-conformance-adapter/src/main.rs
+++ b/tools/bindings-conformance-adapter/src/main.rs
@@ -192,6 +192,67 @@ fn configuration_custom() -> Result<JsonValue, String> {
     }))
 }
 
+fn configuration_observation(
+    fixture_name: &str,
+    config: EngineConfig,
+) -> Result<JsonValue, String> {
+    let mut engine = Engine::with_rules_config(&fixture(fixture_name)?, config)
+        .map_err(|error| format!("init failed: {error}"))?;
+    let unicode = engine
+        .create_string("é")
+        .map(|_| "accepted")
+        .unwrap_or("rejected");
+    let run = engine
+        .run(RunLimit::Unlimited)
+        .map_err(|error| error.to_string())?;
+    Ok(json!({
+        "halt_reason": halt_reason(run.halt_reason),
+        "unicode": unicode
+    }))
+}
+
+fn configuration_strategy_fired(config: EngineConfig) -> Result<usize, String> {
+    let mut engine =
+        Engine::with_rules_config(&fixture("configuration-strategy-order.clp")?, config)
+            .map_err(|error| format!("init failed: {error}"))?;
+    let run = engine
+        .run(RunLimit::Unlimited)
+        .map_err(|error| error.to_string())?;
+    Ok(run.rules_fired)
+}
+
+fn configuration_isolation() -> Result<JsonValue, String> {
+    let mut encoding_ascii = EngineConfig::default();
+    encoding_ascii.string_encoding = StringEncoding::Ascii;
+
+    let mut strategy_breadth = EngineConfig::default();
+    strategy_breadth.strategy = ConflictResolutionStrategy::Breadth;
+
+    let mut depth_one = EngineConfig::default();
+    depth_one.max_call_depth = 1;
+
+    let mut depth_256 = EngineConfig::default();
+    depth_256.max_call_depth = 256;
+
+    let strategy_fired = configuration_strategy_fired(strategy_breadth.clone())?;
+    let mut strategy_observation =
+        configuration_observation("configuration-default-depth.clp", strategy_breadth)?;
+    strategy_observation["strategy_fired"] = json!(strategy_fired);
+
+    Ok(json!({
+        "depth_1_only": configuration_observation("custom-config.clp", depth_one)?,
+        "depth_256_only": configuration_observation(
+            "configuration-default-depth.clp",
+            depth_256
+        )?,
+        "encoding_ascii_only": configuration_observation(
+            "configuration-default-depth.clp",
+            encoding_ascii
+        )?,
+        "strategy_breadth_only": strategy_observation
+    }))
+}
+
 fn error_case(case_id: &str) -> Result<JsonValue, String> {
     let mut engine = Engine::new(EngineConfig::default());
     let family = match case_id {
@@ -385,6 +446,7 @@ fn run_case(case_id: &str) -> Result<JsonValue, String> {
     match case_id {
         "configuration.default" => Ok(configuration_default()),
         "configuration.custom" => configuration_custom(),
+        "configuration.isolation" => configuration_isolation(),
         "fact.lifecycle" => fact_lifecycle(),
         "execution.run-limits" => execution_run_limits(),
         "execution.step" => execution_step(),

--- a/tools/ferric-tools/src/ferric_tools/bindings_conformance.py
+++ b/tools/ferric-tools/src/ferric_tools/bindings_conformance.py
@@ -26,6 +26,7 @@ REQUIRED_SEMANTICS = (
     "value.external_address",
     "configuration.default",
     "configuration.custom",
+    "configuration.isolation",
     "error.parse",
     "error.compile",
     "error.runtime",

--- a/tools/ferric-tools/tests/test_bindings_conformance.py
+++ b/tools/ferric-tools/tests/test_bindings_conformance.py
@@ -49,6 +49,28 @@ def test_case_ids_are_unique_and_all_adapters_are_required() -> None:
     assert all(case.required_bindings == frozenset(REQUIRED_BINDINGS) for case in corpus.cases)
 
 
+def test_configuration_isolation_uses_behavioral_observations() -> None:
+    corpus = load_corpus(CORPUS)
+    case = next(case for case in corpus.cases if case.id == "configuration.isolation")
+
+    assert case.semantic == "configuration.isolation"
+    assert case.required_bindings == frozenset(REQUIRED_BINDINGS)
+    assert set(case.deviations) == {"python"}
+    assert case.canonical["encoding_ascii_only"] == {
+        "halt_reason": "action_error",
+        "unicode": "rejected",
+    }
+    assert case.canonical["strategy_breadth_only"] == {
+        "halt_reason": "action_error",
+        "strategy_fired": 2,
+        "unicode": "accepted",
+    }
+    assert case.canonical["depth_256_only"] == {
+        "halt_reason": "agenda_empty",
+        "unicode": "accepted",
+    }
+
+
 def test_unknown_semantic_drift_fails() -> None:
     corpus = _single_case_corpus()
 


### PR DESCRIPTION
## Summary

- resolve Go engine options from the Rust/FFI defaults (UTF-8, Depth, max call depth 64)
- track option presence independently so zero/default-valued selections and depth 256 are not mistaken for omission
- validate supplied options before any native constructor or snapshot deserializer call
- add behavior-backed configuration isolation coverage across Rust, C, Go, Node, and Python

## Validation

- `just preflight-pr`
- `go test -race ./...`
- `golangci-lint run ./...`
- five-adapter bindings conformance: 26 cases, 5 adapters

Closes #125