### PR TITLE
[FR-GO-016] Validate internal Go template slice lengths

### DIFF
--- a/bindings/go/internal/ffi/ffi.go
+++ b/bindings/go/internal/ffi/ffi.go
@@ -190,7 +190,12 @@ func EngineAssertOrdered(h EngineHandle, relation string, fields []Value) (uint6
 }
 
 // EngineAssertTemplate asserts a template fact with named slots.
+// It rejects unequal slot-name and slot-value counts before entering C.
 func EngineAssertTemplate(h EngineHandle, templateName string, slotNames []string, slotValues []Value) (uint64, ErrorCode) {
+	if len(slotNames) != len(slotValues) {
+		return 0, ErrInvalidArgument
+	}
+
 	ctmpl, err := checkedCString("templateName", templateName)
 	if err != nil {
 		return 0, ErrInvalidArgument

--- a/bindings/go/internal/ffi/template_slice_lengths_test.go
+++ b/bindings/go/internal/ffi/template_slice_lengths_test.go
@@ -1,0 +1,96 @@
+package ffi
+
+import "testing"
+
+func TestEngineAssertTemplateRejectsMismatchedSlotSlicesBeforeNativeCall(t *testing.T) {
+	tests := []struct {
+		name       string
+		slotNames  []string
+		slotValues []Value
+	}{
+		{name: "name_without_value", slotNames: []string{"payload"}},
+		{name: "value_without_name", slotValues: []Value{ValueInteger(1)}},
+		{
+			name:       "more_names_than_values",
+			slotNames:  []string{"first", "second"},
+			slotValues: []Value{ValueInteger(1)},
+		},
+		{
+			name:       "more_values_than_names",
+			slotNames:  []string{"first"},
+			slotValues: []Value{ValueInteger(1), ValueInteger(2)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					t.Fatalf("EngineAssertTemplate panicked: %v", recovered)
+				}
+			}()
+
+			factID, rc := EngineAssertTemplate(nil, "item", tt.slotNames, tt.slotValues)
+			if factID != 0 || rc != ErrInvalidArgument {
+				t.Fatalf(
+					"EngineAssertTemplate = (%d, %d), want (0, ErrInvalidArgument=%d)",
+					factID,
+					rc,
+					ErrInvalidArgument,
+				)
+			}
+		})
+	}
+}
+
+func TestEngineAssertTemplateAcceptsEmptySlotSlices(t *testing.T) {
+	lockThread(t)
+
+	handle := EngineNewWithSource(`
+		(deftemplate item
+			(slot payload (type INTEGER) (default 42)))
+	`)
+	if handle == nil {
+		t.Fatal("EngineNewWithSource returned nil")
+	}
+	t.Cleanup(func() {
+		if rc := EngineFree(handle); rc != ErrOK {
+			t.Errorf("EngineFree returned %d", rc)
+		}
+	})
+
+	tests := []struct {
+		name       string
+		slotNames  []string
+		slotValues []Value
+	}{
+		{name: "nil_slices"},
+		{name: "non_nil_empty_slices", slotNames: []string{}, slotValues: []Value{}},
+	}
+
+	for _, tt := range tests {
+		factID, rc := EngineAssertTemplate(handle, "item", tt.slotNames, tt.slotValues)
+		if rc != ErrOK || factID == 0 {
+			t.Fatalf(
+				"%s: EngineAssertTemplate = (%d, %d), want nonzero fact ID and ErrOK",
+				tt.name,
+				factID,
+				rc,
+			)
+		}
+
+		value, rc := EngineGetFactSlotByName(handle, factID, "payload")
+		if rc != ErrOK {
+			t.Fatalf("%s: EngineGetFactSlotByName returned %d", tt.name, rc)
+		}
+		if got := ValueGetType(&value); got != ValueTypeInteger {
+			ValueFree(&value)
+			t.Fatalf("%s: default slot type = %d, want ValueTypeInteger=%d", tt.name, got, ValueTypeInteger)
+		}
+		if got := ValueGetInteger(&value); got != 42 {
+			ValueFree(&value)
+			t.Fatalf("%s: default slot value = %d, want 42", tt.name, got)
+		}
+		ValueFree(&value)
+	}
+}


### PR DESCRIPTION
Closes #132

## What changed

- reject unequal internal template slot-name and slot-value slice lengths before any C-string allocation, indexing, or native call
- preserve valid zero-length calls with nil native pointers
- add focused regressions for all mismatch directions and real-engine nil/non-nil empty-slice assertions

## Root cause and impact

`EngineAssertTemplate` derived the native count solely from `slotNames`. A non-empty name slice with no corresponding values could panic while indexing `slotValues[0]`; other mismatches could silently ignore values or expose an undersized logical array to the C boundary. Public callers currently construct paired slices, but the internal boundary must remain defensive.

## Validation

- deterministic pre-fix regression: one mismatch panicked; the remaining mismatches reached native code and returned `ErrNullPointer`
- focused regressions: 100 iterations normal and race-clean
- `just go-full`
- `just go-lint` — 0 issues
- `just preflight-pr`
- independent acceptance, production, and test-quality audits: no material findings