### PR TITLE
[FR-GO-005] Preserve Go logical runs across cancelable batches

### DIFF
--- a/bindings/go/coverage_edge_test.go
+++ b/bindings/go/coverage_edge_test.go
@@ -36,6 +36,7 @@ func resetFFIHooks() {
 	ffiEngineFindFactIDs = ffi.EngineFindFactIDs
 	ffiEngineFactCount = ffi.EngineFactCount
 	ffiEngineRunEx = ffi.EngineRunEx
+	ffiEngineContinueRunEx = ffi.EngineContinueRunEx
 	ffiEngineStep = ffi.EngineStep
 	ffiEngineHalt = ffi.EngineHalt
 	ffiEngineReset = ffi.EngineReset

--- a/bindings/go/engine.go
+++ b/bindings/go/engine.go
@@ -425,7 +425,9 @@ func (e *Engine) Run(ctx context.Context) (*RunResult, error) {
 
 // RunWithLimit runs the engine with a maximum number of rule firings.
 // A limit of 0 means unlimited. Checks context for cancellation between
-// batches of rule firings.
+// batches of rule firings. Cancellation returns the partial RunResult with
+// HaltRequested and an error wrapping ctx.Err(); an engine-requested halt
+// returns HaltRequested with a nil error.
 func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error) {
 	handle, release, err := e.leaseHandle()
 	if err != nil {
@@ -445,10 +447,14 @@ func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error
 		}
 		return e.runDirect(handle, ffiLimit)
 	}
+	return e.runCancelable(ctx, handle, limit)
+}
 
+func (e *Engine) runCancelable(ctx context.Context, handle ffi.EngineHandle, limit int) (*RunResult, error) {
 	// For cancelable contexts, run in small batches and check context.
 	const batchSize = 100
 	totalFired := 0
+	runChunk := ffiEngineRunEx
 	for {
 		if err := ctx.Err(); err != nil {
 			return &RunResult{RulesFired: totalFired, HaltReason: HaltRequested}, fmt.Errorf("ferric: run canceled: %w", err)
@@ -466,7 +472,7 @@ func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error
 			}
 		}
 
-		fired, reason, rc := ffiEngineRunEx(handle, batch)
+		fired, reason, rc := runChunk(handle, batch)
 		if rc != ffi.ErrOK {
 			return &RunResult{RulesFired: totalFired}, errorFromFFI(rc, handle)
 		}
@@ -488,7 +494,19 @@ func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error
 			if limit > 0 && totalFired >= limit {
 				return &RunResult{RulesFired: totalFired, HaltReason: HaltLimitReached}, nil
 			}
-			// Otherwise loop and check context before next batch.
+			if err := ctx.Err(); err != nil {
+				return &RunResult{RulesFired: totalFired, HaltReason: HaltRequested}, fmt.Errorf("ferric: run canceled: %w", err)
+			}
+			halted, rc := ffiEngineIsHalted(handle)
+			if rc != ffi.ErrOK {
+				return &RunResult{RulesFired: totalFired}, errorFromFFI(rc, handle)
+			}
+			if halted {
+				return &RunResult{RulesFired: totalFired, HaltReason: HaltRequested}, nil
+			}
+			// Otherwise preserve this logical run and check context before the
+			// next continuation chunk.
+			runChunk = ffiEngineContinueRunEx
 		}
 	}
 }

