### PR TITLE
[FR-GO-012] Reject embedded NUL in Go C strings

### DIFF
--- a/bindings/go/cmd/bindings-conformance/main.go
+++ b/bindings/go/cmd/bindings-conformance/main.go
@@ -556,7 +556,11 @@ func lifecycleClose() (any, error) {
 }
 
 func embeddedNUL() (any, error) {
-	return assertedField("a\x00b")
+	_, err := assertedField("a\x00b")
+	if !errors.Is(err, ferric.ErrInvalidArgument) {
+		return nil, fmt.Errorf("embedded NUL should return ErrInvalidArgument: %w", err)
+	}
+	return map[string]any{"error": "invalid_argument"}, nil
 }
 
 func highFactID() (any, error) {

--- a/bindings/go/coverage_edge_test.go
+++ b/bindings/go/coverage_edge_test.go
@@ -53,7 +53,7 @@ func resetFFIHooks() {
 	ffiEngineFocusStackEntry = ffi.EngineFocusStackEntry
 	ffiEngineAgendaCount = ffi.EngineAgendaCount
 	ffiEngineIsHalted = ffi.EngineIsHalted
-	ffiEngineGetOutput = ffi.EngineGetOutput
+	ffiEngineGetOutputCopy = ffi.EngineGetOutputCopy
 	ffiEngineClearOutput = ffi.EngineClearOutput
 	ffiEnginePushInput = ffi.EnginePushInput
 	ffiEngineActionDiagnosticCount = ffi.EngineActionDiagnosticCount
@@ -66,6 +66,8 @@ func resetFFIHooks() {
 	ffiEngineTemplateSlotCount = ffi.EngineTemplateSlotCount
 	ffiEngineTemplateSlotName = ffi.EngineTemplateSlotName
 	ffiEngineGetFactRelation = ffi.EngineGetFactRelation
+	ffiValueSymbolBytes = ffi.ValueSymbolBytes
+	ffiValueStringBytes = ffi.ValueStringBytes
 	ffiValueMultifieldCopy = ffi.ValueMultifieldCopy
 	ffiValueFree = ffi.ValueFree
 	factsToWire = FactsToWire
@@ -1686,6 +1688,9 @@ func TestManagerCoordinatorPinnedSurface(t *testing.T) {
 func TestPropertyErrorSentinelsAndFFIValueConversions(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		text := rapid.String().Draw(t, "text")
+		ffiText := rapid.String().Filter(func(value string) bool {
+			return !strings.ContainsRune(value, '\x00')
+		}).Draw(t, "ffi_text")
 		i := rapid.Int64().Draw(t, "integer")
 		i32 := rapid.Int32().Draw(t, "integer32")
 		f := rapid.Float64().Filter(func(v float64) bool { return !math.IsNaN(v) }).Draw(t, "float")
@@ -1720,12 +1725,12 @@ func TestPropertyErrorSentinelsAndFFIValueConversions(t *testing.T) {
 			i32,
 			f,
 			float32(f),
-			Symbol(text),
-			text,
+			Symbol(ffiText),
+			ffiText,
 			true,
 			false,
 			nil,
-			[]any{i, Symbol(text), text},
+			[]any{i, Symbol(ffiText), ffiText},
 		}
 		for _, value := range values {
 			fv, err := goToFFIValue(value)

--- a/bindings/go/embedded_nul_test.go
+++ b/bindings/go/embedded_nul_test.go
@@ -1,0 +1,391 @@
+package ferric
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/prb/ferric-rules/bindings/go/internal/ffi"
+)
+
+const embeddedNULPublicFixture = `
+	(deftemplate item (slot payload))
+	(defglobal ?*answer* = 42)
+	(defrule emit => (printout t "kept"))
+`
+
+func TestNewEngineRejectsEmbeddedNULSource(t *testing.T) {
+	source := `(defrule prefix => (assert (kept)))` + "\x00" + `(defrule truncated`
+	tests := []struct {
+		name string
+		opts []EngineOption
+	}{
+		{name: "default", opts: []EngineOption{WithSource(source)}},
+		{
+			name: "configured",
+			opts: []EngineOption{WithSource(source), WithStrategy(StrategyBreadth)},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lockThread(t)
+			engine, err := NewEngine(tc.opts...)
+			if engine != nil {
+				_ = engine.Close()
+				t.Fatal("NewEngine accepted an embedded-NUL source")
+			}
+			assertEmbeddedNULArgument(t, err, "source", source)
+		})
+	}
+
+	pinned, err := NewPinnedEngine(WithSource(source))
+	if pinned != nil {
+		_ = pinned.Close()
+		t.Fatal("NewPinnedEngine accepted an embedded-NUL source")
+	}
+	assertEmbeddedNULArgument(t, err, "source", source)
+}
+
+//nolint:funlen // One table keeps the public CString-boundary audit complete and reviewable.
+func TestEngineRejectsEmbeddedNULArgumentsWithoutMutation(t *testing.T) {
+	lockThread(t)
+	engine, err := NewEngine(WithSource(embeddedNULPublicFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, engine)
+
+	// Leave a native diagnostic behind. Every rejection below must use its
+	// fresh Go-owned message rather than this stale channel (#126).
+	if err = engine.Load("(defrule stale"); !errors.Is(err, ErrParse) {
+		t.Fatalf("stale diagnostic setup = %v, want ErrParse", err)
+	}
+
+	badSource := `(deftemplate alias (slot value))` + "\x00" + `(defrule truncated`
+	badAssert := `(assert (alias kept))` + "\x00" + `(assert (truncated))`
+	badName := "alias\x00suffix"
+	badValue := "value\x00suffix"
+	tests := []struct {
+		name     string
+		argument string
+		value    string
+		call     func() error
+	}{
+		{name: "load source", argument: "source", value: badSource, call: func() error {
+			return engine.Load(badSource)
+		}},
+		{name: "assert source", argument: "source", value: badAssert, call: func() error {
+			_, callErr := engine.AssertString(badAssert)
+			return callErr
+		}},
+		{name: "ordered relation", argument: "relation", value: badName, call: func() error {
+			_, callErr := engine.AssertFact(badName, int64(1))
+			return callErr
+		}},
+		{name: "string field", argument: "fields[0]", value: badValue, call: func() error {
+			_, callErr := engine.AssertFact("alias", badValue)
+			return callErr
+		}},
+		{name: "symbol field", argument: "fields[0]", value: badValue, call: func() error {
+			_, callErr := engine.AssertFact("alias", Symbol(badValue))
+			return callErr
+		}},
+		{name: "nested field", argument: "fields[0][1]", value: badValue, call: func() error {
+			_, callErr := engine.AssertFact("alias", []any{"valid", badValue})
+			return callErr
+		}},
+		{name: "template name", argument: "template name", value: "item\x00suffix", call: func() error {
+			_, callErr := engine.AssertTemplate("item\x00suffix", map[string]any{"payload": int64(1)})
+			return callErr
+		}},
+		{name: "slot name", argument: `slot name "payload\x00suffix"`, value: "payload\x00suffix", call: func() error {
+			_, callErr := engine.AssertTemplate("item", map[string]any{"payload\x00suffix": int64(1)})
+			return callErr
+		}},
+		{name: "slot string", argument: `slots["payload"]`, value: badValue, call: func() error {
+			_, callErr := engine.AssertTemplate("item", map[string]any{"payload": badValue})
+			return callErr
+		}},
+		{name: "slot symbol", argument: `slots["payload"]`, value: badValue, call: func() error {
+			_, callErr := engine.AssertTemplate("item", map[string]any{"payload": Symbol(badValue)})
+			return callErr
+		}},
+		{name: "nested slot", argument: `slots["payload"][0]`, value: badValue, call: func() error {
+			_, callErr := engine.AssertTemplate("item", map[string]any{"payload": []any{badValue}})
+			return callErr
+		}},
+		{name: "find relation", argument: "relation", value: badName, call: func() error {
+			_, callErr := engine.FindFacts(badName)
+			return callErr
+		}},
+		{name: "global name", argument: "global name", value: "answer\x00suffix", call: func() error {
+			_, callErr := engine.GetGlobal("answer\x00suffix")
+			return callErr
+		}},
+	}
+
+	for _, tc := range tests {
+		beforeFacts, countErr := engine.FactCount()
+		if countErr != nil {
+			t.Fatalf("%s: %v", tc.name, countErr)
+		}
+		beforeTemplates := len(engine.Templates())
+		assertEmbeddedNULArgument(t, tc.call(), tc.argument, tc.value)
+		afterFacts, countErr := engine.FactCount()
+		if countErr != nil {
+			t.Fatalf("%s: %v", tc.name, countErr)
+		}
+		if afterFacts != beforeFacts || len(engine.Templates()) != beforeTemplates {
+			t.Fatalf(
+				"%s: engine mutated: facts %d -> %d, templates %d -> %d",
+				tc.name,
+				beforeFacts,
+				afterFacts,
+				beforeTemplates,
+				len(engine.Templates()),
+			)
+		}
+	}
+
+	if _, err = engine.AssertFact("valid-after-rejection", "ok"); err != nil {
+		t.Fatalf("engine was not reusable after rejection: %v", err)
+	}
+}
+
+func TestEngineEmbeddedNULIOErrorsAndLegacyBehavior(t *testing.T) {
+	lockThread(t)
+	engine, err := NewEngine(WithSource(embeddedNULPublicFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, engine)
+	if _, err = engine.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	badChannel := "t\x00suffix"
+	output, ok, err := engine.GetOutputE(badChannel)
+	if output != "" || ok {
+		t.Fatalf("GetOutputE invalid result = (%q, %v), want empty false", output, ok)
+	}
+	assertEmbeddedNULArgument(t, err, "output channel", badChannel)
+	if output, ok = engine.GetOutput(badChannel); output != "" || ok {
+		t.Fatalf("legacy GetOutput invalid result = (%q, %v), want empty false", output, ok)
+	}
+
+	assertEmbeddedNULArgument(t, engine.ClearOutputE(badChannel), "output channel", badChannel)
+	engine.ClearOutput(badChannel)
+	if output, ok, err = engine.GetOutputE("t"); err != nil || !ok || output != "kept" {
+		t.Fatalf("valid output after rejected clear = (%q, %v, %v)", output, ok, err)
+	}
+
+	badLine := "prefix\x00suffix"
+	assertEmbeddedNULArgument(t, engine.PushInputE(badLine), "input line", badLine)
+	engine.PushInput(badLine)
+	if err = engine.PushInputE("valid"); err != nil {
+		t.Fatalf("valid input after rejection = %v", err)
+	}
+	snapshot, err := engine.Serialize(FormatJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := decodeJSONSnapshot(t, snapshot)
+	input, ok := state["input_buffer"].([]any)
+	if !ok || len(input) != 1 || input[0] != "valid" {
+		t.Fatalf("serialized input buffer = %#v, want only the valid line", state["input_buffer"])
+	}
+}
+
+func TestGetOutputEPreservesEmbeddedNULFromSnapshot(t *testing.T) {
+	lockThread(t)
+	engine, err := NewEngine(WithSource(embeddedNULPublicFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = engine.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := engine.Serialize(FormatJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = engine.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	state := decodeJSONSnapshot(t, snapshot)
+	router, ok := state["router"].(map[string]any)
+	if !ok {
+		t.Fatalf("snapshot router = %#v, want object", state["router"])
+	}
+	buffers, ok := router["buffers"].([]any)
+	if !ok {
+		t.Fatalf("snapshot buffers = %#v, want entries", router["buffers"])
+	}
+	replaced := false
+	for _, rawEntry := range buffers {
+		entry, entryOK := rawEntry.([]any)
+		if entryOK && len(entry) == 2 && entry[0] == "t" {
+			entry[1] = "a\x00b"
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		t.Fatalf("snapshot buffers = %#v, missing t entry", buffers)
+	}
+	modified, err := json.Marshal(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	restored, err := NewEngine(WithSnapshot(modified, FormatJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, restored)
+	output, found, err := restored.GetOutputE("t")
+	if err != nil || !found || output != "a\x00b" {
+		t.Fatalf("GetOutputE = (%q, %v, %v), want exact embedded-NUL output", output, found, err)
+	}
+}
+
+func TestPinnedAndManagerRejectEmbeddedNULAndRemainReusable(t *testing.T) {
+	pinned, err := NewPinnedEngine(WithSource(embeddedNULPublicFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, pinned)
+	badRelation := "alias\x00suffix"
+	_, err = pinned.AssertFact(badRelation, "value")
+	assertEmbeddedNULArgument(t, err, "relation", badRelation)
+	if _, err = pinned.AssertFact("pinned-valid", "value"); err != nil {
+		t.Fatalf("PinnedEngine was not reusable: %v", err)
+	}
+
+	badChannel := "t\x00suffix"
+	_, _, err = pinned.GetOutputE(badChannel)
+	assertEmbeddedNULArgument(t, err, "output channel", badChannel)
+	assertEmbeddedNULArgument(t, pinned.ClearOutputE(badChannel), "output channel", badChannel)
+	badLine := "line\x00suffix"
+	assertEmbeddedNULArgument(t, pinned.PushInputE(badLine), "input line", badLine)
+
+	manager, err := NewManager(WithSource(embeddedNULPublicFixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, manager)
+	err = manager.Do(context.Background(), func(engine *Engine) error {
+		_, callErr := engine.AssertFact(badRelation, "value")
+		return callErr
+	})
+	assertEmbeddedNULArgument(t, err, "relation", badRelation)
+	if err = manager.Do(context.Background(), func(engine *Engine) error {
+		_, callErr := engine.AssertFact("manager-valid", "value")
+		return callErr
+	}); err != nil {
+		t.Fatalf("Manager worker was not reusable: %v", err)
+	}
+}
+
+func TestEmbeddedNULValueFailureFreesEarlierNestedValues(t *testing.T) {
+	withFFIHooks(t)
+	originalFree := ffiValueFree
+	freed := 0
+	ffiValueFree = func(value *ffi.Value) {
+		freed++
+		originalFree(value)
+	}
+
+	badValue := "bad\x00suffix"
+	_, err := goToFFIValue([]any{"outer-converted", []any{"inner-converted", badValue}})
+	assertEmbeddedNULArgument(t, err, "value[1][1]", badValue)
+	if freed != 2 {
+		t.Fatalf("freed values = %d, want converted values at both nesting levels", freed)
+	}
+}
+
+func TestSnapshotBytesAndFilePathsDoNotUseCStringPolicy(t *testing.T) {
+	lockThread(t)
+	withFFIHooks(t)
+	snapshot := []byte("snapshot\x00payload")
+	ffiEngineDeserializeAs = func(data []byte, format ffi.SerializationFormat) (ffi.EngineHandle, ffi.ErrorCode) {
+		if string(data) != string(snapshot) {
+			t.Fatalf("snapshot bytes = %q, want %q", data, snapshot)
+		}
+		if format != ffi.FormatBincode {
+			t.Fatalf("format = %d, want bincode", format)
+		}
+		return nil, ffi.ErrSerializationError
+	}
+	_, err := NewEngine(WithSnapshot(snapshot, FormatBincode))
+	if !errors.Is(err, ErrSerialization) {
+		t.Fatalf("snapshot result = %v, want ErrSerialization", err)
+	}
+
+	prefix := t.TempDir() + "/snapshot"
+	if err = os.WriteFile(prefix, []byte("prefix file"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewEngineFromFile(prefix+"\x00suffix", FormatBincode)
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("NUL path error = %T %v, want *os.PathError", err, err)
+	}
+
+	engine, err := NewEngine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mustClose(t, engine)
+	err = engine.SerializeToFile(prefix+"\x00suffix", FormatBincode)
+	if !errors.As(err, &pathErr) {
+		t.Fatalf("NUL output path error = %T %v, want *os.PathError", err, err)
+	}
+	// #nosec G304 -- prefix is a test-owned path inside t.TempDir.
+	prefixData, err := os.ReadFile(prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(prefixData) != "prefix file" {
+		t.Fatalf("prefix file changed to %q", prefixData)
+	}
+}
+
+func decodeJSONSnapshot(t *testing.T, snapshot []byte) map[string]any {
+	t.Helper()
+	var state map[string]any
+	if err := json.Unmarshal(snapshot, &state); err != nil {
+		t.Fatal(err)
+	}
+	return state
+}
+
+func assertEmbeddedNULArgument(t *testing.T, err error, argument, value string) {
+	t.Helper()
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("error = %v, want ErrInvalidArgument", err)
+	}
+	var invalid *InvalidArgumentError
+	if !errors.As(err, &invalid) {
+		t.Fatalf("error = %T %v, want *InvalidArgumentError", err, err)
+	}
+	if invalid.Code != int(ffi.ErrInvalidArgument) {
+		t.Fatalf("error code = %d, want %d", invalid.Code, ffi.ErrInvalidArgument)
+	}
+	wantMessage := fmt.Sprintf(
+		"%s contains embedded NUL at byte %d",
+		argument,
+		strings.IndexByte(value, 0),
+	)
+	if invalid.Message != wantMessage || !strings.Contains(err.Error(), wantMessage) {
+		t.Fatalf("error = %#v (%q), want message %q", invalid, err.Error(), wantMessage)
+	}
+	if strings.Contains(invalid.Message, "stale") {
+		t.Fatalf("fresh validation error leaked prior diagnostic: %q", invalid.Message)
+	}
+}

--- a/bindings/go/engine.go
+++ b/bindings/go/engine.go
@@ -13,6 +13,16 @@ import (
 
 var errIntOverflow = fmt.Errorf("ferric: integer overflow")
 
+func validateCStringArgument(argument, value string) error {
+	if err := ffi.ValidateCString(argument, value); err != nil {
+		return &InvalidArgumentError{FerricError{
+			Code:    int(ffi.ErrInvalidArgument),
+			Message: err.Error(),
+		}}
+	}
+	return nil
+}
+
 // runBatchSize bounds the number of rule firings between host-side
 // cancellation or interruption checks in a chunked run.
 const runBatchSize = 100
@@ -72,17 +82,9 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 		}
 	} else {
 		if cfg.hasSource() {
-			if cfg.hasEngineConfig() {
-				h = ffiEngineNewWithSourceConfig(cfg.source, config)
-			} else {
-				h = ffiEngineNewWithSource(cfg.source)
-			}
-			if h == nil {
-				msg := ffiLastErrorGlobal()
-				if msg == "" {
-					msg = "failed to create engine from source"
-				}
-				return nil, &ParseError{FerricError{Message: msg}}
+			h, err = newEngineFromSource(&cfg, config)
+			if err != nil {
+				return nil, err
 			}
 		} else {
 			if cfg.hasEngineConfig() {
@@ -99,6 +101,26 @@ func NewEngine(opts ...EngineOption) (*Engine, error) {
 	e := &Engine{handle: h}
 	runtime.SetFinalizer(e, finalizeEngine)
 	return e, nil
+}
+
+func newEngineFromSource(cfg *engineConfig, config *ffi.Config) (ffi.EngineHandle, error) {
+	if err := validateCStringArgument("source", cfg.source); err != nil {
+		return nil, err
+	}
+	var handle ffi.EngineHandle
+	if cfg.hasEngineConfig() {
+		handle = ffiEngineNewWithSourceConfig(cfg.source, config)
+	} else {
+		handle = ffiEngineNewWithSource(cfg.source)
+	}
+	if handle == nil {
+		msg := ffiLastErrorGlobal()
+		if msg == "" {
+			msg = "failed to create engine from source"
+		}
+		return nil, &ParseError{FerricError{Message: msg}}
+	}
+	return handle, nil
 }
 
 func finalizeEngine(e *Engine) {
@@ -245,6 +267,9 @@ func (e *Engine) Load(source string) error {
 		return err
 	}
 	defer release()
+	if err = validateCStringArgument("source", source); err != nil {
+		return err
+	}
 
 	rc := ffiEngineLoadString(handle, source)
 	if rc != ffi.ErrOK {
@@ -263,6 +288,9 @@ func (e *Engine) AssertString(source string) (uint64, error) {
 		return 0, err
 	}
 	defer release()
+	if err = validateCStringArgument("source", source); err != nil {
+		return 0, err
+	}
 
 	id, rc := ffiEngineAssertString(handle, source)
 	if rc != ffi.ErrOK {
@@ -281,6 +309,9 @@ func (e *Engine) AssertFact(relation string, fields ...any) (uint64, error) {
 		return 0, err
 	}
 	defer release()
+	if err = validateCStringArgument("relation", relation); err != nil {
+		return 0, err
+	}
 
 	vals := make([]ffi.Value, len(fields))
 	defer func() {
@@ -289,7 +320,7 @@ func (e *Engine) AssertFact(relation string, fields ...any) (uint64, error) {
 		}
 	}()
 	for i, f := range fields {
-		v, conversionErr := goToFFIValue(f)
+		v, conversionErr := goToFFIValueAtPath(f, fmt.Sprintf("fields[%d]", i), 0)
 		if conversionErr != nil {
 			return 0, conversionErr
 		}
@@ -313,6 +344,9 @@ func (e *Engine) AssertTemplate(templateName string, slots map[string]any) (uint
 		return 0, err
 	}
 	defer release()
+	if err = validateCStringArgument("template name", templateName); err != nil {
+		return 0, err
+	}
 
 	names := make([]string, 0, len(slots))
 	vals := make([]ffi.Value, 0, len(slots))
@@ -322,7 +356,10 @@ func (e *Engine) AssertTemplate(templateName string, slots map[string]any) (uint
 		}
 	}()
 	for k, v := range slots {
-		fv, conversionErr := goToFFIValue(v)
+		if err = validateCStringArgument(fmt.Sprintf("slot name %q", k), k); err != nil {
+			return 0, err
+		}
+		fv, conversionErr := goToFFIValueAtPath(v, fmt.Sprintf("slots[%q]", k), 0)
 		if conversionErr != nil {
 			return 0, conversionErr
 		}
@@ -397,6 +434,9 @@ func (e *Engine) FindFacts(relation string) ([]Fact, error) {
 		return nil, err
 	}
 	defer release()
+	if err = validateCStringArgument("relation", relation); err != nil {
+		return nil, err
+	}
 
 	ids, rc := ffiEngineFindFactIDs(handle, relation)
 	if rc != ffi.ErrOK {
@@ -707,6 +747,9 @@ func (e *Engine) GetGlobal(name string) (any, error) {
 		return nil, err
 	}
 	defer release()
+	if err = validateCStringArgument("global name", name); err != nil {
+		return nil, err
+	}
 
 	val, rc := ffiEngineGetGlobal(handle, name)
 	if rc != ffi.ErrOK {
@@ -771,38 +814,84 @@ func (e *Engine) IsHalted() bool {
 
 // --- I/O ---
 
-// GetOutput retrieves captured output for a named channel.
-// Returns the output string and true, or empty string and false if no output.
+// GetOutput retrieves captured output for a named channel. It returns the
+// output string and true, or empty string and false if no output. For backward
+// compatibility it discards validation, closed-state, and native errors; use
+// GetOutputE when the error must be observed.
 func (e *Engine) GetOutput(channel string) (string, bool) {
-	handle, release, err := e.leaseHandle()
-	if err != nil {
-		return "", false
-	}
-	defer release()
-
-	return ffiEngineGetOutput(handle, channel)
+	value, ok, _ := e.GetOutputE(channel)
+	return value, ok
 }
 
-// ClearOutput clears a specific output channel. It is a no-op after Close.
+// GetOutputE retrieves captured output for a named channel and reports
+// validation, closed-state, or native errors.
+func (e *Engine) GetOutputE(channel string) (string, bool, error) {
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return "", false, err
+	}
+	defer release()
+	if err = validateCStringArgument("output channel", channel); err != nil {
+		return "", false, err
+	}
+
+	value, ok, rc := ffiEngineGetOutputCopy(handle, channel)
+	if rc != ffi.ErrOK {
+		return "", false, errorFromFFI(rc, handle)
+	}
+	return value, ok, nil
+}
+
+// ClearOutput clears a specific output channel. For backward compatibility it
+// discards validation, closed-state, and native errors; use ClearOutputE when
+// the error must be observed.
 func (e *Engine) ClearOutput(channel string) {
-	handle, release, err := e.leaseHandle()
-	if err != nil {
-		return
-	}
-	defer release()
-
-	ffiEngineClearOutput(handle, channel)
+	_ = e.ClearOutputE(channel)
 }
 
-// PushInput pushes an input line for read/readline. It is a no-op after Close.
-func (e *Engine) PushInput(line string) {
+// ClearOutputE clears a specific output channel and reports validation,
+// closed-state, or native errors.
+func (e *Engine) ClearOutputE(channel string) error {
 	handle, release, err := e.leaseHandle()
 	if err != nil {
-		return
+		return err
 	}
 	defer release()
+	if err = validateCStringArgument("output channel", channel); err != nil {
+		return err
+	}
 
-	ffiEnginePushInput(handle, line)
+	rc := ffiEngineClearOutput(handle, channel)
+	if rc != ffi.ErrOK {
+		return errorFromFFI(rc, handle)
+	}
+	return nil
+}
+
+// PushInput pushes an input line for read/readline. For backward compatibility
+// it discards validation, closed-state, and native errors; use PushInputE when
+// the error must be observed.
+func (e *Engine) PushInput(line string) {
+	_ = e.PushInputE(line)
+}
+
+// PushInputE pushes an input line for read/readline and reports validation,
+// closed-state, or native errors.
+func (e *Engine) PushInputE(line string) error {
+	handle, release, err := e.leaseHandle()
+	if err != nil {
+		return err
+	}
+	defer release()
+	if err = validateCStringArgument("input line", line); err != nil {
+		return err
+	}
+
+	rc := ffiEnginePushInput(handle, line)
+	if rc != ffi.ErrOK {
+		return errorFromFFI(rc, handle)
+	}
+	return nil
 }
 
 // --- Diagnostics ---
@@ -1030,28 +1119,8 @@ func (e *Engine) buildFact(handle ffi.EngineHandle, factID uint64) (*Fact, error
 
 	if ft == ffi.FactTypeTemplate {
 		fact.Type = FactTemplate
-		name, rc := ffiEngineGetFactTemplateName(handle, factID)
-		if rc != ffi.ErrOK {
-			return nil, errorFromFFI(rc, handle)
-		}
-		fact.TemplateName = name
-
-		// Build slot map by querying template slot names.
-		slotCount, rc := ffiEngineTemplateSlotCount(handle, name)
-		if rc != ffi.ErrOK {
-			return nil, fmt.Errorf("ferric: failed to get slot count for template %q: %w", name, errorFromFFI(rc, handle))
-		}
-		if slotCount > 0 {
-			fact.Slots = make(map[string]any, slotCount)
-			for i := range slotCount {
-				slotName, rc := ffiEngineTemplateSlotName(handle, name, i)
-				if rc != ffi.ErrOK {
-					return nil, fmt.Errorf("ferric: failed to get slot name %d for template %q: %w", i, name, errorFromFFI(rc, handle))
-				}
-				if i < fieldCount {
-					fact.Slots[slotName] = fields[i]
-				}
-			}
+		if err := e.populateTemplateFact(handle, fact, fields, fieldCount); err != nil {
+			return nil, err
 		}
 	} else {
 		fact.Type = FactOrdered
@@ -1063,4 +1132,40 @@ func (e *Engine) buildFact(handle ffi.EngineHandle, factID uint64) (*Fact, error
 	}
 
 	return fact, nil
+}
+
+func (e *Engine) populateTemplateFact(
+	handle ffi.EngineHandle,
+	fact *Fact,
+	fields []any,
+	fieldCount uintptr,
+) error {
+	name, rc := ffiEngineGetFactTemplateName(handle, fact.ID)
+	if rc != ffi.ErrOK {
+		return errorFromFFI(rc, handle)
+	}
+	fact.TemplateName = name
+	if err := validateCStringArgument("template name", name); err != nil {
+		return err
+	}
+
+	// Build the slot map by querying template slot names.
+	slotCount, rc := ffiEngineTemplateSlotCount(handle, name)
+	if rc != ffi.ErrOK {
+		return fmt.Errorf("ferric: failed to get slot count for template %q: %w", name, errorFromFFI(rc, handle))
+	}
+	if slotCount == 0 {
+		return nil
+	}
+	fact.Slots = make(map[string]any, slotCount)
+	for i := range slotCount {
+		slotName, rc := ffiEngineTemplateSlotName(handle, name, i)
+		if rc != ffi.ErrOK {
+			return fmt.Errorf("ferric: failed to get slot name %d for template %q: %w", i, name, errorFromFFI(rc, handle))
+		}
+		if i < fieldCount {
+			fact.Slots[slotName] = fields[i]
+		}
+	}
+	return nil
 }

--- a/bindings/go/engine_close_test.go
+++ b/bindings/go/engine_close_test.go
@@ -202,14 +202,23 @@ func TestEngineMethodsAfterClose(t *testing.T) {
 			}
 			return nil
 		}},
+		{"GetOutputE", func() error {
+			output, ok, err := e.GetOutputE("stdout")
+			if output != "" || ok {
+				return fmt.Errorf("output = (%q, %v), want empty false", output, ok)
+			}
+			return wantClosed(err)
+		}},
 		{"ClearOutput", func() error {
 			e.ClearOutput("stdout")
 			return nil
 		}},
+		{"ClearOutputE", func() error { return wantClosed(e.ClearOutputE("stdout")) }},
 		{"PushInput", func() error {
 			e.PushInput("line")
 			return nil
 		}},
+		{"PushInputE", func() error { return wantClosed(e.PushInputE("line")) }},
 		{"Diagnostics", func() error {
 			if value := e.Diagnostics(); value != nil {
 				return fmt.Errorf("diagnostics = %#v, want nil", value)
@@ -593,9 +602,9 @@ func forbidEngineOperationFFI(t *testing.T) {
 		called("IsHalted")
 		return false, ffi.ErrOK
 	}
-	ffiEngineGetOutput = func(ffi.EngineHandle, string) (string, bool) {
-		called("GetOutput")
-		return "", false
+	ffiEngineGetOutputCopy = func(ffi.EngineHandle, string) (string, bool, ffi.ErrorCode) {
+		called("GetOutputCopy")
+		return "", false, ffi.ErrOK
 	}
 	ffiEngineClearOutput = func(ffi.EngineHandle, string) ffi.ErrorCode {
 		called("ClearOutput")

--- a/bindings/go/engine_options_presence_test.go
+++ b/bindings/go/engine_options_presence_test.go
@@ -265,13 +265,13 @@ func TestEmptySnapshotValidationFailsBeforeNativeConstruction(t *testing.T) {
 }
 
 func TestSnapshotInputsReachDeserializerUnchanged(t *testing.T) {
-	directData := []byte("direct snapshot")
+	directData := []byte("direct\x00snapshot")
 	assertSnapshotInput(t, directData, FormatMessagePack, func() error {
 		_, err := NewEngine(WithSnapshot(directData, FormatMessagePack))
 		return err
 	})
 
-	fileData := []byte("file snapshot")
+	fileData := []byte("file\x00snapshot")
 	path := t.TempDir() + "/snapshot.cbor"
 	if err := os.WriteFile(path, fileData, 0o600); err != nil {
 		t.Fatal(err)

--- a/bindings/go/engine_test.go
+++ b/bindings/go/engine_test.go
@@ -1523,6 +1523,15 @@ func TestEngineWrongThreadMultipleOps(t *testing.T) {
 		_, err = e.AssertString("(assert (z))")
 		results <- opResult{"AssertString", err}
 
+		_, _, err = e.GetOutputE("t")
+		results <- opResult{"GetOutputE", err}
+
+		err = e.ClearOutputE("t")
+		results <- opResult{"ClearOutputE", err}
+
+		err = e.PushInputE("line")
+		results <- opResult{"PushInputE", err}
+
 		close(results)
 	}()
 

--- a/bindings/go/ffi_hooks.go
+++ b/bindings/go/ffi_hooks.go
@@ -38,7 +38,7 @@ var (
 	ffiEngineFocusStackEntry        = ffi.EngineFocusStackEntry
 	ffiEngineAgendaCount            = ffi.EngineAgendaCount
 	ffiEngineIsHalted               = ffi.EngineIsHalted
-	ffiEngineGetOutput              = ffi.EngineGetOutput
+	ffiEngineGetOutputCopy          = ffi.EngineGetOutputCopy
 	ffiEngineClearOutput            = ffi.EngineClearOutput
 	ffiEnginePushInput              = ffi.EnginePushInput
 	ffiEngineActionDiagnosticCount  = ffi.EngineActionDiagnosticCount
@@ -51,6 +51,8 @@ var (
 	ffiEngineTemplateSlotCount      = ffi.EngineTemplateSlotCount
 	ffiEngineTemplateSlotName       = ffi.EngineTemplateSlotName
 	ffiEngineGetFactRelation        = ffi.EngineGetFactRelation
+	ffiValueSymbolBytes             = ffi.ValueSymbolBytes
+	ffiValueStringBytes             = ffi.ValueStringBytes
 	ffiValueMultifieldCopy          = ffi.ValueMultifieldCopy
 	ffiValueFree                    = ffi.ValueFree
 )

--- a/bindings/go/internal/ffi/embedded_nul_test.go
+++ b/bindings/go/internal/ffi/embedded_nul_test.go
@@ -1,0 +1,386 @@
+package ffi
+
+import (
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+const embeddedNULFixture = `
+	(deftemplate item (slot payload))
+	(defglobal ?*answer* = 42)
+	(defrule emit => (printout t "kept"))
+`
+
+func TestValidateCStringRejectsEmbeddedNUL(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		wantByte int
+	}{
+		{name: "first", value: "\x00suffix", wantByte: 0},
+		{name: "middle", value: "prefix\x00suffix", wantByte: 6},
+		{name: "unicode byte offset", value: "pré\x00suffix", wantByte: 4},
+		{name: "last", value: "prefix\x00", wantByte: 6},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateCString("argument", tc.value)
+			var nulErr *CStringError
+			if !errors.As(err, &nulErr) {
+				t.Fatalf("ValidateCString error = %T %v, want *CStringError", err, err)
+			}
+			if nulErr.Argument != "argument" || nulErr.Byte != tc.wantByte {
+				t.Fatalf("CStringError = %+v, want argument at byte %d", nulErr, tc.wantByte)
+			}
+			want := "argument contains embedded NUL at byte " + strconv.Itoa(tc.wantByte)
+			if err.Error() != want {
+				t.Fatalf("error = %q, want %q", err, want)
+			}
+		})
+	}
+
+	for _, value := range []string{"", "plain ASCII", "héllo"} {
+		if err := ValidateCString("argument", value); err != nil {
+			t.Fatalf("ValidateCString(%q) = %v, want nil", value, err)
+		}
+	}
+}
+
+func TestEngineConstructorsRejectEmbeddedNULSource(t *testing.T) {
+	lockThread(t)
+	source := `(deftemplate prefix (slot value))` + "\x00" + `(defrule truncated`
+
+	if handle := EngineNewWithSource(source); handle != nil {
+		_ = EngineFree(handle)
+		t.Fatal("EngineNewWithSource accepted an embedded-NUL source")
+	}
+
+	config := MakeConfig(StringEncodingUTF8, ConflictStrategyBreadth, 64)
+	if handle := EngineNewWithSourceConfig(source, config); handle != nil {
+		_ = EngineFree(handle)
+		t.Fatal("EngineNewWithSourceConfig accepted an embedded-NUL source")
+	}
+}
+
+//nolint:funlen // The table intentionally locks every C.CString-bearing engine wrapper in one audit.
+func TestEngineCStringWrappersRejectEmbeddedNUL(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*testing.T, EngineHandle)
+	}{
+		{
+			name: "load source",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				before, rc := EngineTemplateCount(handle)
+				requireFFIOK(t, rc)
+				rc = EngineLoadString(handle, `(deftemplate alias (slot value))`+"\x00"+`(defrule truncated`)
+				requireFFIInvalid(t, rc)
+				after, rc := EngineTemplateCount(handle)
+				requireFFIOK(t, rc)
+				if after != before {
+					t.Fatalf("template count changed from %d to %d", before, after)
+				}
+			},
+		},
+		{
+			name: "assert source",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				before, rc := EngineFactCount(handle)
+				requireFFIOK(t, rc)
+				id, rc := EngineAssertString(handle, `(assert (alias kept))`+"\x00"+`(assert (truncated))`)
+				requireFFIInvalid(t, rc)
+				if id != 0 {
+					t.Fatalf("fact ID = %d, want zero", id)
+				}
+				requireFactCount(t, handle, before)
+			},
+		},
+		{
+			name: "ordered relation",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				before, rc := EngineFactCount(handle)
+				requireFFIOK(t, rc)
+				id, rc := EngineAssertOrdered(handle, "alias\x00suffix", []Value{ValueInteger(7)})
+				requireFFIInvalid(t, rc)
+				if id != 0 {
+					t.Fatalf("fact ID = %d, want zero", id)
+				}
+				requireFactCount(t, handle, before)
+			},
+		},
+		{
+			name: "template name",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				before, rc := EngineFactCount(handle)
+				requireFFIOK(t, rc)
+				id, rc := EngineAssertTemplate(handle, "item\x00suffix", []string{"payload"}, []Value{ValueInteger(7)})
+				requireFFIInvalid(t, rc)
+				if id != 0 {
+					t.Fatalf("fact ID = %d, want zero", id)
+				}
+				requireFactCount(t, handle, before)
+			},
+		},
+		{
+			name: "slot name",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				before, rc := EngineFactCount(handle)
+				requireFFIOK(t, rc)
+				id, rc := EngineAssertTemplate(handle, "item", []string{"payload\x00suffix"}, []Value{ValueInteger(7)})
+				requireFFIInvalid(t, rc)
+				if id != 0 {
+					t.Fatalf("fact ID = %d, want zero", id)
+				}
+				requireFactCount(t, handle, before)
+			},
+		},
+		{
+			name: "find relation",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				if _, rc := EngineAssertOrdered(handle, "alias", nil); rc != ErrOK {
+					t.Fatalf("seed fact: %d", rc)
+				}
+				ids, rc := EngineFindFactIDs(handle, "alias\x00suffix")
+				requireFFIInvalid(t, rc)
+				if ids != nil {
+					t.Fatalf("IDs = %v, want nil", ids)
+				}
+			},
+		},
+		{
+			name: "named fact slot",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				id, rc := EngineAssertTemplate(handle, "item", []string{"payload"}, []Value{ValueInteger(7)})
+				requireFFIOK(t, rc)
+				value, rc := EngineGetFactSlotByName(handle, id, "payload\x00suffix")
+				requireFFIInvalid(t, rc)
+				if got := ValueGetType(&value); got != ValueTypeVoid {
+					t.Fatalf("value type = %d, want Void", got)
+				}
+			},
+		},
+		{
+			name: "global name",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				value, rc := EngineGetGlobal(handle, "answer\x00suffix")
+				requireFFIInvalid(t, rc)
+				if got := ValueGetType(&value); got != ValueTypeVoid {
+					t.Fatalf("value type = %d, want Void", got)
+				}
+			},
+		},
+		{
+			name: "get output channel",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				runFixtureToOutput(t, handle)
+				output, ok := EngineGetOutput(handle, "t\x00suffix")
+				if output != "" || ok {
+					t.Fatalf("invalid-channel output = (%q, %v), want empty false", output, ok)
+				}
+				if output, ok = EngineGetOutput(handle, "t"); !ok || output != "kept" {
+					t.Fatalf("valid output = (%q, %v), want kept true", output, ok)
+				}
+			},
+		},
+		{
+			name: "copy output channel",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				output, ok, rc := EngineGetOutputCopy(handle, "t\x00suffix")
+				requireFFIInvalid(t, rc)
+				if output != "" || ok {
+					t.Fatalf("invalid-channel output copy = (%q, %v), want empty false", output, ok)
+				}
+				output, ok, rc = EngineGetOutputCopy(handle, "missing")
+				requireFFIOK(t, rc)
+				if output != "" || ok {
+					t.Fatalf("missing output copy = (%q, %v), want empty false", output, ok)
+				}
+			},
+		},
+		{
+			name: "clear output channel",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				runFixtureToOutput(t, handle)
+				requireFFIInvalid(t, EngineClearOutput(handle, "t\x00suffix"))
+				if output, ok := EngineGetOutput(handle, "t"); !ok || output != "kept" {
+					t.Fatalf("valid output = (%q, %v), want kept true", output, ok)
+				}
+			},
+		},
+		{
+			name: "input line",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				requireFFIInvalid(t, EnginePushInput(handle, "prefix\x00suffix"))
+				requireFFIOK(t, EnginePushInput(handle, "valid"))
+			},
+		},
+		{
+			name: "template slot count",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				count, rc := EngineTemplateSlotCount(handle, "item\x00suffix")
+				requireFFIInvalid(t, rc)
+				if count != 0 {
+					t.Fatalf("slot count = %d, want zero", count)
+				}
+			},
+		},
+		{
+			name: "template slot name",
+			run: func(t *testing.T, handle EngineHandle) {
+				t.Helper()
+				name, rc := EngineTemplateSlotName(handle, "item\x00suffix", 0)
+				requireFFIInvalid(t, rc)
+				if name != "" {
+					t.Fatalf("slot name = %q, want empty", name)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lockThread(t)
+			handle := EngineNewWithSource(embeddedNULFixture)
+			if handle == nil {
+				t.Fatal("EngineNewWithSource returned nil")
+			}
+			t.Cleanup(func() {
+				if rc := EngineFree(handle); rc != ErrOK {
+					t.Errorf("EngineFree returned %d", rc)
+				}
+			})
+			tc.run(t, handle)
+		})
+	}
+}
+
+func TestValueCStringWrappersRejectEmbeddedNUL(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		legacy func(string) Value
+		bytes  func(string) (Value, ErrorCode)
+	}{
+		{name: "symbol", legacy: ValueSymbol, bytes: ValueSymbolBytes},
+		{name: "string", legacy: ValueString, bytes: ValueStringBytes},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			legacy := tc.legacy("a\x00b")
+			if got := ValueGetType(&legacy); got != ValueTypeVoid {
+				ValueFree(&legacy)
+				t.Fatalf("legacy value type = %d, want Void", got)
+			}
+
+			value, rc := tc.bytes("a\x00b")
+			requireFFIInvalid(t, rc)
+			if got := ValueGetType(&value); got != ValueTypeVoid {
+				ValueFree(&value)
+				t.Fatalf("checked value type = %d, want Void", got)
+			}
+
+			valid, rc := tc.bytes("héllo")
+			requireFFIOK(t, rc)
+			defer ValueFree(&valid)
+			if got := ValueGetStringPtr(&valid); got != "héllo" {
+				t.Fatalf("valid value = %q, want héllo", got)
+			}
+		})
+	}
+}
+
+func TestCStringConversionIsCentralized(t *testing.T) {
+	paths, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fset := token.NewFileSet()
+	var calls []string
+	for _, path := range paths {
+		if filepath.Ext(path) != ".go" || filepath.Base(path) == "embedded_nul_test.go" {
+			continue
+		}
+		file, parseErr := parser.ParseFile(fset, path, nil, 0)
+		if parseErr != nil {
+			t.Fatal(parseErr)
+		}
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Body == nil {
+				continue
+			}
+			ast.Inspect(function.Body, func(node ast.Node) bool {
+				call, ok := node.(*ast.CallExpr)
+				if !ok || !isCCStringCall(call) {
+					return true
+				}
+				position := fset.Position(call.Pos())
+				calls = append(calls, position.String()+" in "+function.Name.Name)
+				if function.Name.Name != "checkedCString" {
+					t.Errorf("C.CString outside checkedCString: %s", calls[len(calls)-1])
+				}
+				return true
+			})
+		}
+	}
+	if len(calls) != 1 {
+		t.Fatalf("C.CString calls = %v, want exactly one checked conversion", calls)
+	}
+}
+
+func isCCStringCall(call *ast.CallExpr) bool {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || selector.Sel.Name != "CString" {
+		return false
+	}
+	identifier, ok := selector.X.(*ast.Ident)
+	return ok && identifier.Name == "C"
+}
+
+func requireFFIInvalid(t *testing.T, code ErrorCode) {
+	t.Helper()
+	if code != ErrInvalidArgument {
+		t.Fatalf("error code = %d, want ErrInvalidArgument (%d)", code, ErrInvalidArgument)
+	}
+}
+
+func requireFFIOK(t *testing.T, code ErrorCode) {
+	t.Helper()
+	if code != ErrOK {
+		t.Fatalf("error code = %d, want ErrOK", code)
+	}
+}
+
+func requireFactCount(t *testing.T, handle EngineHandle, want uintptr) {
+	t.Helper()
+	got, rc := EngineFactCount(handle)
+	requireFFIOK(t, rc)
+	if got != want {
+		t.Fatalf("fact count = %d, want %d", got, want)
+	}
+}
+
+func runFixtureToOutput(t *testing.T, handle EngineHandle) {
+	t.Helper()
+	fired, _, rc := EngineRunEx(handle, -1)
+	requireFFIOK(t, rc)
+	if fired != 1 {
+		t.Fatalf("rules fired = %d, want 1", fired)
+	}
+}

--- a/bindings/go/internal/ffi/ffi.go
+++ b/bindings/go/internal/ffi/ffi.go
@@ -9,7 +9,17 @@ package ffi
 #include <stdlib.h>
 */
 import "C"
-import "unsafe"
+import (
+	"fmt"
+	"unsafe"
+)
+
+func checkedCString(argument, value string) (*C.char, error) {
+	if err := ValidateCString(argument, value); err != nil {
+		return nil, err
+	}
+	return C.CString(value), nil
+}
 
 // ---------------------------------------------------------------------------
 // Engine lifecycle
@@ -38,14 +48,20 @@ func EngineNewWithConfigHelper(encoding StringEncoding, strategy ConflictStrateg
 
 // EngineNewWithSource creates an engine from CLIPS source (load + reset).
 func EngineNewWithSource(source string) EngineHandle {
-	cs := C.CString(source)
+	cs, err := checkedCString("source", source)
+	if err != nil {
+		return nil
+	}
 	defer C.free(unsafe.Pointer(cs))
 	return C.ferric_engine_new_with_source(cs)
 }
 
 // EngineNewWithSourceConfig creates an engine from CLIPS source with config.
 func EngineNewWithSourceConfig(source string, config *Config) EngineHandle {
-	cs := C.CString(source)
+	cs, err := checkedCString("source", source)
+	if err != nil {
+		return nil
+	}
 	defer C.free(unsafe.Pointer(cs))
 	return C.ferric_engine_new_with_source_config(cs, config)
 }
@@ -67,7 +83,10 @@ func EngineFreeUnchecked(h EngineHandle) ErrorCode {
 
 // EngineLoadString loads CLIPS source into the engine.
 func EngineLoadString(h EngineHandle, source string) ErrorCode {
-	cs := C.CString(source)
+	cs, err := checkedCString("source", source)
+	if err != nil {
+		return ErrInvalidArgument
+	}
 	defer C.free(unsafe.Pointer(cs))
 	return ErrorCode(C.ferric_engine_load_string(h, cs))
 }
@@ -140,7 +159,10 @@ func EngineIsHalted(h EngineHandle) (bool, ErrorCode) {
 
 // EngineAssertString asserts a fact from a CLIPS source string.
 func EngineAssertString(h EngineHandle, source string) (uint64, ErrorCode) {
-	cs := C.CString(source)
+	cs, err := checkedCString("source", source)
+	if err != nil {
+		return 0, ErrInvalidArgument
+	}
 	defer C.free(unsafe.Pointer(cs))
 	var factID C.uint64_t
 	rc := ErrorCode(C.ferric_engine_assert_string(h, cs, &factID))
@@ -149,7 +171,10 @@ func EngineAssertString(h EngineHandle, source string) (uint64, ErrorCode) {
 
 // EngineAssertOrdered asserts an ordered fact from structured values.
 func EngineAssertOrdered(h EngineHandle, relation string, fields []Value) (uint64, ErrorCode) {
-	crel := C.CString(relation)
+	crel, err := checkedCString("relation", relation)
+	if err != nil {
+		return 0, ErrInvalidArgument
+	}
 	defer C.free(unsafe.Pointer(crel))
 
 	var fieldsPtr *C.struct_FerricValue
@@ -166,21 +191,27 @@ func EngineAssertOrdered(h EngineHandle, relation string, fields []Value) (uint6
 
 // EngineAssertTemplate asserts a template fact with named slots.
 func EngineAssertTemplate(h EngineHandle, templateName string, slotNames []string, slotValues []Value) (uint64, ErrorCode) {
-	ctmpl := C.CString(templateName)
+	ctmpl, err := checkedCString("templateName", templateName)
+	if err != nil {
+		return 0, ErrInvalidArgument
+	}
 	defer C.free(unsafe.Pointer(ctmpl))
 
 	count := len(slotNames)
 
 	// Allocate C strings for slot names.
 	cnames := make([]*C.char, count)
-	for i, name := range slotNames {
-		cnames[i] = C.CString(name)
-	}
 	defer func() {
 		for _, cn := range cnames {
 			C.free(unsafe.Pointer(cn))
 		}
 	}()
+	for i, name := range slotNames {
+		cnames[i], err = checkedCString(fmt.Sprintf("slotNames[%d]", i), name)
+		if err != nil {
+			return 0, ErrInvalidArgument
+		}
+	}
 
 	var namesPtr **C.char
 	if count > 0 {
@@ -234,7 +265,10 @@ func EngineFactIDs(h EngineHandle) ([]uint64, ErrorCode) {
 
 // EngineFindFactIDs finds fact IDs by relation name.
 func EngineFindFactIDs(h EngineHandle, relation string) ([]uint64, ErrorCode) {
-	crel := C.CString(relation)
+	crel, err := checkedCString("relation", relation)
+	if err != nil {
+		return nil, ErrInvalidArgument
+	}
 	defer C.free(unsafe.Pointer(crel))
 
 	return uint64IDsFromTwoCall(func(dst []uint64) (uintptr, ErrorCode) {
@@ -317,7 +351,10 @@ func EngineGetFactTemplateName(h EngineHandle, factID uint64) (string, ErrorCode
 // EngineGetFactSlotByName retrieves a slot value from a template fact by name.
 // The caller owns the returned Value and must free it with ValueFree.
 func EngineGetFactSlotByName(h EngineHandle, factID uint64, slotName string) (Value, ErrorCode) {
-	cs := C.CString(slotName)
+	cs, err := checkedCString("slotName", slotName)
+	if err != nil {
+		return ValueVoid(), ErrInvalidArgument
+	}
 	defer C.free(unsafe.Pointer(cs))
 	var val C.struct_FerricValue
 	//nolint:gocritic // false positive from cgo pointer argument pattern.
@@ -333,7 +370,10 @@ func EngineGetFactSlotByName(h EngineHandle, factID uint64, slotName string) (Va
 // EngineGetGlobal retrieves a global variable's value by name.
 // The caller owns the returned Value and must free it with ValueFree.
 func EngineGetGlobal(h EngineHandle, name string) (Value, ErrorCode) {
-	cn := C.CString(name)
+	cn, err := checkedCString("name", name)
+	if err != nil {
+		return ValueVoid(), ErrInvalidArgument
+	}
 	defer C.free(unsafe.Pointer(cn))
 	var val C.struct_FerricValue
 	//nolint:gocritic // false positive from cgo pointer argument pattern.
@@ -349,7 +389,10 @@ func EngineGetGlobal(h EngineHandle, name string) (Value, ErrorCode) {
 // EngineGetOutput retrieves captured output for a named channel.
 // Returns empty string and false if no output.
 func EngineGetOutput(h EngineHandle, channel string) (string, bool) {
-	cc := C.CString(channel)
+	cc, err := checkedCString("channel", channel)
+	if err != nil {
+		return "", false
+	}
 	defer C.free(unsafe.Pointer(cc))
 	ptr := C.ferric_engine_get_output(h, cc)
 	if ptr == nil {
@@ -358,16 +401,44 @@ func EngineGetOutput(h EngineHandle, channel string) (string, bool) {
 	return C.GoString(ptr), true
 }
 
+// EngineGetOutputCopy retrieves a caller-owned copy of captured output for a
+// named channel. The length-bearing copy preserves embedded NUL bytes. Missing
+// or empty output is reported as empty, false, ErrOK.
+func EngineGetOutputCopy(h EngineHandle, channel string) (string, bool, ErrorCode) {
+	cc, err := checkedCString("channel", channel)
+	if err != nil {
+		return "", false, ErrInvalidArgument
+	}
+	defer C.free(unsafe.Pointer(cc))
+
+	value, rc := getString(func(buf *C.char, bufLen C.uintptr_t, outLen *C.uintptr_t) ErrorCode {
+		return ErrorCode(C.ferric_engine_get_output_copy(h, cc, buf, bufLen, outLen))
+	})
+	if rc == ErrNotFound {
+		return "", false, ErrOK
+	}
+	if rc != ErrOK {
+		return "", false, rc
+	}
+	return value, true, ErrOK
+}
+
 // EngineClearOutput clears a specific output channel.
 func EngineClearOutput(h EngineHandle, channel string) ErrorCode {
-	cc := C.CString(channel)
+	cc, err := checkedCString("channel", channel)
+	if err != nil {
+		return ErrInvalidArgument
+	}
 	defer C.free(unsafe.Pointer(cc))
 	return ErrorCode(C.ferric_engine_clear_output(h, cc))
 }
 
 // EnginePushInput pushes an input line for read/readline.
 func EnginePushInput(h EngineHandle, line string) ErrorCode {
-	cl := C.CString(line)
+	cl, err := checkedCString("line", line)
+	if err != nil {
+		return ErrInvalidArgument
+	}
 	defer C.free(unsafe.Pointer(cl))
 	return ErrorCode(C.ferric_engine_push_input(h, cl))
 }
@@ -415,7 +486,10 @@ func EngineTemplateName(h EngineHandle, index uintptr) (string, ErrorCode) {
 
 // EngineTemplateSlotCount returns the number of slots in a named template.
 func EngineTemplateSlotCount(h EngineHandle, templateName string) (uintptr, ErrorCode) {
-	ct := C.CString(templateName)
+	ct, err := checkedCString("templateName", templateName)
+	if err != nil {
+		return 0, ErrInvalidArgument
+	}
 	defer C.free(unsafe.Pointer(ct))
 	var count C.uintptr_t
 	rc := ErrorCode(C.ferric_engine_template_slot_count(h, ct, &count))
@@ -424,7 +498,10 @@ func EngineTemplateSlotCount(h EngineHandle, templateName string) (uintptr, Erro
 
 // EngineTemplateSlotName retrieves a slot name by template name and slot index.
 func EngineTemplateSlotName(h EngineHandle, templateName string, slotIndex uintptr) (string, ErrorCode) {
-	ct := C.CString(templateName)
+	ct, err := checkedCString("templateName", templateName)
+	if err != nil {
+		return "", ErrInvalidArgument
+	}
 	defer C.free(unsafe.Pointer(ct))
 	return getString(func(buf *C.char, bufLen C.uintptr_t, outLen *C.uintptr_t) ErrorCode {
 		return ErrorCode(C.ferric_engine_template_slot_name(h, ct, C.uintptr_t(slotIndex), buf, bufLen, outLen))
@@ -572,18 +649,48 @@ func ValueFloat(v float64) Value {
 	return Value(C.ferric_value_float(C.double(v)))
 }
 
+// ValueSymbolBytes creates a symbol FerricValue from an explicit byte span.
+func ValueSymbolBytes(name string) (Value, ErrorCode) {
+	var value C.struct_FerricValue
+	var data *C.uint8_t
+	if len(name) > 0 {
+		data = (*C.uint8_t)(unsafe.Pointer(unsafe.StringData(name)))
+	}
+	//nolint:gocritic // dupSubExpr false positive in cgo-generated code.
+	rc := ErrorCode(C.ferric_value_symbol_bytes(data, C.uintptr_t(len(name)), &value))
+	return Value(value), rc
+}
+
 // ValueSymbol creates a symbol FerricValue (heap-copies the string).
+// It returns Void when the checked byte-span constructor rejects the value.
 func ValueSymbol(name string) Value {
-	cs := C.CString(name)
-	defer C.free(unsafe.Pointer(cs))
-	return Value(C.ferric_value_symbol(cs))
+	value, rc := ValueSymbolBytes(name)
+	if rc != ErrOK {
+		return ValueVoid()
+	}
+	return value
+}
+
+// ValueStringBytes creates a string FerricValue from an explicit byte span.
+func ValueStringBytes(s string) (Value, ErrorCode) {
+	var value C.struct_FerricValue
+	var data *C.uint8_t
+	if len(s) > 0 {
+		data = (*C.uint8_t)(unsafe.Pointer(unsafe.StringData(s)))
+	}
+	//nolint:gocritic // dupSubExpr false positive in cgo-generated code.
+	rc := ErrorCode(C.ferric_value_string_bytes(data, C.uintptr_t(len(s)), &value))
+	return Value(value), rc
 }
 
 // ValueString creates a string FerricValue (heap-copies the string).
+// It returns Void when the checked byte-span constructor rejects the value.
 func ValueString(s string) Value {
-	cs := C.CString(s)
-	defer C.free(unsafe.Pointer(cs))
-	return Value(C.ferric_value_string(cs))
+	value, rc := ValueStringBytes(s)
+	if rc != ErrOK {
+		return ValueVoid()
+	}
+	return value
 }
 
 // ValueVoid creates a void FerricValue.

--- a/bindings/go/internal/ffi/string_validation.go
+++ b/bindings/go/internal/ffi/string_validation.go
@@ -1,0 +1,27 @@
+package ffi
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CStringError reports an embedded NUL in a Go string that would otherwise
+// cross a legacy NUL-terminated C string boundary.
+type CStringError struct {
+	Argument string
+	Byte     int
+}
+
+// Error describes the rejected argument and the byte offset of its first NUL.
+func (e *CStringError) Error() string {
+	return fmt.Sprintf("%s contains embedded NUL at byte %d", e.Argument, e.Byte)
+}
+
+// ValidateCString rejects embedded NUL before value crosses a legacy
+// NUL-terminated C string boundary.
+func ValidateCString(argument, value string) error {
+	if index := strings.IndexByte(value, 0); index >= 0 {
+		return &CStringError{Argument: argument, Byte: index}
+	}
+	return nil
+}

--- a/bindings/go/pinned_engine.go
+++ b/bindings/go/pinned_engine.go
@@ -406,28 +406,51 @@ func (p *PinnedEngine) IsHalted() bool {
 // I/O
 // ---------------------------------------------------------------------------
 
-// GetOutput retrieves captured output for a named channel.
+// GetOutput retrieves captured output for a named channel. For backward
+// compatibility it discards validation, dispatch, closed-state, and native
+// errors; use GetOutputE when the error must be observed.
 func (p *PinnedEngine) GetOutput(channel string) (string, bool) {
+	value, ok, _ := p.GetOutputE(channel)
+	return value, ok
+}
+
+// GetOutputE retrieves captured output for a named channel and reports
+// validation, dispatch, closed-state, or native errors.
+func (p *PinnedEngine) GetOutputE(channel string) (string, bool, error) {
 	response := pinnedCall(context.Background(), p, func(e *Engine) (valueOK[string], error) {
-		value, ok := e.GetOutput(channel)
-		return valueOK[string]{value: value, ok: ok}, nil
+		value, ok, err := e.GetOutputE(channel)
+		return valueOK[string]{value: value, ok: ok}, err
 	})
-	return response.value.value, response.value.ok
+	return response.value.value, response.value.ok, response.err
 }
 
-// ClearOutput clears a specific output channel.
+// ClearOutput clears a specific output channel. For backward compatibility it
+// discards validation, dispatch, closed-state, and native errors; use
+// ClearOutputE when the error must be observed.
 func (p *PinnedEngine) ClearOutput(channel string) {
-	_ = p.do(func(e *Engine) error {
-		e.ClearOutput(channel)
-		return nil
+	_ = p.ClearOutputE(channel)
+}
+
+// ClearOutputE clears a specific output channel and reports validation,
+// dispatch, closed-state, or native errors.
+func (p *PinnedEngine) ClearOutputE(channel string) error {
+	return p.do(func(e *Engine) error {
+		return e.ClearOutputE(channel)
 	})
 }
 
-// PushInput pushes an input line for read/readline.
+// PushInput pushes an input line for read/readline. For backward compatibility
+// it discards validation, dispatch, closed-state, and native errors; use
+// PushInputE when the error must be observed.
 func (p *PinnedEngine) PushInput(line string) {
-	_ = p.do(func(e *Engine) error {
-		e.PushInput(line)
-		return nil
+	_ = p.PushInputE(line)
+}
+
+// PushInputE pushes an input line for read/readline and reports validation,
+// dispatch, closed-state, or native errors.
+func (p *PinnedEngine) PushInputE(line string) error {
+	return p.do(func(e *Engine) error {
+		return e.PushInputE(line)
 	})
 }
 

--- a/bindings/go/pinned_engine_test.go
+++ b/bindings/go/pinned_engine_test.go
@@ -477,7 +477,14 @@ func TestPinnedEngine_DoAfterClose(t *testing.T) {
 	require.NoError(t, p.Close())
 
 	err = p.Do(context.Background(), func(_ *Engine) error { return nil })
-	assert.ErrorIs(t, err, errPinnedEngineClosed)
+	require.ErrorIs(t, err, errPinnedEngineClosed)
+
+	output, ok, err := p.GetOutputE("t")
+	assert.Empty(t, output)
+	assert.False(t, ok)
+	require.ErrorIs(t, err, errPinnedEngineClosed)
+	require.ErrorIs(t, p.ClearOutputE("t"), errPinnedEngineClosed)
+	require.ErrorIs(t, p.PushInputE("line"), errPinnedEngineClosed)
 }
 
 func TestPinnedEngine_DoContextCanceled(t *testing.T) {

--- a/bindings/go/values.go
+++ b/bindings/go/values.go
@@ -22,10 +22,10 @@ type Symbol string
 // to the FFI layer. Recursive multifields are constructed through Ferric's
 // copy API; no Go- or C-allocated value array is transferred to Rust cleanup.
 func goToFFIValue(v any) (ffi.Value, error) {
-	return goToFFIValueAtDepth(v, 0)
+	return goToFFIValueAtPath(v, "value", 0)
 }
 
-func goToFFIValueAtDepth(v any, depth int) (ffi.Value, error) {
+func goToFFIValueAtPath(v any, path string, depth int) (ffi.Value, error) {
 	switch val := v.(type) {
 	case int:
 		return ffi.ValueInteger(int64(val)), nil
@@ -38,27 +38,28 @@ func goToFFIValueAtDepth(v any, depth int) (ffi.Value, error) {
 	case float32:
 		return ffi.ValueFloat(float64(val)), nil
 	case Symbol:
-		return ffi.ValueSymbol(string(val)), nil
+		return goStringToFFIValue(path, string(val), ffiValueSymbolBytes)
 	case string:
-		return ffi.ValueString(val), nil
+		return goStringToFFIValue(path, val, ffiValueStringBytes)
 	case bool:
 		if val {
-			return ffi.ValueSymbol("TRUE"), nil
+			return goStringToFFIValue(path, "TRUE", ffiValueSymbolBytes)
 		}
-		return ffi.ValueSymbol("FALSE"), nil
+		return goStringToFFIValue(path, "FALSE", ffiValueSymbolBytes)
 	case nil:
 		return ffi.ValueVoid(), nil
 	case []any:
 		if depth >= maxMultifieldNestingDepth {
 			return ffi.Value{}, fmt.Errorf(
-				"%w: multifield nesting exceeds %d levels",
+				"%w: %s multifield nesting exceeds %d levels",
 				ErrInvalidArgument,
+				path,
 				maxMultifieldNestingDepth,
 			)
 		}
 		elements := make([]ffi.Value, len(val))
 		for i, elem := range val {
-			ev, err := goToFFIValueAtDepth(elem, depth+1)
+			ev, err := goToFFIValueAtPath(elem, fmt.Sprintf("%s[%d]", path, i), depth+1)
 			if err != nil {
 				// Free the elements converted before this failure. Goes through
 				// the ffiValueFree seam (as AssertFact/AssertTemplate do) so the
@@ -79,8 +80,23 @@ func goToFFIValueAtDepth(v any, depth int) (ffi.Value, error) {
 		}
 		return result, nil
 	default:
-		return ffi.Value{}, fmt.Errorf("%w: %T", errUnsupportedGoTypeForFFI, v)
+		return ffi.Value{}, fmt.Errorf("%w at %s: %T", errUnsupportedGoTypeForFFI, path, v)
 	}
+}
+
+func goStringToFFIValue(
+	path string,
+	value string,
+	constructor func(string) (ffi.Value, ffi.ErrorCode),
+) (ffi.Value, error) {
+	if err := validateCStringArgument(path, value); err != nil {
+		return ffi.Value{}, err
+	}
+	result, rc := constructor(value)
+	if rc != ffi.ErrOK {
+		return ffi.Value{}, fmt.Errorf("%s: %w", path, errorFromFFI(rc, nil))
+	}
+	return result, nil
 }
 
 // ffiValueToGo converts a C FerricValue to a native Go value.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -980,8 +980,18 @@ The C ABI therefore uses an explicit-rejection policy at that legacy boundary:
   their serialized bytes exactly. If a restored engine contains NUL-bearing
   values, the same legacy-egress rejection rules apply.
 
-The dependent Go boundary audit tracks applying this policy before every
-`C.CString` conversion.
+The Go binding rejects embedded NUL before every legacy `C.CString`
+conversion. Rejections return `ErrInvalidArgument` through error-bearing APIs;
+their diagnostic identifies the offending argument and the byte offset of the
+first NUL. `Engine.GetOutputE`, `Engine.ClearOutputE`, and
+`Engine.PushInputE` (and their `PinnedEngine` counterparts) expose these
+errors for I/O arguments. The older convenience methods delegate to those
+error-aware methods and intentionally discard the error for compatibility;
+an invalid channel never aliases its prefix, and invalid input is not queued.
+
+Snapshot payloads remain byte-oriented and may contain NUL. Snapshot file
+paths are handled by Go's filesystem APIs rather than `C.CString`; invalid
+paths therefore retain the platform's `os.PathError` behavior.
 
 ### Copy-to-Buffer Contract
 

--- a/tests/bindings-conformance/corpus.json
+++ b/tests/bindings-conformance/corpus.json
@@ -349,10 +349,10 @@
           "tracking_issue": "https://github.com/plx/ferric-rules/issues/115"
         },
         "go": {
-          "expected": {"type": "string", "value": "a"},
-          "rationale": "Go currently passes host strings through C.CString; rejecting embedded NUL across the binding remains tracked by FR-GO-012.",
+          "expected": {"error": "invalid_argument"},
+          "rationale": "The Go binding rejects embedded NUL before crossing the legacy NUL-terminated C string boundary.",
           "since": "1.0.0",
-          "tracking_issue": "https://github.com/plx/ferric-rules/issues/131"
+          "tracking_issue": "https://github.com/plx/ferric-rules/issues/115"
         }
       }
     },


### PR DESCRIPTION
Closes #131

## Summary

- centralize every Go legacy C-string conversion behind checked embedded-NUL validation
- use length-aware value constructors and caller-owned output copies where the C ABI supports them
- return fresh, argument-specific `InvalidArgumentError` values, including precise nested field/slot paths
- add fallible Engine and PinnedEngine I/O variants while preserving the legacy convenience signatures
- update compatibility documentation and the cross-binding corpus to record Go's intentional C-boundary rejection

## Root cause

Go strings can contain embedded NUL bytes, but the legacy C ABI reads `char *` inputs only through the first NUL. The binding called `C.CString` directly at each wrapper, allowing suffixes to be silently discarded before the native policy could validate them.

## User impact

Go callers now receive a typed invalid-argument error naming the offending argument and byte offset instead of having source, identifiers, channel names, or nested values silently truncated. Snapshot bytes and filesystem paths keep their existing length-aware/OS semantics, and output copies preserve embedded NUL bytes exactly.

## Validation

- `just preflight-pr`
- `just test-go`
- `just test-go-race`
- `just test-go-stress 10`
- `just bindings-conformance` (26 cases, 5 adapters)
- focused embedded-NUL race tests, 20 repetitions
- `just run-golang-ci` (0 issues)
- static AST audit: the sole production `C.CString` call is inside the checked helper
