### PR TITLE
[FR-GO-006] Interrupt active Go pinned runs

### DIFF
--- a/bindings/go/engine.go
+++ b/bindings/go/engine.go
@@ -13,6 +13,10 @@ import (
 
 var errIntOverflow = fmt.Errorf("ferric: integer overflow")
 
+// runBatchSize bounds the number of rule firings between host-side
+// cancellation or interruption checks in a chunked run.
+const runBatchSize = 100
+
 // Engine wraps a single ferric rules engine instance.
 //
 // An Engine is bound to the OS thread that created it. All methods
@@ -424,11 +428,24 @@ func (e *Engine) Run(ctx context.Context) (*RunResult, error) {
 }
 
 // RunWithLimit runs the engine with a maximum number of rule firings.
-// A limit of 0 means unlimited. Checks context for cancellation between
-// batches of rule firings. Cancellation returns the partial RunResult with
-// HaltRequested and an error wrapping ctx.Err(); an engine-requested halt
-// returns HaltRequested with a nil error.
+// A limit of 0 means unlimited. A cancelable context is checked between batches
+// of at most 100 rule firings; a noncancelable context uses one direct native
+// call. Cancellation returns the partial RunResult with HaltRequested and an
+// error wrapping ctx.Err(); an engine-requested halt returns HaltRequested with
+// a nil error.
 func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error) {
+	return e.runWithLimit(ctx, limit, nil)
+}
+
+// runWithLimit is the shared raw-engine run implementation. A non-nil
+// shouldInterrupt predicate forces chunked execution even when ctx itself is
+// not cancelable. The predicate is evaluated only on the engine's owner
+// thread, before the first chunk and between continuation chunks.
+func (e *Engine) runWithLimit(
+	ctx context.Context,
+	limit int,
+	shouldInterrupt func() bool,
+) (*RunResult, error) {
 	handle, release, err := e.leaseHandle()
 	if err != nil {
 		return nil, err
@@ -439,29 +456,35 @@ func (e *Engine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error
 		return nil, errNilContext
 	}
 
-	// If context has no deadline/cancel, use a single direct FFI call.
-	if ctx.Done() == nil {
+	// Preserve the raw Engine fast path when no host-side polling is needed.
+	if ctx.Done() == nil && shouldInterrupt == nil {
 		ffiLimit := int64(-1)
 		if limit > 0 {
 			ffiLimit = int64(limit)
 		}
 		return e.runDirect(handle, ffiLimit)
 	}
-	return e.runCancelable(ctx, handle, limit)
+	return e.runChunked(ctx, handle, limit, shouldInterrupt)
 }
 
-func (e *Engine) runCancelable(ctx context.Context, handle ffi.EngineHandle, limit int) (*RunResult, error) {
-	// For cancelable contexts, run in small batches and check context.
-	const batchSize = 100
+func (e *Engine) runChunked(
+	ctx context.Context,
+	handle ffi.EngineHandle,
+	limit int,
+	shouldInterrupt func() bool,
+) (*RunResult, error) {
 	totalFired := 0
 	runChunk := ffiEngineRunEx
 	for {
 		if err := ctx.Err(); err != nil {
 			return &RunResult{RulesFired: totalFired, HaltReason: HaltRequested}, fmt.Errorf("ferric: run canceled: %w", err)
 		}
+		if shouldInterrupt != nil && shouldInterrupt() {
+			return &RunResult{RulesFired: totalFired, HaltReason: HaltRequested}, nil
+		}
 
 		// Compute batch limit.
-		batch := int64(batchSize)
+		batch := int64(runBatchSize)
 		if limit > 0 {
 			remaining := int64(limit - totalFired)
 			if remaining <= 0 {

--- a/bindings/go/pinned_engine.go
+++ b/bindings/go/pinned_engine.go
@@ -16,7 +16,9 @@ var errPinnedEngineClosed = errors.New("ferric: pinned engine is closed")
 // serializes all engine operations through it.
 //
 // All methods are safe for concurrent use from multiple goroutines.
-// Operations are serialized on the internal worker goroutine in FIFO order.
+// Engine operations are serialized on the internal worker goroutine in FIFO
+// order. Halt and the initial Close signal are out-of-band controls so they can
+// interrupt an active Run without violating engine thread affinity.
 //
 // PinnedEngine implements io.Closer. Always defer Close() after creation.
 type PinnedEngine struct {
@@ -25,7 +27,12 @@ type PinnedEngine struct {
 	done       chan struct{}
 	closeOnce  sync.Once
 	closed     atomic.Bool
+	activeRun  atomic.Pointer[pinnedRunControl]
 	closeGuard sync.RWMutex // protects enqueue windows during shutdown
+}
+
+type pinnedRunControl struct {
+	halted atomic.Bool
 }
 
 type pinnedRequest struct {
@@ -89,14 +96,25 @@ func (p *PinnedEngine) drain(eng *Engine) {
 	}
 }
 
-// Close shuts down the PinnedEngine. It stops accepting new requests,
-// waits for all in-progress enqueue attempts to resolve, drains all
-// previously-accepted work, closes the underlying engine, and blocks
-// until the worker goroutine exits.
+// Close shuts down the PinnedEngine. It stops accepting new requests and
+// interrupts active and already-accepted queued Run requests. Close-induced
+// interruption uses the same cooperative-cancellation outcome as Halt: a
+// partial (or zero) RunResult with HaltRequested and a nil error, rather than
+// errPinnedEngineClosed. Requests rejected after Close begins return
+// errPinnedEngineClosed. Other previously-accepted work is drained before the
+// underlying engine is closed. Close then blocks until the worker goroutine
+// exits.
+//
+// Run interruption is cooperative and is observed between batches of at most
+// 100 rule firings. Close cannot preempt an arbitrary function submitted with
+// Do while that function is executing.
 //
 // Close is idempotent and safe to call from any goroutine.
 func (p *PinnedEngine) Close() error {
 	p.closeOnce.Do(func() {
+		// The run loop observes this sticky flag without going through the
+		// request queue. Publish it before waiting for enqueue readers so an
+		// active run can release a full queue and let shutdown make progress.
 		p.closed.Store(true)
 		// Wait for all in-progress enqueue attempts to resolve,
 		// then signal worker to stop while holding the write lock.
@@ -271,20 +289,50 @@ func (p *PinnedEngine) FactCount() (int, error) {
 // Execution
 // ---------------------------------------------------------------------------
 
-// Run runs the engine to completion, checking context for cancellation.
+// Run runs the engine to completion, checking context for cancellation and
+// PinnedEngine interruption between batches of at most 100 rule firings.
 func (p *PinnedEngine) Run(ctx context.Context) (*RunResult, error) {
 	return p.RunWithLimit(ctx, 0)
 }
 
 // RunWithLimit runs the engine with a maximum number of rule firings.
-// A limit of 0 means unlimited. Checks context for cancellation.
+// A limit of 0 means unlimited. Context cancellation before queue acceptance
+// rejects the request. Once accepted, RunWithLimit waits for the cooperative
+// worker response; context cancellation returns a partial RunResult with
+// HaltRequested and an error wrapping ctx.Err(). Halt or Close interruption
+// returns a partial (or zero) RunResult with HaltRequested and a nil error.
+// A native terminal result or completed explicit limit wins first; at an
+// internal batch boundary, caller context cancellation wins over simultaneous
+// Halt or Close interruption.
 func (p *PinnedEngine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error) {
+	if ctx == nil {
+		return nil, errNilContext
+	}
+
 	var result *RunResult
-	err := p.Do(ctx, func(e *Engine) error {
-		var err error
-		result, err = e.RunWithLimit(ctx, limit)
-		return err
-	})
+	resp := make(chan error, 1)
+	req := pinnedRequest{
+		resp: resp,
+		fn: func(e *Engine) error {
+			control := &pinnedRunControl{}
+			p.activeRun.Store(control)
+			defer p.activeRun.CompareAndSwap(control, nil)
+
+			var err error
+			result, err = e.runWithLimit(ctx, limit, func() bool {
+				return control.halted.Load() || p.closed.Load()
+			})
+			return err
+		},
+	}
+	if err := p.tryEnqueue(ctx, req); err != nil {
+		return nil, err
+	}
+
+	// An accepted run observes ctx itself between chunks. Waiting for the
+	// worker's sole response gives the captured result a channel happens-before
+	// edge and prevents Do's post-dispatch cancellation select from racing it.
+	err := <-resp
 	return result, err
 }
 
@@ -300,12 +348,13 @@ func (p *PinnedEngine) Step() (*FiredRule, error) {
 	return fr, err
 }
 
-// Halt requests the engine to halt.
+// Halt requests that the currently active Run stop at the next batch boundary.
+// It returns immediately, has no effect while the worker is idle or handling a
+// non-Run operation, and does not latch onto queued or future runs.
 func (p *PinnedEngine) Halt() {
-	_ = p.do(func(e *Engine) error {
-		e.Halt()
-		return nil
-	})
+	if control := p.activeRun.Load(); control != nil {
+		control.halted.Store(true)
+	}
 }
 
 // Reset resets the engine to its initial state (facts cleared, rules kept).

--- a/bindings/go/pinned_engine_interrupt_test.go
+++ b/bindings/go/pinned_engine_interrupt_test.go
@@ -1,0 +1,690 @@
+package ferric
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
+)
+
+const pinnedInterruptTestTimeout = 2 * time.Second
+
+const pinnedCyclingRules = `
+	(defrule cycle
+		?fact <- (counter ?value)
+		=>
+		(retract ?fact)
+		(assert (counter (+ ?value 1))))
+	(deffacts initial (counter 0))
+`
+
+type pinnedRunTestOutcome struct {
+	result *RunResult
+	err    error
+}
+
+func startPinnedTestRun(ctx context.Context, engine *PinnedEngine, limit int) <-chan pinnedRunTestOutcome {
+	outcomes := make(chan pinnedRunTestOutcome, 1)
+	go func() {
+		result, err := engine.RunWithLimit(ctx, limit)
+		outcomes <- pinnedRunTestOutcome{result: result, err: err}
+		close(outcomes)
+	}()
+	return outcomes
+}
+
+func waitForPinnedActiveRun(t *testing.T, engine *PinnedEngine) {
+	t.Helper()
+
+	deadline := time.NewTimer(pinnedInterruptTestTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if engine.activeRun.Load() != nil {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatal("pinned run did not become active")
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForPinnedQueueDepth(t *testing.T, engine *PinnedEngine, depth int) {
+	t.Helper()
+
+	deadline := time.NewTimer(pinnedInterruptTestTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if len(engine.requests) >= depth {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("pinned request queue depth did not reach %d", depth)
+		case <-ticker.C:
+		}
+	}
+}
+
+func receivePinnedRunOutcome(t *testing.T, outcomes <-chan pinnedRunTestOutcome) pinnedRunTestOutcome {
+	t.Helper()
+	select {
+	case outcome := <-outcomes:
+		return outcome
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("pinned run did not settle")
+		return pinnedRunTestOutcome{}
+	}
+}
+
+func newPinnedCyclingEngine(t *testing.T) *PinnedEngine {
+	t.Helper()
+	engine, err := NewPinnedEngine(WithSource(pinnedCyclingRules))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engine.Reset(); err != nil {
+		_ = engine.Close()
+		t.Fatal(err)
+	}
+	return engine
+}
+
+func TestPinnedEngineRunUsesBoundedLogicalContinuation(t *testing.T) {
+	withFFIHooks(t)
+
+	var calls []string
+	ffiEngineRunEx = func(_ ffi.EngineHandle, limit int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		calls = append(calls, fmt.Sprintf("run:%d", limit))
+		return uint64(runBatchSize), ffi.HaltReasonLimitReached, ffi.ErrOK
+	}
+	ffiEngineIsHalted = func(ffi.EngineHandle) (bool, ffi.ErrorCode) {
+		calls = append(calls, "is-halted")
+		return false, ffi.ErrOK
+	}
+	ffiEngineContinueRunEx = func(_ ffi.EngineHandle, limit int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		calls = append(calls, fmt.Sprintf("continue:%d", limit))
+		return 1, ffi.HaltReasonAgendaEmpty, ffi.ErrOK
+	}
+
+	engine, err := NewPinnedEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, engine)
+
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := RunResult{RulesFired: runBatchSize + 1, HaltReason: HaltAgendaEmpty}
+	if result == nil || *result != want {
+		t.Fatalf("run result = %+v, want %+v", result, want)
+	}
+	wantCalls := []string{
+		fmt.Sprintf("run:%d", runBatchSize),
+		"is-halted",
+		fmt.Sprintf("continue:%d", runBatchSize),
+	}
+	if !slices.Equal(calls, wantCalls) {
+		t.Fatalf("FFI calls = %v, want %v", calls, wantCalls)
+	}
+}
+
+//nolint:funlen // Keep the interruption handshake and its timeout-safe cleanup together.
+func TestPinnedEngineHaltInterruptsActiveUnlimitedRun(t *testing.T) {
+	withFFIHooks(t)
+
+	originalRunEx := ffiEngineRunEx
+	enteredChunk := make(chan struct{})
+	releaseChunk := make(chan struct{})
+	var enterOnce sync.Once
+	var releaseOnce sync.Once
+	ffiEngineRunEx = func(handle ffi.EngineHandle, limit int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		enterOnce.Do(func() { close(enteredChunk) })
+		<-releaseChunk
+		return originalRunEx(handle, limit)
+	}
+
+	engine := newPinnedCyclingEngine(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(func() {
+		cancel()
+		releaseOnce.Do(func() { close(releaseChunk) })
+		_ = engine.Close()
+	})
+	outcomes := startPinnedTestRun(ctx, engine, 0)
+
+	select {
+	case <-enteredChunk:
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("unlimited run did not enter its first native chunk")
+	}
+
+	haltDone := make(chan struct{})
+	go func() {
+		engine.Halt()
+		close(haltDone)
+	}()
+	select {
+	case <-haltDone:
+	case <-time.After(pinnedInterruptTestTimeout):
+		cancel()
+		releaseOnce.Do(func() { close(releaseChunk) })
+		t.Fatal("Halt blocked behind the active unlimited run")
+	}
+	releaseOnce.Do(func() { close(releaseChunk) })
+
+	outcome := receivePinnedRunOutcome(t, outcomes)
+	if outcome.err != nil {
+		t.Fatalf("halted run error = %v, want nil", outcome.err)
+	}
+	if outcome.result == nil || outcome.result.HaltReason != HaltRequested {
+		t.Fatalf("halted run result = %+v, want partial HaltRequested", outcome.result)
+	}
+	if outcome.result.RulesFired == 0 || outcome.result.RulesFired > runBatchSize {
+		t.Fatalf("halted run fired %d rules, want 1..%d", outcome.result.RulesFired, runBatchSize)
+	}
+
+	result, err := engine.RunWithLimit(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("worker reuse run failed: %v", err)
+	}
+	want := RunResult{RulesFired: 5, HaltReason: HaltLimitReached}
+	if result == nil || *result != want {
+		t.Fatalf("worker reuse run result = %+v, want %+v", result, want)
+	}
+}
+
+func TestPinnedEngineHaltWhileIdleDoesNotLatch(t *testing.T) {
+	engine := newPinnedCyclingEngine(t)
+	defer mustClose(t, engine)
+
+	engine.Halt()
+	result, err := engine.RunWithLimit(context.Background(), 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := RunResult{RulesFired: 5, HaltReason: HaltLimitReached}
+	if result == nil || *result != want {
+		t.Fatalf("run after idle Halt = %+v, want %+v", result, want)
+	}
+}
+
+func TestPinnedEngineHaltDoesNotLatchOntoQueuedRun(t *testing.T) {
+	engine := newPinnedCyclingEngine(t)
+	releaseBlocker := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseBlocker) })
+		_ = engine.Close()
+	})
+
+	blockerEntered := make(chan struct{})
+	blockerDone := make(chan error, 1)
+	go func() {
+		blockerDone <- engine.Do(context.Background(), func(*Engine) error {
+			close(blockerEntered)
+			<-releaseBlocker
+			return nil
+		})
+	}()
+	select {
+	case <-blockerEntered:
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("blocking request did not start")
+	}
+
+	runCtx, cancelRun := context.WithCancel(t.Context())
+	defer cancelRun()
+	outcomes := startPinnedTestRun(runCtx, engine, 5)
+	waitForPinnedQueueDepth(t, engine, 1)
+
+	haltDone := make(chan struct{})
+	go func() {
+		engine.Halt()
+		close(haltDone)
+	}()
+	select {
+	case <-haltDone:
+	case <-time.After(pinnedInterruptTestTimeout):
+		cancelRun()
+		releaseOnce.Do(func() { close(releaseBlocker) })
+		t.Fatal("Halt blocked behind a non-Run request")
+	}
+
+	releaseOnce.Do(func() { close(releaseBlocker) })
+	select {
+	case err := <-blockerDone:
+		if err != nil {
+			t.Fatalf("blocking request failed: %v", err)
+		}
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("blocking request did not finish")
+	}
+	outcome := receivePinnedRunOutcome(t, outcomes)
+	if outcome.err != nil {
+		t.Fatal(outcome.err)
+	}
+	want := RunResult{RulesFired: 5, HaltReason: HaltLimitReached}
+	if outcome.result == nil || *outcome.result != want {
+		t.Fatalf("queued run result = %+v, want %+v", outcome.result, want)
+	}
+}
+
+//nolint:funlen // Keep the shutdown handshake and all terminal assertions together.
+func TestPinnedEngineCloseInterruptsActiveUnlimitedRun(t *testing.T) {
+	withFFIHooks(t)
+
+	originalRunEx := ffiEngineRunEx
+	enteredChunk := make(chan struct{})
+	releaseChunk := make(chan struct{})
+	var enterOnce sync.Once
+	var releaseOnce sync.Once
+	ffiEngineRunEx = func(handle ffi.EngineHandle, limit int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		enterOnce.Do(func() { close(enteredChunk) })
+		<-releaseChunk
+		return originalRunEx(handle, limit)
+	}
+
+	engine := newPinnedCyclingEngine(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(func() {
+		cancel()
+		releaseOnce.Do(func() { close(releaseChunk) })
+		_ = engine.Close()
+	})
+	outcomes := startPinnedTestRun(ctx, engine, 0)
+	select {
+	case <-enteredChunk:
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("unlimited run did not enter its first native chunk")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- engine.Close() }()
+	deadline := time.NewTimer(pinnedInterruptTestTimeout)
+	defer deadline.Stop()
+	for !engine.closed.Load() {
+		select {
+		case <-deadline.C:
+			t.Fatal("Close did not publish closed state before waiting")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	releaseOnce.Do(func() { close(releaseChunk) })
+
+	outcome := receivePinnedRunOutcome(t, outcomes)
+	if outcome.err != nil {
+		t.Fatalf("run interrupted by Close error = %v, want nil", outcome.err)
+	}
+	if outcome.result == nil || outcome.result.HaltReason != HaltRequested {
+		t.Fatalf("run interrupted by Close = %+v, want partial HaltRequested", outcome.result)
+	}
+	if outcome.result.RulesFired == 0 || outcome.result.RulesFired > runBatchSize {
+		t.Fatalf("closed run fired %d rules, want 1..%d", outcome.result.RulesFired, runBatchSize)
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("Close did not finish after the active chunk returned")
+	}
+
+	result, err := engine.Run(context.Background())
+	if result != nil || !errors.Is(err, errPinnedEngineClosed) {
+		t.Fatalf("post-close run = (%+v, %v), want nil/errPinnedEngineClosed", result, err)
+	}
+}
+
+//nolint:funlen // The staged queue verifies run cancellation and non-run draining together.
+func TestPinnedEngineCloseInterruptsQueuedRunAndDrainsNonRunWork(t *testing.T) {
+	engine := newPinnedCyclingEngine(t)
+	releaseBlocker := make(chan struct{})
+	var releaseOnce sync.Once
+	runCtx, cancelRun := context.WithCancel(t.Context())
+	t.Cleanup(func() {
+		cancelRun()
+		releaseOnce.Do(func() { close(releaseBlocker) })
+		_ = engine.Close()
+	})
+
+	blockerEntered := make(chan struct{})
+	blockerDone := make(chan error, 1)
+	go func() {
+		blockerDone <- engine.Do(context.Background(), func(*Engine) error {
+			close(blockerEntered)
+			<-releaseBlocker
+			return nil
+		})
+	}()
+	select {
+	case <-blockerEntered:
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("blocking request did not start")
+	}
+
+	runOutcomes := startPinnedTestRun(runCtx, engine, 0)
+	waitForPinnedQueueDepth(t, engine, 1)
+	drainDone := make(chan error, 1)
+	go func() {
+		drainDone <- engine.Do(context.Background(), func(*Engine) error {
+			return errTestSentinel
+		})
+	}()
+	waitForPinnedQueueDepth(t, engine, 2)
+
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- engine.Close() }()
+	deadline := time.NewTimer(pinnedInterruptTestTimeout)
+	defer deadline.Stop()
+	for !engine.closed.Load() {
+		select {
+		case <-deadline.C:
+			t.Fatal("Close did not publish closed state")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	releaseOnce.Do(func() { close(releaseBlocker) })
+
+	select {
+	case err := <-blockerDone:
+		if err != nil {
+			t.Fatalf("blocking request failed: %v", err)
+		}
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("blocking request did not finish")
+	}
+	runOutcome := receivePinnedRunOutcome(t, runOutcomes)
+	wantRun := RunResult{RulesFired: 0, HaltReason: HaltRequested}
+	if runOutcome.err != nil || runOutcome.result == nil || *runOutcome.result != wantRun {
+		t.Fatalf("queued run outcome = (%+v, %v), want %+v/nil", runOutcome.result, runOutcome.err, wantRun)
+	}
+	select {
+	case err := <-drainDone:
+		if !errors.Is(err, errTestSentinel) {
+			t.Fatalf("accepted non-Run result = %v, want sentinel", err)
+		}
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("accepted non-Run work was not drained")
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("Close did not finish after draining accepted work")
+	}
+}
+
+func TestPinnedEngineExplicitLimitWinsAtInterruptBoundary(t *testing.T) {
+	withFFIHooks(t)
+
+	enteredChunk := make(chan struct{})
+	releaseChunk := make(chan struct{})
+	var releaseOnce sync.Once
+	ffiEngineRunEx = func(_ ffi.EngineHandle, _ int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		close(enteredChunk)
+		<-releaseChunk
+		return uint64(runBatchSize), ffi.HaltReasonLimitReached, ffi.ErrOK
+	}
+
+	engine, err := NewPinnedEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(func() {
+		cancel()
+		releaseOnce.Do(func() { close(releaseChunk) })
+		_ = engine.Close()
+	})
+	outcomes := startPinnedTestRun(ctx, engine, runBatchSize)
+	select {
+	case <-enteredChunk:
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("limited run did not enter its native chunk")
+	}
+	engine.Halt()
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- engine.Close() }()
+	deadline := time.NewTimer(pinnedInterruptTestTimeout)
+	defer deadline.Stop()
+	for !engine.closed.Load() {
+		select {
+		case <-deadline.C:
+			t.Fatal("Close did not publish closed state")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	cancel()
+	releaseOnce.Do(func() { close(releaseChunk) })
+
+	outcome := receivePinnedRunOutcome(t, outcomes)
+	want := RunResult{RulesFired: runBatchSize, HaltReason: HaltLimitReached}
+	if outcome.err != nil || outcome.result == nil || *outcome.result != want {
+		t.Fatalf("exact-boundary outcome = (%+v, %v), want %+v/nil", outcome.result, outcome.err, want)
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("Close did not settle after the explicit-limit run")
+	}
+}
+
+func TestPinnedEngineContextWinsAtInterruptBoundary(t *testing.T) {
+	withFFIHooks(t)
+
+	enteredChunk := make(chan struct{})
+	releaseChunk := make(chan struct{})
+	var releaseOnce sync.Once
+	ffiEngineRunEx = func(_ ffi.EngineHandle, _ int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		close(enteredChunk)
+		<-releaseChunk
+		return 1, ffi.HaltReasonLimitReached, ffi.ErrOK
+	}
+
+	engine, err := NewPinnedEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(func() {
+		cancel()
+		releaseOnce.Do(func() { close(releaseChunk) })
+		_ = engine.Close()
+	})
+	outcomes := startPinnedTestRun(ctx, engine, 0)
+	select {
+	case <-enteredChunk:
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("run did not enter its native chunk")
+	}
+
+	engine.Halt()
+	closeDone := make(chan error, 1)
+	go func() { closeDone <- engine.Close() }()
+	deadline := time.NewTimer(pinnedInterruptTestTimeout)
+	defer deadline.Stop()
+	for !engine.closed.Load() {
+		select {
+		case <-deadline.C:
+			t.Fatal("Close did not publish closed state")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	cancel()
+	releaseOnce.Do(func() { close(releaseChunk) })
+
+	outcome := receivePinnedRunOutcome(t, outcomes)
+	want := RunResult{RulesFired: 1, HaltReason: HaltRequested}
+	if outcome.result == nil || *outcome.result != want || !errors.Is(outcome.err, context.Canceled) {
+		t.Fatalf("context-priority outcome = (%+v, %v), want %+v/context.Canceled", outcome.result, outcome.err, want)
+	}
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("Close did not settle after context cancellation")
+	}
+}
+
+func TestPinnedEngineAcceptedQueuedRunWaitsForCooperativeCancellation(t *testing.T) {
+	engine := newPinnedCyclingEngine(t)
+	releaseBlocker := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseBlocker) })
+		_ = engine.Close()
+	})
+
+	blockerEntered := make(chan struct{})
+	blockerDone := make(chan error, 1)
+	go func() {
+		blockerDone <- engine.Do(context.Background(), func(*Engine) error {
+			close(blockerEntered)
+			<-releaseBlocker
+			return nil
+		})
+	}()
+	select {
+	case <-blockerEntered:
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("blocking request did not start")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	outcomes := startPinnedTestRun(ctx, engine, 0)
+	waitForPinnedQueueDepth(t, engine, 1)
+	cancel()
+
+	select {
+	case outcome := <-outcomes:
+		t.Fatalf("accepted queued run returned before its worker response: (%+v, %v)", outcome.result, outcome.err)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	releaseOnce.Do(func() { close(releaseBlocker) })
+	select {
+	case err := <-blockerDone:
+		if err != nil {
+			t.Fatalf("blocking request failed: %v", err)
+		}
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("blocking request did not finish")
+	}
+	outcome := receivePinnedRunOutcome(t, outcomes)
+	want := RunResult{RulesFired: 0, HaltReason: HaltRequested}
+	if outcome.result == nil || *outcome.result != want || !errors.Is(outcome.err, context.Canceled) {
+		t.Fatalf("queued cancellation outcome = (%+v, %v), want %+v/context.Canceled", outcome.result, outcome.err, want)
+	}
+}
+
+//nolint:funlen // Each iteration owns a complete three-way race and cleanup barrier.
+func TestPinnedEngineCompetingInterruptsSettleRunOnce(t *testing.T) {
+	const iterations = 25
+	for iteration := range iterations {
+		t.Run(fmt.Sprintf("iteration-%d", iteration), func(t *testing.T) {
+			withFFIHooks(t)
+
+			enteredChunk := make(chan struct{})
+			releaseChunk := make(chan struct{})
+			ffiEngineRunEx = func(_ ffi.EngineHandle, _ int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+				close(enteredChunk)
+				<-releaseChunk
+				return 1, ffi.HaltReasonLimitReached, ffi.ErrOK
+			}
+
+			engine, err := NewPinnedEngine()
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			t.Cleanup(func() {
+				cancel()
+				_ = engine.Close()
+			})
+			outcomes := startPinnedTestRun(ctx, engine, 0)
+			select {
+			case <-enteredChunk:
+			case <-time.After(pinnedInterruptTestTimeout):
+				t.Fatal("run did not enter native chunk")
+			}
+
+			start := make(chan struct{})
+			haltDone := make(chan struct{})
+			closeDone := make(chan error, 1)
+			cancelDone := make(chan struct{})
+			go func() {
+				<-start
+				engine.Halt()
+				close(haltDone)
+			}()
+			go func() {
+				<-start
+				closeDone <- engine.Close()
+			}()
+			go func() {
+				<-start
+				cancel()
+				close(cancelDone)
+			}()
+			close(start)
+			<-haltDone
+			<-cancelDone
+			deadline := time.NewTimer(pinnedInterruptTestTimeout)
+			for !engine.closed.Load() {
+				select {
+				case <-deadline.C:
+					t.Fatal("competing Close did not publish closed state")
+				default:
+					time.Sleep(time.Millisecond)
+				}
+			}
+			deadline.Stop()
+			close(releaseChunk)
+
+			outcome := receivePinnedRunOutcome(t, outcomes)
+			if outcome.result == nil || outcome.result.HaltReason != HaltRequested {
+				t.Fatalf("competing interrupt result = %+v, want HaltRequested", outcome.result)
+			}
+			if !errors.Is(outcome.err, context.Canceled) {
+				t.Fatalf("competing interrupt error = %v, want context.Canceled", outcome.err)
+			}
+			if _, ok := <-outcomes; ok {
+				t.Fatal("run produced more than one terminal outcome")
+			}
+			select {
+			case err := <-closeDone:
+				if err != nil {
+					t.Fatalf("Close failed: %v", err)
+				}
+			case <-time.After(pinnedInterruptTestTimeout):
+				t.Fatal("competing Close did not settle")
+			}
+		})
+	}
+}

--- a/bindings/go/pinned_engine_test.go
+++ b/bindings/go/pinned_engine_test.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -223,20 +222,21 @@ func TestPinnedEngine_RunWithLimit(t *testing.T) {
 }
 
 func TestPinnedEngine_RunContextCancellation(t *testing.T) {
-	// Use a rule that produces unbounded activations so we can test cancel.
-	src := `(defrule loop (initial-fact) => (assert (tick)))`
-	p, err := NewPinnedEngine(WithSource(src))
+	p, err := NewPinnedEngine(WithSource(pinnedCyclingRules))
 	require.NoError(t, err)
 	defer mustClose(t, p)
+	require.NoError(t, p.Reset())
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	_, err = p.Run(ctx)
-	// Should either complete or be canceled — both are acceptable.
-	if err != nil {
-		assert.ErrorIs(t, err, context.DeadlineExceeded)
-	}
+	outcomes := startPinnedTestRun(ctx, p, 0)
+	waitForPinnedActiveRun(t, p)
+	cancel()
+	outcome := receivePinnedRunOutcome(t, outcomes)
+	require.ErrorIs(t, outcome.err, context.Canceled)
+	require.NotNil(t, outcome.result)
+	assert.Equal(t, HaltRequested, outcome.result.HaltReason)
 }
 
 func TestPinnedEngine_Step(t *testing.T) {


### PR DESCRIPTION
Closes #128

## Summary

- force `PinnedEngine` runs through bounded 100-firing continuation chunks, including unlimited runs with a background context
- make `Halt` signal only the currently active run without queueing or latching onto future work
- make `Close` publish a sticky out-of-band interruption before waiting, so active and already-accepted queued runs settle and shutdown can drain
- preserve raw `Engine` fast-path behavior and the continuation/limit/cancellation precedence established by FR-GO-005
- replace the vacuous cancellation test and add deterministic active, queued, exact-boundary, reuse, shutdown, and three-way race coverage

## Root cause

`PinnedEngine.Run` previously submitted a single unlimited native run to its sole worker. `Halt` was queued behind that run, while `Close` waited for the same blocked worker, so neither could interrupt a genuinely cycling ruleset.

## Behavior

Accepted runs interrupted by `Halt` or `Close` return a partial (or zero) `RunResult` with `HaltRequested` and no error, matching the Rust pinned-engine contract. Context cancellation remains distinguishable through an error wrapping `ctx.Err()`; work rejected after closure still returns the closed-engine error. Interruption latency is bounded by 100 rule firings, and all engine/FFI calls remain on the pinned worker thread.

## Validation

- `just preflight-pr`
- `just go-full`
- `just test-go-stress 50`
- `just run-golang-ci`
- full `go test -race ./... -count=1`
- focused interrupt/race tests and isolated red/green exact-boundary reproduction
