### PR TITLE
[FR-GO-008] Own Go worker cancellation results

### DIFF
--- a/bindings/go/coordinator.go
+++ b/bindings/go/coordinator.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -43,14 +42,13 @@ func (roundRobinPolicy) PickWorker(_ RouteHint, numWorkers int, counter uint64) 
 // Coordinator manages a pool of OS threads and a fixed set of engine types.
 // Engines are lazily instantiated per-thread on first use.
 type Coordinator struct {
-	specs      map[string][]EngineOption
-	workers    []*worker
-	next       atomic.Uint64
-	policy     DispatchPolicy
-	done       chan struct{}
-	closed     atomic.Bool
-	obs        *obs
-	closeGuard sync.RWMutex // protects enqueue windows during shutdown
+	specs   map[string][]EngineOption
+	workers []*worker
+	next    atomic.Uint64
+	policy  DispatchPolicy
+	done    chan struct{}
+	closed  atomic.Bool
+	obs     *obs
 }
 
 // NewCoordinator creates a Coordinator with the given engine specs and
@@ -94,24 +92,20 @@ func (c *Coordinator) pickWorker(hint RouteHint) *worker {
 	return c.workers[idx]
 }
 
-// Close shuts down the coordinator. It stops accepting new requests, drains
-// all previously-accepted work so that every in-flight request completes with
-// its real result, and then frees all engines. Blocks until every accepted
-// request has been processed and all worker goroutines have exited.
+// Close shuts down the coordinator. It stops accepting new requests, completes
+// all non-canceled work already queued or started, and then frees all engines.
+// It blocks until the worker goroutines have exited.
 func (c *Coordinator) Close() error {
 	if !c.closed.CompareAndSwap(false, true) {
 		return nil
 	}
 	// Phase 1: Signal callers that no new work will be accepted.
 	close(c.done)
-	// Phase 2: Wait for all in-progress enqueue attempts to resolve,
-	// then drain and stop workers while holding the write lock.
-	// The write lock blocks until every RLock holder (tryEnqueue) exits.
-	// After this returns, no goroutine can write to any worker channel.
-	c.closeGuard.Lock()
+	// Phase 2: Closing each request queue wakes blocked submitters and lets its
+	// worker drain all remaining, non-canceled requests before exiting.
 	for _, w := range c.workers {
 		if w != nil {
-			close(w.stop)
+			w.requests.close()
 		}
 	}
 	for _, w := range c.workers {
@@ -119,7 +113,6 @@ func (c *Coordinator) Close() error {
 			<-w.done
 		}
 	}
-	c.closeGuard.Unlock()
 	return nil
 }
 
@@ -129,16 +122,14 @@ func (c *Coordinator) Close() error {
 
 type workerRequest struct {
 	specName   string
-	fn         func(*Engine) error
-	resp       chan error
+	call       *workerCall
 	enqueuedAt time.Time
 }
 
 type worker struct {
 	specs    map[string][]EngineOption
 	engines  map[string]*Engine
-	requests chan workerRequest
-	stop     chan struct{}
+	requests *requestQueue[workerRequest]
 	done     chan struct{}
 	obs      *obs
 }
@@ -147,8 +138,7 @@ func newWorker(specs map[string][]EngineOption, o *obs) *worker {
 	w := &worker{
 		specs:    specs,
 		engines:  make(map[string]*Engine),
-		requests: make(chan workerRequest, 16),
-		stop:     make(chan struct{}),
+		requests: newRequestQueue[workerRequest](workerRequestQueueCapacity),
 		done:     make(chan struct{}),
 		obs:      o,
 	}
@@ -164,13 +154,11 @@ func newWorker(specs map[string][]EngineOption, o *obs) *worker {
 		close(ready)
 
 		for {
-			select {
-			case <-w.stop:
-				w.drain()
+			request := w.requests.dequeue()
+			if !request.ok {
 				return
-			case req := <-w.requests:
-				w.handle(req)
 			}
+			w.handle(request.value)
 		}
 	}()
 
@@ -185,24 +173,7 @@ func (w *worker) handle(req workerRequest) {
 			metric.WithAttributes(specAttr))
 	}
 	engine, err := w.getOrCreateEngine(req.specName)
-	if err != nil {
-		req.resp <- err
-		return
-	}
-	req.resp <- invokeWorkerCallback(engine, req.fn)
-}
-
-// drain processes all buffered requests remaining in the channel so that
-// accepted work always completes with its real result during shutdown.
-func (w *worker) drain() {
-	for {
-		select {
-		case req := <-w.requests:
-			w.handle(req)
-		default:
-			return
-		}
-	}
+	req.call.complete(engine, err)
 }
 
 func (w *worker) getOrCreateEngine(specName string) (*Engine, error) {

--- a/bindings/go/coordinator_test.go
+++ b/bindings/go/coordinator_test.go
@@ -806,15 +806,15 @@ func TestCoordinatorCancelDuringEnqueue(t *testing.T) {
 			})
 		})
 	}
-	runtime.Gosched()
-	time.Sleep(30 * time.Millisecond)
+	waitForRequestQueueLength(t, coord.workers[0].requests, workerRequestQueueCapacity)
 
 	// Now try to enqueue with a context that will be canceled shortly.
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
 	defer cancel()
 
+	var callbackCalls atomic.Int32
 	err = mgr.Do(ctx, func(_ *Engine) error {
-		t.Fatal("callback should not run — context canceled before dispatch")
+		callbackCalls.Add(1)
 		return nil
 	})
 	if err == nil {
@@ -822,6 +822,9 @@ func TestCoordinatorCancelDuringEnqueue(t *testing.T) {
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected DeadlineExceeded, got: %v", err)
+	}
+	if calls := callbackCalls.Load(); calls != 0 {
+		t.Fatalf("callback canceled before admission ran %d times, want 0", calls)
 	}
 }
 
@@ -842,7 +845,8 @@ func TestCoordinatorCancelDuringWait(t *testing.T) {
 	// Block the worker with a slow request.
 	workerBusy := make(chan struct{})
 	proceed := make(chan struct{})
-	defer close(proceed)
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(proceed) }) })
 
 	var wg sync.WaitGroup
 	wg.Go(func() {
@@ -854,19 +858,35 @@ func TestCoordinatorCancelDuringWait(t *testing.T) {
 	})
 	<-workerBusy
 
-	// Enqueue a request whose context will expire while waiting.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	// Enqueue a request, then cancel it while it is still removable.
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	err = mgr.Do(ctx, func(_ *Engine) error {
-		return nil
-	})
+	var callbackCalls atomic.Int32
+	result := make(chan error, 1)
+	go func() {
+		result <- mgr.Do(ctx, func(_ *Engine) error {
+			callbackCalls.Add(1)
+			return nil
+		})
+	}()
+	waitForRequestQueueLength(t, coord.workers[0].requests, 1)
+	cancel()
+	select {
+	case err = <-result:
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatal("queued cancellation did not return while worker remained blocked")
+	}
 	if err == nil {
 		t.Fatal("expected cancellation error")
 	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("expected DeadlineExceeded, got: %v", err)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
 	}
+	waitForRequestQueueLength(t, coord.workers[0].requests, 0)
+	if calls := callbackCalls.Load(); calls != 0 {
+		t.Fatalf("queued canceled callback ran %d times, want 0", calls)
+	}
+	releaseOnce.Do(func() { close(proceed) })
 }
 
 // TestCoordinatorCancelRacesWithClose verifies correctness when cancellation

