### PR TITLE
[FR-NODE-003] Give EnginePool.do an exclusive worker lease

### DIFF
--- a/docs/typescript-binding-api.md
+++ b/docs/typescript-binding-api.md
@@ -545,6 +545,10 @@ export class EngineHandle {
 `EnginePool` manages multiple Worker threads for concurrent, stateless evaluation. It is the TypeScript equivalent of Go's `Coordinator` + `Manager` pattern.
 
 Each worker lazily creates engines from named specs. Requests are dispatched round-robin across workers.
+Work assigned to one worker slot is admitted FIFO. A `do()` callback receives
+an exclusive lease over its selected slot before the callback begins, so no
+unrelated task can use that worker until the pool processes the callback's
+normal settlement and its accepted proxy calls drain.
 
 ```typescript
 export interface EngineSpec {
@@ -591,15 +595,14 @@ export class EnginePool {
 
   /**
    * Dispatch a function to run on a pooled engine.
-   * The callback receives a proxy object for the named engine.
-   * The proxy must not be retained beyond the callback's return.
+   * The callback receives a proxy object for the named engine and exclusively
+   * leases the selected worker slot for its whole asynchronous lifetime.
+   * Proxy calls execute serially in invocation order. The proxy must not be
+   * retained after `do()` delivers the callback's value or error.
    *
    * @param specName Engine spec to use.
    * @param fn Callback receiving an EngineHandle-like proxy.
    * @param options.signal AbortSignal for cancellation.
-   *
-   * Note: `T` must be structured-clonable because results cross the
-   * worker-thread boundary.
    */
   do<T>(
     specName: string,
@@ -623,7 +626,10 @@ export class EnginePool {
     options?: { signal?: AbortSignal },
   ): Promise<EvaluateResult>;
 
-  /** Shut down all workers. Blocks until in-flight requests complete. */
+  /**
+   * Shut down all workers. Blocks until in-flight requests and callbacks that
+   * already acquired a worker-slot lease complete.
+   */
   close(): Promise<void>;
 
   [Symbol.asyncDispose](): Promise<void>;
@@ -632,7 +638,9 @@ export class EnginePool {
 /**
  * Proxy object passed to EnginePool.do() callbacks.
  * Has the same shape as EngineHandle but operations are
- * dispatched to a specific worker's engine.
+ * dispatched to a specific worker's engine. Calls are serialized in invocation
+ * order and reject deterministically before `do()` delivers the callback's
+ * value or error.
  */
 export interface EngineProxy {
   load(source: string): Promise<void>;
@@ -660,6 +668,41 @@ export interface EngineProxy {
   pushInput(line: string): Promise<void>;
 }
 ```
+
+#### `EnginePool.do()` lease and proxy lifetime
+
+- The lease covers the entire selected worker slot, not only the named engine.
+  A task for a different spec cannot execute on that worker during the callback.
+- Admission is FIFO within each slot. Different slots remain concurrent, so the
+  pool does not promise global start or completion order.
+- The callback begins only after acquiring its lease. External awaits and a
+  callback that makes no proxy calls still retain it.
+- Proxy methods are serialized in invocation order, including calls started in
+  parallel.
+- Normal callback settlement is observed when the pool's registered reaction
+  to the returned Promise begins. Promise reactions that the callback itself
+  registered before returning that Promise run first under JavaScript's FIFO
+  reaction ordering and remain inside the lease; proxy calls they invoke are
+  accepted and drain in order.
+- At the pool-observed settlement boundary, the proxy becomes invalid before
+  `do()` delivers the callback's value or error. Calls already accepted drain
+  before the lease releases. Every call after that boundary rejects with one
+  deterministic lifetime error without reaching the worker.
+- The callback return value stays on the main thread and does not need to be
+  structured-clonable. Only proxy arguments and results cross the worker
+  boundary.
+- A lease supplies isolation, not rollback. Facts, rules, output, and other
+  engine state changed by the callback remain changed if it rejects.
+- Calling `do()`, `evaluate()`, or `close()` on the same pool from inside its
+  active callback rejects rather than waiting on the callback's own lease.
+  Calling another pool is supported.
+- `close()` waits for a callback that already acquired its lease, including an
+  idle await between proxy calls. A callback still waiting to acquire a lease
+  is rejected as not-yet-admitted work.
+
+Abort-driven proxy invalidation and the state effects of an operation accepted
+before abort are reserved for FR-NODE-009. An outer `do()` rejection does not
+allow unrelated work onto a slot while its callback is still running.
 
 ## Value Conversion Details
 
@@ -790,10 +833,16 @@ parentPort!.on("message", (req: WorkerRequest) => {
 - **Waiting for worker**: If aborted while queued, the request is dequeued (if possible) and rejected.
 - **During execution**: The run phase follows the same fresh-run, continuation,
   exact-boundary, and out-of-band cancellation contract as `EngineHandle`.
+- **Callback lease**: Rejecting the outer `do()` promise does not release a
+  worker slot that is still owned by a running callback. Unrelated work remains
+  queued until the pool-observed callback settlement boundary and accepted-call
+  drain.
 
 The partial `HaltRequested` result is the existing JavaScript API projection of
 host cancellation; it does not imply that the native engine halt latch was set.
 A later `run()` always starts fresh and clears the documented execution state.
+FR-NODE-009 separately defines abort-time proxy invalidation and whether work
+accepted before abort may finish mutating engine state.
 
 ## Usage Examples
 

--- a/docs/typescript-binding-architecture.md
+++ b/docs/typescript-binding-architecture.md
@@ -1,6 +1,7 @@
 # TypeScript Binding Architecture (Revised)
 
 Date: 2026-04-11
+Updated: 2026-08-09 (FR-NODE-003 worker-slot callback leases)
 Status: Draft for reimplementation
 
 Companion documents:
@@ -45,6 +46,13 @@ This document is intentionally descriptive. If this document conflicts with the 
 - TypeScript orchestration over multiple workers.
 - Dispatches work round-robin across worker slots.
 - Supports stateless one-shot evaluation plus stateful proxy operations.
+- Gives each `do` callback an exclusive, FIFO lease over its selected worker
+  slot and serializes that callback's proxy operations for the lease lifetime.
+- Defines normal callback completion at the pool's registered settlement
+  reaction, so callback-pre-registered Promise reactions remain inside the
+  lease and the proxy is invalid before `do` delivers the callback outcome.
+- Treats the lease as scheduling isolation only: state mutations persist and
+  are not rolled back when a callback rejects.
 
 ## Package Layout
 
@@ -84,7 +92,8 @@ per-runtime artifact-smoke contract.
 
 ## Ownership Boundaries
 - Rust owns engine correctness and low-level conversion primitives.
-- TypeScript owns worker protocol, cancellation orchestration, and high-level lifecycle semantics.
+- TypeScript owns worker protocol, worker-slot leasing, cancellation
+  orchestration, and high-level lifecycle semantics.
 - Public API typing is owned by TypeScript package surface (`dist/index.d.ts`), not by generated native d.ts alone.
 
 ## Design Constraints
@@ -92,20 +101,24 @@ per-runtime artifact-smoke contract.
 2. Sync and async layers must not diverge semantically unless explicitly documented.
 3. Error behavior must be class-stable across boundaries.
 4. Lifecycle behavior (`close`, dispose, post-close failures) must be deterministic.
+5. One worker slot is the isolation unit: unrelated pool work must not execute
+   there while a `do` callback owns its lease, even when it targets another
+   named engine.
 
 ## Risk Seams (Must Receive Focused Review)
 1. Symbol/value conversion across worker boundaries.
 2. Error class mapping across native and workers.
 3. Cancellation semantics for queued vs in-flight operations.
-4. `EnginePool.close()` behavior under concurrency.
-5. Public TS API shape drift (`undefined` exports, mismatched unions).
-6. JavaScript/native package version skew or a missing optional native package.
+4. `EnginePool.do()` lease admission, proxy lifetime, and reentrant calls.
+5. `EnginePool.close()` behavior under active callbacks and concurrency.
+6. Public TS API shape drift (`undefined` exports, mismatched unions).
+7. JavaScript/native package version skew or a missing optional native package.
 
 ## Delivery Model
 Reimplementation should be staged and gated:
 1. Native sync correctness and typing.
 2. EngineHandle transport and cancellation.
-3. EnginePool concurrency semantics.
+3. EnginePool concurrency semantics, including exclusive callback leases.
 4. Packaging and distribution hardening.
 
 Each stage is complete only when its corresponding rows in the Conformance Matrix are `PASS` and required tests from the Test Specification are green.

--- a/docs/typescript-binding-conformance-matrix.md
+++ b/docs/typescript-binding-conformance-matrix.md
@@ -1,7 +1,7 @@
 # TypeScript Binding Conformance Matrix
 
 Date: 2026-04-11
-Updated: 2026-08-09 (FR-NODE-002 logical-run semantics)
+Updated: 2026-08-09 (FR-NODE-003 worker-slot callback leases)
 
 Companion documents:
 - [TypeScript Binding Architecture (Revised)](/Users/prb/conductor/workspaces/ferric-rules/santo-domingo/docs/typescript-binding-architecture.md)
@@ -18,7 +18,7 @@ Each item is:
 - Traceable (spec reference + remediation linkage)
 
 ## Status Legend
-- `PASS`: Verified conformant in the 2026-04-11 audit.
+- `PASS`: Verified conformant by the current conformance suite.
 - `FAIL`: Verified non-conformant in the 2026-04-11 audit.
 - `UNKNOWN`: Not yet verified by direct probe.
 
@@ -35,6 +35,7 @@ Each item is:
 | `N-07` | Fact IDs have one canonical output representation, `FactId = bigint`; ID-taking APIs additionally accept only legacy safe-integer `number` values through `FactIdInput`. This is separate from CLIPS integer values and run counts/limits. |
 | `N-08` | A worker-backed run starts one fresh logical run and uses continuation for later chunks. Absent host cancellation it matches synchronous fired count, halt reason, halted state, agenda, and diagnostics, including exact batch-boundary halts. Caller-limit exhaustion has synchronous precedence over a pending boundary halt. |
 | `N-09` | Host abort is an out-of-band worker outcome. Existing APIs retain their partial `HaltRequested` projection, but the worker does not call native `halt()` merely to represent host cancellation; every later public run starts fresh. |
+| `N-10` | `EnginePool.do` acquires a FIFO, slot-wide exclusive lease before callback invocation. The callback's proxy serializes calls in invocation order. Normal settlement is the pool's registered reaction to the returned Promise: callback-pre-registered reactions remain within the lease, accepted calls drain before release, and the proxy is invalid before `do` delivers the callback outcome. The lease does not roll back state. Same-pool `do`/`evaluate`/`close` reentry rejects, other-pool calls remain allowed, and `close` waits for an admitted callback. Abort-driven invalidation and accepted-operation semantics remain assigned to FR-NODE-009. |
 
 ## Release Gates
 
@@ -113,6 +114,7 @@ A release is conformant only if all are true:
 | `E-009` | `close()` is idempotent. | Multiple `close()` calls succeed. | EnginePool lifecycle | TSB-005 | PASS |
 | `E-010` | `EngineProxy` preserves `FactId` bigint values through pool structured clone in responses and ID-taking requests. | High-generation pool assert/get/retract round-trip. | Worker boundary + N-07 | FR-NODE-001 | PASS |
 | `E-011` | Pool `evaluate` and proxy runs preserve one logical run across chunks and match synchronous exact-boundary results and state. | Exercise proxy/direct runs at `1`, batch size, batch size + 1, and twice batch size, plus `evaluate` at an exact batch boundary; compare totals/state/diagnostics, exact-limit precedence, and a later fresh run. E-005 covers cancellation. | Logical-run batching + N-08/N-09 | FR-NODE-002 | PASS |
+| `E-012` | A `do` callback exclusively leases its whole worker slot through the pool-observed normal-settlement boundary and accepted-call drain, with per-slot FIFO admission, serial proxy calls, deterministic invalidation before `do` delivers the outcome, no rollback, topology-independent same-pool reentry rejection, and close waiting for admitted callbacks. | One- and multi-thread delayed callbacks across same and different specs; FIFO and parallel-call ordering; callback-pre-registered Promise reaction ordering; fulfillment/rejection release; retained-proxy method table after the `do` barrier; same-pool `do`/`evaluate`/`close` versus other-pool nesting; close during an idle callback gap; seeded randomized-await stress. | EnginePool worker-slot lease + N-10 | FR-NODE-003 | PASS |
 
 ### F) Lifecycle and Closed-State Behavior
 
@@ -146,6 +148,6 @@ Each test should include the matrix ID in its title, for example `E-004 queued e
 
 Recommended remediation sequence aligned with risk:
 1. `A-001` / `A-002` / `A-003` / `B-002` / `B-004` / `C-*`
-2. `D-003` / `D-006` / `D-009` / `E-004` / `E-006` / `E-008` / `E-011`
+2. `D-003` / `D-006` / `D-009` / `E-004` / `E-006` / `E-008` / `E-011` / `E-012`
 3. `A-005` / `F-*`
 4. `G-*` hardening and CI gating

--- a/docs/typescript-binding-normative-contract.md
+++ b/docs/typescript-binding-normative-contract.md
@@ -1,7 +1,7 @@
 # TypeScript Binding Normative Contract (Revised)
 
 Date: 2026-04-11
-Updated: 2026-08-09 (FR-NODE-002 logical-run semantics)
+Updated: 2026-08-09 (FR-NODE-003 worker-slot callback leases)
 Status: Draft for reimplementation
 
 Companion documents:
@@ -101,10 +101,55 @@ If this contract conflicts with legacy design docs, this contract wins.
 2. `evaluate(spec, req)` `MUST` perform: `reset -> assert facts -> run -> collect facts/output`.
 3. `EnginePool.close()` `MUST`:
    - reject new requests after close starts,
-   - allow already-dispatched requests to settle,
+   - allow already-dispatched requests and admitted `do` callbacks to settle,
    - then terminate workers.
 4. `EnginePool.close()` `MUST` be idempotent.
 5. `EnginePool` `MUST` support `[Symbol.asyncDispose]()` and delegate to `close()`.
+
+### 4.4 EnginePool.do Worker-Slot Lease
+
+1. Before invoking a `do` callback, the pool `MUST` acquire an exclusive lease
+   on the selected worker slot. The lease covers the whole slot, including all
+   named engines hosted by that worker, rather than only the requested spec.
+2. From callback invocation until the pool's registered reaction to its
+   returned Promise begins, no unrelated `do`, `evaluate`, or other pool task
+   `MAY` execute on the leased worker. Time spent awaiting non-Ferric work and
+   callbacks that issue no proxy calls remain inside the lease lifetime.
+3. Lease acquisitions and ordinary work assigned to one worker slot `MUST` be
+   admitted in FIFO order. The pool does not guarantee global start or
+   completion order across different worker slots.
+4. Calls made through the active callback's proxy `MUST` execute serially in
+   invocation order, including calls submitted concurrently without awaiting
+   the preceding call.
+5. Normal callback settlement is the pool-observed boundary at which the
+   pool's registered fulfillment or rejection reaction to the returned Promise
+   begins. Promise reactions that the callback registered on that Promise
+   before returning it execute first under JavaScript's FIFO reaction ordering
+   and `MUST` remain inside the lease. Proxy calls they invoke are accepted as
+   callback work.
+6. At the pool-observed settlement boundary, the proxy `MUST` become invalid
+   before `do` delivers the callback's value or error. Every proxy method call
+   after that boundary `MUST` reject with the same deterministic lifetime error
+   before allocating, validating, or enqueueing a worker request.
+7. Proxy calls accepted before the pool-observed settlement boundary `MUST`
+   drain in invocation order before the worker-slot lease is released. The
+   callback's result or exception is delivered only after that release barrier
+   completes.
+8. A lease is an execution-isolation boundary, not a database transaction.
+   Engine mutations persist after callback fulfillment or rejection; the pool
+   performs no automatic rollback.
+9. While a callback is active, reentering the same `EnginePool` through
+   `do`, `evaluate`, or `close` `MUST` reject deterministically rather than
+   wait for the callback's own lease. Calling another `EnginePool` from the
+   callback remains supported.
+10. A callback whose lease was acquired before `close()` began is admitted
+   work. `close()` `MUST` wait for that callback and its accepted proxy calls;
+   those proxy calls remain permitted as part of the admitted callback. A
+   queued callback that has not acquired a lease is new work and `MUST` reject.
+11. Abort-driven proxy invalidation and the settlement rule for work accepted
+    before an abort are specified by FR-NODE-009. This lease contract does not
+    redefine that cancellation boundary; until the callback actually settles,
+    its slot nevertheless `MUST NOT` run unrelated work.
 
 ## 5. Run Limit Semantics
 
@@ -211,11 +256,19 @@ The following classes `MUST` exist and be constructible in JS:
 
 ### 7.3 EnginePool.do
 1. If already aborted before dispatch, `MUST` reject with `AbortError`.
-2. If aborted before callback completes, returned promise `MUST` reject with `AbortError`.
+2. If aborted before the pool observes the callback settlement boundary,
+   the returned promise `MUST` reject with `AbortError`.
 3. Proxy `run` operations issued during `do` `MUST` use the same fresh-run and
    continuation contract when cancellation is active.
 4. Rejecting the outer `do` promise for host cancellation `MUST NOT` require
    setting the proxied native engine's halt latch.
+5. Rejection of the outer promise does not by itself end the callback's
+   worker-slot lease. Unrelated work `MUST` remain excluded until the
+   pool-observed callback settlement boundary and accepted-call drain.
+6. FR-NODE-009 defines when abort invalidates the proxy, whether an operation
+   accepted before abort may mutate engine state, and when cancellation may
+   release the lease. FR-NODE-003 defines only the lease and normal
+   callback-settlement lifetime rules.
 
 ## 8. Worker Protocol Contract
 

--- a/docs/typescript-binding-test-spec.md
+++ b/docs/typescript-binding-test-spec.md
@@ -1,7 +1,7 @@
 # TypeScript Binding Test Specification (Revised)
 
 Date: 2026-04-11
-Updated: 2026-08-09 (FR-NODE-002 logical-run semantics)
+Updated: 2026-08-09 (FR-NODE-003 worker-slot callback leases)
 Status: Required for reimplementation
 
 Companion documents:
@@ -27,7 +27,9 @@ This is not optional guidance. The implementation is incomplete until this speci
 - Exercise wire conversion, cancellation, worker protocol, and error reconstruction.
 
 ### 2.4 Pool Runtime Unit Tests (`EnginePool`)
-- Exercise queueing, dispatch, cancellation states, `close()` behavior, and stateless evaluation behavior.
+- Exercise queueing, dispatch, cancellation states, worker-slot lease isolation,
+  proxy lifetime and ordering, same-pool reentrancy, `close()` behavior, and
+  stateless evaluation behavior.
 
 ### 2.5 Package/Load Tests
 - Validate native load behavior and package entrypoint surface guarantees.
@@ -100,14 +102,15 @@ Must include:
 - Error payload and reconstruction correctness (`C-001` to `C-005`).
 - `FactId` structured-clone response/request round-trip (`D-008`).
 
-### 4.4 Pool Runtime Tests (minimum 35 cases)
+### 4.4 Pool Runtime Tests (minimum 45 cases)
 Must include:
 - Evaluate lifecycle (`E-002`).
 - Cancellation for pre-abort, queued abort, and in-flight abort (`E-003`,
   `E-004`, `E-005`), including the no-synthetic-native-halt assertion.
 - `do()` cancellation behavior (`E-006`).
 - Proxy behavior parity (`E-007`).
-- `close()` contract (in-flight completion and idempotency) (`E-008`, `E-009`).
+- `close()` contract (in-flight completion, admitted-callback completion, and
+  idempotency) (`E-008`, `E-009`, `E-012`).
 - Thread default behavior (`E-001`).
 - `FactId` structured-clone response/request round-trip through a proxy
   (`E-010`).
@@ -116,6 +119,28 @@ Must include:
   diagnostics, accumulated totals, explicit-limit precedence, and a later
   fresh run. E-005 covers cancellation between chunks without a synthetic
   native halt.
+- Exclusive `do` worker-slot leases (`E-012`, `N-10`), including:
+  - deterministic one-thread and multi-thread delayed callbacks;
+  - exclusion across both the same spec and different specs on one worker;
+  - per-slot FIFO callback admission and serialization of parallel proxy calls
+    in invocation order;
+  - lease release after callback fulfillment, synchronous throw, and
+    asynchronous rejection;
+  - callback-pre-registered Promise reactions remaining inside the lease,
+    followed by invalidation at the pool's registered settlement reaction;
+  - draining calls accepted before that pool-observed settlement boundary;
+  - a retained-proxy method table proving the same lifetime error and no new
+    request allocation or dispatch after `do` delivers the callback outcome;
+  - persistent state after rejection, proving that leases do not roll back;
+  - deterministic rejection for same-pool `do`, `evaluate`, and `close`
+    reentry with one or multiple threads, while another pool remains usable;
+  - `close()` waiting through an admitted callback's idle await and accepted
+    proxy calls; and
+  - seeded randomized-await stress whose failure identifies the seed.
+
+Cancellation-time proxy invalidation, mutation by work accepted before abort,
+and cancellation-triggered lease release are FR-NODE-009 coverage. E-012 covers
+the lease and normal callback-settlement boundary without preempting that work.
 
 ### 4.5 Package Tests (minimum 10 cases)
 Must include:
@@ -147,6 +172,10 @@ Must include:
 4. Logical-run routing tests `MUST` use deterministic seams or direct worker
    protocol observation to distinguish fresh-run, continuation, halt-query, and
    host-abort paths.
+5. Lease tests `MUST` use explicit callback-entry and release barriers rather
+   than sleeps as their correctness oracle.
+6. Randomized-await lease stress `MUST` use a recorded deterministic seed and
+   bounded iteration count.
 
 ## 7. CI and Local Gates
 

--- a/packages/ferric/src/engine-pool.ts
+++ b/packages/ferric/src/engine-pool.ts
@@ -906,8 +906,9 @@ export class EnginePool {
     const context: PoolCallbackContext = { active: true };
     let callbackPromise: Promise<T>;
     try {
-      callbackPromise = Promise.resolve(
-        this.callbackContext.run(context, () => fn(proxy)),
+      callbackPromise = this.callbackContext.run(
+        context,
+        () => Promise.resolve(fn(proxy)),
       );
     } catch (error) {
       callbackPromise = Promise.reject(error);

--- a/packages/ferric/src/engine-pool.ts
+++ b/packages/ferric/src/engine-pool.ts
@@ -12,9 +12,11 @@
  * This is efficient and safe for concurrent use.
  *
  * ### Stateful operations
- * `do()` dispatches a callback that receives an `EngineProxy`. Each proxy method
- * sends one round-trip message to the worker. The callback runs on the main
- * thread; only individual operations cross the thread boundary.
+ * `do()` reserves one whole worker slot in the slot's root FIFO and invokes a
+ * callback with an `EngineProxy`. The callback runs on the main thread; proxy
+ * operations cross the worker boundary one at a time in invocation order. No
+ * unrelated pool work can use that worker until the pool observes the
+ * callback's returned Promise settle and its accepted proxy operations drain.
  *
  * ## Cooperative cancellation
  *
@@ -27,6 +29,7 @@
  */
 
 import { Worker } from "node:worker_threads";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { resolve } from "node:path";
 import type { WorkerRequest, WorkerResponse, PoolWorkerInit } from "./wire";
 import { ABORT_BUFFER_SIZE, ABORT_FLAG_INDEX, toWire, fromWire } from "./wire";
@@ -56,7 +59,11 @@ export type { EngineSpec, EvaluateRequest, EvaluateResult };
  * Proxy object passed to EnginePool.do() callbacks.
  *
  * Each method dispatches a single round-trip message to the pool worker.
- * Do not retain the proxy beyond the lifetime of the callback.
+ * Calls are serialized on the callback's exclusive worker lease. Once the pool
+ * observes the callback's returned Promise settle, every later method rejects
+ * with a deterministic lifetime error. Promise reactions that the callback
+ * registers before returning can run before that observation and remain inside
+ * the lease.
  */
 export interface EngineProxy {
   load(source: string): Promise<void>;
@@ -96,6 +103,7 @@ interface PendingEntry {
 
 /** A request waiting to be dispatched to a worker. */
 interface QueuedRequest {
+  kind: "request";
   req: WorkerRequest;
   entry: PendingEntry;
   signal?: AbortSignal;
@@ -104,15 +112,59 @@ interface QueuedRequest {
   transferList?: ArrayBuffer[];
 }
 
+interface WorkerLease {
+  /** Whether the callback may still submit new proxy operations. */
+  active: boolean;
+  /** Whether this lease has reached its single terminal release. */
+  released: boolean;
+  /** Proxy requests accepted by this lease, in invocation order. */
+  queue: QueuedRequest[];
+  /** Accepted proxy requests that have not settled yet. */
+  pendingCalls: number;
+  /**
+   * Waiters used after the pool observes settlement with accepted work
+   * outstanding.
+   */
+  drainWaiters: Array<() => void>;
+  /** Completion barrier used by close() for an already-admitted callback. */
+  releasedPromise: Promise<void>;
+  resolveReleased: () => void;
+  releasePromise?: Promise<void>;
+}
+
+interface QueuedLease {
+  kind: "lease";
+  lease: WorkerLease;
+  resolve: (lease: WorkerLease) => void;
+  reject: (error: Error) => void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+}
+
+type QueuedWork = QueuedRequest | QueuedLease;
+
+interface PoolCallbackContext {
+  /** Mutable so descendants stop being reentrant at pool-observed settlement. */
+  active: boolean;
+}
+
 interface WorkerSlot {
   worker: Worker;
   nextId: number;
   pending: Map<number, PendingEntry>;
   /** Number of requests currently being processed by the worker. */
   inflight: number;
-  /** Requests waiting for the worker to become available. */
-  queue: QueuedRequest[];
+  /** Root requests and lease admissions waiting in per-slot FIFO order. */
+  queue: QueuedWork[];
+  /** Exclusive callback lease currently admitted on this whole worker slot. */
+  activeLease?: WorkerLease;
 }
+
+const INACTIVE_PROXY_MESSAGE =
+  "EngineProxy is no longer valid outside its EnginePool.do callback";
+const REENTRANT_POOL_MESSAGE =
+  "EnginePool.do, EnginePool.evaluate, and EnginePool.close cannot be called " +
+  "from within an active EnginePool.do callback on the same pool";
 
 // ---------------------------------------------------------------------------
 // Error reconstruction
@@ -160,6 +212,7 @@ function reconstructError(payload: WorkerResponse["error"]): Error {
  */
 export class EnginePool {
   private readonly slots: WorkerSlot[];
+  private readonly callbackContext = new AsyncLocalStorage<PoolCallbackContext>();
   private roundRobin = 0;
   private closed = false;
 
@@ -258,6 +311,10 @@ export class EnginePool {
     worker.on("error", (err: Error) => {
       const snapshot = [...slot.pending.values()];
       slot.pending.clear();
+      // Reject owner work already accepted behind the failed in-flight call so
+      // callback cleanup can drain and release its lease. Full terminal slot
+      // cleanup remains the responsibility of FR-NODE-005.
+      EnginePool.rejectActiveLeaseQueue(slot, err);
       for (const entry of snapshot) {
         entry.reject(err);
       }
@@ -275,6 +332,7 @@ export class EnginePool {
         );
         const snapshot = [...slot.pending.values()];
         slot.pending.clear();
+        EnginePool.rejectActiveLeaseQueue(slot, err);
         for (const entry of snapshot) {
           entry.reject(err);
         }
@@ -305,27 +363,214 @@ export class EnginePool {
     return slot;
   }
 
-  /** Dispatch queued requests for a slot until it's busy or queue is empty. */
+  private assertNotInActiveCallback(): void {
+    if (this.callbackContext.getStore()?.active) {
+      throw new Error(REENTRANT_POOL_MESSAGE);
+    }
+  }
+
+  private static createLease(): WorkerLease {
+    let resolveReleased!: () => void;
+    const releasedPromise = new Promise<void>((resolve) => {
+      resolveReleased = resolve;
+    });
+    return {
+      active: false,
+      released: false,
+      queue: [],
+      pendingCalls: 0,
+      drainWaiters: [],
+      releasedPromise,
+      resolveReleased,
+    };
+  }
+
+  private static markLeaseReleased(lease: WorkerLease): void {
+    if (lease.released) return;
+    lease.active = false;
+    lease.released = true;
+    lease.resolveReleased();
+  }
+
+  private static removeAbortListener(
+    queued: Pick<QueuedRequest, "signal" | "onAbort">,
+  ): void {
+    if (queued.signal && queued.onAbort) {
+      queued.signal.removeEventListener("abort", queued.onAbort);
+    }
+  }
+
+  private static dispatchRequest(slot: WorkerSlot, queued: QueuedRequest): void {
+    slot.pending.set(queued.req.id, queued.entry);
+    slot.inflight++;
+    slot.worker.postMessage(queued.req);
+  }
+
+  private static rejectActiveLeaseQueue(slot: WorkerSlot, error: Error): void {
+    const lease = slot.activeLease;
+    if (!lease) return;
+    const snapshot = lease.queue.splice(0);
+    for (const queued of snapshot) {
+      EnginePool.removeAbortListener(queued);
+      queued.entry.reject(error);
+    }
+  }
+
+  private static settleLeaseCall(lease: WorkerLease): void {
+    lease.pendingCalls--;
+    if (lease.pendingCalls !== 0) return;
+    const waiters = lease.drainWaiters.splice(0);
+    for (const resolve of waiters) resolve();
+  }
+
+  private static trackLeaseCall<T>(
+    lease: WorkerLease,
+    promise: Promise<T>,
+  ): Promise<T> {
+    lease.pendingCalls++;
+    promise.then(
+      () => EnginePool.settleLeaseCall(lease),
+      () => EnginePool.settleLeaseCall(lease),
+    );
+    return promise;
+  }
+
+  private static waitForLeaseCalls(lease: WorkerLease): Promise<void> {
+    if (lease.pendingCalls === 0) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      lease.drainWaiters.push(resolve);
+    });
+  }
+
+  /** Dispatch the next owner request or root FIFO item for an idle slot. */
   private static drainQueue(slot: WorkerSlot): void {
-    while (slot.queue.length > 0 && slot.inflight === 0) {
+    if (slot.inflight !== 0) return;
+
+    const lease = slot.activeLease;
+    if (lease) {
+      while (lease.queue.length > 0) {
+        const queued = lease.queue.shift()!;
+
+        if (queued.signal?.aborted) {
+          EnginePool.removeAbortListener(queued);
+          queued.entry.reject(
+            new DOMException("The operation was aborted", "AbortError"),
+          );
+          continue;
+        }
+
+        // This request is no longer dequeue-cancellable once dispatched. Its
+        // method-specific in-flight cancellation (notably batched run) remains
+        // independently wired by the proxy.
+        EnginePool.removeAbortListener(queued);
+        EnginePool.dispatchRequest(slot, queued);
+        return;
+      }
+
+      // An exclusive callback retains the worker even while it is between
+      // awaits and has no native request in flight.
+      return;
+    }
+
+    while (slot.queue.length > 0) {
       const queued = slot.queue.shift()!;
 
-      // If the request was aborted while queued, reject it immediately.
-      if (queued.signal?.aborted) {
-        if (queued.onAbort) {
-          queued.signal.removeEventListener("abort", queued.onAbort);
+      if (queued.kind === "lease") {
+        if (queued.signal?.aborted) {
+          EnginePool.removeAbortListener(queued);
+          EnginePool.markLeaseReleased(queued.lease);
+          queued.reject(
+            new DOMException("The operation was aborted", "AbortError"),
+          );
+          continue;
         }
-        queued.entry.reject(
-          new DOMException("The operation was aborted", "AbortError")
+
+        EnginePool.removeAbortListener(queued);
+        slot.activeLease = queued.lease;
+        queued.lease.active = true;
+        queued.resolve(queued.lease);
+        return;
+      }
+
+      const request = queued as QueuedRequest;
+
+      // If the request was aborted while queued, reject it immediately.
+      if (request.signal?.aborted) {
+        EnginePool.removeAbortListener(request);
+        request.entry.reject(
+          new DOMException("The operation was aborted", "AbortError"),
         );
         continue;
       }
 
-      // Dispatch the request.
-      slot.pending.set(queued.req.id, queued.entry);
-      slot.inflight++;
-      slot.worker.postMessage(queued.req);
+      EnginePool.dispatchRequest(slot, request);
+      return;
     }
+  }
+
+  /** Reserve a whole worker slot in root FIFO order for one do() callback. */
+  private acquireLease(
+    slot: WorkerSlot,
+    signal?: AbortSignal,
+  ): Promise<WorkerLease> {
+    if (this.closed) {
+      return Promise.reject(new Error("EnginePool has been closed"));
+    }
+    if (signal?.aborted) {
+      return Promise.reject(
+        new DOMException("The operation was aborted", "AbortError"),
+      );
+    }
+
+    const lease = EnginePool.createLease();
+    return new Promise<WorkerLease>((resolve, reject) => {
+      if (
+        slot.inflight === 0 &&
+        slot.activeLease === undefined &&
+        slot.queue.length === 0
+      ) {
+        slot.activeLease = lease;
+        lease.active = true;
+        resolve(lease);
+        return;
+      }
+
+      const queued: QueuedLease = {
+        kind: "lease",
+        lease,
+        resolve,
+        reject,
+        signal,
+      };
+      if (signal) {
+        queued.onAbort = () => {
+          const idx = slot.queue.indexOf(queued);
+          if (idx !== -1) {
+            slot.queue.splice(idx, 1);
+            EnginePool.markLeaseReleased(lease);
+            reject(new DOMException("The operation was aborted", "AbortError"));
+          }
+        };
+        signal.addEventListener("abort", queued.onAbort, { once: true });
+      }
+      slot.queue.push(queued);
+    });
+  }
+
+  /** Invalidate one callback proxy, drain accepted owner work, and release once. */
+  private releaseLease(slot: WorkerSlot, lease: WorkerLease): Promise<void> {
+    if (lease.releasePromise) return lease.releasePromise;
+
+    lease.active = false;
+    lease.releasePromise = (async () => {
+      await EnginePool.waitForLeaseCalls(lease);
+      if (slot.activeLease === lease) {
+        slot.activeLease = undefined;
+      }
+      EnginePool.markLeaseReleased(lease);
+      EnginePool.drainQueue(slot);
+    })();
+    return lease.releasePromise;
   }
 
   /** Send a request to a specific slot, queueing if busy. */
@@ -344,14 +589,23 @@ export class EnginePool {
     return new Promise<unknown>((resolve, reject) => {
       const entry: PendingEntry = { resolve, reject };
 
-      if (slot.inflight === 0) {
+      if (
+        slot.inflight === 0 &&
+        slot.activeLease === undefined &&
+        slot.queue.length === 0
+      ) {
         // Dispatch immediately.
         slot.pending.set(id, entry);
         slot.inflight++;
         slot.worker.postMessage(req);
       } else {
         // Queue and set up abort listener for queued cancellation.
-        const queued: QueuedRequest = { req, entry, signal };
+        const queued: QueuedRequest = {
+          kind: "request",
+          req,
+          entry,
+          signal,
+        };
         if (signal) {
           queued.onAbort = () => {
             const idx = slot.queue.indexOf(queued);
@@ -367,6 +621,49 @@ export class EnginePool {
     });
   }
 
+  /** Send an owner request through its lease-private FIFO. */
+  private sendOnLease(
+    slot: WorkerSlot,
+    lease: WorkerLease,
+    method: string,
+    args: unknown[],
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    if (!lease.active || lease.released || slot.activeLease !== lease) {
+      return Promise.reject(new Error(INACTIVE_PROXY_MESSAGE));
+    }
+
+    const id = slot.nextId++;
+    const req: WorkerRequest = { id, method, args };
+    const promise = new Promise<unknown>((resolve, reject) => {
+      const entry: PendingEntry = { resolve, reject };
+      const queued: QueuedRequest = {
+        kind: "request",
+        req,
+        entry,
+        signal,
+      };
+
+      if (slot.inflight === 0 && lease.queue.length === 0) {
+        EnginePool.dispatchRequest(slot, queued);
+      } else {
+        if (signal) {
+          queued.onAbort = () => {
+            const idx = lease.queue.indexOf(queued);
+            if (idx !== -1) {
+              lease.queue.splice(idx, 1);
+              reject(new DOMException("The operation was aborted", "AbortError"));
+            }
+          };
+          signal.addEventListener("abort", queued.onAbort, { once: true });
+        }
+        lease.queue.push(queued);
+      }
+    });
+
+    return EnginePool.trackLeaseCall(lease, promise);
+  }
+
   // ---------------------------------------------------------------------------
   // EngineProxy builder
   // ---------------------------------------------------------------------------
@@ -374,65 +671,109 @@ export class EnginePool {
   private makeProxy(
     specName: string,
     slot: WorkerSlot,
+    lease: WorkerLease,
     signal?: AbortSignal,
   ): EngineProxy {
     const send = (method: string, args: unknown[]): Promise<unknown> =>
-      this.sendToSlot(slot, method, [specName, ...args], signal);
+      this.sendOnLease(slot, lease, method, [specName, ...args], signal);
 
-    const runWithAbort = async (options?: { limit?: number }): Promise<RunResult> => {
-      const limit = normalizeRunLimit(
-        (options as { limit?: unknown } | undefined)?.limit,
-        "EngineProxy.run",
-      );
-
-      // Allocate a per-call abort buffer for out-of-band host cancellation;
-      // the worker polls it between logical-run continuation chunks.
-      const sab = new SharedArrayBuffer(
-        ABORT_BUFFER_SIZE * Int32Array.BYTES_PER_ELEMENT,
-      );
-      const abortFlag = new Int32Array(sab);
-
-      let onAbort: (() => void) | undefined;
-      if (signal) {
-        if (signal.aborted) {
-          Atomics.store(abortFlag, ABORT_FLAG_INDEX, 1);
-        } else {
-          onAbort = () => { Atomics.store(abortFlag, ABORT_FLAG_INDEX, 1); };
-          signal.addEventListener("abort", onAbort, { once: true });
-        }
+    const withActiveLease = <T>(operation: () => Promise<T>): Promise<T> => {
+      if (!lease.active || lease.released || slot.activeLease !== lease) {
+        return Promise.reject(new Error(INACTIVE_PROXY_MESSAGE));
       }
-
-      try {
-        return (await send("__batched_run", [
-          limit ?? null,
-          sab,
-        ])) as RunResult;
-      } finally {
-        if (signal && onAbort) {
-          signal.removeEventListener("abort", onAbort);
-        }
-      }
+      return operation();
     };
 
+    const runWithAbort = (options?: { limit?: number }): Promise<RunResult> =>
+      withActiveLease(async () => {
+        const limit = normalizeRunLimit(
+          (options as { limit?: unknown } | undefined)?.limit,
+          "EngineProxy.run",
+        );
+
+        // Allocate a per-call abort buffer for out-of-band host cancellation;
+        // the worker polls it between logical-run continuation chunks.
+        const sab = new SharedArrayBuffer(
+          ABORT_BUFFER_SIZE * Int32Array.BYTES_PER_ELEMENT,
+        );
+        const abortFlag = new Int32Array(sab);
+
+        let onAbort: (() => void) | undefined;
+        if (signal) {
+          if (signal.aborted) {
+            Atomics.store(abortFlag, ABORT_FLAG_INDEX, 1);
+          } else {
+            onAbort = () => { Atomics.store(abortFlag, ABORT_FLAG_INDEX, 1); };
+            signal.addEventListener("abort", onAbort, { once: true });
+          }
+        }
+
+        try {
+          return (await send("__batched_run", [
+            limit ?? null,
+            sab,
+          ])) as RunResult;
+        } finally {
+          if (signal && onAbort) {
+            signal.removeEventListener("abort", onAbort);
+          }
+        }
+      });
+
     return {
-      load: (source) => send("load", [source]) as Promise<void>,
-      assertString: (source) => send("assertString", [source]) as Promise<FactId[]>,
+      load: (source) =>
+        withActiveLease(() => send("load", [source]) as Promise<void>),
+      assertString: (source) =>
+        withActiveLease(
+          () => send("assertString", [source]) as Promise<FactId[]>,
+        ),
       assertFact: (relation, ...fields) =>
-        send("assertFact", [relation, ...fields.map(toWire)]) as Promise<FactId>,
+        withActiveLease(
+          () => send(
+            "assertFact",
+            [relation, ...fields.map(toWire)],
+          ) as Promise<FactId>,
+        ),
       assertTemplate: (templateName, slots) =>
-        send("assertTemplate", [templateName, toWire(slots)]) as Promise<FactId>,
-      retract: (factId) => send("retract", [factId]) as Promise<void>,
-      getFact: (factId) => send("getFact", [factId]) as Promise<Fact | null>,
-      facts: () => send("facts", []) as Promise<Fact[]>,
-      findFacts: (relation) => send("findFacts", [relation]) as Promise<Fact[]>,
+        withActiveLease(
+          () => send(
+            "assertTemplate",
+            [templateName, toWire(slots)],
+          ) as Promise<FactId>,
+        ),
+      retract: (factId) =>
+        withActiveLease(() => send("retract", [factId]) as Promise<void>),
+      getFact: (factId) =>
+        withActiveLease(
+          () => send("getFact", [factId]) as Promise<Fact | null>,
+        ),
+      facts: () =>
+        withActiveLease(() => send("facts", []) as Promise<Fact[]>),
+      findFacts: (relation) =>
+        withActiveLease(
+          () => send("findFacts", [relation]) as Promise<Fact[]>,
+        ),
       run: runWithAbort,
-      step: () => send("step", []) as Promise<FiredRule | null>,
-      halt: () => send("halt", []) as Promise<void>,
-      reset: () => send("reset", []) as Promise<void>,
-      clear: () => send("clear", []) as Promise<void>,
-      getOutput: (channel) => send("getOutput", [channel]) as Promise<string | null>,
-      clearOutput: (channel) => send("clearOutput", [channel]) as Promise<void>,
-      pushInput: (line) => send("pushInput", [line]) as Promise<void>,
+      step: () =>
+        withActiveLease(
+          () => send("step", []) as Promise<FiredRule | null>,
+        ),
+      halt: () =>
+        withActiveLease(() => send("halt", []) as Promise<void>),
+      reset: () =>
+        withActiveLease(() => send("reset", []) as Promise<void>),
+      clear: () =>
+        withActiveLease(() => send("clear", []) as Promise<void>),
+      getOutput: (channel) =>
+        withActiveLease(
+          () => send("getOutput", [channel]) as Promise<string | null>,
+        ),
+      clearOutput: (channel) =>
+        withActiveLease(
+          () => send("clearOutput", [channel]) as Promise<void>,
+        ),
+      pushInput: (line) =>
+        withActiveLease(() => send("pushInput", [line]) as Promise<void>),
     };
   }
 
@@ -459,6 +800,7 @@ export class EnginePool {
     request: EvaluateRequest,
     options?: { signal?: AbortSignal },
   ): Promise<EvaluateResult> {
+    this.assertNotInActiveCallback();
     if (this.closed) throw new Error("EnginePool has been closed");
 
     const signal = options?.signal;
@@ -511,27 +853,38 @@ export class EnginePool {
   }
 
   /**
-   * Dispatch a function to run using a pooled engine.
+   * Run a callback with an exclusive lease on one pooled worker slot.
    *
-   * The callback receives an `EngineProxy` whose methods each send a single
-   * round-trip to the worker. The callback executes on the main thread —
-   * only individual operations cross the thread boundary.
+   * Root work enters each selected slot in FIFO order. While this callback's
+   * Promise is pending, no unrelated `do()` or `evaluate()` work can execute on
+   * that worker, even when the callback is between proxy calls. Concurrent
+   * proxy calls are serialized in invocation order.
    *
-   * The proxy must not be retained beyond the callback's return value.
+   * This is scheduling isolation, not rollback: successful mutations remain if
+   * the callback later rejects. The proxy becomes invalid when the pool's
+   * registered Promise reaction observes the callback outcome, before `do()`
+   * delivers that value or error. Promise reactions registered by the callback
+   * before it returns can run first and remain inside the lease. An AbortSignal
+   * can reject the public Promise earlier, but the lease remains exclusive until
+   * the pool observes the callback outcome.
+   *
+   * Calling `do()`, `evaluate()`, or `close()` on this same pool from inside an
+   * active callback rejects; use the supplied proxy instead. Other pools remain
+   * independent.
    *
    * @param specName Engine spec to use.
    * @param fn Callback receiving an EngineProxy.
    * @param options.signal AbortSignal for cancellation.
    *
-   * Note: `T` must be structured-clonable (or a primitive) because the
-   * return value of individual proxy methods crosses the thread boundary.
-   * The callback itself returns its value directly on the main thread.
+   * Only proxy arguments and results cross the worker boundary. The callback's
+   * `T` value remains on the main thread and need not be structured-clonable.
    */
   async do<T>(
     specName: string,
     fn: (engine: EngineProxy) => Promise<T>,
     options?: { signal?: AbortSignal },
   ): Promise<T> {
+    this.assertNotInActiveCallback();
     if (this.closed) throw new Error("EnginePool has been closed");
 
     const signal = options?.signal;
@@ -540,29 +893,70 @@ export class EnginePool {
     }
 
     const slot = this.pickSlot();
-    const proxy = this.makeProxy(specName, slot, signal);
+    const lease = await this.acquireLease(slot, signal);
 
-    // E-006: If the signal aborts during fn execution, reject with AbortError.
-    if (signal) {
-      return new Promise<T>((resolve, reject) => {
-        const onAbort = () => {
-          reject(new DOMException("The operation was aborted", "AbortError"));
-        };
-        signal.addEventListener("abort", onAbort, { once: true });
-        fn(proxy).then(
-          (val) => {
-            signal.removeEventListener("abort", onAbort);
-            resolve(val);
-          },
-          (err) => {
-            signal.removeEventListener("abort", onAbort);
-            reject(err);
-          },
-        );
-      });
+    // Abort can race with admission after the queued listener is removed but
+    // before this async continuation resumes. Such a callback never starts.
+    if (signal?.aborted) {
+      await this.releaseLease(slot, lease);
+      throw new DOMException("The operation was aborted", "AbortError");
     }
 
-    return fn(proxy);
+    const proxy = this.makeProxy(specName, slot, lease, signal);
+    const context: PoolCallbackContext = { active: true };
+    let callbackPromise: Promise<T>;
+    try {
+      callbackPromise = Promise.resolve(
+        this.callbackContext.run(context, () => fn(proxy)),
+      );
+    } catch (error) {
+      callbackPromise = Promise.reject(error);
+    }
+
+    // Cleanup follows the pool-observed callback lifetime, not the
+    // caller-visible AbortError race. Promise reactions registered by callback
+    // code before it returns may run before this reaction and remain inside the
+    // lease. Once this reaction begins, the proxy is invalidated before accepted
+    // work drains and before do() delivers the callback's value or error.
+    const completion = callbackPromise.then(
+      async (value) => {
+        context.active = false;
+        await this.releaseLease(slot, lease);
+        return value;
+      },
+      async (error: unknown) => {
+        context.active = false;
+        await this.releaseLease(slot, lease);
+        throw error;
+      },
+    );
+
+    if (!signal) return completion;
+
+    // E-006: abort rejects the public do() promise promptly, but completion
+    // above remains attached and owns the eventual lease cleanup.
+    return new Promise<T>((resolve, reject) => {
+      const onAbort = () => {
+        reject(new DOMException("The operation was aborted", "AbortError"));
+      };
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+      const stopListening = () => {
+        signal.removeEventListener("abort", onAbort);
+      };
+      // The cancellation contract is phrased against pool-observed callback
+      // completion, not the later accepted-work drain barrier. Once the pool's
+      // callback reaction runs, a subsequent signal change cannot replace the
+      // callback result with AbortError.
+      callbackPromise.then(stopListening, stopListening);
+      completion.then(
+        (value) => resolve(value),
+        (error: unknown) => reject(error),
+      );
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -573,12 +967,14 @@ export class EnginePool {
    * Gracefully shut down all worker threads.
    *
    * - New requests are rejected immediately after close() is called.
-   * - Queued (not yet dispatched) requests are rejected with "EnginePool closed".
-   * - Already-dispatched in-flight requests are allowed to settle.
+   * - Queued requests and not-yet-admitted leases reject with "EnginePool closed".
+   * - Already-admitted callbacks retain owner dispatch access and may settle.
+   * - Already-dispatched ordinary requests are allowed to settle.
    * - Workers are terminated after all in-flight requests complete.
    * - Idempotent — safe to call multiple times.
    */
   async close(): Promise<void> {
+    this.assertNotInActiveCallback();
     if (this.closed) return;
     this.closed = true;
 
@@ -588,12 +984,24 @@ export class EnginePool {
       this.slots.map(async (slot) => {
         // Reject all queued (not yet dispatched) requests.
         for (const queued of slot.queue) {
-          if (queued.onAbort && queued.signal) {
-            queued.signal.removeEventListener("abort", queued.onAbort);
+          EnginePool.removeAbortListener(queued);
+          if (queued.kind === "lease") {
+            EnginePool.markLeaseReleased(queued.lease);
+            queued.reject(closeErr);
+          } else {
+            queued.entry.reject(closeErr);
           }
-          queued.entry.reject(closeErr);
         }
         slot.queue.length = 0;
+
+        // A do() callback is admitted work even while it has no native request
+        // in flight. Its owner calls remain valid after close starts, and close
+        // waits for pool-observed callback settlement plus accepted-call
+        // draining.
+        const activeLease = slot.activeLease;
+        if (activeLease) {
+          await activeLease.releasedPromise;
+        }
 
         // Wait for in-flight requests to settle. The existing message
         // handler installed in createSlot() clears slot.pending as

--- a/packages/ferric/test/conformance/coverage-entrypoint.test.ts
+++ b/packages/ferric/test/conformance/coverage-entrypoint.test.ts
@@ -26,6 +26,7 @@ import "./runtime/pool/additional.test.ts";
 import "./runtime/pool/cancellation.test.ts";
 import "./runtime/pool/close-semantics.test.ts";
 import "./runtime/pool/create-cleanup.test.ts";
+import "./runtime/pool/exclusive-lease.test.ts";
 import "./runtime/pool/fact-id.test.ts";
 import "./runtime/pool/logical-run.test.ts";
 import "./runtime/pool/pool-internals.test.ts";

--- a/packages/ferric/test/conformance/runtime/pool/exclusive-lease.test.ts
+++ b/packages/ferric/test/conformance/runtime/pool/exclusive-lease.test.ts
@@ -714,6 +714,39 @@ test("E-012 same-pool do evaluate and close reject inside callbacks", { timeout:
   }
 });
 
+test("E-012 returned thenable assimilation preserves same-pool reentrancy guards", async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+  let nestedOutcome!: Promise<{ status: "fulfilled" } | { status: "rejected"; error: unknown }>;
+
+  try {
+    const value = await pool.do("rules", () => ({
+      then(resolve: (value: string) => void): void {
+        nestedOutcome = pool.evaluate("rules", {}).then(
+          () => ({ status: "fulfilled" as const }),
+          (error: unknown) => ({ status: "rejected" as const, error }),
+        );
+        resolve("callback result");
+      },
+    }) as Promise<string>);
+
+    assert.strictEqual(value, "callback result");
+    const outcome = await nestedOutcome;
+    assert.strictEqual(outcome.status, "rejected");
+    if (outcome.status === "rejected") {
+      assert.match(String(outcome.error), REENTRANT_ERROR);
+    }
+
+    const reused = await pool.do("rules", async (proxy) => {
+      await proxy.reset();
+      await proxy.assertFact("thenable-reuse", 1);
+      return (await proxy.findFacts("thenable-reuse")).length;
+    });
+    assert.strictEqual(reused, 1);
+  } finally {
+    await pool.close();
+  }
+});
+
 test("E-012 a do callback may use a distinct EnginePool", async () => {
   const outerPool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
   const innerPool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });

--- a/packages/ferric/test/conformance/runtime/pool/exclusive-lease.test.ts
+++ b/packages/ferric/test/conformance/runtime/pool/exclusive-lease.test.ts
@@ -1,0 +1,791 @@
+/**
+ * EnginePool callback-lease isolation tests (FR-NODE-003 / E-012).
+ */
+import { setImmediate as yieldImmediate } from "node:timers/promises";
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+
+import type { EngineProxy } from "../../../helpers/ferric";
+import { EnginePool } from "../../../helpers/ferric";
+
+const RETAINED_PROXY_ERROR =
+  "EngineProxy is no longer valid outside its EnginePool.do callback";
+const REENTRANT_ERROR =
+  /cannot be called from within an active EnginePool\.do callback on the same pool/;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function deferred<T = void>(): Deferred<T> {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function yieldTurns(count = 1): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await yieldImmediate();
+  }
+}
+
+function assertRetainedProxyError(error: unknown): boolean {
+  assert.ok(error instanceof Error);
+  assert.strictEqual(error.name, "Error");
+  assert.strictEqual(error.message, RETAINED_PROXY_ERROR);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// E-012: the whole worker, including its other named engines, is leased
+// ---------------------------------------------------------------------------
+test("E-012 one worker excludes same-spec, different-spec, and evaluate work", { timeout: 5_000 }, async () => {
+  const pool = await EnginePool.create(
+    [
+      { name: "alpha", source: "" },
+      { name: "beta", source: "" },
+    ],
+    { threads: 1 },
+  );
+  const firstEntered = deferred();
+  const releaseFirst = deferred();
+  let secondEntered = false;
+  let evaluateSettled = false;
+  const completionOrder: string[] = [];
+  let first: Promise<unknown> | undefined;
+  let second: Promise<unknown> | undefined;
+  let evaluation: Promise<unknown> | undefined;
+
+  try {
+    first = pool.do("alpha", async (proxy) => {
+      await proxy.reset();
+      await proxy.assertFact("lease-owner", "alpha");
+      firstEntered.resolve();
+      await releaseFirst.promise;
+      const owners = await proxy.findFacts("lease-owner");
+      return owners.map((fact) => fact.fields[0]);
+    });
+    await firstEntered.promise;
+
+    second = pool.do("beta", async (proxy) => {
+      secondEntered = true;
+      await proxy.reset();
+      await proxy.assertFact("lease-owner", "beta");
+      return "second";
+    }).then((value) => {
+      completionOrder.push("do:beta");
+      return value;
+    });
+    evaluation = pool.evaluate("alpha", {
+      facts: [
+        {
+          kind: "ordered",
+          relation: "evaluation",
+          fields: [1],
+        },
+      ],
+    }).then((value) => {
+      completionOrder.push("evaluate:alpha");
+      return value;
+    });
+    void evaluation.then(
+      () => { evaluateSettled = true; },
+      () => { evaluateSettled = true; },
+    );
+
+    await yieldTurns(2);
+    assert.strictEqual(secondEntered, false, "a waiting do callback started inside the lease");
+    assert.strictEqual(evaluateSettled, false, "evaluate reached a leased worker");
+
+    releaseFirst.resolve();
+    assert.deepStrictEqual(await first, ["alpha"]);
+    assert.strictEqual(await second, "second");
+    const evaluated = await evaluation;
+    assert.ok(evaluated.facts.some((fact) => fact.relation === "evaluation"));
+    assert.deepStrictEqual(completionOrder, ["do:beta", "evaluate:alpha"]);
+  } finally {
+    releaseFirst.resolve();
+    await Promise.allSettled(
+      [first, second, evaluation].filter((promise): promise is Promise<unknown> => promise !== undefined),
+    );
+    await pool.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// E-012: owner requests bypass unrelated waiters without sacrificing FIFO
+// ---------------------------------------------------------------------------
+test("E-012 lease owner keeps dispatch access after another callback queues", { timeout: 5_000 }, async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+  const ownerEntered = deferred();
+  const continueOwner = deferred();
+  let waiterEntered = false;
+  let owner: Promise<unknown> | undefined;
+  let waiter: Promise<unknown> | undefined;
+
+  try {
+    owner = pool.do("rules", async (proxy) => {
+      await proxy.reset();
+      ownerEntered.resolve();
+      await continueOwner.promise;
+
+      // These owner requests must not queue behind the lease waiter. A single
+      // undifferentiated FIFO would deadlock here.
+      await proxy.assertFact("lease-owner", 1);
+      return (await proxy.findFacts("lease-owner")).map((fact) => fact.fields[0]);
+    });
+    await ownerEntered.promise;
+
+    waiter = pool.do("rules", async (proxy) => {
+      waiterEntered = true;
+      await proxy.reset();
+      return "waiter";
+    });
+    await yieldTurns(2);
+    assert.strictEqual(waiterEntered, false);
+
+    continueOwner.resolve();
+    assert.deepStrictEqual(await owner, [1]);
+    assert.strictEqual(await waiter, "waiter");
+  } finally {
+    continueOwner.resolve();
+    await Promise.allSettled(
+      [owner, waiter].filter((promise): promise is Promise<unknown> => promise !== undefined),
+    );
+    await pool.close();
+  }
+});
+
+test("E-012 one-worker lease waiters enter FIFO without starvation", { timeout: 5_000 }, async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+  const holderEntered = deferred();
+  const releaseHolder = deferred();
+  const starts: string[] = [];
+  let holder: Promise<unknown> | undefined;
+  let waiters: Array<Promise<unknown>> = [];
+
+  try {
+    holder = pool.do("rules", async () => {
+      holderEntered.resolve();
+      await releaseHolder.promise;
+    });
+    await holderEntered.promise;
+
+    waiters = ["B", "C", "D"].map((label) =>
+      pool.do("rules", async (proxy) => {
+        starts.push(label);
+        await proxy.facts();
+        return label;
+      }),
+    );
+
+    await yieldTurns(2);
+    assert.deepStrictEqual(starts, [], "a queued callback entered before lease release");
+
+    releaseHolder.resolve();
+    await holder;
+    assert.deepStrictEqual(await Promise.all(waiters), ["B", "C", "D"]);
+    assert.deepStrictEqual(starts, ["B", "C", "D"]);
+  } finally {
+    releaseHolder.resolve();
+    await Promise.allSettled(
+      [holder, ...waiters].filter((promise): promise is Promise<unknown> => promise !== undefined),
+    );
+    await pool.close();
+  }
+});
+
+test("E-012 root FIFO keeps an older evaluate ahead of a later lease", { timeout: 5_000 }, async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+  const holderEntered = deferred();
+  const releaseHolder = deferred();
+  let laterLeaseEntered = false;
+  let holder: Promise<unknown> | undefined;
+  let evaluation: Promise<unknown> | undefined;
+  let laterLease: Promise<unknown> | undefined;
+
+  try {
+    holder = pool.do("rules", async () => {
+      holderEntered.resolve();
+      await releaseHolder.promise;
+    });
+    await holderEntered.promise;
+
+    evaluation = pool.evaluate("rules", {
+      facts: [
+        {
+          kind: "ordered",
+          relation: "older-evaluate",
+          fields: [1],
+        },
+      ],
+    });
+    laterLease = pool.do("rules", async (proxy) => {
+      laterLeaseEntered = true;
+      return (await proxy.findFacts("older-evaluate")).map(
+        (fact) => fact.fields[0],
+      );
+    });
+
+    assert.strictEqual(laterLeaseEntered, false);
+    releaseHolder.resolve();
+    await holder;
+
+    const evaluated = await evaluation as Awaited<ReturnType<EnginePool["evaluate"]>>;
+    assert.ok(evaluated.facts.some((fact) => fact.relation === "older-evaluate"));
+    // The worker admits the next root item from its message handler before the
+    // older Promise continuation runs. Persisted engine state is therefore the
+    // deterministic execution-order oracle: the later lease can observe this
+    // fact only if the older evaluate ran first.
+    assert.deepStrictEqual(await laterLease, [1]);
+  } finally {
+    releaseHolder.resolve();
+    await Promise.allSettled(
+      [holder, evaluation, laterLease].filter(
+        (promise): promise is Promise<unknown> => promise !== undefined,
+      ),
+    );
+    await pool.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// E-012: every worker can host one lease, never two
+// ---------------------------------------------------------------------------
+test("E-012 two workers isolate two active callbacks from later callbacks", { timeout: 5_000 }, async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 2 });
+  const entered = [deferred(), deferred()];
+  const release = [deferred(), deferred()];
+  const laterStarts: string[] = [];
+  let active: Array<Promise<unknown>> = [];
+  let later: Array<Promise<unknown>> = [];
+
+  try {
+    active = ["A", "B"].map((label, index) =>
+      pool.do("rules", async (proxy) => {
+        await proxy.reset();
+        await proxy.assertFact("lease-owner", label);
+        entered[index].resolve();
+        await release[index].promise;
+        return (await proxy.findFacts("lease-owner")).map((fact) => fact.fields[0]);
+      }),
+    );
+    await Promise.all(entered.map((item) => item.promise));
+
+    later = ["C", "D"].map((label) =>
+      pool.do("rules", async (proxy) => {
+        laterStarts.push(label);
+        await proxy.reset();
+        await proxy.assertFact("lease-owner", label);
+        return label;
+      }),
+    );
+
+    await yieldTurns(2);
+    assert.deepStrictEqual(laterStarts, [], "a third callback entered a leased worker");
+
+    release[0].resolve();
+    release[1].resolve();
+    assert.deepStrictEqual(await Promise.all(active), [["A"], ["B"]]);
+    assert.deepStrictEqual(await Promise.all(later), ["C", "D"]);
+    assert.deepStrictEqual(laterStarts.sort(), ["C", "D"]);
+  } finally {
+    release[0].resolve();
+    release[1].resolve();
+    await Promise.allSettled([...active, ...later]);
+    await pool.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// E-012: proxy calls are serialized in invocation order inside the lease
+// ---------------------------------------------------------------------------
+test("E-012 parallel proxy calls preserve invocation order ahead of waiters", { timeout: 5_000 }, async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+  const ownerEntered = deferred();
+  const issueParallelCalls = deferred();
+  let waiterEntered = false;
+  let owner: Promise<unknown> | undefined;
+  let waiter: Promise<unknown> | undefined;
+
+  try {
+    owner = pool.do("rules", async (proxy) => {
+      await proxy.reset();
+      ownerEntered.resolve();
+      await issueParallelCalls.promise;
+
+      const assertedBeforeReset = proxy.assertFact("ordered", 1);
+      const reset = proxy.reset();
+      const assertedAfterReset = proxy.assertFact("ordered", 3);
+      await Promise.all([assertedBeforeReset, reset, assertedAfterReset]);
+      return (await proxy.findFacts("ordered")).map((fact) => fact.fields[0]);
+    });
+    await ownerEntered.promise;
+
+    waiter = pool.do("rules", async () => {
+      waiterEntered = true;
+    });
+    await yieldTurns(2);
+    assert.strictEqual(waiterEntered, false);
+
+    issueParallelCalls.resolve();
+    assert.deepStrictEqual(await owner, [3]);
+    await waiter;
+  } finally {
+    issueParallelCalls.resolve();
+    await Promise.allSettled(
+      [owner, waiter].filter((promise): promise is Promise<unknown> => promise !== undefined),
+    );
+    await pool.close();
+  }
+});
+
+test("E-012 normal callback settlement drains accepted unawaited proxy calls", async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+  let acceptedCalls!: Promise<unknown[]>;
+  let acceptedCallsSettled = false;
+
+  try {
+    const result = await pool.do("rules", async (proxy) => {
+      const assertedBeforeReset = proxy.assertFact("accepted-order", 1);
+      const reset = proxy.reset();
+      const assertedAfterReset = proxy.assertFact("accepted-order", 3);
+      acceptedCalls = Promise.all([assertedBeforeReset, reset, assertedAfterReset]);
+      void acceptedCalls.then(
+        () => { acceptedCallsSettled = true; },
+        () => { acceptedCallsSettled = true; },
+      );
+      return "callback-return";
+    });
+
+    assert.strictEqual(result, "callback-return");
+    assert.strictEqual(
+      acceptedCallsSettled,
+      true,
+      "do resolved before an operation accepted during the callback settled",
+    );
+    await acceptedCalls;
+
+    const values = await pool.do("rules", async (proxy) =>
+      (await proxy.findFacts("accepted-order")).map((fact) => fact.fields[0]),
+    );
+    assert.deepStrictEqual(values, [3]);
+  } finally {
+    await pool.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// E-012: callback settlement invalidates and releases exactly once
+// ---------------------------------------------------------------------------
+test("E-012 synchronous and asynchronous callback failures release their leases", async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+
+  try {
+    const cases = [
+      {
+        label: "synchronous throw",
+        invoke: (proxy: EngineProxy): Promise<never> => {
+          void proxy;
+          throw new Error("sync callback failure");
+        },
+        message: /sync callback failure/,
+      },
+      {
+        label: "asynchronous rejection",
+        invoke: async (proxy: EngineProxy): Promise<never> => {
+          await proxy.assertFact("persists-after-error", "async");
+          throw new Error("async callback failure");
+        },
+        message: /async callback failure/,
+      },
+    ];
+
+    for (const item of cases) {
+      let retained!: EngineProxy;
+      await assert.rejects(
+        () => pool.do("rules", ((proxy: EngineProxy) => {
+          retained = proxy;
+          return item.invoke(proxy);
+        }) as (proxy: EngineProxy) => Promise<never>),
+        item.message,
+        item.label,
+      );
+      await assert.rejects(() => retained.facts(), assertRetainedProxyError);
+
+      const followUp = await pool.do("rules", async (proxy) => {
+        const persisted = await proxy.findFacts("persists-after-error");
+        await proxy.reset();
+        return persisted.length;
+      });
+      assert.strictEqual(followUp, item.label === "asynchronous rejection" ? 1 : 0);
+    }
+
+    let nativeFailureProxy!: EngineProxy;
+    await assert.rejects(
+      () => pool.do("rules", async (proxy) => {
+        nativeFailureProxy = proxy;
+        await proxy.load("(");
+      }),
+      /parse|expected|unexpected/i,
+    );
+    await assert.rejects(() => nativeFailureProxy.facts(), assertRetainedProxyError);
+    await assert.doesNotReject(() => pool.do("rules", async (proxy) => proxy.reset()));
+  } finally {
+    await pool.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// E-012: queued and active host abort preserve the lease boundary
+// ---------------------------------------------------------------------------
+test("E-012 abort while waiting removes the lease waiter without invoking it", { timeout: 5_000 }, async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+  const holderEntered = deferred();
+  const releaseHolder = deferred();
+  const abortController = new AbortController();
+  let abortedCallbackEntered = false;
+  let finalCallbackEntered = false;
+  let holder: Promise<unknown> | undefined;
+  let aborted: Promise<unknown> | undefined;
+  let final: Promise<unknown> | undefined;
+
+  try {
+    holder = pool.do("rules", async () => {
+      holderEntered.resolve();
+      await releaseHolder.promise;
+    });
+    await holderEntered.promise;
+
+    aborted = pool.do("rules", async () => {
+      abortedCallbackEntered = true;
+    }, { signal: abortController.signal });
+    final = pool.do("rules", async () => {
+      finalCallbackEntered = true;
+      return "final";
+    });
+
+    abortController.abort();
+    await assert.rejects(aborted, (error: any) => error?.name === "AbortError");
+    assert.strictEqual(abortedCallbackEntered, false);
+    assert.strictEqual(finalCallbackEntered, false);
+
+    releaseHolder.resolve();
+    await holder;
+    assert.strictEqual(await final, "final");
+    assert.strictEqual(finalCallbackEntered, true);
+  } finally {
+    releaseHolder.resolve();
+    await Promise.allSettled(
+      [holder, aborted, final].filter((promise): promise is Promise<unknown> => promise !== undefined),
+    );
+    await pool.close();
+  }
+});
+
+test("E-012 abort races at lease admission never strand the slot", async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+
+  try {
+    const admissionAbort = new AbortController();
+    let admissionCallbackEntered = false;
+    const abortedAtAdmission = pool.do("rules", async () => {
+      admissionCallbackEntered = true;
+    }, { signal: admissionAbort.signal });
+    // acquireLease() resolves synchronously for an idle slot, but do() resumes
+    // in a microtask. Abort in that deliberate admission window.
+    admissionAbort.abort();
+    await assert.rejects(abortedAtAdmission, (error: any) => error?.name === "AbortError");
+    assert.strictEqual(admissionCallbackEntered, false);
+
+    const callbackAbort = new AbortController();
+    let callbackEntered = false;
+    const abortedByCallback = pool.do("rules", async () => {
+      callbackEntered = true;
+      // This fires before do() installs its caller-facing completion listener.
+      callbackAbort.abort();
+    }, { signal: callbackAbort.signal });
+    await assert.rejects(abortedByCallback, (error: any) => error?.name === "AbortError");
+    assert.strictEqual(callbackEntered, true);
+
+    await assert.doesNotReject(() => pool.do("rules", async (proxy) => proxy.facts()));
+  } finally {
+    await pool.close();
+  }
+});
+
+test("E-012 active abort keeps the lease until the callback really settles", { timeout: 5_000 }, async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+  const callbackEntered = deferred();
+  const releaseCallback = deferred();
+  const callbackDone = deferred();
+  const abortController = new AbortController();
+  let waiterEntered = false;
+  let active: Promise<unknown> | undefined;
+  let waiter: Promise<unknown> | undefined;
+
+  try {
+    active = pool.do("rules", async () => {
+      callbackEntered.resolve();
+      try {
+        await releaseCallback.promise;
+      } finally {
+        callbackDone.resolve();
+      }
+    }, { signal: abortController.signal });
+    await callbackEntered.promise;
+
+    abortController.abort();
+    await assert.rejects(active, (error: any) => error?.name === "AbortError");
+
+    waiter = pool.do("rules", async () => {
+      waiterEntered = true;
+      return "waiter";
+    });
+    await yieldTurns(2);
+    assert.strictEqual(waiterEntered, false, "abort released a still-running callback lease");
+
+    releaseCallback.resolve();
+    await callbackDone.promise;
+    assert.strictEqual(await waiter, "waiter");
+  } finally {
+    releaseCallback.resolve();
+    await Promise.allSettled(
+      [active, waiter].filter((promise): promise is Promise<unknown> => promise !== undefined),
+    );
+    await pool.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// E-012: close treats an admitted callback as in-flight work
+// ---------------------------------------------------------------------------
+test("E-012 close waits for an active lease and rejects waiting work", { timeout: 5_000 }, async () => {
+  const pool = await EnginePool.create(
+    [
+      { name: "active", source: "" },
+      { name: "waiting", source: "" },
+    ],
+    { threads: 1 },
+  );
+  const activeEntered = deferred();
+  const finishActive = deferred();
+  let waitingCallbackEntered = false;
+  let closeSettled = false;
+  let closing: Promise<void> | undefined;
+
+  const active = pool.do("active", async (proxy) => {
+    await proxy.reset();
+    activeEntered.resolve();
+    await finishActive.promise;
+
+    // This belongs to an already-admitted callback and remains allowed while
+    // close rejects new/unleased submissions.
+    await proxy.assertFact("completed-during-close", 1);
+    return (await proxy.findFacts("completed-during-close")).length;
+  });
+  await activeEntered.promise;
+
+  const waiting = pool.do("waiting", async () => {
+    waitingCallbackEntered = true;
+  });
+  const evaluation = pool.evaluate("waiting", {});
+  const waitingOutcome = waiting.then(
+    () => ({ status: "resolved" as const }),
+    (error: unknown) => ({ status: "rejected" as const, error }),
+  );
+  const evaluateOutcome = evaluation.then(
+    () => ({ status: "resolved" as const }),
+    (error: unknown) => ({ status: "rejected" as const, error }),
+  );
+
+  try {
+    await yieldTurns(2);
+    closing = pool.close().finally(() => { closeSettled = true; });
+    await yieldTurns(2);
+    assert.strictEqual(closeSettled, false, "close ignored an admitted callback lease");
+    assert.strictEqual(waitingCallbackEntered, false);
+
+    const waitingResult = await waitingOutcome;
+    assert.strictEqual(waitingResult.status, "rejected");
+    assert.match((waitingResult as { error: Error }).error.message, /closed/i);
+    const evaluateResult = await evaluateOutcome;
+    assert.strictEqual(evaluateResult.status, "rejected");
+    assert.match((evaluateResult as { error: Error }).error.message, /closed/i);
+
+    finishActive.resolve();
+    assert.strictEqual(await active, 1);
+    await closing;
+    assert.strictEqual(closeSettled, true);
+  } finally {
+    finishActive.resolve();
+    await Promise.allSettled([active, waiting, evaluation]);
+    if (closing) {
+      await closing.catch(() => undefined);
+    } else {
+      await pool.close();
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// E-012: proxy validity ends before do() settles to its caller
+// ---------------------------------------------------------------------------
+test("E-012 every retained proxy method rejects one stable lifetime error", async () => {
+  const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+  let retained!: EngineProxy;
+
+  try {
+    await pool.do("rules", async (proxy) => {
+      retained = proxy;
+      await proxy.reset();
+      await proxy.assertFact("baseline", 1);
+    });
+
+    const calls: Array<[string, () => Promise<unknown>]> = [
+      ["load", () => retained.load("(defrule leaked (never) =>)")],
+      ["assertString", () => retained.assertString("(retained-string 1)")],
+      ["assertFact", () => retained.assertFact("retained-fact", 1)],
+      ["assertTemplate", () => retained.assertTemplate("missing", { value: 1 })],
+      ["retract", () => retained.retract(1n)],
+      ["getFact", () => retained.getFact(1n)],
+      ["facts", () => retained.facts()],
+      ["findFacts", () => retained.findFacts("baseline")],
+      // Lifetime failure deliberately wins over method-specific validation.
+      ["run", () => retained.run({ limit: Number.NaN })],
+      ["step", () => retained.step()],
+      ["halt", () => retained.halt()],
+      ["reset", () => retained.reset()],
+      ["clear", () => retained.clear()],
+      ["getOutput", () => retained.getOutput("t")],
+      ["clearOutput", () => retained.clearOutput("t")],
+      ["pushInput", () => retained.pushInput("retained")],
+    ];
+
+    for (const [method, call] of calls) {
+      await assert.rejects(call, assertRetainedProxyError, method);
+    }
+
+    const baseline = await pool.do("rules", async (proxy) => proxy.findFacts("baseline"));
+    assert.strictEqual(baseline.length, 1, "a retained mutator reached the worker");
+  } finally {
+    await pool.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// E-012: same-pool reentrancy is rejected consistently instead of deadlocking
+// ---------------------------------------------------------------------------
+test("E-012 same-pool do evaluate and close reject inside callbacks", { timeout: 5_000 }, async () => {
+  for (const threads of [1, 2]) {
+    const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads });
+    try {
+      const result = await pool.do("rules", async (proxy) => {
+        await assert.rejects(
+          () => pool.do("rules", async () => "nested"),
+          REENTRANT_ERROR,
+          `nested do with threads=${threads}`,
+        );
+        await assert.rejects(
+          () => pool.evaluate("rules", {}),
+          REENTRANT_ERROR,
+          `nested evaluate with threads=${threads}`,
+        );
+        await assert.rejects(
+          () => pool.close(),
+          REENTRANT_ERROR,
+          `nested close with threads=${threads}`,
+        );
+
+        await proxy.reset();
+        await proxy.assertFact("outer-still-valid", threads);
+        return (await proxy.findFacts("outer-still-valid")).length;
+      });
+      assert.strictEqual(result, 1);
+    } finally {
+      await pool.close();
+    }
+  }
+});
+
+test("E-012 a do callback may use a distinct EnginePool", async () => {
+  const outerPool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+  const innerPool = await EnginePool.create([{ name: "rules", source: "" }], { threads: 1 });
+
+  try {
+    const result = await outerPool.do("rules", async (outerProxy) => {
+      await outerProxy.reset();
+      return innerPool.do("rules", async (innerProxy) => {
+        await innerProxy.reset();
+        await innerProxy.assertFact("cross-pool", 1);
+        return (await innerProxy.findFacts("cross-pool")).length;
+      });
+    });
+    assert.strictEqual(result, 1);
+  } finally {
+    await Promise.all([outerPool.close(), innerPool.close()]);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// E-012: seeded scheduling stress (fixed seed is included in every failure)
+// ---------------------------------------------------------------------------
+function makePrng(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state;
+  };
+}
+
+test("E-012 seeded randomized awaits never mix callback sessions", { timeout: 20_000 }, async () => {
+  const seed = 0x1350cafe;
+  const random = makePrng(seed);
+
+  for (const threads of [1, 2, 4]) {
+    const pool = await EnginePool.create([{ name: "rules", source: "" }], { threads });
+    try {
+      for (let round = 0; round < 3; round++) {
+        const schedules = Array.from({ length: 16 }, (_, index) => ({
+          id: round * 100 + index,
+          afterReset: 1 + (random() % 3),
+          afterAssert: 1 + (random() % 3),
+        }));
+
+        const observed = await Promise.all(
+          schedules.map((schedule, index) =>
+            pool.do("rules", async (proxy) => {
+              await proxy.reset();
+              await yieldTurns(schedule.afterReset);
+              await proxy.assertFact("lease-session", schedule.id);
+              await yieldTurns(schedule.afterAssert);
+              const sessions = await proxy.findFacts("lease-session");
+              return sessions.map((fact) => fact.fields[0]);
+            }).catch((error: unknown) => {
+              throw new Error(
+                `seed=0x${seed.toString(16)} threads=${threads} round=${round} index=${index} rejected`,
+                { cause: error },
+              );
+            }),
+          ),
+        );
+
+        for (let index = 0; index < schedules.length; index++) {
+          assert.deepStrictEqual(
+            observed[index],
+            [schedules[index].id],
+            `seed=0x${seed.toString(16)} threads=${threads} round=${round} index=${index}`,
+          );
+        }
+      }
+    } finally {
+      await pool.close();
+    }
+  }
+});

--- a/packages/ferric/test/conformance/runtime/pool/pool-internals.test.ts
+++ b/packages/ferric/test/conformance/runtime/pool/pool-internals.test.ts
@@ -4,6 +4,7 @@
 import { EventEmitter } from "node:events";
 import { test } from "node:test";
 import * as assert from "node:assert/strict";
+import { setImmediate as yieldImmediate } from "node:timers/promises";
 
 import {
   Encoding,
@@ -32,6 +33,14 @@ function makePool(): { pool: EnginePool; worker: FakeWorker; slot: any } {
   const slot = (EnginePool as any).createSlot(worker);
   const pool = new (EnginePool as any)([slot]) as EnginePool;
   return { pool, worker, slot };
+}
+
+async function waitForPostedMessage(worker: FakeWorker): Promise<any> {
+  for (let turn = 0; turn < 20; turn++) {
+    if (worker.messages.length > 0) return worker.messages[0];
+    await yieldImmediate();
+  }
+  assert.fail("EnginePool did not post the expected fake-worker request");
 }
 
 // ---------------------------------------------------------------------------
@@ -122,6 +131,292 @@ test("E-008 EnginePool rejects pending requests when worker emits error", async 
 });
 
 // ---------------------------------------------------------------------------
+// E-012 lease cleanup: a worker error rejecting the owner request invalidates
+// the callback proxy. Full failed-slot queue/future-work cleanup belongs to
+// FR-NODE-005; this seam only locks the callback lease's terminal path.
+// ---------------------------------------------------------------------------
+test("E-012 EnginePool worker error invalidates the active callback lease", async () => {
+  const { pool, worker } = makePool();
+  let retained: any;
+
+  const active = pool.do("rules", async (proxy) => {
+    retained = proxy;
+    return Promise.all([proxy.facts(), proxy.facts()]);
+  });
+  await waitForPostedMessage(worker);
+
+  worker.emit("error", new Error("leased worker exploded"));
+  await assert.rejects(active, /leased worker exploded/);
+
+  const postsBeforeRetainedCall = worker.messages.length;
+  await assert.rejects(
+    () => retained.facts(),
+    /EngineProxy is no longer valid outside its EnginePool\.do callback/,
+  );
+  assert.strictEqual(
+    worker.messages.length,
+    postsBeforeRetainedCall,
+    "a retained proxy posted work after its callback failed",
+  );
+
+  await pool.close();
+});
+
+test("E-012 defensive drain rejects already-aborted owner and lease work", async () => {
+  const { pool, slot } = makePool();
+
+  const activeLease = await (pool as any).acquireLease(slot);
+  const ownerAbort = new AbortController();
+  ownerAbort.abort();
+  const ownerPending = new Promise((_resolve, reject) => {
+    activeLease.queue.push({
+      kind: "request",
+      req: { id: 0, method: "facts", args: ["rules"] },
+      entry: { resolve: () => undefined, reject },
+      signal: ownerAbort.signal,
+      onAbort: () => undefined,
+    });
+  });
+  (EnginePool as any).drainQueue(slot);
+  await assert.rejects(ownerPending, (error: any) => error?.name === "AbortError");
+  await (pool as any).releaseLease(slot, activeLease);
+
+  const waitingLease = (EnginePool as any).createLease();
+  const leaseAbort = new AbortController();
+  leaseAbort.abort();
+  const leasePending = new Promise((_resolve, reject) => {
+    slot.queue.push({
+      kind: "lease",
+      lease: waitingLease,
+      resolve: () => undefined,
+      reject,
+      signal: leaseAbort.signal,
+      onAbort: () => undefined,
+    });
+  });
+  (EnginePool as any).drainQueue(slot);
+  await assert.rejects(leasePending, (error: any) => error?.name === "AbortError");
+  assert.strictEqual(waitingLease.released, true);
+
+  await pool.close();
+});
+
+test("E-012 private lease send guards reject before bookkeeping", async () => {
+  const { pool, worker, slot } = makePool();
+  const inactiveLease = (EnginePool as any).createLease();
+  const snapshot = () => ({
+    activeLease: slot.activeLease,
+    inflight: slot.inflight,
+    messages: worker.messages.length,
+    nextId: slot.nextId,
+    rootQueue: slot.queue.length,
+  });
+
+  const beforeInactiveSend = snapshot();
+  await assert.rejects(
+    () => (pool as any).sendOnLease(slot, inactiveLease, "facts", ["rules"]),
+    /EngineProxy is no longer valid/,
+  );
+  assert.deepStrictEqual(snapshot(), beforeInactiveSend);
+  assert.strictEqual(inactiveLease.pendingCalls, 0);
+  assert.strictEqual(inactiveLease.queue.length, 0);
+
+  const preAborted = new AbortController();
+  preAborted.abort();
+  const beforePreAbortedAcquire = snapshot();
+  await assert.rejects(
+    () => (pool as any).acquireLease(slot, preAborted.signal),
+    (error: any) => error?.name === "AbortError",
+  );
+  assert.deepStrictEqual(snapshot(), beforePreAbortedAcquire);
+
+  (pool as any).closed = true;
+  const beforeClosedGuards = snapshot();
+  await assert.rejects(
+    () => (pool as any).acquireLease(slot),
+    /EnginePool has been closed/,
+  );
+  await assert.rejects(
+    () => (pool as any).sendToSlot(slot, "facts", ["rules"]),
+    /EnginePool has been closed/,
+  );
+  assert.deepStrictEqual(snapshot(), beforeClosedGuards);
+  (pool as any).closed = false;
+  await pool.close();
+});
+
+test("E-012 lease release and terminal marking are idempotent", async () => {
+  const { pool, slot } = makePool();
+  const lease = await (pool as any).acquireLease(slot);
+
+  const firstRelease = (pool as any).releaseLease(slot, lease);
+  const repeatedRelease = (pool as any).releaseLease(slot, lease);
+  assert.strictEqual(repeatedRelease, firstRelease);
+  await firstRelease;
+
+  assert.strictEqual(lease.released, true);
+  assert.doesNotThrow(() => (EnginePool as any).markLeaseReleased(lease));
+  assert.strictEqual(lease.released, true);
+
+  await pool.close();
+});
+
+test("E-012 dispatch removes a queued owner abort listener", async () => {
+  const { pool, worker, slot } = makePool();
+  const abortController = new AbortController();
+  let removed = false;
+  const originalRemove = abortController.signal.removeEventListener.bind(
+    abortController.signal,
+  );
+  abortController.signal.removeEventListener = ((type, listener, options) => {
+    if (type === "abort") removed = true;
+    return originalRemove(type, listener, options);
+  }) as typeof abortController.signal.removeEventListener;
+  const lease = await (pool as any).acquireLease(slot);
+  const proxy = (pool as any).makeProxy(
+    "rules",
+    slot,
+    lease,
+    abortController.signal,
+  );
+
+  const first = proxy.facts();
+  const second = proxy.facts();
+  assert.strictEqual(lease.queue.length, 1);
+
+  const firstMessage = worker.messages[0];
+  worker.emit("message", { id: firstMessage.id, result: [] });
+  assert.deepStrictEqual(await first, []);
+  assert.strictEqual(removed, true);
+  assert.strictEqual(worker.messages.length, 2);
+
+  const secondMessage = worker.messages[1];
+  worker.emit("message", { id: secondMessage.id, result: [] });
+  assert.deepStrictEqual(await second, []);
+  await (pool as any).releaseLease(slot, lease);
+  await pool.close();
+});
+
+test("E-012 abort listener removes a queued owner request", async () => {
+  const { pool, worker, slot } = makePool();
+  const abortController = new AbortController();
+  const lease = await (pool as any).acquireLease(slot);
+  const proxy = (pool as any).makeProxy(
+    "rules",
+    slot,
+    lease,
+    abortController.signal,
+  );
+
+  const inflight = proxy.facts();
+  const queued = proxy.facts();
+  assert.strictEqual(lease.queue.length, 1);
+
+  abortController.abort();
+  await assert.rejects(queued, (error: any) => error?.name === "AbortError");
+  assert.strictEqual(lease.queue.length, 0);
+
+  const message = worker.messages[0];
+  worker.emit("message", { id: message.id, result: [] });
+  assert.deepStrictEqual(await inflight, []);
+  await (pool as any).releaseLease(slot, lease);
+  await pool.close();
+});
+
+test("E-012 retained proxy rejects before request allocation or postMessage", async () => {
+  const { pool, worker, slot } = makePool();
+  let retained: any;
+
+  await pool.do("rules", async (proxy) => {
+    retained = proxy;
+  });
+
+  const nextIdBeforeRetainedCall = slot.nextId;
+  const postsBeforeRetainedCall = worker.messages.length;
+  await assert.rejects(
+    () => retained.run({ limit: Number.NaN }),
+    /EngineProxy is no longer valid outside its EnginePool\.do callback/,
+  );
+  assert.strictEqual(slot.nextId, nextIdBeforeRetainedCall);
+  assert.strictEqual(worker.messages.length, postsBeforeRetainedCall);
+
+  await pool.close();
+});
+
+test("E-012 an earlier returned-Promise reaction drains before proxy invalidation", { timeout: 5_000 }, async () => {
+  const { pool, worker, slot } = makePool();
+  let resolveReturned!: (value: string) => void;
+  const returned = new Promise<string>((resolve) => {
+    resolveReturned = resolve;
+  });
+  let resolveCallbackEntered!: () => void;
+  const callbackEntered = new Promise<void>((resolve) => {
+    resolveCallbackEntered = resolve;
+  });
+  let retained: any;
+  let reactionCall!: Promise<unknown>;
+  let reactionIssued = false;
+  let reactionSettled = false;
+
+  const pending = pool.do("rules", (proxy) => {
+    retained = proxy;
+    // This reaction is registered before do() attaches its own settlement
+    // reaction to the returned Promise, so it still belongs to the callback's
+    // achievable lifetime boundary.
+    void returned.then(() => {
+      reactionIssued = true;
+      reactionCall = proxy.facts().then((value) => {
+        reactionSettled = true;
+        return value;
+      });
+    });
+    resolveCallbackEntered();
+    return returned;
+  });
+  await callbackEntered;
+
+  let doSettled = false;
+  void pending.then(
+    () => { doSettled = true; },
+    () => { doSettled = true; },
+  );
+  resolveReturned("callback result");
+
+  const message = await waitForPostedMessage(worker);
+  assert.strictEqual(reactionIssued, true);
+  assert.strictEqual(doSettled, false, "do() settled before the accepted reaction call drained");
+
+  worker.emit("message", { id: message.id, result: [] });
+  assert.deepStrictEqual(await reactionCall, []);
+  assert.strictEqual(reactionSettled, true);
+  assert.strictEqual(await pending, "callback result");
+
+  const bookkeepingAfterSettlement = {
+    inflight: slot.inflight,
+    messages: worker.messages.length,
+    nextId: slot.nextId,
+    ownerQueue: slot.activeLease?.queue.length ?? 0,
+    rootQueue: slot.queue.length,
+  };
+  await assert.rejects(
+    () => retained.facts(),
+    /EngineProxy is no longer valid outside its EnginePool\.do callback/,
+  );
+  assert.deepStrictEqual(
+    {
+      inflight: slot.inflight,
+      messages: worker.messages.length,
+      nextId: slot.nextId,
+      ownerQueue: slot.activeLease?.queue.length ?? 0,
+      rootQueue: slot.queue.length,
+    },
+    bookkeepingAfterSettlement,
+  );
+
+  await pool.close();
+});
+
+// ---------------------------------------------------------------------------
 // E-008 table-driven cleanup: worker exit rejects pending pool requests
 // ---------------------------------------------------------------------------
 test("E-008 table-driven EnginePool rejects pending requests on worker exit", async () => {
@@ -137,17 +432,6 @@ test("E-008 table-driven EnginePool rejects pending requests on worker exit", as
 });
 
 // ---------------------------------------------------------------------------
-// E-008 manual send guard: retained proxy calls reject after close
-// ---------------------------------------------------------------------------
-test("E-008 EnginePool retained proxy calls use closed send guard", async () => {
-  const { pool, slot } = makePool();
-  const proxy = (pool as any).makeProxy("rules", slot);
-  (pool as any).closed = true;
-
-  await assert.rejects(() => proxy.facts(), /EnginePool has been closed/);
-});
-
-// ---------------------------------------------------------------------------
 // E-004 manual queue cleanup: drainQueue rejects already-aborted queued work
 // ---------------------------------------------------------------------------
 test("E-004 EnginePool drainQueue rejects a queued request whose signal aborted", async () => {
@@ -157,6 +441,7 @@ test("E-004 EnginePool drainQueue rejects a queued request whose signal aborted"
 
   const pending = new Promise((_resolve, reject) => {
     slot.queue.push({
+      kind: "request",
       req: { id: 0, method: "facts", args: ["rules"] },
       entry: { resolve: () => undefined, reject },
       signal: ac.signal,
@@ -188,6 +473,60 @@ test("E-006 EnginePool.do with signal propagates callback rejection", async () =
   );
 });
 
+test("E-006 E-012 abort after callback settlement cannot replace its outcome", async () => {
+  for (const callbackError of [undefined, new Error("callback outcome")]) {
+    const { pool, worker } = makePool();
+    const ac = new AbortController();
+    let acceptedCall!: Promise<unknown>;
+    let outerAbortListenerRemoved = false;
+    const originalRemove = ac.signal.removeEventListener.bind(ac.signal);
+    ac.signal.removeEventListener = ((type, listener, options) => {
+      if (type === "abort") outerAbortListenerRemoved = true;
+      return originalRemove(type, listener, options);
+    }) as typeof ac.signal.removeEventListener;
+
+    const pending = pool.do("rules", async (proxy) => {
+      acceptedCall = proxy.facts();
+      if (callbackError) throw callbackError;
+      return "callback result";
+    }, { signal: ac.signal });
+    let settled = false;
+    const outcome = pending.then(
+      (value) => {
+        settled = true;
+        return { status: "fulfilled" as const, value };
+      },
+      (error: unknown) => {
+        settled = true;
+        return { status: "rejected" as const, error };
+      },
+    );
+    const message = await waitForPostedMessage(worker);
+
+    // The raw callback has settled, but do() remains pending until its accepted
+    // worker request drains. Cancellation after this boundary cannot replace
+    // either the callback's value or its error.
+    assert.strictEqual(outerAbortListenerRemoved, true);
+    ac.abort();
+    await Promise.resolve();
+    assert.strictEqual(settled, false);
+
+    worker.emit("message", { id: message.id, result: [] });
+    assert.deepStrictEqual(await acceptedCall, []);
+    const observed = await outcome;
+    if (callbackError) {
+      assert.strictEqual(observed.status, "rejected");
+      assert.strictEqual((observed as { error: unknown }).error, callbackError);
+    } else {
+      assert.deepStrictEqual(observed, {
+        status: "fulfilled",
+        value: "callback result",
+      });
+    }
+    await pool.close();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // F-004 manual closed-state: do() uses the same closed guard as evaluate()
 // ---------------------------------------------------------------------------
@@ -210,7 +549,8 @@ test("D-006 EnginePool proxy run honors already-aborted retained signal", async 
   const { pool, worker, slot } = makePool();
   const ac = new AbortController();
   ac.abort();
-  const proxy = (pool as any).makeProxy("rules", slot, ac.signal);
+  const lease = await (pool as any).acquireLease(slot);
+  const proxy = (pool as any).makeProxy("rules", slot, lease, ac.signal);
 
   const pending = proxy.run({ limit: 3 });
   const message = worker.messages[0];
@@ -222,6 +562,8 @@ test("D-006 EnginePool proxy run honors already-aborted retained signal", async 
     result: { rulesFired: 0, haltReason: 2 },
   });
   assert.deepStrictEqual(await pending, { rulesFired: 0, haltReason: 2 });
+  await (pool as any).releaseLease(slot, lease);
+  await pool.close();
 });
 
 // ---------------------------------------------------------------------------
@@ -230,7 +572,8 @@ test("D-006 EnginePool proxy run honors already-aborted retained signal", async 
 test("D-006 table-driven EnginePool proxy run handles abort states", async () => {
   const { pool, worker, slot } = makePool();
   const ac = new AbortController();
-  const proxy = (pool as any).makeProxy("rules", slot, ac.signal);
+  const lease = await (pool as any).acquireLease(slot);
+  const proxy = (pool as any).makeProxy("rules", slot, lease, ac.signal);
 
   const pending = proxy.run({ limit: 5 });
   const message = worker.messages[0];
@@ -245,6 +588,8 @@ test("D-006 table-driven EnginePool proxy run handles abort states", async () =>
     result: { rulesFired: 2, haltReason: 2 },
   });
   assert.deepStrictEqual(await pending, { rulesFired: 2, haltReason: 2 });
+  await (pool as any).releaseLease(slot, lease);
+  await pool.close();
 });
 
 // ---------------------------------------------------------------------------
@@ -270,6 +615,7 @@ test("E-008 EnginePool close removes queued abort listeners", async () => {
   }) as typeof ac.signal.removeEventListener;
 
   slot.queue.push({
+    kind: "request",
     req: { id: 0, method: "facts", args: ["rules"] },
     entry: { resolve: () => undefined, reject: () => undefined },
     signal: ac.signal,


### PR DESCRIPTION
Closes #135

## What changed

- add a per-worker-slot exclusive lease for the full lifetime of each `EnginePool.do()` callback
- serialize proxy calls through a lease-private FIFO while preserving the slot's root FIFO for ordinary work and later callbacks
- invalidate retained proxies at the pool-observed callback settlement boundary, drain already-accepted calls, and release the lease exactly once
- keep returned-Promise and custom-thenable assimilation inside the callback's async-local context so same-pool reentrancy cannot bypass the lease guard
- make close wait for admitted callbacks, reject queued leases, and reject same-pool `do`/`evaluate`/`close` reentrancy without preventing cross-pool nesting
- document the lease, FIFO, cancellation, close, and Promise-reaction settlement contracts
- add deterministic one-/multi-worker, FIFO, abort, close, failure, lifetime, thenable, reentrancy, and seeded isolation regressions

## Root cause

`EnginePool.do()` selected a worker only once. Every proxy method then re-entered the ordinary per-request queue, allowing unrelated requests to run on that worker between callback awaits and exposing retained proxies after the callback returned.

## Impact

A callback now owns its selected worker slot until the pool observes callback settlement and all accepted proxy work drains. Other work cannot observe or mutate that worker mid-callback. This is lease isolation, not rollback: completed mutations remain durable if the callback later rejects.

## Validation

- `just preflight-pr`
- `just napi-full` (types 14, sync 49, worker 60, pool 101, package 48)
- `just node-package-smoke`
- `npm run lint`
- `npm run test:runtime:types` (14/14)
- `npm run test:coverage`: 258/258 tests pass; all `dist`/native files are 100% covered. The command's aggregate threshold remains nonzero only because unchanged `scripts/node-package-lib.mjs` is included by the local Node coverage collector.
- `git diff --check`