--- a/bindings/go/ffi_hooks.go
+++ b/bindings/go/ffi_hooks.go
@@ -21,6 +21,7 @@ var (
 	ffiEngineFindFactIDs            = ffi.EngineFindFactIDs
 	ffiEngineFactCount              = ffi.EngineFactCount
 	ffiEngineRunEx                  = ffi.EngineRunEx
+	ffiEngineContinueRunEx          = ffi.EngineContinueRunEx
 	ffiEngineStep                   = ffi.EngineStep
 	ffiEngineHalt                   = ffi.EngineHalt
 	ffiEngineReset                  = ffi.EngineReset

--- a/bindings/go/internal/ffi/ffi.go
+++ b/bindings/go/internal/ffi/ffi.go
@@ -106,6 +106,14 @@ func EngineRunEx(h EngineHandle, limit int64) (uint64, HaltReason, ErrorCode) {
 	return uint64(fired), HaltReason(reason), rc
 }
 
+// EngineContinueRunEx continues a logical run after a limit-reached result.
+func EngineContinueRunEx(h EngineHandle, limit int64) (uint64, HaltReason, ErrorCode) {
+	var fired C.uint64_t
+	var reason C.enum_FerricHaltReason
+	rc := ErrorCode(C.ferric_engine_continue_run_ex(h, C.int64_t(limit), &fired, &reason))
+	return uint64(fired), HaltReason(reason), rc
+}
+
 // EngineStep executes a single rule firing.
 // Returns a status: 1 = rule fired, 0 = agenda empty, -1 = halted.
 func EngineStep(h EngineHandle) (int32, ErrorCode) {

--- a/bindings/go/internal/ffi/run_continuation_test.go
+++ b/bindings/go/internal/ffi/run_continuation_test.go
@@ -1,0 +1,32 @@
+package ffi
+
+import "testing"
+
+func TestEngineContinueRunEx(t *testing.T) {
+	lockThread(t)
+
+	handle := EngineNewWithSource(`
+		(defrule first
+			(initial-fact)
+			=>
+			(assert (next)))
+		(defrule second
+			(next)
+			=>
+			(assert (done)))
+	`)
+	if handle == nil {
+		t.Fatal("EngineNewWithSource returned nil")
+	}
+	defer EngineFree(handle)
+
+	fired, reason, rc := EngineRunEx(handle, 1)
+	if rc != ErrOK || fired != 1 || reason != HaltReasonLimitReached {
+		t.Fatalf("first chunk = (%d, %d, %d), want (1, LimitReached, OK)", fired, reason, rc)
+	}
+
+	fired, reason, rc = EngineContinueRunEx(handle, -1)
+	if rc != ErrOK || fired != 1 || reason != HaltReasonAgendaEmpty {
+		t.Fatalf("continuation = (%d, %d, %d), want (1, AgendaEmpty, OK)", fired, reason, rc)
+	}
+}

--- a/bindings/go/run_continuation_test.go
+++ b/bindings/go/run_continuation_test.go
@@ -1,0 +1,301 @@
+package ferric
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
+)
+
+type goLogicalRunObservation struct {
+	result      RunResult
+	diagnostics []string
+	halted      bool
+	agendaSize  int
+}
+
+func observeGoLogicalRun(t *testing.T, source string, cancelable bool) goLogicalRunObservation {
+	t.Helper()
+	return observeGoLogicalRunWithLimit(t, source, cancelable, 0)
+}
+
+func observeGoLogicalRunWithLimit(
+	t *testing.T,
+	source string,
+	cancelable bool,
+	limit int,
+) goLogicalRunObservation {
+	t.Helper()
+
+	engine, err := NewEngine(WithSource(source))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, engine)
+
+	ctx := context.Background()
+	cancel := func() {}
+	if cancelable {
+		ctx, cancel = context.WithCancel(t.Context())
+	}
+	defer cancel()
+
+	result, err := engine.RunWithLimit(ctx, limit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	diagnostics, err := engine.DiagnosticsE()
+	if err != nil {
+		t.Fatal(err)
+	}
+	halted, err := engine.IsHaltedE()
+	if err != nil {
+		t.Fatal(err)
+	}
+	agendaSize, err := engine.AgendaSizeE()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return goLogicalRunObservation{
+		result:      *result,
+		diagnostics: diagnostics,
+		halted:      halted,
+		agendaSize:  agendaSize,
+	}
+}
+
+func haltAtActivationSource(boundary int) string {
+	target := boundary - 1
+	return fmt.Sprintf(`
+		(deffacts start (position 0))
+		(defrule halt-at-boundary
+			(declare (salience 100))
+			(position %d)
+			=>
+			(halt))
+		(defrule advance
+			?current <- (position ?n&:(< ?n %d))
+			=>
+			(retract ?current)
+			(assert (position (+ ?n 1))))
+		(defrule after-halt
+			(declare (salience -100))
+			?current <- (position %d)
+			=>
+			(retract ?current)
+			(assert (past-boundary)))
+	`, target, target, target)
+}
+
+func assertLogicalRunObservationsEqual(
+	t *testing.T,
+	got goLogicalRunObservation,
+	want goLogicalRunObservation,
+) {
+	t.Helper()
+
+	if got.result != want.result {
+		t.Fatalf("run result = %+v, want %+v", got.result, want.result)
+	}
+	if !slices.Equal(got.diagnostics, want.diagnostics) {
+		t.Fatalf("diagnostics = %q, want %q", got.diagnostics, want.diagnostics)
+	}
+	if got.halted != want.halted {
+		t.Fatalf("halted = %v, want %v", got.halted, want.halted)
+	}
+	if got.agendaSize != want.agendaSize {
+		t.Fatalf("agenda size = %d, want %d", got.agendaSize, want.agendaSize)
+	}
+}
+
+func TestCancelableRunMatchesDirectAtHaltBoundaries(t *testing.T) {
+	for _, boundary := range []int{1, 100, 101, 200} {
+		t.Run(fmt.Sprintf("activation-%d", boundary), func(t *testing.T) {
+			lockThread(t)
+			source := haltAtActivationSource(boundary)
+			direct := observeGoLogicalRun(t, source, false)
+			cancelable := observeGoLogicalRun(t, source, true)
+
+			want := RunResult{RulesFired: boundary, HaltReason: HaltRequested}
+			if direct.result != want {
+				t.Fatalf("direct run result = %+v, want %+v", direct.result, want)
+			}
+			if !direct.halted || direct.agendaSize != 1 {
+				t.Fatalf(
+					"direct terminal state = halted %v, agenda %d; want true/1",
+					direct.halted,
+					direct.agendaSize,
+				)
+			}
+			assertLogicalRunObservationsEqual(t, cancelable, direct)
+		})
+	}
+}
+
+func TestRunLimitWinsAtExactHaltBoundary(t *testing.T) {
+	lockThread(t)
+
+	const boundary = 100
+	source := haltAtActivationSource(boundary)
+	direct := observeGoLogicalRunWithLimit(t, source, false, boundary)
+	cancelable := observeGoLogicalRunWithLimit(t, source, true, boundary)
+
+	want := RunResult{RulesFired: boundary, HaltReason: HaltLimitReached}
+	if direct.result != want {
+		t.Fatalf("direct run result = %+v, want %+v", direct.result, want)
+	}
+	if !direct.halted || direct.agendaSize != 1 {
+		t.Fatalf(
+			"direct terminal state = halted %v, agenda %d; want true/1",
+			direct.halted,
+			direct.agendaSize,
+		)
+	}
+	assertLogicalRunObservationsEqual(t, cancelable, direct)
+}
+
+func TestCancelableRunPreservesDiagnosticsAcrossChunks(t *testing.T) {
+	lockThread(t)
+
+	const source = `
+		(defrule seed
+			(initial-fact)
+			=>
+			(assert (candidate 1))
+			(assert (position 0)))
+		(defrule bad-match
+			(candidate ?value&:(/ 1 0))
+			=>
+			(assert (must-not-fire)))
+		(defrule advance
+			?current <- (position ?n&:(< ?n 100))
+			=>
+			(retract ?current)
+			(assert (position (+ ?n 1))))
+	`
+
+	direct := observeGoLogicalRun(t, source, false)
+	if direct.result != (RunResult{RulesFired: 101, HaltReason: HaltAgendaEmpty}) {
+		t.Fatalf("direct run result = %+v, want 101/AgendaEmpty", direct.result)
+	}
+	if len(direct.diagnostics) == 0 {
+		t.Fatal("diagnostic fixture did not emit an action diagnostic")
+	}
+
+	cancelable := observeGoLogicalRun(t, source, true)
+	assertLogicalRunObservationsEqual(t, cancelable, direct)
+}
+
+func TestCancelableRunStartsOnceThenContinues(t *testing.T) {
+	withFFIHooks(t)
+
+	var calls []string
+	ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		calls = append(calls, "run")
+		return 100, ffi.HaltReasonLimitReached, ffi.ErrOK
+	}
+	ffiEngineIsHalted = func(ffi.EngineHandle) (bool, ffi.ErrorCode) {
+		calls = append(calls, "is-halted")
+		return false, ffi.ErrOK
+	}
+	ffiEngineContinueRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		calls = append(calls, "continue")
+		return 1, ffi.HaltReasonAgendaEmpty, ffi.ErrOK
+	}
+
+	result, err := (&Engine{}).Run(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if *result != (RunResult{RulesFired: 101, HaltReason: HaltAgendaEmpty}) {
+		t.Fatalf("run result = %+v, want 101/AgendaEmpty", *result)
+	}
+	if !slices.Equal(calls, []string{"run", "is-halted", "continue"}) {
+		t.Fatalf("FFI calls = %v, want one fresh chunk followed by one continuation", calls)
+	}
+}
+
+func TestCancelableRunReportsCancellationBetweenChunks(t *testing.T) {
+	withFFIHooks(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	haltChecks := 0
+	ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		cancel()
+		return 37, ffi.HaltReasonLimitReached, ffi.ErrOK
+	}
+	ffiEngineIsHalted = func(ffi.EngineHandle) (bool, ffi.ErrorCode) {
+		haltChecks++
+		return false, ffi.ErrOK
+	}
+	ffiEngineContinueRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		t.Fatal("continuation called after context cancellation")
+		return 0, ffi.HaltReasonAgendaEmpty, ffi.ErrInternalError
+	}
+
+	result, err := (&Engine{}).Run(ctx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("run error = %v, want wrapped context.Canceled", err)
+	}
+	if result == nil || *result != (RunResult{RulesFired: 37, HaltReason: HaltRequested}) {
+		t.Fatalf("partial run result = %+v, want 37/HaltRequested", result)
+	}
+	if haltChecks != 0 {
+		t.Fatalf("halt state inspected %d times after cancellation, want 0", haltChecks)
+	}
+}
+
+func TestCancelableRunExplicitLimitPrecedesCancellationAndInspection(t *testing.T) {
+	withFFIHooks(t)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		cancel()
+		return 23, ffi.HaltReasonLimitReached, ffi.ErrOK
+	}
+	ffiEngineIsHalted = func(ffi.EngineHandle) (bool, ffi.ErrorCode) {
+		t.Fatal("halt state inspected after the explicit caller limit was reached")
+		return false, ffi.ErrInternalError
+	}
+	ffiEngineContinueRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		t.Fatal("continuation called after the explicit caller limit was reached")
+		return 0, ffi.HaltReasonAgendaEmpty, ffi.ErrInternalError
+	}
+
+	result, err := (&Engine{}).RunWithLimit(ctx, 23)
+	if err != nil {
+		t.Fatalf("run error = %v, want nil", err)
+	}
+	if result == nil || *result != (RunResult{RulesFired: 23, HaltReason: HaltLimitReached}) {
+		t.Fatalf("run result = %+v, want 23/LimitReached", result)
+	}
+}
+
+func TestCancelableRunReturnsHaltInspectionError(t *testing.T) {
+	withFFIHooks(t)
+
+	ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		return 23, ffi.HaltReasonLimitReached, ffi.ErrOK
+	}
+	ffiEngineIsHalted = func(ffi.EngineHandle) (bool, ffi.ErrorCode) {
+		return false, ffi.ErrRuntimeError
+	}
+	ffiEngineContinueRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		t.Fatal("continuation called after halt-state inspection failed")
+		return 0, ffi.HaltReasonAgendaEmpty, ffi.ErrInternalError
+	}
+
+	result, err := (&Engine{}).Run(t.Context())
+	if !errors.Is(err, ErrRuntime) {
+		t.Fatalf("run error = %v, want ErrRuntime", err)
+	}
+	if result == nil || result.RulesFired != 23 {
+		t.Fatalf("partial run result = %+v, want 23 completed rules", result)
+	}
+}