--- a/bindings/go/coverage_edge_test.go
+++ b/bindings/go/coverage_edge_test.go
@@ -617,8 +617,7 @@ func TestManualCoordinatorWorkerAndManagerErrorBranches(t *testing.T) {
 	w := &worker{
 		specs:    map[string][]EngineOption{"bad": {WithSource("(defrule bad")}},
 		engines:  make(map[string]*Engine),
-		requests: make(chan workerRequest, 1),
-		stop:     make(chan struct{}),
+		requests: newRequestQueue[workerRequest](1),
 		done:     make(chan struct{}),
 		obs:      o,
 	}
@@ -632,10 +631,12 @@ func TestManualCoordinatorWorkerAndManagerErrorBranches(t *testing.T) {
 		t.Fatalf("expected cold-start failure log, got %q", buf.String())
 	}
 
-	resp := make(chan error, 1)
-	w.handle(workerRequest{specName: "missing", resp: resp})
-	if err := <-resp; !errors.Is(err, errUnknownEngineSpec) {
-		t.Fatalf("worker handle missing spec = %v", err)
+	call, responses := newWorkerCall(func(*Engine) (struct{}, error) {
+		return struct{}{}, nil
+	})
+	w.handle(workerRequest{specName: "missing", call: call})
+	if response := <-responses; !errors.Is(response.err, errUnknownEngineSpec) {
+		t.Fatalf("worker handle missing spec = %v", response.err)
 	}
 
 	mgr, err := NewManager(WithSource(`(defrule r => (assert (ok)))`))
@@ -740,8 +741,8 @@ func TestManualAssertWireFactsAndEvaluateNativeErrors(t *testing.T) {
 }
 
 func TestManualPinnedEngineCancellationAndSerializationFile(t *testing.T) {
-	// PinnedEngine should forward file serialization and respect cancellation
-	// while waiting for an already-dispatched worker operation to finish.
+	// PinnedEngine should forward file serialization and preserve the real
+	// callback result once an already-dispatched operation has started.
 	p, err := NewPinnedEngine(WithSource(`(defrule r => (assert (ok)))`))
 	if err != nil {
 		t.Fatal(err)
@@ -760,6 +761,12 @@ func TestManualPinnedEngineCancellationAndSerializationFile(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	started := make(chan struct{})
 	release := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(release)
+		}
+	}()
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- p.Do(ctx, func(*Engine) error {
@@ -770,10 +777,20 @@ func TestManualPinnedEngineCancellationAndSerializationFile(t *testing.T) {
 	}()
 	<-started
 	cancel()
-	err = <-errCh
+	select {
+	case earlyErr := <-errCh:
+		t.Fatalf("started PinnedEngine.Do returned before its callback settled: %v", earlyErr)
+	case <-time.After(25 * time.Millisecond):
+	}
 	close(release)
-	if err == nil || !errors.Is(err, context.Canceled) {
-		t.Fatalf("PinnedEngine.Do canceled while waiting = %v", err)
+	released = true
+	select {
+	case err = <-errCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("started PinnedEngine.Do did not settle after callback release")
+	}
+	if err != nil {
+		t.Fatalf("started PinnedEngine.Do result after cancellation = %v, want callback result", err)
 	}
 
 	if err := p.Close(); err != nil {
@@ -784,13 +801,14 @@ func TestManualPinnedEngineCancellationAndSerializationFile(t *testing.T) {
 	}
 
 	blocked := &PinnedEngine{
-		requests: make(chan pinnedRequest),
+		requests: newRequestQueue[pinnedRequest](0),
 		done:     make(chan struct{}),
 	}
 	blockedCtx, blockedCancel := context.WithCancel(context.Background())
 	blockedErr := make(chan error, 1)
 	go func() {
-		blockedErr <- blocked.tryEnqueue(blockedCtx, pinnedRequest{resp: make(chan error, 1)})
+		_, err := blocked.tryEnqueue(blockedCtx, pinnedRequest{})
+		blockedErr <- err
 	}()
 	blockedCancel()
 	if err := <-blockedErr; err == nil || !errors.Is(err, context.Canceled) {
@@ -1271,8 +1289,8 @@ func TestManualHookedEvaluateAndPinnedEdges(t *testing.T) {
 		withFFIHooks(t)
 		done := make(chan struct{})
 		close(done)
-		p := &PinnedEngine{requests: make(chan pinnedRequest), done: make(chan struct{})}
-		err := p.tryEnqueue(doneOnlyContext{done: done}, pinnedRequest{resp: make(chan error, 1)})
+		p := &PinnedEngine{requests: newRequestQueue[pinnedRequest](0), done: make(chan struct{})}
+		_, err := p.tryEnqueue(doneOnlyContext{done: done}, pinnedRequest{})
 		if err == nil {
 			t.Fatal("tryEnqueue should return an error from ctx.Done")
 		}

--- a/bindings/go/manager.go
+++ b/bindings/go/manager.go
@@ -37,47 +37,52 @@ func (c *Coordinator) Manager(specName string) (*Manager, error) {
 	return &Manager{coord: c, specName: specName}, nil
 }
 
-// tryEnqueue attempts to place req into a worker's request channel.
-// It holds a read lock on closeGuard so that Close (which takes a write
-// lock) blocks until all in-progress enqueue attempts resolve. This
-// eliminates the race where a request is enqueued after the worker's
-// drain has completed.
-func (m *Manager) tryEnqueue(ctx context.Context, w *worker, req workerRequest) error {
-	m.coord.closeGuard.RLock()
-	defer m.coord.closeGuard.RUnlock()
-
+// tryEnqueue places req into a worker's removable request queue. The returned
+// handle owns cancellation until that worker dequeues the request.
+func (m *Manager) tryEnqueue(
+	ctx context.Context,
+	w *worker,
+	req workerRequest,
+) (*queuedRequest[workerRequest], error) {
 	if m.coord.closed.Load() {
-		return errCoordinatorClosed
+		return nil, errCoordinatorClosed
 	}
 
-	// Check for cancellation before enqueueing. Without this explicit
-	// check, a canceled ctx and a ready channel are both selectable and
-	// Go picks pseudo-randomly, allowing a request to be dispatched
-	// after the caller believes it was aborted.
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("ferric: request canceled before dispatch: %w", err)
+	queued, err := w.requests.enqueue(ctx, req)
+	if errors.Is(err, errRequestQueueClosed) {
+		return nil, errCoordinatorClosed
 	}
-
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("ferric: request canceled before dispatch: %w", ctx.Err())
-	case w.requests <- req:
-		return nil
+	if err != nil {
+		return nil, fmt.Errorf("ferric: request canceled before dispatch: %w", err)
 	}
+	return queued, nil
 }
 
 // Do dispatches a function to an engine of this Manager's type.
 // The function runs on a thread-locked worker goroutine. The Engine
 // must not be retained beyond the closure's return.
 // A panic in fn is recovered by the worker as *PanicError; engine changes
-// completed before the panic are not rolled back. If ctx is canceled after
-// dispatch but before the worker response is received, Do may return an error
-// wrapping ctx.Err() instead.
-//
-//nolint:nonamedreturns // named return needed for deferred observability recording.
-func (m *Manager) Do(ctx context.Context, fn func(*Engine) error) (retErr error) {
+// completed before the panic are not rolled back. A request is queued after it
+// enters the worker FIFO and becomes started when that worker dequeues it.
+// Cancellation removes a queued callback and returns an error wrapping
+// ctx.Err(). Once started, Do waits for fn's real result; cancellation does not
+// preempt an arbitrary callback.
+func (m *Manager) Do(ctx context.Context, fn func(*Engine) error) error {
+	response := managerCall(ctx, m, func(engine *Engine) (struct{}, error) {
+		return struct{}{}, fn(engine)
+	})
+	return response.err
+}
+
+//nolint:nonamedreturns // Deferred observability records the typed response error.
+func managerCall[T any](
+	ctx context.Context,
+	m *Manager,
+	fn func(*Engine) (T, error),
+) (response workerResponse[T]) {
 	if ctx == nil {
-		return errNilContext
+		response.err = errNilContext
+		return response
 	}
 
 	o := m.coord.obs
@@ -89,45 +94,39 @@ func (m *Manager) Do(ctx context.Context, fn func(*Engine) error) (retErr error)
 		dur := sinceSeconds(start)
 		o.dispatchDuration.Record(ctx, dur, metric.WithAttributes(specAttr))
 		o.dispatchTotal.Add(ctx, 1, metric.WithAttributes(specAttr))
-		if retErr != nil {
+		if response.err != nil {
 			o.dispatchErrors.Add(ctx, 1, metric.WithAttributes(specAttr))
-			o.recordError(span, retErr)
+			o.recordError(span, response.err)
 			if o.logger != nil {
 				o.logger.WarnContext(ctx, "dispatch failed",
-					"spec", m.specName, "duration_s", dur, "error", retErr)
+					"spec", m.specName, "duration_s", dur, "error", response.err)
 			}
 		}
 		span.End()
 	}()
 
 	w := m.coord.pickWorker(RouteHint{SpecName: m.specName})
-	resp := make(chan error, 1)
+	call, responses := newWorkerCall(fn)
 	req := workerRequest{
 		specName:   m.specName,
-		fn:         fn,
-		resp:       resp,
+		call:       call,
 		enqueuedAt: time.Now(),
 	}
 
-	if err := m.tryEnqueue(ctx, w, req); err != nil {
-		return err
+	queued, err := m.tryEnqueue(ctx, w, req)
+	if err != nil {
+		response.err = err
+		return response
 	}
-
-	// The worker guarantees it will drain all buffered requests before
-	// exiting, so an accepted request always gets a real response.
-	// We intentionally do NOT select on m.coord.done here: doing so
-	// would race with resp and could discard the real result.
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("ferric: request canceled while waiting for worker: %w", ctx.Err())
-	case err := <-resp:
-		return err
-	}
+	return waitWorkerResponse(ctx, queued.cancel, responses)
 }
 
 // Evaluate resets the engine, asserts the given facts, runs to completion,
 // and returns the resulting facts and output. This is the primary entry
-// point for stateless one-shot evaluation.
+// point for stateless one-shot evaluation. Cancellation while queued removes
+// the request before Reset. Once started, Evaluate waits for the worker
+// response; Reset, assertion, or run mutations completed before cancellation
+// are not rolled back.
 func (m *Manager) Evaluate(ctx context.Context, req *EvaluateRequest) (*EvaluateResult, error) {
 	if req == nil {
 		return nil, errNilEvaluateRequest
@@ -138,20 +137,19 @@ func (m *Manager) Evaluate(ctx context.Context, req *EvaluateRequest) (*Evaluate
 	ctx, span := o.tracer.Start(ctx, "ferric.evaluate", trace.WithAttributes(specAttr))
 	defer span.End()
 
-	var result *EvaluateResult
-	err := m.Do(ctx, func(e *Engine) error {
+	response := managerCall(ctx, m, func(e *Engine) (*EvaluateResult, error) {
 		if err := e.Reset(); err != nil {
-			return err
+			return nil, err
 		}
 
 		if err := assertWireFacts(e, req.Facts); err != nil {
-			return err
+			return nil, err
 		}
 
 		runStart := time.Now()
 		runResult, err := runEvaluate(ctx, e, req.Limit)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		o.runDuration.Record(ctx, sinceSeconds(runStart), metric.WithAttributes(specAttr))
 
@@ -167,14 +165,13 @@ func (m *Manager) Evaluate(ctx context.Context, req *EvaluateRequest) (*Evaluate
 				"halt_reason", runResult.HaltReason.String())
 		}
 
-		result, err = buildEvaluateResult(e, runResult)
-		return err
+		return buildEvaluateResult(e, runResult)
 	})
 
-	if err != nil {
-		o.recordError(span, err)
+	if response.err != nil {
+		o.recordError(span, response.err)
 	}
-	return result, err
+	return response.value, response.err
 }
 
 func assertWireFacts(e *Engine, facts []WireFactInput) error {

--- a/bindings/go/manager_test.go
+++ b/bindings/go/manager_test.go
@@ -327,8 +327,8 @@ func TestManagerEvaluateCancelBeforeDispatch(t *testing.T) {
 
 // TestManagerDoCancelDuringRun verifies that a context canceled while
 // the engine is running surfaces through Run's periodic cancellation check.
-// Uses Do (not Evaluate) to avoid the pre-existing Evaluate closure race
-// between the caller and the worker on context cancellation.
+// The callback cooperatively observes ctx, so its worker response may wrap the
+// deadline even though a started arbitrary callback cannot be abandoned.
 func TestManagerDoCancelDuringRun(t *testing.T) {
 	mgr, err := NewManager(WithSource(`
 		(defrule chain

--- a/bindings/go/pinned_engine.go
+++ b/bindings/go/pinned_engine.go
@@ -22,13 +22,11 @@ var errPinnedEngineClosed = errors.New("ferric: pinned engine is closed")
 //
 // PinnedEngine implements io.Closer. Always defer Close() after creation.
 type PinnedEngine struct {
-	requests   chan pinnedRequest
-	stop       chan struct{}
-	done       chan struct{}
-	closeOnce  sync.Once
-	closed     atomic.Bool
-	activeRun  atomic.Pointer[pinnedRunControl]
-	closeGuard sync.RWMutex // protects enqueue windows during shutdown
+	requests  *requestQueue[pinnedRequest]
+	done      chan struct{}
+	closeOnce sync.Once
+	closed    atomic.Bool
+	activeRun atomic.Pointer[pinnedRunControl]
 }
 
 type pinnedRunControl struct {
@@ -36,8 +34,12 @@ type pinnedRunControl struct {
 }
 
 type pinnedRequest struct {
-	fn   func(*Engine) error
-	resp chan error
+	call *workerCall
+}
+
+type valueOK[T any] struct {
+	value T
+	ok    bool
 }
 
 // NewPinnedEngine creates a PinnedEngine backed by a dedicated OS-locked
@@ -45,8 +47,7 @@ type pinnedRequest struct {
 // Returns an error if engine creation fails.
 func NewPinnedEngine(opts ...EngineOption) (*PinnedEngine, error) {
 	p := &PinnedEngine{
-		requests: make(chan pinnedRequest, 16),
-		stop:     make(chan struct{}),
+		requests: newRequestQueue[pinnedRequest](workerRequestQueueCapacity),
 		done:     make(chan struct{}),
 	}
 
@@ -67,13 +68,11 @@ func NewPinnedEngine(opts ...EngineOption) (*PinnedEngine, error) {
 		close(ready) // signal success
 
 		for {
-			select {
-			case <-p.stop:
-				p.drain(eng)
+			request := p.requests.dequeue()
+			if !request.ok {
 				return
-			case req := <-p.requests:
-				req.resp <- invokeWorkerCallback(eng, req.fn)
 			}
+			request.value.call.complete(eng, nil)
 		}
 	}()
 
@@ -83,27 +82,14 @@ func NewPinnedEngine(opts ...EngineOption) (*PinnedEngine, error) {
 	return p, nil
 }
 
-// drain processes all buffered requests so that accepted work completes
-// with its real result during shutdown.
-func (p *PinnedEngine) drain(eng *Engine) {
-	for {
-		select {
-		case req := <-p.requests:
-			req.resp <- invokeWorkerCallback(eng, req.fn)
-		default:
-			return
-		}
-	}
-}
-
 // Close shuts down the PinnedEngine. It stops accepting new requests and
-// interrupts active and already-accepted queued Run requests. Close-induced
+// interrupts active and already-queued Run requests. Close-induced
 // interruption uses the same cooperative-cancellation outcome as Halt: a
 // partial (or zero) RunResult with HaltRequested and a nil error, rather than
 // errPinnedEngineClosed. Requests rejected after Close begins return
-// errPinnedEngineClosed. Other previously-accepted work is drained before the
-// underlying engine is closed. Close then blocks until the worker goroutine
-// exits.
+// errPinnedEngineClosed. Other non-canceled work already queued or started is
+// completed before the underlying engine is closed. Close then blocks until the
+// worker goroutine exits.
 //
 // Run interruption is cooperative and is observed between batches of at most
 // 100 rule firings. Close cannot preempt an arbitrary function submitted with
@@ -113,74 +99,69 @@ func (p *PinnedEngine) drain(eng *Engine) {
 func (p *PinnedEngine) Close() error {
 	p.closeOnce.Do(func() {
 		// The run loop observes this sticky flag without going through the
-		// request queue. Publish it before waiting for enqueue readers so an
-		// active run can release a full queue and let shutdown make progress.
+		// request queue. Publish it before closing the queue so an active run
+		// can make progress toward worker shutdown.
 		p.closed.Store(true)
-		// Wait for all in-progress enqueue attempts to resolve,
-		// then signal worker to stop while holding the write lock.
-		// The write lock blocks until every RLock holder (tryEnqueue) exits.
-		// After this acquires, no goroutine can write to p.requests.
-		p.closeGuard.Lock()
-		close(p.stop)
-		p.closeGuard.Unlock()
+		p.requests.close()
 	})
 	<-p.done
 	return nil
 }
 
-// tryEnqueue attempts to place req into the worker's request channel.
-// It holds a read lock on closeGuard so that Close (which takes a write
-// lock) blocks until all in-progress enqueue attempts resolve. This
-// eliminates the race where a request is enqueued after the worker's
-// drain has completed.
-func (p *PinnedEngine) tryEnqueue(ctx context.Context, req pinnedRequest) error {
-	p.closeGuard.RLock()
-	defer p.closeGuard.RUnlock()
-
+// tryEnqueue places req into the removable worker queue. The returned handle
+// owns cancellation until the worker dequeues the request.
+func (p *PinnedEngine) tryEnqueue(
+	ctx context.Context,
+	req pinnedRequest,
+) (*queuedRequest[pinnedRequest], error) {
 	if p.closed.Load() {
-		return errPinnedEngineClosed
+		return nil, errPinnedEngineClosed
 	}
 
-	if err := ctx.Err(); err != nil {
-		return fmt.Errorf("ferric: request canceled before dispatch: %w", err)
+	queued, err := p.requests.enqueue(ctx, req)
+	if errors.Is(err, errRequestQueueClosed) {
+		return nil, errPinnedEngineClosed
 	}
-
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("ferric: request canceled before dispatch: %w", ctx.Err())
-	case p.requests <- req:
-		return nil
+	if err != nil {
+		return nil, fmt.Errorf("ferric: request canceled before dispatch: %w", err)
 	}
+	return queued, nil
 }
 
 // Do dispatches an arbitrary function to the pinned engine's worker thread.
 // The function runs with exclusive access to the underlying Engine.
 // The Engine must not be retained beyond the closure's return.
 // A panic in fn is recovered by the worker as *PanicError; engine changes
-// completed before the panic are not rolled back. If ctx is canceled after
-// dispatch but before the worker response is received, Do may return an error
-// wrapping ctx.Err() instead.
+// completed before the panic are not rolled back. A request is queued after it
+// enters the FIFO and becomes started when the worker dequeues it. Cancellation
+// removes a queued callback and returns an error wrapping ctx.Err(). Once
+// started, Do waits for fn's real result; cancellation does not preempt an
+// arbitrary callback.
 //
 // Returns errPinnedEngineClosed if the PinnedEngine has been closed.
 // Respects context cancellation for both dispatch and waiting.
 func (p *PinnedEngine) Do(ctx context.Context, fn func(*Engine) error) error {
+	response := pinnedCall(ctx, p, func(engine *Engine) (struct{}, error) {
+		return struct{}{}, fn(engine)
+	})
+	return response.err
+}
+
+func pinnedCall[T any](
+	ctx context.Context,
+	p *PinnedEngine,
+	fn func(*Engine) (T, error),
+) workerResponse[T] {
 	if ctx == nil {
-		return errNilContext
+		return workerResponse[T]{err: errNilContext}
 	}
 
-	resp := make(chan error, 1)
-	req := pinnedRequest{fn: fn, resp: resp}
-
-	if err := p.tryEnqueue(ctx, req); err != nil {
-		return err
+	call, responses := newWorkerCall(fn)
+	queued, err := p.tryEnqueue(ctx, pinnedRequest{call: call})
+	if err != nil {
+		return workerResponse[T]{err: err}
 	}
-
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("ferric: request canceled while waiting for worker: %w", ctx.Err())
-	case err := <-resp:
-		return err
-	}
+	return waitWorkerResponse(ctx, queued.cancel, responses)
 }
 
 // do is the internal dispatch helper used by all typed methods.
@@ -207,35 +188,26 @@ func (p *PinnedEngine) Load(source string) error {
 
 // AssertString asserts a fact from a CLIPS source string.
 func (p *PinnedEngine) AssertString(source string) (uint64, error) {
-	var id uint64
-	err := p.do(func(e *Engine) error {
-		var err error
-		id, err = e.AssertString(source)
-		return err
+	response := pinnedCall(context.Background(), p, func(e *Engine) (uint64, error) {
+		return e.AssertString(source)
 	})
-	return id, err
+	return response.value, response.err
 }
 
 // AssertFact asserts an ordered fact with the given relation and fields.
 func (p *PinnedEngine) AssertFact(relation string, fields ...any) (uint64, error) {
-	var id uint64
-	err := p.do(func(e *Engine) error {
-		var err error
-		id, err = e.AssertFact(relation, fields...)
-		return err
+	response := pinnedCall(context.Background(), p, func(e *Engine) (uint64, error) {
+		return e.AssertFact(relation, fields...)
 	})
-	return id, err
+	return response.value, response.err
 }
 
 // AssertTemplate asserts a template fact with named slot values.
 func (p *PinnedEngine) AssertTemplate(templateName string, slots map[string]any) (uint64, error) {
-	var id uint64
-	err := p.do(func(e *Engine) error {
-		var err error
-		id, err = e.AssertTemplate(templateName, slots)
-		return err
+	response := pinnedCall(context.Background(), p, func(e *Engine) (uint64, error) {
+		return e.AssertTemplate(templateName, slots)
 	})
-	return id, err
+	return response.value, response.err
 }
 
 // Retract removes a fact by its ID.
@@ -247,46 +219,34 @@ func (p *PinnedEngine) Retract(factID uint64) error {
 
 // GetFact returns a snapshot of a single fact.
 func (p *PinnedEngine) GetFact(factID uint64) (*Fact, error) {
-	var f *Fact
-	err := p.do(func(e *Engine) error {
-		var err error
-		f, err = e.GetFact(factID)
-		return err
+	response := pinnedCall(context.Background(), p, func(e *Engine) (*Fact, error) {
+		return e.GetFact(factID)
 	})
-	return f, err
+	return response.value, response.err
 }
 
 // Facts returns snapshots of all user-visible facts.
 func (p *PinnedEngine) Facts() ([]Fact, error) {
-	var facts []Fact
-	err := p.do(func(e *Engine) error {
-		var err error
-		facts, err = e.Facts()
-		return err
+	response := pinnedCall(context.Background(), p, func(e *Engine) ([]Fact, error) {
+		return e.Facts()
 	})
-	return facts, err
+	return response.value, response.err
 }
 
 // FindFacts returns snapshots of facts matching the given relation name.
 func (p *PinnedEngine) FindFacts(relation string) ([]Fact, error) {
-	var facts []Fact
-	err := p.do(func(e *Engine) error {
-		var err error
-		facts, err = e.FindFacts(relation)
-		return err
+	response := pinnedCall(context.Background(), p, func(e *Engine) ([]Fact, error) {
+		return e.FindFacts(relation)
 	})
-	return facts, err
+	return response.value, response.err
 }
 
 // FactCount returns the number of user-visible facts.
 func (p *PinnedEngine) FactCount() (int, error) {
-	var count int
-	err := p.do(func(e *Engine) error {
-		var err error
-		count, err = e.FactCount()
-		return err
+	response := pinnedCall(context.Background(), p, func(e *Engine) (int, error) {
+		return e.FactCount()
 	})
-	return count, err
+	return response.value, response.err
 }
 
 // ---------------------------------------------------------------------------
@@ -300,56 +260,34 @@ func (p *PinnedEngine) Run(ctx context.Context) (*RunResult, error) {
 }
 
 // RunWithLimit runs the engine with a maximum number of rule firings.
-// A limit of 0 means unlimited. Context cancellation before queue acceptance
-// rejects the request. Once accepted, RunWithLimit waits for the cooperative
-// worker response; context cancellation returns a partial RunResult with
-// HaltRequested and an error wrapping ctx.Err(). Halt or Close interruption
-// returns a partial (or zero) RunResult with HaltRequested and a nil error.
-// A native terminal result or completed explicit limit wins first; at an
-// internal batch boundary, caller context cancellation wins over simultaneous
-// Halt or Close interruption.
+// A limit of 0 means unlimited. Context cancellation before the worker starts
+// removes a queued run and returns a nil result with an error wrapping
+// ctx.Err(). Once started, RunWithLimit waits for the cooperative worker
+// response; context cancellation returns a partial RunResult with HaltRequested
+// and an error wrapping ctx.Err(). Halt or Close interruption returns a partial
+// (or zero) RunResult with HaltRequested and a nil error. A native terminal
+// result or completed explicit limit wins first; at an internal batch boundary,
+// caller context cancellation wins over simultaneous Halt or Close interruption.
 func (p *PinnedEngine) RunWithLimit(ctx context.Context, limit int) (*RunResult, error) {
-	if ctx == nil {
-		return nil, errNilContext
-	}
+	response := pinnedCall(ctx, p, func(e *Engine) (*RunResult, error) {
+		control := &pinnedRunControl{}
+		p.activeRun.Store(control)
+		defer p.activeRun.CompareAndSwap(control, nil)
 
-	var result *RunResult
-	resp := make(chan error, 1)
-	req := pinnedRequest{
-		resp: resp,
-		fn: func(e *Engine) error {
-			control := &pinnedRunControl{}
-			p.activeRun.Store(control)
-			defer p.activeRun.CompareAndSwap(control, nil)
-
-			var err error
-			result, err = e.runWithLimit(ctx, limit, func() bool {
-				return control.halted.Load() || p.closed.Load()
-			})
-			return err
-		},
-	}
-	if err := p.tryEnqueue(ctx, req); err != nil {
-		return nil, err
-	}
-
-	// An accepted run observes ctx itself between chunks. Waiting for the
-	// worker's sole response gives the captured result a channel happens-before
-	// edge and prevents Do's post-dispatch cancellation select from racing it.
-	err := <-resp
-	return result, err
+		return e.runWithLimit(ctx, limit, func() bool {
+			return control.halted.Load() || p.closed.Load()
+		})
+	})
+	return response.value, response.err
 }
 
 // Step executes a single rule firing.
 // Returns nil if the agenda is empty.
 func (p *PinnedEngine) Step() (*FiredRule, error) {
-	var fr *FiredRule
-	err := p.do(func(e *Engine) error {
-		var err error
-		fr, err = e.Step()
-		return err
+	response := pinnedCall(context.Background(), p, func(e *Engine) (*FiredRule, error) {
+		return e.Step()
 	})
-	return fr, err
+	return response.value, response.err
 }
 
 // Halt requests that the currently active Run stop at the next batch boundary.
@@ -382,13 +320,10 @@ func (p *PinnedEngine) Clear() {
 
 // Serialize produces a snapshot of the engine's current state.
 func (p *PinnedEngine) Serialize(format Format) ([]byte, error) {
-	var data []byte
-	err := p.do(func(e *Engine) error {
-		var err error
-		data, err = e.Serialize(format)
-		return err
+	response := pinnedCall(context.Background(), p, func(e *Engine) ([]byte, error) {
+		return e.Serialize(format)
 	})
-	return data, err
+	return response.value, response.err
 }
 
 // SerializeToFile writes a serialized snapshot to the given file path.
@@ -404,84 +339,67 @@ func (p *PinnedEngine) SerializeToFile(path string, format Format) error {
 
 // Rules returns information about all registered rules.
 func (p *PinnedEngine) Rules() []RuleInfo {
-	var rules []RuleInfo
-	_ = p.do(func(e *Engine) error {
-		rules = e.Rules()
-		return nil
+	response := pinnedCall(context.Background(), p, func(e *Engine) ([]RuleInfo, error) {
+		return e.Rules(), nil
 	})
-	return rules
+	return response.value
 }
 
 // Templates returns the names of all registered templates.
 func (p *PinnedEngine) Templates() []string {
-	var names []string
-	_ = p.do(func(e *Engine) error {
-		names = e.Templates()
-		return nil
+	response := pinnedCall(context.Background(), p, func(e *Engine) ([]string, error) {
+		return e.Templates(), nil
 	})
-	return names
+	return response.value
 }
 
 // GetGlobal retrieves a global variable's value by name.
 func (p *PinnedEngine) GetGlobal(name string) (any, error) {
-	var val any
-	err := p.do(func(e *Engine) error {
-		var err error
-		val, err = e.GetGlobal(name)
-		return err
+	response := pinnedCall(context.Background(), p, func(e *Engine) (any, error) {
+		return e.GetGlobal(name)
 	})
-	return val, err
+	return response.value, response.err
 }
 
 // CurrentModule returns the name of the current module.
 func (p *PinnedEngine) CurrentModule() string {
-	var name string
-	_ = p.do(func(e *Engine) error {
-		name = e.CurrentModule()
-		return nil
+	response := pinnedCall(context.Background(), p, func(e *Engine) (string, error) {
+		return e.CurrentModule(), nil
 	})
-	return name
+	return response.value
 }
 
 // Focus returns the module at the top of the focus stack.
 func (p *PinnedEngine) Focus() (string, bool) {
-	var name string
-	var ok bool
-	_ = p.do(func(e *Engine) error {
-		name, ok = e.Focus()
-		return nil
+	response := pinnedCall(context.Background(), p, func(e *Engine) (valueOK[string], error) {
+		name, ok := e.Focus()
+		return valueOK[string]{value: name, ok: ok}, nil
 	})
-	return name, ok
+	return response.value.value, response.value.ok
 }
 
 // FocusStack returns the focus stack entries from bottom to top.
 func (p *PinnedEngine) FocusStack() []string {
-	var stack []string
-	_ = p.do(func(e *Engine) error {
-		stack = e.FocusStack()
-		return nil
+	response := pinnedCall(context.Background(), p, func(e *Engine) ([]string, error) {
+		return e.FocusStack(), nil
 	})
-	return stack
+	return response.value
 }
 
 // AgendaSize returns the number of activations on the agenda.
 func (p *PinnedEngine) AgendaSize() int {
-	var count int
-	_ = p.do(func(e *Engine) error {
-		count = e.AgendaSize()
-		return nil
+	response := pinnedCall(context.Background(), p, func(e *Engine) (int, error) {
+		return e.AgendaSize(), nil
 	})
-	return count
+	return response.value
 }
 
 // IsHalted returns true if the engine is halted.
 func (p *PinnedEngine) IsHalted() bool {
-	var halted bool
-	_ = p.do(func(e *Engine) error {
-		halted = e.IsHalted()
-		return nil
+	response := pinnedCall(context.Background(), p, func(e *Engine) (bool, error) {
+		return e.IsHalted(), nil
 	})
-	return halted
+	return response.value
 }
 
 // ---------------------------------------------------------------------------
@@ -490,13 +408,11 @@ func (p *PinnedEngine) IsHalted() bool {
 
 // GetOutput retrieves captured output for a named channel.
 func (p *PinnedEngine) GetOutput(channel string) (string, bool) {
-	var s string
-	var ok bool
-	_ = p.do(func(e *Engine) error {
-		s, ok = e.GetOutput(channel)
-		return nil
+	response := pinnedCall(context.Background(), p, func(e *Engine) (valueOK[string], error) {
+		value, ok := e.GetOutput(channel)
+		return valueOK[string]{value: value, ok: ok}, nil
 	})
-	return s, ok
+	return response.value.value, response.value.ok
 }
 
 // ClearOutput clears a specific output channel.
@@ -521,12 +437,10 @@ func (p *PinnedEngine) PushInput(line string) {
 
 // Diagnostics returns all action diagnostic messages from recent execution.
 func (p *PinnedEngine) Diagnostics() []string {
-	var diags []string
-	_ = p.do(func(e *Engine) error {
-		diags = e.Diagnostics()
-		return nil
+	response := pinnedCall(context.Background(), p, func(e *Engine) ([]string, error) {
+		return e.Diagnostics(), nil
 	})
-	return diags
+	return response.value
 }
 
 // ClearDiagnostics clears all stored action diagnostics.

--- a/bindings/go/pinned_engine_interrupt_test.go
+++ b/bindings/go/pinned_engine_interrupt_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -65,12 +66,31 @@ func waitForPinnedQueueDepth(t *testing.T, engine *PinnedEngine, depth int) {
 	ticker := time.NewTicker(time.Millisecond)
 	defer ticker.Stop()
 	for {
-		if len(engine.requests) >= depth {
+		if engine.requests.len() >= depth {
 			return
 		}
 		select {
 		case <-deadline.C:
 			t.Fatalf("pinned request queue depth did not reach %d", depth)
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForPinnedQueueLength(t *testing.T, engine *PinnedEngine, want int) {
+	t.Helper()
+
+	deadline := time.NewTimer(pinnedInterruptTestTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if engine.requests.len() == want {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("pinned request queue length = %d, want %d", engine.requests.len(), want)
 		case <-ticker.C:
 		}
 	}
@@ -551,8 +571,15 @@ func TestPinnedEngineContextWinsAtInterruptBoundary(t *testing.T) {
 	}
 }
 
-func TestPinnedEngineAcceptedQueuedRunWaitsForCooperativeCancellation(t *testing.T) {
+//nolint:funlen // The worker blocker proves the canceled Run remains queued and never enters FFI.
+func TestPinnedEngineQueuedRunCancellationRemovesRequest(t *testing.T) {
+	withFFIHooks(t)
 	engine := newPinnedCyclingEngine(t)
+	var nativeRunCalls atomic.Int32
+	ffiEngineRunEx = func(ffi.EngineHandle, int64) (uint64, ffi.HaltReason, ffi.ErrorCode) {
+		nativeRunCalls.Add(1)
+		return 0, ffi.HaltReasonAgendaEmpty, ffi.ErrOK
+	}
 	releaseBlocker := make(chan struct{})
 	var releaseOnce sync.Once
 	t.Cleanup(func() {
@@ -581,11 +608,22 @@ func TestPinnedEngineAcceptedQueuedRunWaitsForCooperativeCancellation(t *testing
 	waitForPinnedQueueDepth(t, engine, 1)
 	cancel()
 
-	select {
-	case outcome := <-outcomes:
-		t.Fatalf("accepted queued run returned before its worker response: (%+v, %v)", outcome.result, outcome.err)
-	case <-time.After(25 * time.Millisecond):
+	outcome := receivePinnedRunOutcome(t, outcomes)
+	if outcome.result != nil || !errors.Is(outcome.err, context.Canceled) {
+		t.Fatalf("queued cancellation outcome = (%+v, %v), want nil/context.Canceled", outcome.result, outcome.err)
 	}
+	if _, ok := <-outcomes; ok {
+		t.Fatal("queued run produced more than one terminal outcome")
+	}
+	waitForPinnedQueueLength(t, engine, 0)
+
+	successorDone := make(chan error, 1)
+	go func() {
+		successorDone <- engine.Do(context.Background(), func(callbackEngine *Engine) error {
+			return callbackEngine.Reset()
+		})
+	}()
+	waitForPinnedQueueDepth(t, engine, 1)
 
 	releaseOnce.Do(func() { close(releaseBlocker) })
 	select {
@@ -596,10 +634,16 @@ func TestPinnedEngineAcceptedQueuedRunWaitsForCooperativeCancellation(t *testing
 	case <-time.After(pinnedInterruptTestTimeout):
 		t.Fatal("blocking request did not finish")
 	}
-	outcome := receivePinnedRunOutcome(t, outcomes)
-	want := RunResult{RulesFired: 0, HaltReason: HaltRequested}
-	if outcome.result == nil || *outcome.result != want || !errors.Is(outcome.err, context.Canceled) {
-		t.Fatalf("queued cancellation outcome = (%+v, %v), want %+v/context.Canceled", outcome.result, outcome.err, want)
+	select {
+	case err := <-successorDone:
+		if err != nil {
+			t.Fatalf("successor after queued run cancellation failed: %v", err)
+		}
+	case <-time.After(pinnedInterruptTestTimeout):
+		t.Fatal("successor after queued run cancellation did not settle")
+	}
+	if calls := nativeRunCalls.Load(); calls != 0 {
+		t.Fatalf("queued canceled run entered native execution %d times, want 0", calls)
 	}
 }
 

--- a/bindings/go/request_cancellation_test.go
+++ b/bindings/go/request_cancellation_test.go
@@ -1,0 +1,602 @@
+package ferric
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
+)
+
+const requestCancellationTestTimeout = 2 * time.Second
+
+var (
+	errStartedCallbackResult = errors.New("started callback result")
+	errClaimedCallbackResult = errors.New("claimed callback result")
+)
+
+type requestCancellationOutcome[T any] struct {
+	value T
+	err   error
+}
+
+func waitForRequestQueueLength[T any](t *testing.T, queue *requestQueue[T], want int) {
+	t.Helper()
+
+	deadline := time.NewTimer(requestCancellationTestTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if queue.len() == want {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("request queue length = %d, want %d", queue.len(), want)
+		case <-ticker.C:
+		}
+	}
+}
+
+func receiveRequestCancellationOutcome[T any](
+	t *testing.T,
+	outcomes <-chan requestCancellationOutcome[T],
+	label string,
+) requestCancellationOutcome[T] {
+	t.Helper()
+	select {
+	case outcome, ok := <-outcomes:
+		if !ok {
+			t.Fatalf("%s closed without an outcome", label)
+		}
+		return outcome
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatalf("timed out waiting for %s", label)
+		var zero requestCancellationOutcome[T]
+		return zero
+	}
+}
+
+func assertRequestCancellationPending[T any](
+	t *testing.T,
+	outcomes <-chan requestCancellationOutcome[T],
+	label string,
+) {
+	t.Helper()
+	select {
+	case outcome, ok := <-outcomes:
+		if !ok {
+			t.Fatalf("%s closed before the worker callback settled", label)
+		}
+		t.Fatalf("%s returned before the worker callback settled: (%v, %v)", label, outcome.value, outcome.err)
+	case <-time.After(25 * time.Millisecond):
+	}
+}
+
+func assertRequestCancellationOutcomeClosed[T any](
+	t *testing.T,
+	outcomes <-chan requestCancellationOutcome[T],
+	label string,
+) {
+	t.Helper()
+	select {
+	case _, ok := <-outcomes:
+		if ok {
+			t.Fatalf("%s produced more than one outcome", label)
+		}
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatalf("timed out waiting for %s channel to close", label)
+	}
+}
+
+func TestRequestQueueCancellationReclaimsCapacity(t *testing.T) {
+	queue := newRequestQueue[int](1)
+	t.Cleanup(queue.close)
+	first, err := queue.enqueue(context.Background(), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	secondResult := make(chan requestCancellationOutcome[*queuedRequest[int]], 1)
+	go func() {
+		queued, enqueueErr := queue.enqueue(context.Background(), 2)
+		secondResult <- requestCancellationOutcome[*queuedRequest[int]]{value: queued, err: enqueueErr}
+		close(secondResult)
+	}()
+	assertRequestCancellationPending(t, secondResult, "enqueue into full request queue")
+
+	if !first.cancel() {
+		t.Fatal("canceling queued request reported worker ownership")
+	}
+	outcome := receiveRequestCancellationOutcome(t, secondResult, "replacement enqueue")
+	if outcome.err != nil || outcome.value == nil {
+		t.Fatalf("replacement enqueue = (%v, %v), want admitted request", outcome.value, outcome.err)
+	}
+	assertRequestCancellationOutcomeClosed(t, secondResult, "replacement enqueue")
+	if got := queue.len(); got != 1 {
+		t.Fatalf("queue length after capacity reclamation = %d, want 1", got)
+	}
+	dequeued := queue.dequeue()
+	if !dequeued.ok || dequeued.value != 2 {
+		t.Fatalf("dequeued replacement = (%d, %t), want (2, true)", dequeued.value, dequeued.ok)
+	}
+	if outcome.value.cancel() {
+		t.Fatal("dequeued request remained cancelable")
+	}
+}
+
+func TestCanceledBeforeAdmissionDoesNotRunCallbacks(t *testing.T) {
+	t.Run("PinnedEngine", func(t *testing.T) {
+		engine, err := NewPinnedEngine()
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = engine.Close() })
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		var calls atomic.Int32
+		err = engine.Do(ctx, func(*Engine) error {
+			calls.Add(1)
+			return nil
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("pre-admission cancellation error = %v, want context.Canceled", err)
+		}
+		if calls.Load() != 0 || engine.requests.len() != 0 {
+			t.Fatalf("pre-admission cancellation ran callback %d times with queue length %d", calls.Load(), engine.requests.len())
+		}
+	})
+
+	t.Run("Manager", func(t *testing.T) {
+		coordinator, err := NewCoordinator([]EngineSpec{{Name: "test"}}, Threads(1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = coordinator.Close() })
+		manager, err := coordinator.Manager("test")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		var calls atomic.Int32
+		err = manager.Do(ctx, func(*Engine) error {
+			calls.Add(1)
+			return nil
+		})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("pre-admission cancellation error = %v, want context.Canceled", err)
+		}
+		if calls.Load() != 0 || coordinator.workers[0].requests.len() != 0 {
+			t.Fatalf("pre-admission cancellation ran callback %d times with queue length %d", calls.Load(), coordinator.workers[0].requests.len())
+		}
+	})
+}
+
+//nolint:funlen // The staged blocker, cancellation, and successor form one lifecycle assertion.
+func TestPinnedEngineQueuedCancellationRemovesCallback(t *testing.T) {
+	engine, err := NewPinnedEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseBlocker := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseBlocker) })
+		_ = engine.Close()
+	})
+
+	blockerStarted := make(chan struct{})
+	blockerResult := make(chan error, 1)
+	go func() {
+		blockerResult <- engine.Do(context.Background(), func(*Engine) error {
+			close(blockerStarted)
+			<-releaseBlocker
+			return nil
+		})
+	}()
+	select {
+	case <-blockerStarted:
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatal("pinned blocker did not start")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var canceledCalls atomic.Int32
+	canceledResult := make(chan requestCancellationOutcome[struct{}], 1)
+	go func() {
+		err := engine.Do(ctx, func(callbackEngine *Engine) error {
+			canceledCalls.Add(1)
+			_, callbackErr := callbackEngine.AssertFact("must-not-run")
+			return callbackErr
+		})
+		canceledResult <- requestCancellationOutcome[struct{}]{err: err}
+		close(canceledResult)
+	}()
+	waitForRequestQueueLength(t, engine.requests, 1)
+	cancel()
+
+	outcome := receiveRequestCancellationOutcome(t, canceledResult, "queued pinned cancellation")
+	if !errors.Is(outcome.err, context.Canceled) {
+		t.Fatalf("queued pinned cancellation error = %v, want context.Canceled", outcome.err)
+	}
+	assertRequestCancellationOutcomeClosed(t, canceledResult, "queued pinned cancellation")
+	waitForRequestQueueLength(t, engine.requests, 0)
+
+	var successorFactCount atomic.Int64
+	successorResult := make(chan error, 1)
+	go func() {
+		successorResult <- engine.Do(context.Background(), func(callbackEngine *Engine) error {
+			count, countErr := callbackEngine.FactCount()
+			if countErr != nil {
+				return countErr
+			}
+			successorFactCount.Store(int64(count))
+			return nil
+		})
+	}()
+	waitForRequestQueueLength(t, engine.requests, 1)
+	releaseOnce.Do(func() { close(releaseBlocker) })
+	select {
+	case err := <-blockerResult:
+		if err != nil {
+			t.Fatalf("pinned blocker failed: %v", err)
+		}
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatal("pinned blocker did not settle")
+	}
+	select {
+	case err := <-successorResult:
+		if err != nil {
+			t.Fatalf("pinned successor failed: %v", err)
+		}
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatal("pinned successor did not settle")
+	}
+	if count := successorFactCount.Load(); count != 0 {
+		t.Fatalf("fact count after canceled callback = %d, want 0", count)
+	}
+	if calls := canceledCalls.Load(); calls != 0 {
+		t.Fatalf("queued canceled pinned callback ran %d times, want 0", calls)
+	}
+}
+
+//nolint:funlen // The test keeps cancellation, no-mutation, and reuse barriers in one scenario.
+func TestManagerQueuedEvaluateCancellationReturnsTypedZero(t *testing.T) {
+	withFFIHooks(t)
+	coordinator, err := NewCoordinator([]EngineSpec{{Name: "test"}}, Threads(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseBlocker := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseBlocker) })
+		_ = coordinator.Close()
+	})
+	manager, err := coordinator.Manager("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := coordinator.workers[0]
+
+	blockerStarted := make(chan struct{})
+	blockerResult := make(chan error, 1)
+	go func() {
+		blockerResult <- manager.Do(context.Background(), func(*Engine) error {
+			close(blockerStarted)
+			<-releaseBlocker
+			return nil
+		})
+	}()
+	select {
+	case <-blockerStarted:
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatal("manager blocker did not start")
+	}
+
+	originalReset := ffiEngineReset
+	var resetCalls atomic.Int32
+	ffiEngineReset = func(handle ffi.EngineHandle) ffi.ErrorCode {
+		resetCalls.Add(1)
+		return originalReset(handle)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	evaluateResult := make(chan requestCancellationOutcome[*EvaluateResult], 1)
+	go func() {
+		result, evaluateErr := manager.Evaluate(ctx, &EvaluateRequest{
+			Facts: []WireFactInput{OrderedFact("must-not-run")},
+		})
+		evaluateResult <- requestCancellationOutcome[*EvaluateResult]{value: result, err: evaluateErr}
+		close(evaluateResult)
+	}()
+	waitForRequestQueueLength(t, worker.requests, 1)
+	cancel()
+
+	outcome := receiveRequestCancellationOutcome(t, evaluateResult, "queued Evaluate cancellation")
+	if outcome.value != nil || !errors.Is(outcome.err, context.Canceled) {
+		t.Fatalf("queued Evaluate cancellation = (%+v, %v), want nil/context.Canceled", outcome.value, outcome.err)
+	}
+	assertRequestCancellationOutcomeClosed(t, evaluateResult, "queued Evaluate cancellation")
+	waitForRequestQueueLength(t, worker.requests, 0)
+
+	var successorFactCount atomic.Int64
+	successorResult := make(chan error, 1)
+	go func() {
+		successorResult <- manager.Do(context.Background(), func(callbackEngine *Engine) error {
+			count, countErr := callbackEngine.FactCount()
+			if countErr != nil {
+				return countErr
+			}
+			successorFactCount.Store(int64(count))
+			return nil
+		})
+	}()
+	waitForRequestQueueLength(t, worker.requests, 1)
+	releaseOnce.Do(func() { close(releaseBlocker) })
+	select {
+	case err := <-blockerResult:
+		if err != nil {
+			t.Fatalf("manager blocker failed: %v", err)
+		}
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatal("manager blocker did not settle")
+	}
+	select {
+	case err := <-successorResult:
+		if err != nil {
+			t.Fatalf("manager successor failed: %v", err)
+		}
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatal("manager successor did not settle")
+	}
+	if count := successorFactCount.Load(); count != 0 {
+		t.Fatalf("fact count after canceled Evaluate = %d, want 0", count)
+	}
+	if calls := resetCalls.Load(); calls != 0 {
+		t.Fatalf("queued canceled Evaluate entered engine Reset %d times, want 0", calls)
+	}
+}
+
+func TestManagerStartedCancellationWaitsForCallbackResult(t *testing.T) {
+	coordinator, err := NewCoordinator([]EngineSpec{{Name: "test"}}, Threads(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		_ = coordinator.Close()
+	})
+	manager, err := coordinator.Manager("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	worker := coordinator.workers[0]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{})
+	var mutationComplete atomic.Bool
+	outcomes := make(chan requestCancellationOutcome[struct{}], 1)
+	go func() {
+		err := manager.Do(ctx, func(*Engine) error {
+			close(started)
+			<-release
+			mutationComplete.Store(true)
+			return errStartedCallbackResult
+		})
+		outcomes <- requestCancellationOutcome[struct{}]{err: err}
+		close(outcomes)
+	}()
+	select {
+	case <-started:
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatal("manager callback did not start")
+	}
+	cancel()
+	assertRequestCancellationPending(t, outcomes, "started manager cancellation")
+	releaseOnce.Do(func() { close(release) })
+
+	outcome := receiveRequestCancellationOutcome(t, outcomes, "started manager result")
+	if !errors.Is(outcome.err, errStartedCallbackResult) {
+		t.Fatalf("started manager cancellation error = %v, want callback error %v", outcome.err, errStartedCallbackResult)
+	}
+	assertRequestCancellationOutcomeClosed(t, outcomes, "started manager result")
+	if !mutationComplete.Load() {
+		t.Fatal("started Manager.Do returned before callback mutation completed")
+	}
+	if coordinator.workers[0] != worker {
+		t.Fatal("started cancellation replaced the coordinator worker")
+	}
+	if err := manager.Do(context.Background(), func(callbackEngine *Engine) error {
+		return callbackEngine.Reset()
+	}); err != nil {
+		t.Fatalf("manager worker was not reusable after started cancellation: %v", err)
+	}
+}
+
+//nolint:funlen // The FFI barrier proves cancellation occurs during typed result assembly.
+func TestManagerStartedEvaluateCancellationReturnsTypedResult(t *testing.T) {
+	withFFIHooks(t)
+	coordinator, err := NewCoordinator([]EngineSpec{{Name: "test"}}, Threads(1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = coordinator.Close() })
+	manager, err := coordinator.Manager("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalFactIDs := ffiEngineFactIDs
+	resultAssemblyStarted := make(chan struct{})
+	releaseResultAssembly := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseResultAssembly) }) })
+	var blockOnce sync.Once
+	ffiEngineFactIDs = func(handle ffi.EngineHandle) ([]uint64, ffi.ErrorCode) {
+		blockOnce.Do(func() {
+			close(resultAssemblyStarted)
+			<-releaseResultAssembly
+		})
+		return originalFactIDs(handle)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	outcomes := make(chan requestCancellationOutcome[*EvaluateResult], 1)
+	go func() {
+		result, evaluateErr := manager.Evaluate(ctx, &EvaluateRequest{
+			Facts: []WireFactInput{OrderedFact("typed-result", SymbolValue("kept"))},
+		})
+		outcomes <- requestCancellationOutcome[*EvaluateResult]{value: result, err: evaluateErr}
+		close(outcomes)
+	}()
+	select {
+	case <-resultAssemblyStarted:
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatal("Evaluate did not reach typed result assembly")
+	}
+	cancel()
+	assertRequestCancellationPending(t, outcomes, "started typed Evaluate cancellation")
+	releaseOnce.Do(func() { close(releaseResultAssembly) })
+
+	outcome := receiveRequestCancellationOutcome(t, outcomes, "started typed Evaluate result")
+	if outcome.err != nil || outcome.value == nil {
+		t.Fatalf("started typed Evaluate result = (%+v, %v), want full result", outcome.value, outcome.err)
+	}
+	assertRequestCancellationOutcomeClosed(t, outcomes, "started typed Evaluate result")
+	found := false
+	for _, fact := range outcome.value.Facts {
+		if fact.Kind == WireFactKindOrdered && fact.Ordered != nil && fact.Ordered.Relation == "typed-result" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("started typed Evaluate facts = %+v, want typed-result fact", outcome.value.Facts)
+	}
+	if err := manager.Do(context.Background(), func(callbackEngine *Engine) error {
+		return callbackEngine.Reset()
+	}); err != nil {
+		t.Fatalf("manager worker was not reusable after typed Evaluate cancellation: %v", err)
+	}
+}
+
+//nolint:funlen // Each iteration owns the full cancel, claim, Close, and cleanup race.
+func TestCoordinatorQueuedCancelClaimCloseRace(t *testing.T) {
+	const iterations = 12
+
+	for iteration := range iterations {
+		t.Run(fmt.Sprintf("iteration_%d", iteration), func(t *testing.T) {
+			coordinator, err := NewCoordinator([]EngineSpec{{Name: "test"}}, Threads(1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			manager, err := coordinator.Manager("test")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			releaseBlocker := make(chan struct{})
+			var releaseOnce sync.Once
+			t.Cleanup(func() {
+				releaseOnce.Do(func() { close(releaseBlocker) })
+				_ = coordinator.Close()
+			})
+			blockerStarted := make(chan struct{})
+			blockerResult := make(chan error, 1)
+			go func() {
+				blockerResult <- manager.Do(context.Background(), func(*Engine) error {
+					close(blockerStarted)
+					<-releaseBlocker
+					return nil
+				})
+			}()
+			select {
+			case <-blockerStarted:
+			case <-time.After(requestCancellationTestTimeout):
+				t.Fatal("race blocker did not start")
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			var callbackCalls atomic.Int32
+			outcomes := make(chan requestCancellationOutcome[struct{}], 1)
+			go func() {
+				err := manager.Do(ctx, func(*Engine) error {
+					callbackCalls.Add(1)
+					return errClaimedCallbackResult
+				})
+				outcomes <- requestCancellationOutcome[struct{}]{err: err}
+				close(outcomes)
+			}()
+			waitForRequestQueueLength(t, coordinator.workers[0].requests, 1)
+
+			startRace := make(chan struct{})
+			cancelDone := make(chan struct{})
+			go func() {
+				<-startRace
+				cancel()
+				close(cancelDone)
+			}()
+			releaseDone := make(chan struct{})
+			go func() {
+				<-startRace
+				releaseOnce.Do(func() { close(releaseBlocker) })
+				close(releaseDone)
+			}()
+			closeResult := make(chan error, 1)
+			go func() {
+				<-startRace
+				closeResult <- coordinator.Close()
+			}()
+			close(startRace)
+			<-cancelDone
+			<-releaseDone
+
+			outcome := receiveRequestCancellationOutcome(t, outcomes, "cancel/claim/Close race")
+			assertRequestCancellationOutcomeClosed(t, outcomes, "cancel/claim/Close race")
+			calls := callbackCalls.Load()
+			switch {
+			case errors.Is(outcome.err, context.Canceled):
+				if calls != 0 {
+					t.Fatalf("cancellation won but callback ran %d times", calls)
+				}
+			case errors.Is(outcome.err, errClaimedCallbackResult):
+				if calls != 1 {
+					t.Fatalf("worker claim won but callback ran %d times", calls)
+				}
+			default:
+				t.Fatalf("cancel/claim/Close race error = %v, want context.Canceled or callback result", outcome.err)
+			}
+			select {
+			case err := <-blockerResult:
+				if err != nil {
+					t.Fatalf("race blocker failed: %v", err)
+				}
+			case <-time.After(requestCancellationTestTimeout):
+				t.Fatal("race blocker did not settle")
+			}
+			select {
+			case err := <-closeResult:
+				if err != nil {
+					t.Fatalf("race Close failed: %v", err)
+				}
+			case <-time.After(requestCancellationTestTimeout):
+				t.Fatal("race Close did not settle")
+			}
+		})
+	}
+}

--- a/bindings/go/request_cancellation_test.go
+++ b/bindings/go/request_cancellation_test.go
@@ -94,6 +94,15 @@ func assertRequestCancellationOutcomeClosed[T any](
 	}
 }
 
+func receiveRequestQueueObservation(t *testing.T, observations <-chan struct{}, label string) {
+	t.Helper()
+	select {
+	case <-observations:
+	case <-time.After(requestCancellationTestTimeout):
+		t.Fatalf("timed out waiting for %s", label)
+	}
+}
+
 func TestRequestQueueCancellationReclaimsCapacity(t *testing.T) {
 	queue := newRequestQueue[int](1)
 	t.Cleanup(queue.close)
@@ -127,6 +136,119 @@ func TestRequestQueueCancellationReclaimsCapacity(t *testing.T) {
 	}
 	if outcome.value.cancel() {
 		t.Fatal("dequeued request remained cancelable")
+	}
+}
+
+//nolint:funlen // Gated waiters exercise collapsed and chained capacity signals in one lifecycle.
+func TestRequestQueueNotifiesOneCapacityWaiterPerFreedSlot(t *testing.T) {
+	const waiterCount = 3
+	queue := newRequestQueue[int](waiterCount)
+	releaseWaiters := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseWaiters) })
+		queue.close()
+	})
+
+	residents := make([]*queuedRequest[int], waiterCount)
+	for index := range waiterCount {
+		resident, err := queue.enqueue(context.Background(), index)
+		if err != nil {
+			t.Fatal(err)
+		}
+		residents[index] = resident
+	}
+
+	waits := make(chan struct{}, waiterCount)
+	queue.observer = &requestQueueObserver{
+		onCapacityWait: func() {
+			waits <- struct{}{}
+			<-releaseWaiters
+		},
+	}
+
+	outcomes := make(chan requestCancellationOutcome[int], waiterCount)
+	for value := 2; value < 2+waiterCount; value++ {
+		go func() {
+			_, enqueueErr := queue.enqueue(context.Background(), value)
+			outcomes <- requestCancellationOutcome[int]{value: value, err: enqueueErr}
+		}()
+		receiveRequestQueueObservation(t, waits, fmt.Sprintf("capacity waiter %d", value))
+	}
+
+	for index, resident := range residents {
+		if !resident.cancel() {
+			t.Fatalf("canceling resident request %d reported worker ownership", index)
+		}
+	}
+	if got := len(queue.notFull); got != 1 {
+		t.Fatalf("buffered capacity notifications while three freed slots were held = %d, want 1", got)
+	}
+
+	releaseOnce.Do(func() { close(releaseWaiters) })
+	admitted := make(map[int]bool, waiterCount)
+	for waiter := range waiterCount {
+		outcome := receiveRequestCancellationOutcome(t, outcomes, fmt.Sprintf("capacity waiter %d", waiter+1))
+		if outcome.err != nil {
+			t.Fatalf("capacity waiter %d failed: %v", waiter+1, outcome.err)
+		}
+		admitted[outcome.value] = true
+	}
+	if got := len(queue.notFull); got != 0 {
+		t.Fatalf("buffered capacity notifications after filling all freed slots = %d, want 0", got)
+	}
+	if got := queue.len(); got != waiterCount {
+		t.Fatalf("queue length after filling all freed slots = %d, want %d", got, waiterCount)
+	}
+	for range waiterCount {
+		dequeued := queue.dequeue()
+		if !dequeued.ok || !admitted[dequeued.value] {
+			t.Fatalf("dequeued request = (%d, %t), want a newly admitted waiter", dequeued.value, dequeued.ok)
+		}
+	}
+}
+
+func TestRequestQueueCloseWakesAllCapacityWaiters(t *testing.T) {
+	queue := newRequestQueue[int](1)
+	t.Cleanup(queue.close)
+	if _, err := queue.enqueue(context.Background(), 1); err != nil {
+		t.Fatal(err)
+	}
+
+	const waiterCount = 4
+	waits := make(chan struct{}, waiterCount)
+	queue.observer = &requestQueueObserver{
+		onCapacityWait: func() {
+			waits <- struct{}{}
+		},
+	}
+
+	outcomes := make(chan requestCancellationOutcome[*queuedRequest[int]], waiterCount)
+	for value := 2; value < 2+waiterCount; value++ {
+		go func() {
+			request, err := queue.enqueue(context.Background(), value)
+			outcomes <- requestCancellationOutcome[*queuedRequest[int]]{value: request, err: err}
+		}()
+		receiveRequestQueueObservation(t, waits, fmt.Sprintf("closing capacity waiter %d", value))
+	}
+
+	queue.close()
+	for waiter := range waiterCount {
+		outcome := receiveRequestCancellationOutcome(t, outcomes, fmt.Sprintf("closed capacity waiter %d", waiter+1))
+		if outcome.value != nil || !errors.Is(outcome.err, errRequestQueueClosed) {
+			t.Fatalf("closed capacity waiter %d = (%v, %v), want (nil, errRequestQueueClosed)", waiter+1, outcome.value, outcome.err)
+		}
+	}
+	if got := len(queue.notFull); got != 0 {
+		t.Fatalf("Close buffered %d ordinary capacity notifications, want broadcast-only wakeup", got)
+	}
+
+	dequeued := queue.dequeue()
+	if !dequeued.ok || dequeued.value != 1 {
+		t.Fatalf("dequeue after Close = (%d, %t), want admitted request (1, true)", dequeued.value, dequeued.ok)
+	}
+	if dequeued = queue.dequeue(); dequeued.ok {
+		t.Fatalf("second dequeue after Close = (%d, true), want drained queue", dequeued.value)
 	}
 }
 

--- a/bindings/go/request_queue.go
+++ b/bindings/go/request_queue.go
@@ -17,11 +17,20 @@ var (
 // submitters. Removal and dequeue share one lock, making worker ownership a
 // single, deterministic transition while immediately reclaiming capacity.
 type requestQueue[T any] struct {
-	mu       sync.Mutex
-	items    []*queuedRequest[T]
-	capacity int
-	closed   bool
-	changed  chan struct{}
+	mu           sync.Mutex
+	items        []*queuedRequest[T]
+	capacity     int
+	closed       bool
+	notEmpty     chan struct{}
+	notFull      chan struct{}
+	closedSignal chan struct{}
+	observer     *requestQueueObserver
+}
+
+// requestQueueObserver is a test-only observation seam. It must be installed
+// before concurrent queue use and remain immutable afterward.
+type requestQueueObserver struct {
+	onCapacityWait func()
 }
 
 // queuedRequest is a cancellation handle for one admitted queue entry. Its
@@ -39,15 +48,18 @@ type dequeuedRequest[T any] struct {
 
 func newRequestQueue[T any](capacity int) *requestQueue[T] {
 	return &requestQueue[T]{
-		items:    make([]*queuedRequest[T], 0, capacity),
-		capacity: capacity,
-		changed:  make(chan struct{}),
+		items:        make([]*queuedRequest[T], 0, capacity),
+		capacity:     capacity,
+		notEmpty:     make(chan struct{}, 1),
+		notFull:      make(chan struct{}, 1),
+		closedSignal: make(chan struct{}),
 	}
 }
 
 // enqueue waits for capacity, returning a handle that can remove the request
 // until dequeue transfers ownership to the worker.
 func (q *requestQueue[T]) enqueue(ctx context.Context, value T) (*queuedRequest[T], error) {
+	wokeForCapacity := false
 	for {
 		q.mu.Lock()
 		if q.closed {
@@ -56,6 +68,9 @@ func (q *requestQueue[T]) enqueue(ctx context.Context, value T) (*queuedRequest[
 		}
 		select {
 		case <-ctx.Done():
+			if wokeForCapacity {
+				q.signalNotFullLocked()
+			}
 			err := requestContextError(ctx)
 			q.mu.Unlock()
 			return nil, err
@@ -64,17 +79,27 @@ func (q *requestQueue[T]) enqueue(ctx context.Context, value T) (*queuedRequest[
 		if len(q.items) < q.capacity {
 			request := &queuedRequest[T]{queue: q, value: value, queued: true}
 			q.items = append(q.items, request)
-			q.notifyLocked()
+			q.signalNotEmptyLocked()
+			if wokeForCapacity {
+				q.signalNotFullLocked()
+			}
 			q.mu.Unlock()
 			return request, nil
 		}
-		changed := q.changed
+		wokeForCapacity = false
+		observer := q.observer
 		q.mu.Unlock()
+		if observer != nil && observer.onCapacityWait != nil {
+			observer.onCapacityWait()
+		}
 
 		select {
 		case <-ctx.Done():
 			return nil, requestContextError(ctx)
-		case <-changed:
+		case <-q.closedSignal:
+			// Loop so the closed check remains serialized with admission.
+		case <-q.notFull:
+			wokeForCapacity = true
 		}
 	}
 }
@@ -96,9 +121,11 @@ func (q *requestQueue[T]) dequeue() dequeuedRequest[T] {
 			q.mu.Unlock()
 			return dequeuedRequest[T]{}
 		}
-		changed := q.changed
 		q.mu.Unlock()
-		<-changed
+		select {
+		case <-q.notEmpty:
+		case <-q.closedSignal:
+		}
 	}
 }
 
@@ -130,7 +157,7 @@ func (q *requestQueue[T]) close() {
 	q.mu.Lock()
 	if !q.closed {
 		q.closed = true
-		q.notifyLocked()
+		close(q.closedSignal)
 	}
 	q.mu.Unlock()
 }
@@ -147,13 +174,25 @@ func (q *requestQueue[T]) removeLocked(index int) *queuedRequest[T] {
 	q.items[len(q.items)-1] = nil
 	q.items = q.items[:len(q.items)-1]
 	request.queued = false
-	q.notifyLocked()
+	q.signalNotFullLocked()
 	return request
 }
 
-func (q *requestQueue[T]) notifyLocked() {
-	close(q.changed)
-	q.changed = make(chan struct{})
+func (q *requestQueue[T]) signalNotEmptyLocked() {
+	select {
+	case q.notEmpty <- struct{}{}:
+	default:
+	}
+}
+
+func (q *requestQueue[T]) signalNotFullLocked() {
+	if q.closed || len(q.items) >= q.capacity {
+		return
+	}
+	select {
+	case q.notFull <- struct{}{}:
+	default:
+	}
 }
 
 func requestContextError(ctx context.Context) error {

--- a/bindings/go/request_queue.go
+++ b/bindings/go/request_queue.go
@@ -1,0 +1,167 @@
+package ferric
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+const workerRequestQueueCapacity = 16
+
+var (
+	errRequestQueueClosed = errors.New("ferric: request queue is closed")
+	errRequestContextDone = errors.New("ferric: request context is done")
+)
+
+// requestQueue is a bounded FIFO whose queued entries can be removed by their
+// submitters. Removal and dequeue share one lock, making worker ownership a
+// single, deterministic transition while immediately reclaiming capacity.
+type requestQueue[T any] struct {
+	mu       sync.Mutex
+	items    []*queuedRequest[T]
+	capacity int
+	closed   bool
+	changed  chan struct{}
+}
+
+// queuedRequest is a cancellation handle for one admitted queue entry. Its
+// fields are protected by queue.mu.
+type queuedRequest[T any] struct {
+	queue  *requestQueue[T]
+	value  T
+	queued bool
+}
+
+type dequeuedRequest[T any] struct {
+	value T
+	ok    bool
+}
+
+func newRequestQueue[T any](capacity int) *requestQueue[T] {
+	return &requestQueue[T]{
+		items:    make([]*queuedRequest[T], 0, capacity),
+		capacity: capacity,
+		changed:  make(chan struct{}),
+	}
+}
+
+// enqueue waits for capacity, returning a handle that can remove the request
+// until dequeue transfers ownership to the worker.
+func (q *requestQueue[T]) enqueue(ctx context.Context, value T) (*queuedRequest[T], error) {
+	for {
+		q.mu.Lock()
+		if q.closed {
+			q.mu.Unlock()
+			return nil, errRequestQueueClosed
+		}
+		select {
+		case <-ctx.Done():
+			err := requestContextError(ctx)
+			q.mu.Unlock()
+			return nil, err
+		default:
+		}
+		if len(q.items) < q.capacity {
+			request := &queuedRequest[T]{queue: q, value: value, queued: true}
+			q.items = append(q.items, request)
+			q.notifyLocked()
+			q.mu.Unlock()
+			return request, nil
+		}
+		changed := q.changed
+		q.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return nil, requestContextError(ctx)
+		case <-changed:
+		}
+	}
+}
+
+// dequeue blocks until it can transfer the oldest request to the worker. Once
+// the queue is closed it drains admitted work and returns false when empty.
+func (q *requestQueue[T]) dequeue() dequeuedRequest[T] {
+	for {
+		q.mu.Lock()
+		if len(q.items) > 0 {
+			request := q.removeLocked(0)
+			value := request.value
+			var zero T
+			request.value = zero
+			q.mu.Unlock()
+			return dequeuedRequest[T]{value: value, ok: true}
+		}
+		if q.closed {
+			q.mu.Unlock()
+			return dequeuedRequest[T]{}
+		}
+		changed := q.changed
+		q.mu.Unlock()
+		<-changed
+	}
+}
+
+// cancel removes this request if it is still queued. A false result means the
+// worker already owns it, so the caller must wait for the worker response.
+func (r *queuedRequest[T]) cancel() bool {
+	q := r.queue
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if !r.queued {
+		return false
+	}
+	for index, request := range q.items {
+		if request == r {
+			q.removeLocked(index)
+			var zero T
+			r.value = zero
+			return true
+		}
+	}
+
+	// queued is cleared while holding the same lock that removes an entry, so
+	// reaching this point would indicate an internal invariant violation.
+	r.queued = false
+	return false
+}
+
+func (q *requestQueue[T]) close() {
+	q.mu.Lock()
+	if !q.closed {
+		q.closed = true
+		q.notifyLocked()
+	}
+	q.mu.Unlock()
+}
+
+func (q *requestQueue[T]) len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.items)
+}
+
+func (q *requestQueue[T]) removeLocked(index int) *queuedRequest[T] {
+	request := q.items[index]
+	copy(q.items[index:], q.items[index+1:])
+	q.items[len(q.items)-1] = nil
+	q.items = q.items[:len(q.items)-1]
+	request.queued = false
+	q.notifyLocked()
+	return request
+}
+
+func (q *requestQueue[T]) notifyLocked() {
+	close(q.changed)
+	q.changed = make(chan struct{})
+}
+
+func requestContextError(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err //nolint:wrapcheck // Public dispatch helpers add operation context.
+	}
+	// Context implementations are required to report a non-nil Err after Done
+	// closes, but keep dispatch deterministic for custom implementations that
+	// violate that contract.
+	return errRequestContextDone
+}

--- a/bindings/go/worker_panic.go
+++ b/bindings/go/worker_panic.go
@@ -1,6 +1,7 @@
 package ferric
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 )
@@ -22,19 +23,73 @@ func (e *PanicError) Error() string {
 	return fmt.Sprintf("ferric: worker callback panicked with %T", e.Value)
 }
 
-func invokeWorkerCallback(engine *Engine, fn func(*Engine) error) (err error) {
+type workerResponse[T any] struct {
+	value T
+	err   error
+}
+
+// workerCall type-erases a typed callback while its completion closure retains
+// the concrete response channel. A dequeued call is completed exactly once by
+// its worker.
+type workerCall struct {
+	complete func(*Engine, error)
+}
+
+func newWorkerCall[T any](fn func(*Engine) (T, error)) (*workerCall, <-chan workerResponse[T]) {
+	responses := make(chan workerResponse[T], 1)
+	call := &workerCall{
+		complete: func(engine *Engine, dispatchErr error) {
+			if dispatchErr != nil {
+				responses <- workerResponse[T]{err: dispatchErr}
+				return
+			}
+			responses <- invokeWorkerCallback(engine, fn)
+		},
+	}
+	return call, responses
+}
+
+func waitWorkerResponse[T any](
+	ctx context.Context,
+	cancelQueued func() bool,
+	responses <-chan workerResponse[T],
+) workerResponse[T] {
+	select {
+	case response := <-responses:
+		return response
+	case <-ctx.Done():
+		if cancelQueued() {
+			return workerResponse[T]{
+				err: fmt.Errorf(
+					"ferric: request canceled while waiting for worker: %w",
+					requestContextError(ctx),
+				),
+			}
+		}
+		// The worker won ownership. Its sole response is authoritative even if
+		// cancellation and completion became observable at the same time.
+		response := <-responses
+		return response
+	}
+}
+
+//nolint:nonamedreturns // Panic recovery must replace the typed response error.
+func invokeWorkerCallback[T any](
+	engine *Engine,
+	fn func(*Engine) (T, error),
+) (response workerResponse[T]) {
 	completed := false
 	defer func() {
-		value := recover()
+		panicValue := recover()
 		if completed {
 			return
 		}
 		stack := make([]byte, workerPanicStackSize)
 		stack = stack[:runtime.Stack(stack, false)]
-		err = &PanicError{Value: value, Stack: stack}
+		response.err = &PanicError{Value: panicValue, Stack: stack}
 	}()
 
-	err = fn(engine)
+	response.value, response.err = fn(engine)
 	completed = true
-	return err
+	return response
 }

--- a/bindings/go/worker_panic_test.go
+++ b/bindings/go/worker_panic_test.go
@@ -171,7 +171,7 @@ func runPinnedPanicRecoveryScenario(t *testing.T) {
 		})
 	}()
 	waitWorkerPanicCondition(t, "queued pinned successor", func() bool {
-		return len(engine.requests) == 1
+		return engine.requests.len() == 1
 	})
 	releaseOnce.Do(func() { close(release) })
 
@@ -232,7 +232,7 @@ func runCoordinatorPanicRecoveryScenario(t *testing.T) {
 		})
 	}()
 	waitWorkerPanicCondition(t, "queued coordinator successor", func() bool {
-		return len(workerBefore.requests) == 1
+		return workerBefore.requests.len() == 1
 	})
 	releaseOnce.Do(func() { close(release) })
 
@@ -357,19 +357,19 @@ func runPinnedPanicCancellationScenario(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	entered := make(chan struct{})
+	payload := &workerPanicPayload{message: "pinned canceled callback boom"}
 	panicResult := make(chan error, 1)
 	go func() {
+		defer close(panicResult)
 		panicResult <- engine.Do(ctx, func(*Engine) error {
 			close(entered)
 			<-release
-			panic("pinned canceled callback boom")
+			panic(payload)
 		})
 	}()
 	waitWorkerPanicSignal(t, entered, "pinned canceled callback entry")
 	cancel()
-	if err := waitWorkerPanicError(t, panicResult, "pinned cancellation response"); !errors.Is(err, context.Canceled) {
-		t.Fatalf("canceled Do error = %v, want context.Canceled", err)
-	}
+	assertWorkerPanicPending(t, panicResult, "started pinned callback after cancellation")
 
 	successorResult := make(chan error, 1)
 	go func() {
@@ -378,13 +378,14 @@ func runPinnedPanicCancellationScenario(t *testing.T) {
 		})
 	}()
 	waitWorkerPanicCondition(t, "queued pinned successor after cancellation", func() bool {
-		return len(engine.requests) == 1
+		return engine.requests.len() == 1
 	})
-	// The canceled caller abandoned a capacity-one response channel. A second
-	// panic response would block the worker and keep this successor from running.
 	releaseOnce.Do(func() { close(release) })
+	panicErr := waitWorkerPanicError(t, panicResult, "pinned panic response after cancellation")
+	assertWorkerPanicError(t, panicErr, payload, "runPinnedPanicCancellationScenario")
+	assertWorkerPanicResultClosed(t, panicResult, "pinned panic response")
 	if err := waitWorkerPanicError(t, successorResult, "pinned successor after cancellation"); err != nil {
-		t.Fatalf("pinned worker wedged after abandoned panic response: %v", err)
+		t.Fatalf("pinned worker was not reusable after canceled callback panic: %v", err)
 	}
 }
 
@@ -407,19 +408,19 @@ func runCoordinatorPanicCancellationScenario(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	entered := make(chan struct{})
+	payload := &workerPanicPayload{message: "coordinator canceled callback boom"}
 	panicResult := make(chan error, 1)
 	go func() {
+		defer close(panicResult)
 		panicResult <- manager.Do(ctx, func(*Engine) error {
 			close(entered)
 			<-release
-			panic("coordinator canceled callback boom")
+			panic(payload)
 		})
 	}()
 	waitWorkerPanicSignal(t, entered, "coordinator canceled callback entry")
 	cancel()
-	if err := waitWorkerPanicError(t, panicResult, "coordinator cancellation response"); !errors.Is(err, context.Canceled) {
-		t.Fatalf("canceled Do error = %v, want context.Canceled", err)
-	}
+	assertWorkerPanicPending(t, panicResult, "started coordinator callback after cancellation")
 
 	successorResult := make(chan error, 1)
 	go func() {
@@ -428,13 +429,14 @@ func runCoordinatorPanicCancellationScenario(t *testing.T) {
 		})
 	}()
 	waitWorkerPanicCondition(t, "queued coordinator successor after cancellation", func() bool {
-		return len(workerBefore.requests) == 1
+		return workerBefore.requests.len() == 1
 	})
-	// The canceled caller abandoned a capacity-one response channel. A second
-	// panic response would block the worker and keep this successor from running.
 	releaseOnce.Do(func() { close(release) })
+	panicErr := waitWorkerPanicError(t, panicResult, "coordinator panic response after cancellation")
+	assertWorkerPanicError(t, panicErr, payload, "runCoordinatorPanicCancellationScenario")
+	assertWorkerPanicResultClosed(t, panicResult, "coordinator panic response")
 	if err := waitWorkerPanicError(t, successorResult, "coordinator successor after cancellation"); err != nil {
-		t.Fatalf("coordinator worker wedged after abandoned panic response: %v", err)
+		t.Fatalf("coordinator worker was not reusable after canceled callback panic: %v", err)
 	}
 	assertCoordinatorWorkerAlive(t, coordinator, workerBefore)
 }
@@ -497,35 +499,59 @@ func runPinnedNilPanicScenario(t *testing.T) {
 	}
 }
 
+//nolint:funlen // The closed-queue drain must cover the blocker, panic, successor, and Close barriers.
 func runPinnedPanicDrainScenario(t *testing.T) {
 	t.Helper()
 
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-	engine, err := NewEngine()
+	engine, err := NewPinnedEngine()
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = engine.Close() }()
+
+	releaseBlocker := make(chan struct{})
+	var releaseOnce sync.Once
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseBlocker) })
+		_ = engine.Close()
+	})
+	blockerStarted := make(chan struct{})
+	blockerResult := make(chan error, 1)
+	go func() {
+		blockerResult <- engine.Do(context.Background(), func(*Engine) error {
+			close(blockerStarted)
+			<-releaseBlocker
+			return nil
+		})
+	}()
+	waitWorkerPanicSignal(t, blockerStarted, "pinned drain blocker entry")
 
 	payload := &workerPanicPayload{message: "pinned drain callback boom"}
 	panicResult := make(chan error, 1)
 	successorResult := make(chan error, 1)
-	pinned := &PinnedEngine{requests: make(chan pinnedRequest, 2)}
-	pinned.requests <- pinnedRequest{
-		fn: func(*Engine) error {
+	go func() {
+		panicResult <- engine.Do(context.Background(), func(*Engine) error {
 			panic(payload)
-		},
-		resp: panicResult,
-	}
-	pinned.requests <- pinnedRequest{
-		fn: func(callbackEngine *Engine) error {
+		})
+	}()
+	waitWorkerPanicCondition(t, "queued pinned drain panic", func() bool {
+		return engine.requests.len() == 1
+	})
+	go func() {
+		successorResult <- engine.Do(context.Background(), func(callbackEngine *Engine) error {
 			return callbackEngine.Reset()
-		},
-		resp: successorResult,
-	}
+		})
+	}()
+	waitWorkerPanicCondition(t, "queued pinned drain successor", func() bool {
+		return engine.requests.len() == 2
+	})
 
-	pinned.drain(engine)
+	closeResult := make(chan error, 1)
+	go func() { closeResult <- engine.Close() }()
+	waitWorkerPanicCondition(t, "pinned drain closed state", engine.closed.Load)
+	releaseOnce.Do(func() { close(releaseBlocker) })
+	if err := waitWorkerPanicError(t, blockerResult, "pinned drain blocker response"); err != nil {
+		t.Fatalf("pinned drain blocker failed: %v", err)
+	}
 	assertWorkerPanicError(
 		t,
 		waitWorkerPanicError(t, panicResult, "pinned drain panic response"),
@@ -534,6 +560,9 @@ func runPinnedPanicDrainScenario(t *testing.T) {
 	)
 	if err := waitWorkerPanicError(t, successorResult, "pinned drain successor"); err != nil {
 		t.Fatalf("pinned drain stopped after recovered callback panic: %v", err)
+	}
+	if err := waitWorkerPanicError(t, closeResult, "pinned drain Close"); err != nil {
+		t.Fatalf("pinned drain Close failed: %v", err)
 	}
 }
 
@@ -600,6 +629,27 @@ func waitWorkerPanicSignal(t *testing.T, signal <-chan struct{}, label string) {
 	case <-signal:
 	case <-time.After(workerPanicTestTimeout):
 		t.Fatalf("timed out waiting for %s", label)
+	}
+}
+
+func assertWorkerPanicPending(t *testing.T, result <-chan error, label string) {
+	t.Helper()
+	select {
+	case err := <-result:
+		t.Fatalf("%s settled before its callback completed: %v", label, err)
+	case <-time.After(25 * time.Millisecond):
+	}
+}
+
+func assertWorkerPanicResultClosed(t *testing.T, result <-chan error, label string) {
+	t.Helper()
+	select {
+	case _, ok := <-result:
+		if ok {
+			t.Fatalf("%s produced more than one result", label)
+		}
+	case <-time.After(workerPanicTestTimeout):
+		t.Fatalf("timed out waiting for %s channel to close", label)
 	}
 }
 


### PR DESCRIPTION
Closes #130

## Summary

- replace the fixed worker channels with one bounded, removable FIFO shared by `PinnedEngine` and Coordinator workers
- wake one blocked producer per freed slot while reserving broadcast wakeups for queue closure
- linearize cancellation against worker claim: queued cancellation physically removes the request and reclaims capacity, while started work waits for its sole worker-owned response
- return typed response envelopes for every result-bearing `PinnedEngine` operation and `Manager.Evaluate`, eliminating caller-captured result slots
- preserve cooperative active-run cancellation from #128 and per-request panic recovery from #129
- document queued versus started mutation and cancellation semantics

## Root cause

After a request entered a worker channel, callers could still return on `ctx.Done()` while the worker executed the callback and wrote caller-captured result state. That allowed engine mutation and result writes after the public call had returned. Channel admission also offered no way to remove canceled queued work or immediately reclaim its queue capacity.

The new queue makes cancellation and dequeue a single lock-linearized ownership transition. If cancellation wins, the exact pending node is removed and the callback never runs. If dequeue wins, the caller waits for the worker's typed value/error envelope, so there is one response owner and no post-return result write. Separate not-empty/not-full signals avoid waking every blocked submitter for a single freed slot; a close-only signal still wakes all waiters for shutdown.

## Validation

- deterministic pre-fix regression: a started `PinnedEngine.Do` returned `context.Canceled` before its blocked callback settled
- `just go-full`
- focused #130 race matrix, `-count=100`
- all request-queue tests under `-race -count=1000`
- `GOFLAGS=-timeout=30m just test-go-stress 100` (100 full race repetitions; 1008.198s for the main Go package)
- `just run-golang-ci` — 0 issues
- `just preflight-pr`

The ordinary 10-minute Go package watchdog was insufficient for the count-100 run after #129 added subprocess-backed panic tests: it stopped after 59 clean repetitions with no assertion or race failure. The terminal rerun changed only the package watchdog, not the workload.