### PR TITLE
[FR-NODE-005] Make EnginePool worker faults terminal

### DIFF
--- a/docs/typescript-binding-api.md
+++ b/docs/typescript-binding-api.md
@@ -565,7 +565,7 @@ export class EngineHandle {
 
 `EnginePool` manages multiple Worker threads for concurrent, stateless evaluation. It is the TypeScript equivalent of Go's `Coordinator` + `Manager` pattern.
 
-Each worker lazily creates engines from named specs. Requests are dispatched round-robin across workers.
+Each worker lazily creates engines from named specs. Requests are dispatched round-robin across workers while the pool is healthy.
 Work assigned to one worker slot is admitted FIFO. A `do()` callback receives
 an exclusive lease over its selected slot before the callback begins, so no
 unrelated task can use that worker until the pool processes the callback's
@@ -724,6 +724,43 @@ export interface EngineProxy {
 Abort-driven proxy invalidation and the state effects of an operation accepted
 before abort are reserved for FR-NODE-009. An outer `do()` rejection does not
 allow unrelated work onto a slot while its callback is still running.
+
+#### Worker terminal failure policy
+
+Each pool slot has an explicit lifecycle. The first Worker `error` or
+unexpected `exit` observed before close begins terminating that Worker marks
+its slot failed and establishes one pool-wide terminal failure. An `error`
+retains the exact emitted object; an unexpected exit creates one stable error
+for its exit code. Later terminal signals cannot replace that primary failure
+or settle work a second time.
+
+The failed slot rejects every request, root queue entry, lease admission, and
+lease-private proxy operation assigned to it. It clears its counters, removes
+owned abort and Worker listeners, and wakes close bookkeeping. The pool does
+not replay that work or respawn the Worker because replacement would silently
+discard the mutable engines hosted by the failed slot.
+
+Once the failure is observed, new `evaluate()` and `do()` calls reject with the
+same primary error before round-robin selection or request bookkeeping. Work
+already accepted on another healthy slot remains eligible to finish through
+that slot's FIFO. An already-admitted healthy `do()` lease may continue its
+owner proxy operations until the callback settles. Recovery is explicit:
+close the failed pool and create a new one.
+
+A failed-slot callback's pending and queued proxy operations reject, and later
+proxy sends fail fast. The pool cannot forcibly settle arbitrary JavaScript in
+that callback, such as an unrelated Promise awaited while the worker is idle;
+the existing admitted-callback release barrier remains in force until the
+callback settles. `close()` therefore still observes the documented callback
+lifetime while no pool-generated request or close waiter remains stranded.
+
+An ordinary response error from a live Worker rejects only its matching
+request and does not poison the pool. An exit caused after `close()`
+deliberately starts Worker termination is also expected, not a fault.
+Synchronous ordinary `postMessage` rollback is FR-NODE-008; general
+queued-listener cleanup is FR-NODE-006; abort-time proxy semantics are
+FR-NODE-009; bounded backpressure is FR-NODE-011; and the Promise shared by
+concurrent close callers is FR-NODE-010.
 
 ## Value Conversion Details
 

--- a/docs/typescript-binding-architecture.md
+++ b/docs/typescript-binding-architecture.md
@@ -1,7 +1,7 @@
 # TypeScript Binding Architecture (Revised)
 
 Date: 2026-04-11
-Updated: 2026-08-09 (FR-NODE-004 failed EngineHandle creation cleanup)
+Updated: 2026-08-09 (FR-NODE-005 terminal EnginePool worker faults)
 Status: Draft for reimplementation
 
 Companion documents:
@@ -55,6 +55,21 @@ This document is intentionally descriptive. If this document conflicts with the 
 - TypeScript orchestration over multiple workers.
 - Dispatches work round-robin across worker slots.
 - Supports stateless one-shot evaluation plus stateful proxy operations.
+- Gives every slot an explicit running, failed, terminating, or closed state.
+  The first unexpected Worker `error` or `exit` observed by a returned pool
+  establishes one pool-wide terminal failure; an `error` retains the exact
+  emitted object, while an unexpected exit creates one stable error for its
+  code. Later terminal signals cannot replace that primary failure.
+- Does not respawn a failed Worker. Recreating a slot would silently discard
+  the mutable engines owned by that Worker, so recovery requires constructing
+  a new pool explicitly.
+- Rejects every request and lease already assigned to the failed slot,
+  including its undispatched root and lease-private queues. Work already
+  accepted on another healthy slot remains eligible to finish through that
+  slot's existing FIFO, and an already-admitted healthy active lease may keep
+  accepting owner calls until its callback settles. All later `evaluate` and
+  `do` admissions fail before round-robin selection, request allocation,
+  listener registration, or Worker dispatch.
 - Gives each `do` callback an exclusive, FIFO lease over its selected worker
   slot and serializes that callback's proxy operations for the lease lifetime.
 - Defines normal callback completion at the pool's registered settlement
@@ -62,6 +77,15 @@ This document is intentionally descriptive. If this document conflicts with the 
   lease and the proxy is invalid before `do` delivers the callback outcome.
 - Treats the lease as scheduling isolation only: state mutations persist and
   are not rolled back when a callback rejects.
+- Does not forcibly settle arbitrary JavaScript performed by an admitted `do`
+  callback on the failed slot. Its pending or queued proxy operations reject,
+  later proxy sends through that callback fail fast, and the existing callback
+  release barrier remains in force until the callback itself settles.
+
+An ordinary Worker response containing an engine/protocol error rejects only
+the matching request and leaves the pool usable. An `exit` caused after
+`EnginePool.close()` deliberately starts Worker termination is likewise an
+expected lifecycle transition, not a pool failure.
 
 ## Package Layout
 
@@ -107,6 +131,11 @@ per-runtime artifact-smoke contract.
   through successful initialization. A failed transaction tears down that
   unpublished Worker before rejecting; a successful transaction transfers the
   live Worker and its ordinary listeners to the returned handle.
+- `EnginePool` owns every returned pool slot until close completes. A terminal
+  slot transition clears pending counters and all root/lease work assigned to
+  that slot, removes its request and abort listeners, and wakes any close
+  waiter. The pool retains failed Worker objects only so explicit close can
+  finish their lifecycle alongside the remaining healthy Workers.
 - Public API typing is owned by TypeScript package surface (`dist/index.d.ts`), not by generated native d.ts alone.
 
 Pre-Worker argument validation and a synchronous Worker-constructor throw do
@@ -116,6 +145,13 @@ ordinary handle and pool requests remains FR-NODE-008. The shared completion
 barrier for concurrent public `close()` calls remains FR-NODE-010; unpublished
 failed-create teardown does not define that behavior.
 
+EnginePool terminal cleanup removes abort listeners from work discarded by a
+Worker fault, as FR-NODE-005 requires. Generic queued-listener cleanup remains
+FR-NODE-006; abort-driven proxy lifetime and mutation semantics remain
+FR-NODE-009; queue capacity and metrics remain FR-NODE-011. FR-NODE-005 must
+wake a close already waiting for a failed request, but it does not add the
+shared concurrent-close completion Promise assigned to FR-NODE-010.
+
 ## Design Constraints
 1. Canonical value wire schema must be single-source-of-truth.
 2. Sync and async layers must not diverge semantically unless explicitly documented.
@@ -124,6 +160,9 @@ failed-create teardown does not define that behavior.
 5. One worker slot is the isolation unit: unrelated pool work must not execute
    there while a `do` callback owns its lease, even when it targets another
    named engine.
+6. One unexpected Worker terminal event poisons future admission for the whole
+   pool; silent slot replacement and partially available round-robin behavior
+   are not recovery mechanisms.
 
 ## Risk Seams (Must Receive Focused Review)
 1. Symbol/value conversion across worker boundaries.
@@ -132,9 +171,11 @@ failed-create teardown does not define that behavior.
 4. `EngineHandle.create()` ownership transfer and exactly-once failed-init
    cleanup, including secondary termination failure reporting.
 5. `EnginePool.do()` lease admission, proxy lifetime, and reentrant calls.
-6. `EnginePool.close()` behavior under active callbacks and concurrency.
-7. Public TS API shape drift (`undefined` exports, mismatched unions).
-8. JavaScript/native package version skew or a missing optional native package.
+6. First-event-wins EnginePool Worker failure cleanup across pending requests,
+   both queue levels, leases, listeners, counters, and close waiters.
+7. `EnginePool.close()` behavior under active callbacks and concurrency.
+8. Public TS API shape drift (`undefined` exports, mismatched unions).
+9. JavaScript/native package version skew or a missing optional native package.
 
 ## Delivery Model
 Reimplementation should be staged and gated:

--- a/docs/typescript-binding-conformance-matrix.md
+++ b/docs/typescript-binding-conformance-matrix.md
@@ -1,7 +1,7 @@
 # TypeScript Binding Conformance Matrix
 
 Date: 2026-04-11
-Updated: 2026-08-09 (FR-NODE-004 failed EngineHandle creation cleanup)
+Updated: 2026-08-09 (FR-NODE-005 terminal EnginePool worker faults)
 
 Companion documents:
 - [TypeScript Binding Architecture (Revised)](/Users/prb/conductor/workspaces/ferric-rules/santo-domingo/docs/typescript-binding-architecture.md)
@@ -36,6 +36,7 @@ Each item is:
 | `N-08` | A worker-backed run starts one fresh logical run and uses continuation for later chunks. Absent host cancellation it matches synchronous fired count, halt reason, halted state, agenda, and diagnostics, including exact batch-boundary halts. Caller-limit exhaustion has synchronous precedence over a pending boundary halt. |
 | `N-09` | Host abort is an out-of-band worker outcome. Existing APIs retain their partial `HaltRequested` projection, but the worker does not call native `halt()` merely to represent host cancellation; every later public run starts fresh. |
 | `N-10` | `EnginePool.do` acquires a FIFO, slot-wide exclusive lease before callback invocation. The callback's proxy serializes calls in invocation order. Normal settlement is the pool's registered reaction to the returned Promise: callback-pre-registered reactions remain within the lease, accepted calls drain before release, and the proxy is invalid before `do` delivers the callback outcome. The lease does not roll back state. Same-pool `do`/`evaluate`/`close` reentry rejects, other-pool calls remain allowed, and `close` waits for an admitted callback. Abort-driven invalidation and accepted-operation semantics remain assigned to FR-NODE-009. |
+| `N-11` | The first unexpected EnginePool Worker `error` or pre-termination `exit` establishes one pool-wide terminal failure whose exact error identity cannot be replaced. The pool does not respawn or replay: all work assigned to the failed slot rejects once with that failure, its counters/listeners/waiters are reconciled, and future pool admission fails before dispatch. Work already accepted by another healthy slot, including its FIFO and active-lease owner work, may finish. Ordinary response errors and close-triggered exits do not poison the pool. A failed-slot fault rejects proxy work but does not forcibly settle arbitrary JavaScript in an admitted `do` callback. |
 
 ## Release Gates
 
@@ -116,6 +117,7 @@ A release is conformant only if all are true:
 | `E-010` | `EngineProxy` preserves `FactId` bigint values through pool structured clone in responses and ID-taking requests. | High-generation pool assert/get/retract round-trip. | Worker boundary + N-07 | FR-NODE-001 | PASS |
 | `E-011` | Pool `evaluate` and proxy runs preserve one logical run across chunks and match synchronous exact-boundary results and state. | Exercise proxy/direct runs at `1`, batch size, batch size + 1, and twice batch size, plus `evaluate` at an exact batch boundary; compare totals/state/diagnostics, exact-limit precedence, and a later fresh run. E-005 covers cancellation. | Logical-run batching + N-08/N-09 | FR-NODE-002 | PASS |
 | `E-012` | A `do` callback exclusively leases its whole worker slot through the pool-observed normal-settlement boundary and accepted-call drain, with per-slot FIFO admission, serial proxy calls, deterministic invalidation before `do` delivers the outcome, no rollback, topology-independent same-pool reentry rejection, and close waiting for admitted callbacks. | One- and multi-thread delayed callbacks across same and different specs; FIFO and parallel-call ordering; callback-pre-registered Promise reaction ordering; fulfillment/rejection release; retained-proxy method table after the `do` barrier; same-pool `do`/`evaluate`/`close` versus other-pool nesting; close during an idle callback gap; seeded randomized-await stress. | EnginePool worker-slot lease + N-10 | FR-NODE-003 | PASS |
+| `E-013` | A Worker error or unexpected zero/nonzero exit applies N-11 exactly once: it creates an explicit failed slot, preserves the first terminal failure pool-wide, rejects all work assigned to that slot, removes its owned listeners, reconciles counters and close waiters, forbids respawn/replay, and makes future pool or failed-slot proxy sends fail before bookkeeping or dispatch while previously accepted healthy-slot work remains eligible to finish. | Inject error, zero/nonzero exit, duplicate terminal signals, pending/root-queued/lease-queued failed-slot work, multi-slot healthy accepted work, close races, and retained proxy calls; assert exact rejection identity, single settlement, listener/counter baselines, no replacement Worker, later root admission, or failed-slot post, ordinary response-error survival, expected close-exit behavior, and natural subprocess exit. | EnginePool terminal Worker lifecycle + N-11 | FR-NODE-005 | PASS |
 
 ### F) Lifecycle and Closed-State Behavior
 
@@ -149,6 +151,6 @@ Each test should include the matrix ID in its title, for example `E-004 queued e
 
 Recommended remediation sequence aligned with risk:
 1. `A-001` / `A-002` / `A-003` / `B-002` / `B-004` / `C-*`
-2. `D-003` / `D-006` / `D-009` / `D-010` / `E-004` / `E-006` / `E-008` / `E-011` / `E-012`
+2. `D-003` / `D-006` / `D-009` / `D-010` / `E-004` / `E-006` / `E-008` / `E-011` / `E-012` / `E-013`
 3. `A-005` / `F-*`
 4. `G-*` hardening and CI gating

--- a/docs/typescript-binding-normative-contract.md
+++ b/docs/typescript-binding-normative-contract.md
@@ -1,7 +1,7 @@
 # TypeScript Binding Normative Contract (Revised)
 
 Date: 2026-04-11
-Updated: 2026-08-09 (FR-NODE-004 failed EngineHandle creation cleanup)
+Updated: 2026-08-09 (FR-NODE-005 terminal EnginePool worker faults)
 Status: Draft for reimplementation
 
 Companion documents:
@@ -138,6 +138,63 @@ If this contract conflicts with legacy design docs, this contract wins.
    - then terminate workers.
 4. `EnginePool.close()` `MUST` be idempotent.
 5. `EnginePool` `MUST` support `[Symbol.asyncDispose]()` and delegate to `close()`.
+6. Every pool Worker slot `MUST` have an explicit `running`, `failed`,
+   `terminating`, or `closed` state. A Worker `error`, or an `exit` before the
+   pool deliberately begins terminating that Worker, `MUST` move a running
+   slot to `failed` even when it has no pending request and even when the exit
+   code is zero. A Worker response carrying an ordinary request error
+   `MUST NOT` fail the slot. An exit caused after the pool deliberately begins
+   terminating that Worker `MUST NOT` establish a pool failure.
+7. The first unexpected Worker terminal event observed after successful pool
+   creation `MUST` establish one immutable pool-wide terminal failure. If the
+   event is `error`, the exact emitted error object `MUST` be retained. If it
+   is `exit`, the pool `MUST` construct and retain one deterministic `Error`
+   describing that exit. Later `error`, `exit`, response, abort, and close
+   races `MUST NOT` replace the primary failure or settle affected work twice.
+   A later terminal event from another running slot `MUST` still perform that
+   slot's local cleanup using the original pool failure.
+8. Establishing the terminal failure `MUST` atomically:
+   - clear and reject every pending request on the failed slot;
+   - set that slot's in-flight count to zero;
+   - clear and reject all ordinary requests, lease admissions, and
+     lease-private proxy requests already assigned to the failed slot;
+   - mark rejected lease admissions released and remove every abort listener
+     owned by discarded work;
+   - wake any pending-drain waiter used by `close()`; and
+   - detach the failed Worker's message, error, and exit listeners.
+
+   Every rejection caused by this transition `MUST` use the retained primary
+   failure and occur exactly once.
+9. EnginePool `MUST NOT` respawn or silently replace a failed Worker. After the
+   pool-wide terminal failure is established, every later `evaluate` or `do`
+   admission `MUST` reject with the retained primary failure before
+   round-robin selection, request-ID allocation, abort-listener registration,
+   or `postMessage`. Callers recover by closing the failed pool and creating a
+   new one.
+10. Work accepted on another still-running slot before the failure was
+    observed, including that slot's existing root FIFO, `MUST` remain eligible
+    to finish normally. An already-admitted healthy active lease `MUST` retain
+    its N-10 owner-dispatch rights until its callback settles. The pool
+    `MUST NOT` replay failed-slot work on that healthy slot, and the healthy
+    slot remains owned by the pool until close.
+11. A Worker fault `MUST` reject in-flight and queued proxy operations of an
+    admitted `do` callback on the failed slot and make any later proxy send
+    through that callback fail with the retained pool failure. It `MUST NOT`
+    forcibly settle arbitrary JavaScript in that callback, such as an unrelated
+    user Promise awaited while the slot is idle. The callback's existing
+    lease/release barrier remains in force until the callback settles. Item 10
+    continues to govern an admitted callback on another healthy slot.
+12. `close()` begun before or after a Worker fault `MUST` be able to observe
+    the terminal cleanup, finish terminating all owned Workers, and complete;
+    it `MUST NOT` wait forever on pending bookkeeping cleared by the fault.
+    This requirement does not define the shared completion barrier for
+    concurrent public close calls.
+13. Atomic rollback when an ordinary `postMessage` throws synchronously remains
+    FR-NODE-008. Generic queued AbortSignal-listener cleanup remains
+    FR-NODE-006; cancellation-time proxy invalidation remains FR-NODE-009;
+    bounded queue capacity remains FR-NODE-011; and concurrent close callers
+    sharing one completion Promise remains FR-NODE-010. FR-NODE-005 owns the
+    corresponding cleanup only when a Worker terminal event occurs.
 
 ### 4.4 EnginePool.do Worker-Slot Lease
 

--- a/docs/typescript-binding-test-spec.md
+++ b/docs/typescript-binding-test-spec.md
@@ -1,7 +1,7 @@
 # TypeScript Binding Test Specification (Revised)
 
 Date: 2026-04-11
-Updated: 2026-08-09 (FR-NODE-004 failed EngineHandle creation cleanup)
+Updated: 2026-08-09 (FR-NODE-005 terminal EnginePool worker faults)
 Status: Required for reimplementation
 
 Companion documents:
@@ -29,8 +29,8 @@ This is not optional guidance. The implementation is incomplete until this speci
 
 ### 2.4 Pool Runtime Unit Tests (`EnginePool`)
 - Exercise queueing, dispatch, cancellation states, worker-slot lease isolation,
-  proxy lifetime and ordering, same-pool reentrancy, `close()` behavior, and
-  stateless evaluation behavior.
+  proxy lifetime and ordering, same-pool reentrancy, terminal Worker faults,
+  `close()` behavior, and stateless evaluation behavior.
 
 ### 2.5 Package/Load Tests
 - Validate native load behavior and package entrypoint surface guarantees.
@@ -163,10 +163,44 @@ Must include:
   - `close()` waiting through an admitted callback's idle await and accepted
     proxy calls; and
   - seeded randomized-await stress whose failure identifies the seed.
+- Terminal pool Worker state (`E-013`, `N-11`), including:
+  - Worker `error`, unexpected nonzero exit, unexpected zero exit, and the
+    normal error-followed-by-exit duplicate signal sequence;
+  - first-event-wins preservation of the exact emitted error object or one
+    stable synthesized exit error across every affected rejection and every
+    later root admission, including local cleanup after a second slot faults;
+  - one or more failed-slot pending requests together with ordinary root FIFO
+    work, queued lease admissions, and active-lease proxy work, all settling
+    exactly once;
+  - failed-slot pending, in-flight, root-queue, lease-queue, lease-call,
+    request-listener, and abort-listener bookkeeping returning to its terminal
+    baseline;
+  - a multi-worker failure proving already accepted healthy-slot FIFO work and
+    active-lease owner work remain eligible to finish, while later
+    `evaluate()` and `do()` admissions reject before round-robin selection,
+    request allocation, listener registration, or dispatch;
+  - no Worker reconstruction, failed-work replay, or post-failure dispatch to
+    the failed slot;
+  - ordinary response errors leaving the pool healthy and an exit caused by
+    deliberate close-time termination not establishing a failure;
+  - an admitted failed-slot callback whose proxy calls reject while unrelated
+    callback JavaScript is not forcibly settled and its existing release
+    barrier remains intact;
+  - close-before-fault and close-after-fault races proving cleared pending
+    bookkeeping wakes close, every owned Worker is terminated, and no
+    temporary waiter/listener remains; and
+  - a timeout-guarded real-Worker subprocess that injects a terminal exit with
+    pending and queued work, closes the pool, returns active Worker resources
+    to baseline, and exits naturally without `process.exit()` or `unref()`.
 
 Cancellation-time proxy invalidation, mutation by work accepted before abort,
 and cancellation-triggered lease release are FR-NODE-009 coverage. E-012 covers
 the lease and normal callback-settlement boundary without preempting that work.
+Atomic rollback after an ordinary synchronous `postMessage` throw remains
+FR-NODE-008. Generic queue-listener cleanup remains FR-NODE-006; bounded queue
+capacity remains FR-NODE-011; and concurrent close calls sharing one completion
+Promise remains FR-NODE-010. E-013 covers those resources only on a Worker
+terminal transition.
 
 ### 4.5 Package Tests (minimum 10 cases)
 Must include:

--- a/packages/ferric/src/engine-pool.ts
+++ b/packages/ferric/src/engine-pool.ts
@@ -18,6 +18,12 @@
  * unrelated pool work can use that worker until the pool observes the
  * callback's returned Promise settle and its accepted proxy operations drain.
  *
+ * ## Terminal worker failures
+ * The first unexpected Worker error or exit permanently poisons future pool
+ * admission; workers are not respawned. Work already accepted by healthy slots
+ * may finish, including owner calls from an admitted callback. The failed slot
+ * rejects everything it owns and cannot accept more work.
+ *
  * ## Cooperative cancellation
  *
  * `evaluate()` and `do()` accept an `AbortSignal`. Cancellation sets a
@@ -148,8 +154,21 @@ interface PoolCallbackContext {
   active: boolean;
 }
 
+type WorkerSlotState =
+  | { kind: "running" }
+  | { kind: "failed"; error: Error }
+  | { kind: "terminating" }
+  | { kind: "closed" };
+
+interface WorkerSlotListeners {
+  message: (response: WorkerResponse) => void;
+  error: (error: Error) => void;
+  exit: (code: number) => void;
+}
+
 interface WorkerSlot {
   worker: Worker;
+  state: WorkerSlotState;
   nextId: number;
   pending: Map<number, PendingEntry>;
   /** Number of requests currently being processed by the worker. */
@@ -158,6 +177,13 @@ interface WorkerSlot {
   queue: QueuedWork[];
   /** Exclusive callback lease currently admitted on this whole worker slot. */
   activeLease?: WorkerLease;
+  /** Close waiters that wake when every already-dispatched call is settled. */
+  pendingDrainWaiters: Array<() => void>;
+  /** Exact owned listener references, retained for deterministic detachment. */
+  listeners: WorkerSlotListeners;
+  listenersAttached: boolean;
+  /** Installed once the slot belongs to a published EnginePool. */
+  onTerminal?: (slot: WorkerSlot, error: Error) => void;
 }
 
 const INACTIVE_PROXY_MESSAGE =
@@ -215,9 +241,21 @@ export class EnginePool {
   private readonly callbackContext = new AsyncLocalStorage<PoolCallbackContext>();
   private roundRobin = 0;
   private closed = false;
+  /** The first terminal Worker failure poisons every later root admission. */
+  private terminalError?: Error;
 
   private constructor(slots: WorkerSlot[]) {
     this.slots = slots;
+    for (const slot of slots) {
+      if (this.terminalError === undefined && slot.state.kind === "failed") {
+        this.terminalError = slot.state.error;
+      }
+      if (slot.state.kind === "running") {
+        slot.onTerminal = (failedSlot, error) => {
+          this.handleSlotTerminal(failedSlot, error);
+        };
+      }
+    }
   }
 
   // ---------------------------------------------------------------------------
@@ -264,12 +302,28 @@ export class EnginePool {
       }
 
       await Promise.all(initPromises);
-      return new EnginePool(slots);
+      const pool = new EnginePool(slots);
+      // Worker events are normally delivered on later event-loop turns, but a
+      // deterministic Worker seam can report init success and then fail from
+      // one synchronous postMessage call. Never publish that prefailed pool.
+      if (pool.terminalError) throw pool.terminalError;
+      return pool;
     } catch (error) {
+      // A Worker constructor can throw after earlier initialization promises
+      // were created but before Promise.all() attached its handlers.
+      for (const initPromise of initPromises) {
+        void initPromise.catch(() => undefined);
+      }
+
+      const cleanupError =
+        error instanceof Error
+          ? error
+          : new Error("EnginePool creation failed during initialization");
       await Promise.all(
         slots.map(async (slot) => {
+          EnginePool.failSlot(slot, cleanupError);
           try {
-            await slot.worker.terminate();
+            await EnginePool.terminateSlot(slot);
           } catch {
             // Ignore best-effort cleanup failures while unwinding create().
           }
@@ -284,62 +338,167 @@ export class EnginePool {
   // ---------------------------------------------------------------------------
 
   private static createSlot(worker: Worker): WorkerSlot {
-    const slot: WorkerSlot = {
+    let slot!: WorkerSlot;
+    const listeners: WorkerSlotListeners = {
+      message: (resp: WorkerResponse) => {
+        if (slot.state.kind !== "running") return;
+
+        const entry = slot.pending.get(resp.id);
+        if (!entry) return;
+        slot.pending.delete(resp.id);
+        slot.inflight--;
+
+        if ("error" in resp) {
+          entry.reject(reconstructError(resp.error));
+        } else {
+          entry.resolve(fromWire(resp.result, FerricSymbol));
+        }
+
+        EnginePool.notifyPendingDrained(slot);
+
+        // Dispatch the next queued request, if any.
+        EnginePool.drainQueue(slot);
+      },
+      error: (err: Error) => {
+        EnginePool.signalSlotFailure(slot, err);
+      },
+      exit: (code: number) => {
+        if (slot.state.kind === "terminating") {
+          slot.state = { kind: "closed" };
+          EnginePool.detachSlotListeners(slot);
+          EnginePool.notifyPendingDrained(slot);
+          return;
+        }
+        if (slot.state.kind !== "running") return;
+
+        const err = new Error(
+          code === 0
+            ? slot.pending.size > 0
+              ? "Pool worker exited before responding to pending request"
+              : "Pool worker exited unexpectedly with code 0"
+            : `Pool worker exited unexpectedly with code ${code}`,
+        );
+        EnginePool.signalSlotFailure(slot, err);
+      },
+    };
+
+    slot = {
       worker,
+      state: { kind: "running" },
       nextId: 0,
       pending: new Map(),
       inflight: 0,
       queue: [],
+      pendingDrainWaiters: [],
+      listeners,
+      listenersAttached: false,
     };
 
-    worker.on("message", (resp: WorkerResponse) => {
-      const entry = slot.pending.get(resp.id);
-      if (!entry) return;
-      slot.pending.delete(resp.id);
-      slot.inflight--;
-
-      if ("error" in resp) {
-        entry.reject(reconstructError(resp.error));
-      } else {
-        entry.resolve(fromWire(resp.result, FerricSymbol));
-      }
-
-      // Dispatch the next queued request, if any.
-      EnginePool.drainQueue(slot);
-    });
-
-    worker.on("error", (err: Error) => {
-      const snapshot = [...slot.pending.values()];
-      slot.pending.clear();
-      // Reject owner work already accepted behind the failed in-flight call so
-      // callback cleanup can drain and release its lease. Full terminal slot
-      // cleanup remains the responsibility of FR-NODE-005.
-      EnginePool.rejectActiveLeaseQueue(slot, err);
-      for (const entry of snapshot) {
-        entry.reject(err);
-      }
-    });
-
-    worker.on("exit", (code: number) => {
-      // Any pending request when a pool worker exits — even with code 0 —
-      // will never be answered. Without this rejection those promises
-      // would hang forever.
-      if (slot.pending.size > 0) {
-        const err = new Error(
-          code === 0
-            ? "Pool worker exited before responding to pending request"
-            : `Pool worker exited unexpectedly with code ${code}`,
-        );
-        const snapshot = [...slot.pending.values()];
-        slot.pending.clear();
-        EnginePool.rejectActiveLeaseQueue(slot, err);
-        for (const entry of snapshot) {
-          entry.reject(err);
-        }
-      }
-    });
+    EnginePool.attachSlotListeners(slot);
 
     return slot;
+  }
+
+  private static attachSlotListeners(slot: WorkerSlot): void {
+    if (slot.listenersAttached) return;
+    slot.worker.on("message", slot.listeners.message);
+    slot.worker.on("error", slot.listeners.error);
+    slot.worker.on("exit", slot.listeners.exit);
+    slot.listenersAttached = true;
+  }
+
+  private static detachSlotListeners(slot: WorkerSlot): void {
+    if (!slot.listenersAttached) return;
+    slot.worker.off("message", slot.listeners.message);
+    slot.worker.off("error", slot.listeners.error);
+    slot.worker.off("exit", slot.listeners.exit);
+    slot.listenersAttached = false;
+  }
+
+  private static signalSlotFailure(slot: WorkerSlot, error: Error): void {
+    if (slot.state.kind !== "running") return;
+    if (slot.onTerminal) {
+      slot.onTerminal(slot, error);
+    } else {
+      EnginePool.failSlot(slot, error);
+    }
+  }
+
+  private handleSlotTerminal(slot: WorkerSlot, error: Error): void {
+    if (slot.state.kind !== "running") return;
+    this.terminalError ??= error;
+    EnginePool.failSlot(slot, this.terminalError);
+  }
+
+  /** Atomically make one Worker slot unusable and settle all work it owns. */
+  private static failSlot(slot: WorkerSlot, error: Error): void {
+    if (slot.state.kind !== "running") return;
+
+    // Publish failure before rejecting anything so Promise reactions can never
+    // enqueue more work onto this Worker.
+    slot.state = { kind: "failed", error };
+    slot.onTerminal = undefined;
+    EnginePool.detachSlotListeners(slot);
+
+    const pending = [...slot.pending.values()];
+    const rootQueue = slot.queue.splice(0);
+    const ownerQueue = slot.activeLease?.queue.splice(0) ?? [];
+    slot.pending.clear();
+    slot.inflight = 0;
+
+    for (const queued of rootQueue) {
+      EnginePool.rejectQueuedWork(queued, error);
+    }
+    for (const queued of ownerQueue) {
+      EnginePool.removeAbortListener(queued);
+      queued.entry.reject(error);
+    }
+    for (const entry of pending) {
+      entry.reject(error);
+    }
+
+    EnginePool.notifyPendingDrained(slot);
+  }
+
+  private static rejectQueuedWork(queued: QueuedWork, error: Error): void {
+    EnginePool.removeAbortListener(queued);
+    if (queued.kind === "lease") {
+      EnginePool.markLeaseReleased(queued.lease);
+      queued.reject(error);
+    } else {
+      queued.entry.reject(error);
+    }
+  }
+
+  private static notifyPendingDrained(slot: WorkerSlot): void {
+    if (slot.pending.size !== 0) return;
+    const waiters = slot.pendingDrainWaiters.splice(0);
+    for (const resolve of waiters) resolve();
+  }
+
+  private static waitForPending(slot: WorkerSlot): Promise<void> {
+    if (slot.pending.size === 0) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      slot.pendingDrainWaiters.push(resolve);
+    });
+  }
+
+  private static async terminateSlot(slot: WorkerSlot): Promise<void> {
+    if (slot.state.kind === "closed" || slot.state.kind === "terminating") return;
+    if (slot.state.kind === "running" || slot.state.kind === "failed") {
+      slot.state = { kind: "terminating" };
+    }
+
+    try {
+      await slot.worker.terminate();
+    } finally {
+      if (slot.state.kind === "terminating") {
+        slot.state = { kind: "closed" };
+      }
+      slot.onTerminal = undefined;
+      EnginePool.detachSlotListeners(slot);
+      EnginePool.notifyPendingDrained(slot);
+    }
   }
 
   private static initSlot(slot: WorkerSlot, init: PoolWorkerInit): Promise<void> {
@@ -406,16 +565,6 @@ export class EnginePool {
     slot.worker.postMessage(queued.req);
   }
 
-  private static rejectActiveLeaseQueue(slot: WorkerSlot, error: Error): void {
-    const lease = slot.activeLease;
-    if (!lease) return;
-    const snapshot = lease.queue.splice(0);
-    for (const queued of snapshot) {
-      EnginePool.removeAbortListener(queued);
-      queued.entry.reject(error);
-    }
-  }
-
   private static settleLeaseCall(lease: WorkerLease): void {
     lease.pendingCalls--;
     if (lease.pendingCalls !== 0) return;
@@ -444,6 +593,7 @@ export class EnginePool {
 
   /** Dispatch the next owner request or root FIFO item for an idle slot. */
   private static drainQueue(slot: WorkerSlot): void {
+    if (slot.state.kind !== "running") return;
     if (slot.inflight !== 0) return;
 
     const lease = slot.activeLease;
@@ -516,6 +666,9 @@ export class EnginePool {
     if (this.closed) {
       return Promise.reject(new Error("EnginePool has been closed"));
     }
+    if (this.terminalError) {
+      return Promise.reject(this.terminalError);
+    }
     if (signal?.aborted) {
       return Promise.reject(
         new DOMException("The operation was aborted", "AbortError"),
@@ -583,6 +736,9 @@ export class EnginePool {
     if (this.closed) {
       return Promise.reject(new Error("EnginePool has been closed"));
     }
+    if (this.terminalError) {
+      return Promise.reject(this.terminalError);
+    }
     const id = slot.nextId++;
     const req: WorkerRequest = { id, method, args };
 
@@ -632,6 +788,12 @@ export class EnginePool {
     if (!lease.active || lease.released || slot.activeLease !== lease) {
       return Promise.reject(new Error(INACTIVE_PROXY_MESSAGE));
     }
+    if (slot.state.kind === "failed") {
+      return Promise.reject(slot.state.error);
+    }
+    if (slot.state.kind !== "running") {
+      return Promise.reject(new Error("EnginePool has been closed"));
+    }
 
     const id = slot.nextId++;
     const req: WorkerRequest = { id, method, args };
@@ -680,6 +842,12 @@ export class EnginePool {
     const withActiveLease = <T>(operation: () => Promise<T>): Promise<T> => {
       if (!lease.active || lease.released || slot.activeLease !== lease) {
         return Promise.reject(new Error(INACTIVE_PROXY_MESSAGE));
+      }
+      if (slot.state.kind === "failed") {
+        return Promise.reject(slot.state.error);
+      }
+      if (slot.state.kind !== "running") {
+        return Promise.reject(new Error("EnginePool has been closed"));
       }
       return operation();
     };
@@ -802,6 +970,7 @@ export class EnginePool {
   ): Promise<EvaluateResult> {
     this.assertNotInActiveCallback();
     if (this.closed) throw new Error("EnginePool has been closed");
+    if (this.terminalError) throw this.terminalError;
 
     const signal = options?.signal;
     const limit = normalizeEvaluateLimit(
@@ -886,6 +1055,7 @@ export class EnginePool {
   ): Promise<T> {
     this.assertNotInActiveCallback();
     if (this.closed) throw new Error("EnginePool has been closed");
+    if (this.terminalError) throw this.terminalError;
 
     const signal = options?.signal;
     if (signal?.aborted) {
@@ -984,16 +1154,10 @@ export class EnginePool {
     await Promise.all(
       this.slots.map(async (slot) => {
         // Reject all queued (not yet dispatched) requests.
-        for (const queued of slot.queue) {
-          EnginePool.removeAbortListener(queued);
-          if (queued.kind === "lease") {
-            EnginePool.markLeaseReleased(queued.lease);
-            queued.reject(closeErr);
-          } else {
-            queued.entry.reject(closeErr);
-          }
+        const rootQueue = slot.queue.splice(0);
+        for (const queued of rootQueue) {
+          EnginePool.rejectQueuedWork(queued, closeErr);
         }
-        slot.queue.length = 0;
 
         // A do() callback is admitted work even while it has no native request
         // in flight. Its owner calls remain valid after close starts, and close
@@ -1004,23 +1168,12 @@ export class EnginePool {
           await activeLease.releasedPromise;
         }
 
-        // Wait for in-flight requests to settle. The existing message
-        // handler installed in createSlot() clears slot.pending as
-        // responses arrive; we piggyback on each message to re-check.
-        if (slot.pending.size > 0) {
-          await new Promise<void>((resolve) => {
-            const check = () => {
-              if (slot.pending.size === 0) {
-                slot.worker.off("message", check);
-                resolve();
-              }
-            };
-            slot.worker.on("message", check);
-            check();
-          });
-        }
+        // A slot-owned waiter is resolved by either its last response or its
+        // atomic terminal-failure cleanup. It does not depend on a later
+        // Worker message that can never arrive after error/exit.
+        await EnginePool.waitForPending(slot);
 
-        await slot.worker.terminate();
+        await EnginePool.terminateSlot(slot);
       }),
     );
   }

--- a/packages/ferric/test/conformance/coverage-entrypoint.test.ts
+++ b/packages/ferric/test/conformance/coverage-entrypoint.test.ts
@@ -33,6 +33,7 @@ import "./runtime/pool/pool-internals.test.ts";
 import "./runtime/pool/pool-smoke.test.ts";
 import "./runtime/pool/protocol-direct.test.ts";
 import "./runtime/pool/run-limit.test.ts";
+import "./runtime/pool/terminal-state.test.ts";
 import "./runtime/pool/thread-default.test.ts";
 import "./runtime/pool/wire-conversion.test.ts";
 

--- a/packages/ferric/test/conformance/runtime/pool/pool-internals.test.ts
+++ b/packages/ferric/test/conformance/runtime/pool/pool-internals.test.ts
@@ -120,9 +120,9 @@ test("E-007 EnginePool ignores replies for unknown request ids", () => {
 });
 
 // ---------------------------------------------------------------------------
-// E-008 manual cleanup: worker error rejects all pending pool requests
+// E-013 manual cleanup: worker error rejects all pending pool requests
 // ---------------------------------------------------------------------------
-test("E-008 EnginePool rejects pending requests when worker emits error", async () => {
+test("E-013 EnginePool rejects pending requests when worker emits error", async () => {
   const { pool, worker } = makePool();
   const pending = pool.evaluate("rules", {});
 
@@ -131,11 +131,11 @@ test("E-008 EnginePool rejects pending requests when worker emits error", async 
 });
 
 // ---------------------------------------------------------------------------
-// E-012 lease cleanup: a worker error rejecting the owner request invalidates
-// the callback proxy. Full failed-slot queue/future-work cleanup belongs to
-// FR-NODE-005; this seam only locks the callback lease's terminal path.
+// E-012/E-013 lease cleanup: a worker error rejecting the owner request
+// invalidates the callback proxy. Comprehensive failed-slot queue and future
+// admission coverage lives in terminal-state.test.ts.
 // ---------------------------------------------------------------------------
-test("E-012 EnginePool worker error invalidates the active callback lease", async () => {
+test("E-012 E-013 EnginePool worker error invalidates the active callback lease", async () => {
   const { pool, worker } = makePool();
   let retained: any;
 
@@ -417,9 +417,9 @@ test("E-012 an earlier returned-Promise reaction drains before proxy invalidatio
 });
 
 // ---------------------------------------------------------------------------
-// E-008 table-driven cleanup: worker exit rejects pending pool requests
+// E-013 table-driven cleanup: worker exit rejects pending pool requests
 // ---------------------------------------------------------------------------
-test("E-008 table-driven EnginePool rejects pending requests on worker exit", async () => {
+test("E-013 table-driven EnginePool rejects pending requests on worker exit", async () => {
   for (const [code, pattern] of [
     [0, /exited before responding/],
     [9, /unexpectedly with code 9/],

--- a/packages/ferric/test/conformance/runtime/pool/terminal-state.test.ts
+++ b/packages/ferric/test/conformance/runtime/pool/terminal-state.test.ts
@@ -1,0 +1,1130 @@
+/**
+ * EnginePool terminal worker-slot state tests (FR-NODE-005 / E-013).
+ *
+ * These cases intentionally keep synchronous postMessage rollback (FR-NODE-008),
+ * successful root-queue AbortSignal cleanup (FR-NODE-006), cancellation-time
+ * proxy invalidation (FR-NODE-009), and concurrent close barriers (FR-NODE-010)
+ * out of scope.
+ */
+import { execFile } from "node:child_process";
+import { EventEmitter, getEventListeners } from "node:events";
+import { resolve } from "node:path";
+import { setImmediate as yieldImmediate } from "node:timers/promises";
+import { test } from "node:test";
+import * as assert from "node:assert/strict";
+
+import { EnginePool } from "../../../helpers/ferric";
+
+const workerThreads = require("node:worker_threads") as typeof import("node:worker_threads");
+
+interface PostedMessage {
+  id: number;
+  method: string;
+  args: unknown[];
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}
+
+class FakeWorker extends EventEmitter {
+  readonly messages: PostedMessage[] = [];
+  terminateCalls = 0;
+  onTerminate?: () => Promise<number>;
+
+  postMessage(message: PostedMessage): void {
+    this.messages.push(message);
+  }
+
+  terminate(): Promise<number> {
+    this.terminateCalls += 1;
+    return this.onTerminate?.() ?? Promise.resolve(0);
+  }
+}
+
+interface PoolFixture {
+  pool: EnginePool;
+  workers: FakeWorker[];
+  slots: any[];
+}
+
+interface TerminalCase {
+  label: string;
+  pattern: RegExp;
+  emit: (worker: FakeWorker) => Error | undefined;
+}
+
+const EMPTY_EVALUATE_RESULT = {
+  runResult: { rulesFired: 0, haltReason: 0 },
+  facts: [],
+  output: {},
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolvePromise!: (value: T | PromiseLike<T>) => void;
+  let rejectPromise!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolveValue, rejectValue) => {
+    resolvePromise = resolveValue;
+    rejectPromise = rejectValue;
+  });
+  return {
+    promise,
+    resolve: resolvePromise,
+    reject: rejectPromise,
+  };
+}
+
+function makePool(threadCount = 1): PoolFixture {
+  const workers = Array.from({ length: threadCount }, () => new FakeWorker());
+  const slots = workers.map((worker) =>
+    (EnginePool as any).createSlot(worker),
+  );
+  const pool = new (EnginePool as any)(slots) as EnginePool;
+  return { pool, workers, slots };
+}
+
+async function within<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs = 2_000,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Timed out waiting for ${label}`)),
+      timeoutMs,
+    );
+  });
+
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+async function rejectionOf<T>(promise: Promise<T>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("Expected Promise to reject");
+}
+
+async function waitForMessage(
+  worker: FakeWorker,
+  index: number,
+  label: string,
+): Promise<PostedMessage> {
+  for (let turn = 0; turn < 20; turn++) {
+    const message = worker.messages[index];
+    if (message !== undefined) return message;
+    await yieldImmediate();
+  }
+  assert.fail(`EnginePool did not post ${label}`);
+}
+
+function respond(
+  worker: FakeWorker,
+  message: PostedMessage,
+  result: unknown = EMPTY_EVALUATE_RESULT,
+): void {
+  worker.emit("message", { id: message.id, result });
+}
+
+function assertWorkerListenersRemoved(worker: FakeWorker): void {
+  assert.strictEqual(worker.listenerCount("message"), 0);
+  assert.strictEqual(worker.listenerCount("error"), 0);
+  assert.strictEqual(worker.listenerCount("exit"), 0);
+}
+
+function assertCleanTerminalSlot(slot: any): void {
+  assert.strictEqual(slot.state.kind, "failed");
+  assert.strictEqual(slot.pending.size, 0);
+  assert.strictEqual(slot.inflight, 0);
+  assert.strictEqual(slot.queue.length, 0);
+  assert.strictEqual(slot.activeLease, undefined);
+  assert.strictEqual(slot.pendingDrainWaiters.length, 0);
+  assert.strictEqual(slot.listenersAttached, false);
+}
+
+function assertAbortListenersRemoved(...signals: AbortSignal[]): void {
+  for (const signal of signals) {
+    assert.strictEqual(getEventListeners(signal, "abort").length, 0);
+  }
+}
+
+function terminalCases(): TerminalCase[] {
+  return [
+    {
+      label: "Worker error",
+      pattern: /forced worker error/,
+      emit: (worker) => {
+        const error = new Error("forced worker error");
+        worker.emit("error", error);
+        return error;
+      },
+    },
+    {
+      label: "nonzero exit",
+      pattern: /Pool worker exited unexpectedly with code 9/,
+      emit: (worker) => {
+        worker.emit("exit", 9);
+        return undefined;
+      },
+    },
+    {
+      label: "zero exit with pending work",
+      pattern: /Pool worker exited before responding to pending request/,
+      emit: (worker) => {
+        worker.emit("exit", 0);
+        return undefined;
+      },
+    },
+  ];
+}
+
+test("E-013 terminal faults reject pending, queued request, and queued lease work", async (t) => {
+  for (const item of terminalCases()) {
+    await t.test(item.label, async () => {
+      const { pool, workers: [worker], slots: [slot] } = makePool();
+      const pendingAbort = new AbortController();
+      const queuedAbort = new AbortController();
+      const leaseAbort = new AbortController();
+      let queuedCallbackEntered = false;
+
+      const pendingOutcome = rejectionOf(
+        pool.evaluate("rules", {}, { signal: pendingAbort.signal }),
+      );
+      const queuedOutcome = rejectionOf(
+        pool.evaluate("rules", {}, { signal: queuedAbort.signal }),
+      );
+      const queuedLeaseOutcome = rejectionOf(
+        pool.do(
+          "rules",
+          async () => {
+            queuedCallbackEntered = true;
+          },
+          { signal: leaseAbort.signal },
+        ),
+      );
+
+      assert.strictEqual(slot.pending.size, 1);
+      assert.strictEqual(slot.inflight, 1);
+      assert.strictEqual(slot.queue.length, 2);
+      const queuedLease = slot.queue.find(
+        (queued: { kind: string }) => queued.kind === "lease",
+      ).lease;
+
+      const emittedError = item.emit(worker);
+      const terminalError = await within(
+        pendingOutcome,
+        `${item.label} pending rejection`,
+      );
+      const queuedError = await within(
+        queuedOutcome,
+        `${item.label} queued rejection`,
+      );
+      const queuedLeaseError = await within(
+        queuedLeaseOutcome,
+        `${item.label} queued lease rejection`,
+      );
+
+      assert.ok(terminalError instanceof Error);
+      assert.match(terminalError.message, item.pattern);
+      assert.strictEqual(queuedError, terminalError);
+      assert.strictEqual(queuedLeaseError, terminalError);
+      if (emittedError !== undefined) {
+        assert.strictEqual(terminalError, emittedError);
+      }
+      assert.strictEqual(slot.state.error, terminalError);
+      assert.strictEqual((pool as any).terminalError, terminalError);
+      assert.strictEqual(queuedCallbackEntered, false);
+      assert.strictEqual(queuedLease.active, false);
+      assert.strictEqual(queuedLease.released, true);
+      assertCleanTerminalSlot(slot);
+      assertAbortListenersRemoved(
+        pendingAbort.signal,
+        queuedAbort.signal,
+        leaseAbort.signal,
+      );
+      assertWorkerListenersRemoved(worker);
+
+      const postsBeforeFutureWork = worker.messages.length;
+      let futureCallbackEntered = false;
+      assert.strictEqual(
+        await rejectionOf(pool.evaluate("rules", {})),
+        terminalError,
+      );
+      assert.strictEqual(
+        await rejectionOf(
+          pool.do("rules", async () => {
+            futureCallbackEntered = true;
+          }),
+        ),
+        terminalError,
+      );
+      assert.strictEqual(futureCallbackEntered, false);
+      assert.strictEqual(worker.messages.length, postsBeforeFutureWork);
+
+      await within(pool.close(), `${item.label} close after terminal fault`);
+      assert.strictEqual(slot.state.kind, "closed");
+    });
+  }
+});
+
+test("E-013 an idle zero exit is terminal and future admission fails fast", async () => {
+  const { pool, workers: [worker], slots: [slot] } = makePool();
+  const nextIdBeforeExit = slot.nextId;
+
+  worker.emit("exit", 0);
+
+  assertCleanTerminalSlot(slot);
+  assertWorkerListenersRemoved(worker);
+  const terminalError = slot.state.error;
+  assert.match(
+    terminalError.message,
+    /Pool worker exited unexpectedly with code 0/,
+  );
+
+  let callbackEntered = false;
+  assert.strictEqual(
+    await rejectionOf(pool.evaluate("rules", {})),
+    terminalError,
+  );
+  assert.strictEqual(
+    await rejectionOf(
+      pool.do("rules", async () => {
+        callbackEntered = true;
+      }),
+    ),
+    terminalError,
+  );
+  assert.strictEqual(callbackEntered, false);
+  assert.strictEqual(worker.messages.length, 0);
+  assert.strictEqual(slot.nextId, nextIdBeforeExit);
+
+  await within(pool.close(), "close after idle zero exit");
+});
+
+test("E-013 duplicate terminal signals and late responses settle entries once", async (t) => {
+  const cases = [
+    {
+      label: "error then exit",
+      pattern: /first worker error/,
+      first: (worker: FakeWorker) => {
+        const error = new Error("first worker error");
+        worker.emit("error", error);
+        return error;
+      },
+      late: (listeners: any) => {
+        listeners.exit(9);
+        listeners.error(new Error("late worker error"));
+      },
+    },
+    {
+      label: "nonzero exit then error",
+      pattern: /Pool worker exited unexpectedly with code 9/,
+      first: (worker: FakeWorker) => {
+        worker.emit("exit", 9);
+        return undefined;
+      },
+      late: (listeners: any) => {
+        listeners.error(new Error("late worker error"));
+        listeners.exit(0);
+      },
+    },
+    {
+      label: "zero exit then error",
+      pattern: /Pool worker exited before responding to pending request/,
+      first: (worker: FakeWorker) => {
+        worker.emit("exit", 0);
+        return undefined;
+      },
+      late: (listeners: any) => {
+        listeners.error(new Error("late worker error"));
+        listeners.exit(7);
+      },
+    },
+  ];
+
+  for (const item of cases) {
+    await t.test(item.label, async () => {
+      const { pool, workers: [worker], slots: [slot] } = makePool();
+      let queuedLeaseEntered = false;
+      const pendingOutcome = rejectionOf(pool.evaluate("rules", {}));
+      const queuedOutcome = rejectionOf(pool.evaluate("rules", {}));
+      const queuedLeaseOutcome = rejectionOf(
+        pool.do("rules", async () => {
+          queuedLeaseEntered = true;
+        }),
+      );
+
+      const pendingEntry = [...slot.pending.values()][0];
+      const queuedRequest = slot.queue.find(
+        (queued: { kind: string }) => queued.kind === "request",
+      );
+      const queuedLease = slot.queue.find(
+        (queued: { kind: string }) => queued.kind === "lease",
+      );
+      const listeners = { ...slot.listeners };
+      const pendingId = worker.messages[0].id;
+      let pendingRejectCalls = 0;
+      let queuedRejectCalls = 0;
+      let queuedLeaseRejectCalls = 0;
+
+      const originalPendingReject = pendingEntry.reject;
+      pendingEntry.reject = (error: Error): void => {
+        pendingRejectCalls += 1;
+        originalPendingReject(error);
+      };
+      const originalQueuedReject = queuedRequest.entry.reject;
+      queuedRequest.entry.reject = (error: Error): void => {
+        queuedRejectCalls += 1;
+        originalQueuedReject(error);
+      };
+      const originalLeaseReject = queuedLease.reject;
+      queuedLease.reject = (error: Error): void => {
+        queuedLeaseRejectCalls += 1;
+        originalLeaseReject(error);
+      };
+
+      const emittedError = item.first(worker);
+      item.late(listeners);
+      listeners.message({ id: pendingId, result: EMPTY_EVALUATE_RESULT });
+
+      const terminalError = await within(
+        pendingOutcome,
+        `${item.label} pending rejection`,
+      );
+      assert.ok(terminalError instanceof Error);
+      assert.match(terminalError.message, item.pattern);
+      assert.strictEqual(
+        await within(queuedOutcome, `${item.label} queued rejection`),
+        terminalError,
+      );
+      assert.strictEqual(
+        await within(
+          queuedLeaseOutcome,
+          `${item.label} queued lease rejection`,
+        ),
+        terminalError,
+      );
+      if (emittedError !== undefined) {
+        assert.strictEqual(terminalError, emittedError);
+      }
+      assert.strictEqual(pendingRejectCalls, 1);
+      assert.strictEqual(queuedRejectCalls, 1);
+      assert.strictEqual(queuedLeaseRejectCalls, 1);
+      assert.strictEqual(queuedLeaseEntered, false);
+      assertCleanTerminalSlot(slot);
+      assertWorkerListenersRemoved(worker);
+
+      assert.strictEqual(
+        await rejectionOf(pool.evaluate("rules", {})),
+        terminalError,
+      );
+      await within(pool.close(), `${item.label} close`);
+    });
+  }
+});
+
+test("E-013 a failed active lease rejects owner and root queues before release", async () => {
+  const { pool, workers: [worker], slots: [slot] } = makePool();
+  const rootAbort = new AbortController();
+  const waitingLeaseAbort = new AbortController();
+  let retainedProxy: any;
+  let ownerErrors: unknown[] | undefined;
+  let postFaultOwnerError: unknown;
+  let waitingLeaseEntered = false;
+
+  const activeOutcome = rejectionOf(
+    pool.do("rules", async (proxy) => {
+      retainedProxy = proxy;
+      const first = proxy.facts();
+      const second = proxy.facts();
+      ownerErrors = await Promise.all([
+        rejectionOf(first),
+        rejectionOf(second),
+      ]);
+      postFaultOwnerError = await rejectionOf(proxy.facts());
+      throw ownerErrors[0];
+    }),
+  );
+  await waitForMessage(worker, 0, "the active lease request");
+  const activeLease = slot.activeLease;
+
+  const rootOutcome = rejectionOf(
+    pool.evaluate("rules", {}, { signal: rootAbort.signal }),
+  );
+  const waitingLeaseOutcome = rejectionOf(
+    pool.do(
+      "rules",
+      async () => {
+        waitingLeaseEntered = true;
+      },
+      { signal: waitingLeaseAbort.signal },
+    ),
+  );
+  assert.strictEqual(activeLease.queue.length, 1);
+  assert.strictEqual(slot.queue.length, 2);
+
+  const terminalError = new Error("active lease worker failed");
+  worker.emit("error", terminalError);
+
+  assert.strictEqual(
+    await within(rootOutcome, "failed-slot root request rejection"),
+    terminalError,
+  );
+  assert.strictEqual(
+    await within(waitingLeaseOutcome, "failed-slot lease waiter rejection"),
+    terminalError,
+  );
+  assert.strictEqual(
+    await within(activeOutcome, "failed active lease rejection"),
+    terminalError,
+  );
+  assert.deepStrictEqual(ownerErrors, [terminalError, terminalError]);
+  assert.strictEqual(postFaultOwnerError, terminalError);
+  assert.strictEqual(waitingLeaseEntered, false);
+  assert.strictEqual(activeLease.pendingCalls, 0);
+  assert.strictEqual(activeLease.queue.length, 0);
+  assert.strictEqual(activeLease.released, true);
+  assertCleanTerminalSlot(slot);
+  assertAbortListenersRemoved(rootAbort.signal, waitingLeaseAbort.signal);
+  assertWorkerListenersRemoved(worker);
+
+  await assert.rejects(
+    () => retainedProxy.facts(),
+    /EngineProxy is no longer valid outside its EnginePool\.do callback/,
+  );
+  await within(pool.close(), "close after active lease failure");
+});
+
+test("E-013 a fault wakes one close already waiting for pending work", async () => {
+  const { pool, workers: [worker], slots: [slot] } = makePool();
+  const requestOutcome = rejectionOf(pool.evaluate("rules", {}));
+  const closePromise = pool.close();
+
+  assert.strictEqual(slot.pendingDrainWaiters.length, 1);
+  const terminalError = new Error("worker failed during close");
+  worker.emit("error", terminalError);
+
+  assert.strictEqual(
+    await within(requestOutcome, "request rejection during close"),
+    terminalError,
+  );
+  await within(closePromise, "close waiting across a terminal fault");
+  assert.strictEqual(slot.pendingDrainWaiters.length, 0);
+  assert.strictEqual(slot.pending.size, 0);
+  assert.strictEqual(slot.inflight, 0);
+  assert.strictEqual(slot.queue.length, 0);
+  assert.strictEqual(slot.state.kind, "closed");
+  assert.strictEqual(slot.listenersAttached, false);
+  assertWorkerListenersRemoved(worker);
+});
+
+test("E-013 close after a terminal fault completes without another message", async () => {
+  const { pool, workers: [worker], slots: [slot] } = makePool();
+  const requestOutcome = rejectionOf(pool.evaluate("rules", {}));
+  worker.emit("exit", 9);
+
+  const terminalError = await within(
+    requestOutcome,
+    "request rejection before close",
+  );
+  assert.strictEqual(slot.state.kind, "failed");
+  assert.strictEqual(slot.state.error, terminalError);
+
+  await within(pool.close(), "close after terminal exit");
+  assert.strictEqual(slot.state.kind, "closed");
+  assert.strictEqual(slot.pendingDrainWaiters.length, 0);
+  assertWorkerListenersRemoved(worker);
+});
+
+test("E-013 an expected zero exit while terminating does not poison close", async () => {
+  const { pool, workers: [worker], slots: [slot] } = makePool();
+  worker.onTerminate = async () => {
+    worker.emit("exit", 0);
+    return 0;
+  };
+
+  await within(pool.close(), "normal close with an exit event");
+
+  assert.strictEqual(worker.terminateCalls, 1);
+  assert.strictEqual(slot.state.kind, "closed");
+  assert.strictEqual((pool as any).terminalError, undefined);
+  assert.strictEqual(slot.listenersAttached, false);
+  assertWorkerListenersRemoved(worker);
+});
+
+test("E-013 protocol error responses are nonterminal and the slot stays usable", async () => {
+  const { pool, workers: [worker], slots: [slot] } = makePool();
+  const first = pool.evaluate("rules", {});
+  const firstMessage = await waitForMessage(worker, 0, "the first request");
+
+  worker.emit("message", {
+    id: firstMessage.id,
+    error: {
+      name: "FerricRuntimeError",
+      message: "ordinary protocol failure",
+      code: "FERRIC_RUNTIME_ERROR",
+    },
+  });
+
+  await assert.rejects(first, /ordinary protocol failure/);
+  assert.strictEqual(slot.state.kind, "running");
+  assert.strictEqual((pool as any).terminalError, undefined);
+  assert.strictEqual(slot.pending.size, 0);
+  assert.strictEqual(slot.inflight, 0);
+  assert.strictEqual(slot.queue.length, 0);
+  assert.strictEqual(slot.listenersAttached, true);
+  assert.deepStrictEqual(
+    ["message", "error", "exit"].map((event) =>
+      worker.listenerCount(event),
+    ),
+    [1, 1, 1],
+  );
+
+  const second = pool.evaluate("rules", {});
+  const secondMessage = await waitForMessage(worker, 1, "the follow-up request");
+  respond(worker, secondMessage);
+  assert.deepStrictEqual(await second, EMPTY_EVALUATE_RESULT);
+  assert.strictEqual(slot.state.kind, "running");
+
+  await within(pool.close(), "close after a protocol response error");
+  assert.strictEqual(slot.state.kind, "closed");
+  assertWorkerListenersRemoved(worker);
+});
+
+test("E-013 a failed slot preserves healthy already-accepted work but poisons future admission", async () => {
+  const {
+    pool,
+    workers: [failedWorker, healthyWorker],
+    slots: [failedSlot, healthySlot],
+  } = makePool(2);
+  const failedQueueAbort = new AbortController();
+  const failedLeaseAbort = new AbortController();
+  let failedLeaseEntered = false;
+  let healthyLeaseEntered = false;
+  let futureLeaseEntered = false;
+
+  const failedPendingOutcome = rejectionOf(pool.evaluate("rules", {}));
+  const healthyPending = pool.evaluate("rules", {});
+  const failedQueuedOutcome = rejectionOf(
+    pool.evaluate("rules", {}, { signal: failedQueueAbort.signal }),
+  );
+  const healthyQueued = pool.evaluate("rules", {});
+  const failedQueuedLeaseOutcome = rejectionOf(
+    pool.do(
+      "rules",
+      async () => {
+        failedLeaseEntered = true;
+      },
+      { signal: failedLeaseAbort.signal },
+    ),
+  );
+  const healthyQueuedLease = pool.do("rules", async (proxy) => {
+    healthyLeaseEntered = true;
+    return proxy.facts();
+  });
+
+  assert.strictEqual(failedSlot.pending.size, 1);
+  assert.strictEqual(failedSlot.queue.length, 2);
+  assert.strictEqual(healthySlot.pending.size, 1);
+  assert.strictEqual(healthySlot.queue.length, 2);
+
+  const terminalError = new Error("first slot failed");
+  failedWorker.emit("error", terminalError);
+
+  assert.strictEqual(
+    await within(failedPendingOutcome, "failed-slot pending rejection"),
+    terminalError,
+  );
+  assert.strictEqual(
+    await within(failedQueuedOutcome, "failed-slot queued rejection"),
+    terminalError,
+  );
+  assert.strictEqual(
+    await within(
+      failedQueuedLeaseOutcome,
+      "failed-slot queued lease rejection",
+    ),
+    terminalError,
+  );
+  assert.strictEqual(failedLeaseEntered, false);
+  assertCleanTerminalSlot(failedSlot);
+  assertAbortListenersRemoved(
+    failedQueueAbort.signal,
+    failedLeaseAbort.signal,
+  );
+  assertWorkerListenersRemoved(failedWorker);
+
+  // A terminal fault poisons only later public admissions. Work already
+  // accepted by another slot keeps its established FIFO and lease semantics.
+  assert.strictEqual(healthySlot.state.kind, "running");
+  assert.strictEqual(healthySlot.pending.size, 1);
+  assert.strictEqual(healthySlot.queue.length, 2);
+  assert.strictEqual(healthyLeaseEntered, false);
+  const failedPostsBeforeFutureWork = failedWorker.messages.length;
+  const healthyPostsBeforeFutureWork = healthyWorker.messages.length;
+  assert.strictEqual(
+    await rejectionOf(pool.evaluate("rules", {})),
+    terminalError,
+  );
+  assert.strictEqual(
+    await rejectionOf(
+      pool.do("rules", async () => {
+        futureLeaseEntered = true;
+      }),
+    ),
+    terminalError,
+  );
+  assert.strictEqual(futureLeaseEntered, false);
+  assert.strictEqual(failedWorker.messages.length, failedPostsBeforeFutureWork);
+  assert.strictEqual(healthyWorker.messages.length, healthyPostsBeforeFutureWork);
+
+  const healthyPendingMessage = await waitForMessage(
+    healthyWorker,
+    0,
+    "the healthy in-flight request",
+  );
+  respond(healthyWorker, healthyPendingMessage);
+  assert.deepStrictEqual(await healthyPending, EMPTY_EVALUATE_RESULT);
+
+  const healthyQueuedMessage = await waitForMessage(
+    healthyWorker,
+    1,
+    "the healthy queued request",
+  );
+  respond(healthyWorker, healthyQueuedMessage);
+  assert.deepStrictEqual(await healthyQueued, EMPTY_EVALUATE_RESULT);
+
+  // The lease admission was accepted and queued before the other slot failed.
+  // Its callback begins after the global poison and its owner send is
+  // nevertheless still accepted.
+  const healthyLeaseMessage = await waitForMessage(
+    healthyWorker,
+    2,
+    "the healthy admitted lease owner request",
+  );
+  assert.strictEqual(healthyLeaseEntered, true);
+  respond(healthyWorker, healthyLeaseMessage, []);
+  assert.deepStrictEqual(await healthyQueuedLease, []);
+  assert.strictEqual(healthySlot.state.kind, "running");
+  assert.strictEqual(healthySlot.pending.size, 0);
+  assert.strictEqual(healthySlot.inflight, 0);
+  assert.strictEqual(healthySlot.queue.length, 0);
+  assert.strictEqual(healthySlot.activeLease, undefined);
+
+  // A later terminal signal from another slot cannot replace the pool's
+  // canonical first failure, including in that second slot's failed state.
+  healthyWorker.emit("error", new Error("later healthy-slot failure"));
+  assert.strictEqual(healthySlot.state.kind, "failed");
+  assert.strictEqual(healthySlot.state.error, terminalError);
+  assert.strictEqual((pool as any).terminalError, terminalError);
+  assertWorkerListenersRemoved(healthyWorker);
+
+  await within(pool.close(), "close mixed failed and healthy slots");
+  assert.strictEqual(failedSlot.state.kind, "closed");
+  assert.strictEqual(healthySlot.state.kind, "closed");
+  assertWorkerListenersRemoved(healthyWorker);
+});
+
+test("E-013 a failed idle callback retains its normal lease lifetime", async () => {
+  const { pool, workers: [worker], slots: [slot] } = makePool();
+  const callbackEntered = deferred<void>();
+  const continueCallback = deferred<void>();
+  let postFaultOwnerError: unknown;
+
+  const active = pool.do("rules", async (proxy) => {
+    callbackEntered.resolve();
+    await continueCallback.promise;
+    postFaultOwnerError = await rejectionOf(proxy.run({ limit: Number.NaN }));
+    return "callback handled terminal failure";
+  });
+  await callbackEntered.promise;
+  const activeLease = slot.activeLease;
+
+  const terminalError = new Error("idle lease worker failed");
+  worker.emit("error", terminalError);
+  assert.strictEqual(slot.state.kind, "failed");
+  assert.strictEqual(slot.activeLease, activeLease);
+  assert.strictEqual(activeLease.released, false);
+
+  const closePromise = pool.close();
+  assert.strictEqual(activeLease.released, false);
+  continueCallback.resolve();
+
+  assert.strictEqual(
+    await within(active, "idle callback settlement after worker failure"),
+    "callback handled terminal failure",
+  );
+  assert.strictEqual(postFaultOwnerError, terminalError);
+  assert.strictEqual(activeLease.released, true);
+  await within(closePromise, "close waiting for failed idle callback release");
+  assert.strictEqual(slot.state.kind, "closed");
+});
+
+test("E-013 terminal cleanup removes only pool-owned Worker listeners", async () => {
+  const worker = new FakeWorker();
+  const externalMessage = (): void => undefined;
+  const externalError = (): void => undefined;
+  const externalExit = (): void => undefined;
+  worker.on("message", externalMessage);
+  worker.on("error", externalError);
+  worker.on("exit", externalExit);
+
+  const slot = (EnginePool as any).createSlot(worker);
+  const pool = new (EnginePool as any)([slot]) as EnginePool;
+  const requestOutcome = rejectionOf(pool.evaluate("rules", {}));
+  const terminalError = new Error("preserve external listeners");
+  worker.emit("error", terminalError);
+
+  assert.strictEqual(await requestOutcome, terminalError);
+  assert.deepStrictEqual(worker.listeners("message"), [externalMessage]);
+  assert.deepStrictEqual(worker.listeners("error"), [externalError]);
+  assert.deepStrictEqual(worker.listeners("exit"), [externalExit]);
+  assert.strictEqual(slot.listenersAttached, false);
+
+  await within(pool.close(), "close with external Worker listeners");
+  assert.deepStrictEqual(worker.listeners("message"), [externalMessage]);
+  assert.deepStrictEqual(worker.listeners("error"), [externalError]);
+  assert.deepStrictEqual(worker.listeners("exit"), [externalExit]);
+});
+
+test("E-013 a slot that fails before pool publication poisons construction", async () => {
+  const worker = new FakeWorker();
+  const slot = (EnginePool as any).createSlot(worker);
+  const terminalError = new Error("slot failed before pool publication");
+  const secondWorker = new FakeWorker();
+  const secondSlot = (EnginePool as any).createSlot(secondWorker);
+  const secondError = new Error("second prepublication slot failure");
+
+  // No pool callback is installed yet, so the slot-local failure fallback owns
+  // these transitions. The later constructor must adopt only the first error.
+  worker.emit("error", terminalError);
+  secondWorker.emit("error", secondError);
+  assertCleanTerminalSlot(slot);
+  assertCleanTerminalSlot(secondSlot);
+  const pool = new (EnginePool as any)([slot, secondSlot]) as EnginePool;
+  assert.strictEqual((pool as any).terminalError, terminalError);
+
+  const nextIdBeforeGuards = slot.nextId;
+  const postsBeforeGuards = worker.messages.length;
+  assert.strictEqual(
+    await rejectionOf((pool as any).acquireLease(slot)),
+    terminalError,
+  );
+  assert.strictEqual(
+    await rejectionOf(
+      (pool as any).sendToSlot(slot, "facts", ["rules"]),
+    ),
+    terminalError,
+  );
+
+  // Direct owner-send defense is deliberately covered independently of the
+  // proxy's earlier withActiveLease guard.
+  const lease = (EnginePool as any).createLease();
+  lease.active = true;
+  slot.activeLease = lease;
+  assert.strictEqual(
+    await rejectionOf(
+      (pool as any).sendOnLease(slot, lease, "facts", ["rules"]),
+    ),
+    terminalError,
+  );
+  slot.activeLease = undefined;
+  (EnginePool as any).markLeaseReleased(lease);
+
+  assert.strictEqual(slot.nextId, nextIdBeforeGuards);
+  assert.strictEqual(worker.messages.length, postsBeforeGuards);
+  await within(pool.close(), "close a prefailed constructed pool");
+  assert.strictEqual(slot.state.kind, "closed");
+  assert.strictEqual(secondSlot.state.kind, "closed");
+});
+
+test("E-013 non-running active-owner guards reject before validation or send", async () => {
+  const { pool, workers: [worker], slots: [slot] } = makePool();
+  const lease = await (pool as any).acquireLease(slot);
+  const proxy = (pool as any).makeProxy("rules", slot, lease);
+  const nextIdBeforeGuards = slot.nextId;
+  const postsBeforeGuards = worker.messages.length;
+  slot.state = { kind: "terminating" };
+
+  await assert.rejects(
+    () => (pool as any).sendOnLease(slot, lease, "facts", ["rules"]),
+    /EnginePool has been closed/,
+  );
+  await assert.rejects(
+    () => proxy.run({ limit: Number.NaN }),
+    /EnginePool has been closed/,
+  );
+  assert.strictEqual(slot.nextId, nextIdBeforeGuards);
+  assert.strictEqual(worker.messages.length, postsBeforeGuards);
+
+  // Restore the seam so ordinary lease release and close own final cleanup.
+  slot.state = { kind: "running" };
+  await (pool as any).releaseLease(slot, lease);
+  await within(pool.close(), "close after non-running owner guards");
+});
+
+test("E-013 private transition helpers are defensive and idempotent", async () => {
+  const { pool, workers: [worker], slots: [slot] } = makePool();
+
+  // createSlot already attached the exact three handlers.
+  (EnginePool as any).attachSlotListeners(slot);
+  assert.deepStrictEqual(
+    ["message", "error", "exit"].map((event) =>
+      worker.listenerCount(event),
+    ),
+    [1, 1, 1],
+  );
+
+  // A defensive drain attempt cannot bypass work already in flight.
+  slot.inflight = 1;
+  (EnginePool as any).drainQueue(slot);
+  assert.strictEqual(worker.messages.length, 0);
+  slot.inflight = 0;
+
+  let prematurelyNotified = false;
+  slot.pending.set(999, {
+    resolve: () => undefined,
+    reject: () => undefined,
+  });
+  slot.pendingDrainWaiters.push(() => {
+    prematurelyNotified = true;
+  });
+  (EnginePool as any).notifyPendingDrained(slot);
+  assert.strictEqual(prematurelyNotified, false);
+  assert.strictEqual(slot.pendingDrainWaiters.length, 1);
+  slot.pending.delete(999);
+  (EnginePool as any).notifyPendingDrained(slot);
+  assert.strictEqual(prematurelyNotified, true);
+  assert.strictEqual(slot.pendingDrainWaiters.length, 0);
+
+  const terminalError = new Error("idempotent transition failure");
+  worker.emit("error", terminalError);
+  (pool as any).handleSlotTerminal(slot, new Error("late pool failure"));
+  (EnginePool as any).failSlot(slot, new Error("late slot failure"));
+  (EnginePool as any).detachSlotListeners(slot);
+  assert.strictEqual(slot.state.error, terminalError);
+  assertWorkerListenersRemoved(worker);
+
+  await (EnginePool as any).terminateSlot(slot);
+  assert.strictEqual(slot.state.kind, "closed");
+  const terminateCallsAfterClose = worker.terminateCalls;
+  await (EnginePool as any).terminateSlot(slot);
+  assert.strictEqual(worker.terminateCalls, terminateCallsAfterClose);
+  slot.state = { kind: "terminating" };
+  await (EnginePool as any).terminateSlot(slot);
+  assert.strictEqual(worker.terminateCalls, terminateCallsAfterClose);
+  slot.state = { kind: "closed" };
+
+  await within(pool.close(), "close after direct terminal helper coverage");
+});
+
+test("E-013 create rejects a synchronous post-init terminal fault before publication", async () => {
+  const OriginalWorker = workerThreads.Worker;
+  const terminalError = new Error("synchronous post-init terminal fault");
+
+  class InitThenFailWorker extends FakeWorker {
+    static instances: InitThenFailWorker[] = [];
+
+    constructor(_filename: string) {
+      super();
+      InitThenFailWorker.instances.push(this);
+    }
+
+    override postMessage(message: PostedMessage): void {
+      super.postMessage(message);
+      if (message.method === "__init") {
+        this.emit("message", { id: message.id, result: undefined });
+        this.emit("error", terminalError);
+      }
+    }
+  }
+
+  workerThreads.Worker = InitThenFailWorker as unknown as typeof workerThreads.Worker;
+  try {
+    assert.strictEqual(
+      await rejectionOf(
+        EnginePool.create([{ name: "rules" }], { threads: 1 }),
+      ),
+      terminalError,
+    );
+    assert.strictEqual(InitThenFailWorker.instances.length, 1);
+    assert.strictEqual(InitThenFailWorker.instances[0].terminateCalls, 1);
+    assertWorkerListenersRemoved(InitThenFailWorker.instances[0]);
+  } finally {
+    workerThreads.Worker = OriginalWorker;
+  }
+});
+
+test("E-013 create preserves a non-Error Worker constructor failure", async () => {
+  const OriginalWorker = workerThreads.Worker;
+  const constructorFailure = { kind: "non-Error constructor failure" };
+
+  class ThrowingWorker {
+    constructor(_filename: string) {
+      throw constructorFailure;
+    }
+  }
+
+  workerThreads.Worker = ThrowingWorker as unknown as typeof workerThreads.Worker;
+  try {
+    assert.strictEqual(
+      await rejectionOf(
+        EnginePool.create([{ name: "rules" }], { threads: 1 }),
+      ),
+      constructorFailure,
+    );
+  } finally {
+    workerThreads.Worker = OriginalWorker;
+  }
+});
+
+function runNodeScript(
+  script: string,
+): Promise<{ stdout: string; stderr: string }> {
+  const packageRoot = resolve(__dirname, "../../../..");
+  const childEnv = { ...process.env };
+  // This subprocess is a fault-isolation oracle rather than another coverage
+  // shard. Inheriting the parent runner's state can contaminate merged V8 data
+  // and prevent the child from demonstrating a natural standalone exit.
+  childEnv.NODE_V8_COVERAGE = "";
+  delete childEnv.NODE_TEST_CONTEXT;
+  return new Promise((resolveRun, rejectRun) => {
+    execFile(
+      process.execPath,
+      ["-e", script],
+      {
+        cwd: packageRoot,
+        env: childEnv,
+        timeout: 8_000,
+        killSignal: "SIGKILL",
+        windowsHide: true,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          rejectRun(
+            new Error(
+              `Node subprocess failed: ${error.message}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+              { cause: error },
+            ),
+          );
+          return;
+        }
+        resolveRun({ stdout, stderr });
+      },
+    );
+  });
+}
+
+function realWorkerFaultScript(
+  mode: "error" | "exit-9" | "exit-0",
+): string {
+  const terminalAction = mode === "error"
+    ? 'throw new Error("real worker uncaught failure");'
+    : mode === "exit-9"
+      ? "process.exitCode = 9; parentPort.close();"
+      : "parentPort.close();";
+  const workerSource = `
+const { parentPort } = require("node:worker_threads");
+parentPort.on("message", (request) => {
+  if (request.method === "__init") {
+    parentPort.postMessage({ id: request.id, result: undefined });
+    return;
+  }
+  ${terminalAction}
+});
+`;
+
+  return `
+const workerThreads = require("node:worker_threads");
+const OriginalWorker = workerThreads.Worker;
+class FaultWorker {
+  constructor() {
+    return new OriginalWorker(${JSON.stringify(workerSource)}, { eval: true });
+  }
+}
+workerThreads.Worker = FaultWorker;
+const { EnginePool } = require("./dist");
+const messagePortCount = () => process.getActiveResourcesInfo()
+  .filter((resource) => resource === "MessagePort").length;
+
+(async () => {
+  const before = messagePortCount();
+  const pool = await EnginePool.create([{ name: "rules" }], { threads: 1 });
+  const requestOutcome = pool.evaluate("rules", {}).then(
+    () => { throw new Error("fault-injected request unexpectedly resolved"); },
+    (error) => error,
+  );
+  const queuedOutcome = pool.evaluate("rules", {}).then(
+    () => { throw new Error("fault-injected queued request unexpectedly resolved"); },
+    (error) => error,
+  );
+  const [failure, queuedFailure] = await Promise.all([
+    requestOutcome,
+    queuedOutcome,
+  ]);
+  await pool.close();
+  await new Promise((resolveValue) => setImmediate(resolveValue));
+  await new Promise((resolveValue) => setImmediate(resolveValue));
+  const after = messagePortCount();
+  console.log(JSON.stringify({
+    before,
+    after,
+    name: failure.name,
+    message: failure.message,
+    queuedSameFailure: queuedFailure === failure,
+  }));
+})().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});
+`;
+}
+
+test("E-013 real Worker faults let close finish and the process exit naturally", async (t) => {
+  const cases = [
+    {
+      mode: "error" as const,
+      pattern: /real worker uncaught failure/,
+    },
+    {
+      mode: "exit-9" as const,
+      pattern: /Pool worker exited unexpectedly with code 9/,
+    },
+    {
+      mode: "exit-0" as const,
+      pattern: /Pool worker exited before responding to pending request/,
+    },
+  ];
+
+  for (const item of cases) {
+    await t.test(item.mode, async () => {
+      const script = realWorkerFaultScript(item.mode);
+      const { stdout } = await runNodeScript(script);
+      assert.notStrictEqual(
+        stdout.trim(),
+        "",
+        "the subprocess exited before its request and close settled",
+      );
+      const report = JSON.parse(stdout.trim()) as {
+        before: number;
+        after: number;
+        name: string;
+        message: string;
+        queuedSameFailure: boolean;
+      };
+      assert.strictEqual(report.name, "Error");
+      assert.match(report.message, item.pattern);
+      assert.strictEqual(report.queuedSameFailure, true);
+      assert.strictEqual(report.after, report.before);
+    });
+  }
+});


### PR DESCRIPTION
Closes #137

## What changed

- add an explicit `running → failed → terminating → closed` lifecycle for each `EnginePool` worker slot
- make the first unexpected Worker error/exit the stable pool-wide failure for all future `evaluate()` and `do()` admissions
- atomically reject and clear failed-slot pending requests, root FIFO work, queued lease admissions, and lease-private work
- reset failed-slot counters, remove owned abort/Worker listeners, and wake close drain waiters
- preserve already-accepted work on healthy slots, including admitted lease owner calls, without replaying or respawning failed workers
- distinguish ordinary response errors and deliberate close-time exits from terminal worker faults
- document the fail-fast/no-respawn contract as N-11 / E-013
- add deterministic fake-worker and real-worker regressions for error, zero/nonzero exit, duplicate signals, leases, healthy slots, close races, listener/counter cleanup, and natural process exit

## Why

The previous Worker `error`/`exit` handlers cleared only part of a slot's pending state. They could leave `inflight` nonzero, root and lease queues unresolved, abort and Worker listeners attached, later requests queued behind a dead worker, and `close()` waiting for a message that could never arrive.

Respawning is intentionally avoided because each worker owns mutable engine state; replacing it would silently discard that state. Callers recover explicitly by closing the failed pool and creating a new one.

## Validation

- `just preflight-pr`
- `just napi-full`
  - types 14/14
  - sync 49/49
  - worker 87/87
  - pool 127/127
  - package 48/48
- `just node-package-smoke`
- focused E-013 suite: 26/26
- aggregate conformance execution: 311/311
- changed `dist/engine-pool.js`: 100% lines / branches / functions
- `git diff --check`

The aggregate coverage command still exits nonzero on unchanged repository-wide deficits in `scripts/node-package-lib.mjs` and defensive `engine-handle.js` lines; the changed EnginePool implementation is fully covered.