--- a/tests/bindings-conformance/corpus.json
+++ b/tests/bindings-conformance/corpus.json
@@ -289,12 +289,6 @@
       "semantic": "execution.halt",
       "canonical": {"fired": 100, "reason": "halt_requested"},
       "deviations": {
-        "go": {
-          "expected": {"fired": 101, "reason": "agenda_empty"},
-          "rationale": "Cancelable Go runs currently start a new logical run after an exact 100-activation batch boundary.",
-          "since": "1.0.0",
-          "tracking_issue": "https://github.com/plx/ferric-rules/issues/127"
-        },
         "node": {
           "expected": {"fired": 101, "reason": "agenda_empty"},
           "rationale": "Node worker runs currently start a new logical run after an exact 100-activation batch boundary.",


### PR DESCRIPTION
Closes #127

## What changed

- bind `ferric_engine_continue_run_ex` in the internal Go FFI layer
- start cancelable execution with one fresh `RunEx` call, then preserve the same logical run with `ContinueRunEx`
- keep caller-limit and host-cancellation precedence explicit, inspect the halt latch before an internal continuation, and retain partial cancellation results
- add direct-versus-cancelable regressions at activations 1, 100, 101, and 200; cover diagnostic retention, continuation routing, cancellation, explicit limits, and error propagation
- retire only Go’s resolved `execution.batch-boundary-halt` conformance deviation; Node’s separate #134 deviation remains

## Why

The Go cancellation loop previously called the fresh-run API for every 100-rule batch. Each new call cleared the prior chunk’s halt latch and action diagnostics, so a rule halting exactly at activation 100 could fire activation 101 and report `AgendaEmpty` instead of `HaltRequested`.

Using the continuation API added by FR-CABI-009 preserves one logical run across host cancellation checks without changing the C ABI, runtime, Node binding, or public Go result types.

## Validation

- `just build-go-ffi`
- `just test-go-race`
- `cargo test -p ferric-rules-ffi logical_run_continuation`
- `uv run --project tools/ferric-tools ferric-bindings-conformance`
- `golangci-lint run ./...` (0 issues)
- `just preflight-pr`

An isolated red/green probe reproduced the old result as 101/`AgendaEmpty` on `main` and 100/`HaltRequested` with this commit.