### PR TITLE
[FR-PY-001] Destroy Python engines on foreign-thread finalization

### DIFF
--- a/crates/ferric-rules-python/README.md
+++ b/crates/ferric-rules-python/README.md
@@ -27,8 +27,9 @@ Verified wheel targets are:
 - macOS 11.0+ on Apple silicon; and
 - 64-bit Windows on x86-64.
 
-Python 3.14, PyPy, GraalPy, free-threaded CPython, macOS universal2, Windows on
-Arm, and every unlisted platform or architecture are outside this contract.
+Python 3.14, PyPy, GraalPy, free-threaded CPython, CPython subinterpreters,
+macOS universal2, Windows on Arm, and every unlisted platform or architecture
+are outside this contract.
 The machine-readable source of truth is
 [`wheel-targets.json`](https://github.com/plx/ferric-rules/blob/main/crates/ferric-rules-python/wheel-targets.json).
 
@@ -52,6 +53,38 @@ with ferric.Engine.from_source(source) as engine:
 with ferric.Engine.from_snapshot(snapshot, format=ferric.Format.JSON) as restored:
     assert restored.fact_count == 2
 ```
+
+## Threading and lifecycle contract
+
+An `Engine` is operationally bound to the OS thread that constructed it.
+Every operation on an existing handle except `close()` and context-manager
+exit checks that affinity before inspecting lifecycle state. A call from
+another thread raises `FerricRuntimeError` with a `wrong thread` diagnostic and
+does not touch engine state; this remains the result for a foreign-thread
+operation even after the handle has been closed.
+
+`close()` is the lifecycle exception: it may be called from any supported
+Python thread. It is synchronous and idempotent, and returning `None` means
+that the native engine has already been destroyed. An operation that has
+already entered completes before `close()` can take ownership; once `close()`
+wins, later creator-thread operations raise
+`FerricRuntimeError("engine has been closed")`. Context-manager exit is also
+allowed on any supported Python thread and applies the same close barrier.
+
+If the final Python reference is released without an explicit close, Ferric
+destroys the native engine exactly once on whichever Python thread performs
+deallocation. Cleanup does not wait for a future creator-thread call, a
+thread-local cleanup pass, a worker thread, or a Python callback. This same
+Rust-only path is safe when CPython deallocates an engine during supported
+main-interpreter shutdown. The creator thread may exit while another thread
+still owns the Python handle; operations remain unavailable from other
+threads, but a later `close()` or final-reference drop still reclaims it.
+
+The raw `Engine` does not provide an asynchronous `aclose()` method and this
+lifecycle guarantee does not make its ordinary operations cross-thread-safe.
+GIL release for long operations and a serialized pinned/async facade are
+separate work. CPython subinterpreters, free-threaded CPython, and alternate
+Python interpreters are outside the current support contract.
 
 ## Building from source
 

--- a/crates/ferric-rules-python/src/engine.rs
+++ b/crates/ferric-rules-python/src/engine.rs
@@ -1,13 +1,13 @@
 //! Python Engine wrapper.
 //!
-//! Engine instances live in a thread-local registry on their creator thread.
-//! `PyEngine` is a lightweight handle (engine ID + thread ID) that is naturally
-//! `Send + Sync` — no `unsafe` required.
+//! Engine operations remain pinned to the creator thread. `PyEngine` owns the
+//! engine behind a mutex so explicit close or Python's final-reference cleanup
+//! can destroy it synchronously on another thread without transferring runtime
+//! access.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard};
 use std::thread::{self, ThreadId};
 
 use pyo3::prelude::*;
@@ -34,9 +34,63 @@ static NEXT_ENGINE_ID: AtomicU64 = AtomicU64::new(1);
 #[cfg(feature = "testing")]
 static ENGINE_INSTANCE_COUNT: AtomicU64 = AtomicU64::new(0);
 
-thread_local! {
-    /// Thread-local registry of engines owned by this thread.
-    static ENGINES: RefCell<HashMap<u64, Engine>> = RefCell::new(HashMap::new());
+/// Exclusive ownership of a thread-affine engine which may be sent solely so
+/// the whole engine can be destroyed on the thread that releases Python's
+/// final reference.
+struct OwnedThreadAffineEngine {
+    // Rust drops struct fields in declaration order. Keep the native engine
+    // before the testing guard so the live count changes only after Engine's
+    // destructor has completed.
+    engine: Box<Engine>,
+    #[cfg(feature = "testing")]
+    _instance_count: EngineInstanceCount,
+}
+
+#[cfg(feature = "testing")]
+struct EngineInstanceCount;
+
+#[cfg(feature = "testing")]
+impl EngineInstanceCount {
+    fn new() -> Self {
+        ENGINE_INSTANCE_COUNT.fetch_add(1, Ordering::Relaxed);
+        Self
+    }
+}
+
+#[cfg(feature = "testing")]
+impl Drop for EngineInstanceCount {
+    fn drop(&mut self) {
+        ENGINE_INSTANCE_COUNT.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+impl OwnedThreadAffineEngine {
+    fn new(engine: Engine) -> Self {
+        Self {
+            engine: Box::new(engine),
+            #[cfg(feature = "testing")]
+            _instance_count: EngineInstanceCount::new(),
+        }
+    }
+
+    fn get_mut(&mut self) -> &mut Engine {
+        &mut self.engine
+    }
+}
+
+// SAFETY: `OwnedThreadAffineEngine` is private and is only stored behind
+// `PyEngine`'s mutex. Runtime access is granted only after checking that the
+// current thread is the engine's creator, and the mutex prevents that access
+// from overlapping destruction. Sending the wrapper is therefore used only
+// to drop the whole, exclusively owned engine. This is the same
+// destruction-only exception documented by `ferric_engine_free_unchecked`;
+// it does not make engine operations transferable between threads.
+unsafe impl Send for OwnedThreadAffineEngine {}
+
+fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 /// Build an `EngineConfig` from optional Python args.
@@ -51,32 +105,31 @@ fn make_config(strategy: Option<Strategy>, encoding: Option<Encoding>) -> Engine
     config
 }
 
-/// Register a newly-created engine in the thread-local registry.
-fn register_engine(engine: Engine) -> (u64, ThreadId) {
-    let engine_id = NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed);
-    ENGINES.with(|engines| {
-        engines.borrow_mut().insert(engine_id, engine);
-    });
-    #[cfg(feature = "testing")]
-    ENGINE_INSTANCE_COUNT.fetch_add(1, Ordering::Relaxed);
-    (engine_id, thread::current().id())
-}
-
 /// The Ferric rules engine.
 ///
 /// Thread-affine: must be used only from the thread that created it.
 /// Cross-thread access raises `FerricRuntimeError` (not a panic).
 ///
-/// The actual engine data lives in a thread-local registry on the creator
-/// thread.  This struct is a lightweight handle that is naturally `Send + Sync`.
+/// The actual engine data remains creator-thread-only for runtime access, but
+/// the handle owns it directly so the final Python reference can destroy it on
+/// any supported Python thread.
 #[pyclass(name = "Engine", module = "ferric")]
 pub struct PyEngine {
     engine_id: u64,
     creator_thread: ThreadId,
+    engine: Mutex<Option<OwnedThreadAffineEngine>>,
 }
 
 impl PyEngine {
-    /// Check thread + look up engine in TLS; run closure with `&mut Engine`.
+    fn from_engine(engine: Engine) -> Self {
+        Self {
+            engine_id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
+            creator_thread: thread::current().id(),
+            engine: Mutex::new(Some(OwnedThreadAffineEngine::new(engine))),
+        }
+    }
+
+    /// Check thread, lock the live engine, and run a closure with mutable access.
     fn with_engine<F, R>(&self, f: F) -> PyResult<R>
     where
         F: FnOnce(&mut Engine) -> PyResult<R>,
@@ -88,45 +141,26 @@ impl PyEngine {
                 self.creator_thread, current,
             )));
         }
-        ENGINES.with(|engines| {
-            let mut map = engines.borrow_mut();
-            let engine = map
-                .get_mut(&self.engine_id)
-                .ok_or_else(|| FerricRuntimeError::new_err("engine has been closed"))?;
-            f(engine)
-        })
+        let mut state = lock_unpoisoned(&self.engine);
+        let engine = state
+            .as_mut()
+            .ok_or_else(|| FerricRuntimeError::new_err("engine has been closed"))?;
+        f(engine.get_mut())
     }
 
-    /// Remove engine from registry.  Returns `true` if it was present.
-    fn remove_engine(&self) -> bool {
-        if thread::current().id() != self.creator_thread {
-            return false;
-        }
-        let removed =
-            ENGINES.with(|engines| engines.borrow_mut().remove(&self.engine_id).is_some());
-        #[cfg(feature = "testing")]
-        if removed {
-            ENGINE_INSTANCE_COUNT.fetch_sub(1, Ordering::Relaxed);
-        }
-        removed
+    /// Destroy the engine exactly once while holding the state mutex so every
+    /// concurrent close observes completion only after native destruction.
+    fn destroy_engine(&self) {
+        let mut state = lock_unpoisoned(&self.engine);
+        let engine = state.take();
+        drop(engine);
+        drop(state);
     }
 }
 
 impl Drop for PyEngine {
     fn drop(&mut self) {
-        if thread::current().id() == self.creator_thread {
-            // Try to remove from TLS.  `try_with` handles TLS-already-destroyed
-            // during interpreter shutdown.
-            let _removed = ENGINES
-                .try_with(|engines| engines.borrow_mut().remove(&self.engine_id).is_some())
-                .unwrap_or(false);
-            #[cfg(feature = "testing")]
-            if _removed {
-                ENGINE_INSTANCE_COUNT.fetch_sub(1, Ordering::Relaxed);
-            }
-        }
-        // Foreign thread: no-op.  Engine stays in creator thread's TLS and is
-        // cleaned up when that thread exits (TLS destructors run).
+        self.destroy_engine();
     }
 }
 
@@ -142,11 +176,7 @@ impl PyEngine {
     #[pyo3(signature = (*, strategy=None, encoding=None))]
     fn new(strategy: Option<Strategy>, encoding: Option<Encoding>) -> Self {
         let config = make_config(strategy, encoding);
-        let (engine_id, creator_thread) = register_engine(Engine::new(config));
-        Self {
-            engine_id,
-            creator_thread,
-        }
+        Self::from_engine(Engine::new(config))
     }
 
     /// Create an engine from CLIPS source, loading and resetting in one step.
@@ -159,17 +189,14 @@ impl PyEngine {
     ) -> PyResult<Self> {
         let config = make_config(strategy, encoding);
         let engine = Engine::with_rules_config(source, config).map_err(init_error_to_pyerr)?;
-        let (engine_id, creator_thread) = register_engine(engine);
-        Ok(Self {
-            engine_id,
-            creator_thread,
-        })
+        Ok(Self::from_engine(engine))
     }
 
     // -- Context manager --
 
-    fn __enter__(slf: Py<Self>) -> Py<Self> {
-        slf
+    fn __enter__(slf: Py<Self>, py: Python<'_>) -> PyResult<Py<Self>> {
+        slf.bind(py).borrow().with_engine(|_| Ok(()))?;
+        Ok(slf)
     }
 
     #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
@@ -178,25 +205,17 @@ impl PyEngine {
         _exc_type: Option<&Bound<'_, PyAny>>,
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
-    ) -> PyResult<bool> {
-        self.close()?;
-        Ok(false) // don't suppress exceptions
+    ) -> bool {
+        self.close();
+        false // don't suppress exceptions
     }
 
-    /// Explicitly close and destroy this engine.
+    /// Explicitly close and destroy this engine from any supported Python thread.
     ///
-    /// After calling `close()`, any further method calls will raise
-    /// `FerricRuntimeError`.  This is idempotent.
-    fn close(&self) -> PyResult<()> {
-        let current = thread::current().id();
-        if current != self.creator_thread {
-            return Err(FerricRuntimeError::new_err(format!(
-                "engine called from wrong thread (created on {:?}, called from {:?})",
-                self.creator_thread, current,
-            )));
-        }
-        self.remove_engine();
-        Ok(())
+    /// After calling `close()`, later ordinary engine operations raise
+    /// `FerricRuntimeError`; close and context-manager exit remain idempotent.
+    fn close(&self) {
+        self.destroy_engine();
     }
 
     // -- Loading --
@@ -608,11 +627,7 @@ impl PyEngine {
         let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
         let engine = Engine::deserialize(data, fmt)
             .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
-        let (engine_id, creator_thread) = register_engine(engine);
-        Ok(Self {
-            engine_id,
-            creator_thread,
-        })
+        Ok(Self::from_engine(engine))
     }
 
     /// Save a serialized engine snapshot to a file.
@@ -650,11 +665,7 @@ impl PyEngine {
         let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
         let engine = Engine::deserialize(&data, fmt)
             .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
-        let (engine_id, creator_thread) = register_engine(engine);
-        Ok(Self {
-            engine_id,
-            creator_thread,
-        })
+        Ok(Self::from_engine(engine))
     }
 
     // -- Python protocols --

--- a/crates/ferric-rules-python/tests/fixtures/foreign_drop_teardown.py
+++ b/crates/ferric-rules-python/tests/fixtures/foreign_drop_teardown.py
@@ -1,0 +1,41 @@
+"""Exercise foreign-thread finalization from CPython's atexit phase."""
+
+import atexit
+import gc
+import os
+import threading
+
+import ferric
+
+
+BASELINE = ferric.engine_instance_count()
+engine = ferric.Engine()
+
+
+def verify_reclaimed() -> None:
+    gc.collect()
+    remaining = ferric.engine_instance_count()
+    print(f"baseline={BASELINE} remaining={remaining}", flush=True)
+    if remaining != BASELINE:
+        os._exit(86)
+
+
+def drop_on_foreign_thread() -> None:
+    global engine
+
+    owned_engine = engine
+    engine = None
+
+    def worker(value) -> None:
+        del value
+        gc.collect()
+
+    thread = threading.Thread(target=worker, args=(owned_engine,))
+    del owned_engine
+    thread.start()
+    thread.join()
+
+
+# atexit callbacks run in reverse registration order: drop first, verify next.
+atexit.register(verify_reclaimed)
+atexit.register(drop_on_foreign_thread)

--- a/crates/ferric-rules-python/tests/test_threading.py
+++ b/crates/ferric-rules-python/tests/test_threading.py
@@ -1,7 +1,11 @@
 """Tests for cross-thread access raising FerricRuntimeError."""
 
 import gc
+import queue
+import subprocess
+import sys
 import threading
+from pathlib import Path
 
 import pytest
 import ferric
@@ -124,8 +128,8 @@ class TestClose:
 
     def test_close_idempotent(self):
         engine = ferric.Engine()
-        engine.close()
-        engine.close()  # should not raise
+        assert engine.close() is None
+        assert engine.close() is None
 
     def test_context_manager_closes(self):
         with ferric.Engine() as engine:
@@ -133,10 +137,48 @@ class TestClose:
         with pytest.raises(ferric.FerricRuntimeError, match="closed"):
             engine.fact_count
 
+    @pytest.mark.parametrize("closed", [False, True])
+    def test_context_enter_preserves_wrong_thread_precedence(self, closed):
+        engine = ferric.Engine()
+        if closed:
+            engine.close()
+
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            _run_in_thread(lambda: engine.__enter__())
+
+    def test_context_enter_rejects_closed_on_creator_thread(self):
+        engine = ferric.Engine()
+        engine.close()
+
+        with pytest.raises(ferric.FerricRuntimeError, match="closed"):
+            engine.__enter__()
+
+    def test_context_exit_closes_from_wrong_thread(self):
+        engine = ferric.Engine()
+        results = []
+
+        _run_in_thread(lambda: results.append(engine.__exit__(None, None, None)))
+
+        assert results == [False]
+        with pytest.raises(ferric.FerricRuntimeError, match="closed"):
+            engine.fact_count
+
     def test_close_from_wrong_thread(self):
         engine = ferric.Engine()
+        results = []
+
+        _run_in_thread(lambda: results.append(engine.close()))
+
+        assert results == [None]
+        with pytest.raises(ferric.FerricRuntimeError, match="closed"):
+            engine.fact_count
+
+    def test_wrong_thread_precedes_closed_for_non_close_operations(self):
+        engine = ferric.Engine()
+        engine.close()
+
         with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
-            _run_in_thread(lambda: engine.close())
+            _run_in_thread(lambda: engine.fact_count)
 
 
 _has_testing = hasattr(ferric, "engine_instance_count")
@@ -144,7 +186,7 @@ _has_testing = hasattr(ferric, "engine_instance_count")
 
 @pytest.mark.skipif(not _has_testing, reason="testing feature not enabled")
 class TestInstanceCount:
-    """Tests for engine instance counting instrumentation."""
+    """FR-PY-001 lifecycle tests using test-only instance instrumentation."""
 
     def test_create_and_drop(self):
         gc.collect()  # flush pending deallocations from earlier tests
@@ -162,13 +204,255 @@ class TestInstanceCount:
         engine.close()
         assert ferric.engine_instance_count() == baseline
 
-    def test_thread_exit_cleans_up(self):
-        """Engine created on a worker thread is cleaned up when thread exits."""
+    def test_foreign_thread_close_is_synchronous_and_exactly_once(self):
+        gc.collect()
+        baseline = ferric.engine_instance_count()
+        engines = [ferric.Engine()]
+        fact_id = engines[0].assert_fact("owner", "foreign-close")
+        assert engines[0].get_fact(fact_id).relation == "owner"
+        results = []
+
+        def close_twice():
+            results.append(engines[0].close())
+            assert ferric.engine_instance_count() == baseline
+            results.append(engines[0].close())
+
+        _run_in_thread(close_twice)
+
+        assert results == [None, None]
+        assert ferric.engine_instance_count() == baseline
+        assert engines[0].close() is None
+        engines.clear()
+        gc.collect()
+        assert ferric.engine_instance_count() == baseline
+
+    def test_foreign_context_exit_decrements_synchronously(self):
+        gc.collect()
+        baseline = ferric.engine_instance_count()
+        engines = [ferric.Engine()]
+        results = []
+
+        _run_in_thread(lambda: results.append(engines[0].__exit__(None, None, None)))
+
+        assert results == [False]
+        assert ferric.engine_instance_count() == baseline
+        engines.clear()
+        gc.collect()
+        assert ferric.engine_instance_count() == baseline
+
+    def test_concurrent_foreign_close_callers_destroy_exactly_once(self):
+        gc.collect()
+        baseline = ferric.engine_instance_count()
+        engines = [ferric.Engine()]
+        assert ferric.engine_instance_count() == baseline + 1
+        start = threading.Barrier(3)
+        results = []
+        errors = []
+
+        def close_after_barrier():
+            start.wait()
+            try:
+                results.append(engines[0].close())
+            except Exception as exc:
+                errors.append(exc)
+
+        workers = [threading.Thread(target=close_after_barrier) for _ in range(2)]
+        for worker in workers:
+            worker.start()
+        start.wait()
+        for worker in workers:
+            worker.join()
+
+        assert errors == []
+        assert results == [None, None]
+        assert ferric.engine_instance_count() == baseline
+        assert engines[0].close() is None
+        engines.clear()
+        gc.collect()
+        assert ferric.engine_instance_count() == baseline
+
+    def test_foreign_thread_final_reference_decrements(self):
+        """The final Python reference may be released off the creator thread."""
+        gc.collect()
+        baseline = ferric.engine_instance_count()
+        engine = ferric.Engine()
+        assert ferric.engine_instance_count() == baseline + 1
+
+        def drop_final_reference(owned_engine):
+            del owned_engine
+            gc.collect()
+
+        worker = threading.Thread(target=drop_final_reference, args=(engine,))
+        del engine
+        worker.start()
+        worker.join()
+        gc.collect()
+
+        assert ferric.engine_instance_count() == baseline
+
+    @pytest.mark.parametrize(
+        "constructor",
+        ["new", "from_source", "from_snapshot", "from_snapshot_file"],
+    )
+    def test_all_constructor_paths_support_foreign_final_drop(
+        self, constructor, tmp_path
+    ):
+        """Every constructor owns the same exact foreign-drop lifecycle."""
+        gc.collect()
+        baseline = ferric.engine_instance_count()
+
+        if constructor == "new":
+            engine = ferric.Engine()
+        elif constructor == "from_source":
+            engine = ferric.Engine.from_source("(deffacts startup (origin source))")
+        else:
+            source = ferric.Engine()
+            source.assert_fact("origin", "snapshot")
+            snapshot = source.serialize()
+            source.close()
+            assert ferric.engine_instance_count() == baseline
+            if constructor == "from_snapshot":
+                engine = ferric.Engine.from_snapshot(snapshot)
+            else:
+                snapshot_path = tmp_path / "engine.bin"
+                snapshot_path.write_bytes(snapshot)
+                engine = ferric.Engine.from_snapshot_file(snapshot_path)
+
+        fact_id = engine.assert_fact("constructor", constructor)
+        fact = engine.get_fact(fact_id)
+        assert fact is not None
+        assert fact.relation == "constructor"
+        assert fact.fields[0] == constructor
+        assert fact.engine_id > 0
+        del fact
+        assert ferric.engine_instance_count() == baseline + 1
+
+        def drop_final_reference(value):
+            del value
+            gc.collect()
+
+        worker = threading.Thread(target=drop_final_reference, args=(engine,))
+        del engine
+        worker.start()
+        worker.join()
+        gc.collect()
+
+        assert ferric.engine_instance_count() == baseline
+
+    @pytest.mark.parametrize("cleanup", ["close", "drop"])
+    def test_creator_may_exit_before_retained_handle_cleanup(self, cleanup):
+        """Ownership follows a live handle after its creator thread exits."""
+        gc.collect()
+        baseline = ferric.engine_instance_count()
+        transferred = queue.Queue()
+
+        def create_and_transfer():
+            engine = ferric.Engine()
+            fact_id = engine.assert_fact("creator", cleanup)
+            fact = engine.get_fact(fact_id)
+            assert fact is not None
+            transferred.put((engine, fact.engine_id))
+
+        creator = threading.Thread(target=create_and_transfer)
+        creator.start()
+        creator.join()
+        engine, engine_identity = transferred.get_nowait()
+
+        assert engine_identity > 0
+        assert ferric.engine_instance_count() == baseline + 1
+        with pytest.raises(ferric.FerricRuntimeError, match="wrong thread"):
+            engine.fact_count
+        if cleanup == "close":
+            assert engine.close() is None
+        del engine
+        gc.collect()
+
+        assert ferric.engine_instance_count() == baseline
+
+    def test_repeated_creator_thread_drops_are_bounded(self):
+        gc.collect()
+        baseline = ferric.engine_instance_count()
+        engine_identities = set()
+
+        for iteration in range(128):
+            engine = ferric.Engine()
+            assert ferric.engine_instance_count() == baseline + 1
+            fact_id = engine.assert_fact("iteration", iteration)
+            fact = engine.get_fact(fact_id)
+            assert fact is not None
+            assert fact.fields[0] == iteration
+            engine_identities.add(fact.engine_id)
+            del fact
+            del engine
+            gc.collect()
+            assert ferric.engine_instance_count() == baseline
+
+        assert len(engine_identities) == 128
+
+    def test_repeated_drops_on_one_foreign_thread_are_bounded(self):
+        """A long-lived foreign worker cannot accumulate abandoned engines."""
+        gc.collect()
+        baseline = ferric.engine_instance_count()
+        work = queue.Queue()
+        completed = queue.Queue()
+        stop = object()
+
+        def drop_work():
+            while True:
+                value = work.get()
+                if value is stop:
+                    return
+                del value
+                gc.collect()
+                completed.put(ferric.engine_instance_count())
+
+        worker = threading.Thread(target=drop_work)
+        worker.start()
+        observed_counts = []
+        engine_identities = set()
+        try:
+            for iteration in range(128):
+                engine = ferric.Engine()
+                assert ferric.engine_instance_count() <= baseline + 1
+                fact_id = engine.assert_fact("iteration", iteration)
+                fact = engine.get_fact(fact_id)
+                assert fact is not None
+                assert fact.fields[0] == iteration
+                engine_identities.add(fact.engine_id)
+                del fact
+                work.put(engine)
+                del engine
+                observed_counts.append(completed.get())
+        finally:
+            work.put(stop)
+            worker.join()
+
+        assert observed_counts == [baseline] * 128
+        assert len(engine_identities) == 128
+        assert ferric.engine_instance_count() == baseline
+
+    def test_interpreter_teardown_reclaims_foreign_thread_drop(self):
+        """Foreign-thread finalization remains observable during shutdown."""
+        fixture = Path(__file__).with_name("fixtures") / "foreign_drop_teardown.py"
+        result = subprocess.run(
+            [sys.executable, str(fixture)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert result.stdout == "baseline=0 remaining=0\n"
+        assert result.stderr == ""
+
+    def test_creator_thread_final_reference_decrements(self):
+        """A creator-thread final reference destroys the engine synchronously."""
         baseline = ferric.engine_instance_count()
 
         def create_engine_on_thread():
             _eng = ferric.Engine()
-            # engine lives in this thread's TLS; thread exit destroys TLS
+            assert ferric.engine_instance_count() == baseline + 1
 
         t = threading.Thread(target=create_engine_on_thread)
         t.start()

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -143,7 +143,9 @@ contract covers GIL-enabled CPython 3.9 through 3.13 across seven native wheel
 targets; see [`python-package-release.md`](python-package-release.md). Located
 in `crates/ferric-rules-python/`; tests are in `tests/*.py`.
 
-- `engine.rs` — `PyEngine`.
+- `engine.rs` — `PyEngine`; ordinary access remains creator-thread-affine,
+  while a mutex-guarded destruction-only ownership path makes synchronous
+  `close()` and final-reference cleanup exact from any supported Python thread.
 - `fact.rs` — `Fact`, `FactType`.
 - `value.rs` — `Symbol`, `ClipsString` (preserves symbol/string distinction).
 - `config.rs` — `Strategy`, `Encoding`, `Format` (serde feature).

--- a/docs/python-package-release.md
+++ b/docs/python-package-release.md
@@ -25,9 +25,12 @@ claim to complete that work.
 - ABI: PyO3 `abi3-py39`, producing `cp39-abi3` wheels.
 
 Python 3.14 is not admitted merely because the stable ABI may be loadable on a
-newer interpreter. PyPy, GraalPy, free-threaded CPython, macOS universal2,
-Windows Arm64, and unlisted platforms and architectures are unsupported. Their
-absence is intentional, not missing CI coverage.
+newer interpreter. PyPy, GraalPy, free-threaded CPython, CPython
+subinterpreters, macOS universal2, Windows Arm64, and unlisted platforms and
+architectures are unsupported. Their absence is intentional, not missing CI
+coverage. Supported main-interpreter shutdown includes Rust-only, exactly-once
+cleanup of `Engine` objects regardless of the Python thread that releases the
+final reference; it does not imply extension loading in a subinterpreter.
 
 ## ABI decision
 

--- a/docs/typescript-binding-api.md
+++ b/docs/typescript-binding-api.md
@@ -1358,12 +1358,12 @@ packages/ferric/
 
 | Aspect | Python | Go | TypeScript |
 |--------|--------|----|------------|
-| Thread safety | TLS registry | LockOSThread / Coordinator | Worker threads |
+| Thread safety | Creator-thread-affine operations; any-thread cleanup | LockOSThread / Coordinator | Worker threads |
 | Sync API | All methods sync | All methods sync | `Engine` (sync) |
 | Async API | N/A | `context.Context` on Run | `EngineHandle` (Promise + AbortSignal) |
 | Concurrency | N/A | Coordinator + Manager | `EnginePool` |
 | Cancellation | N/A | `context.Context` | `AbortSignal` |
-| Resource cleanup | `close()` + context manager | `Close()` (io.Closer) | `close()` + `Symbol.dispose` |
+| Resource cleanup | Any-thread `close()` / context exit + final-reference drop | `Close()` (io.Closer) | `close()` + `Symbol.dispose` |
 | Value distinction | `Symbol` class / `ClipsString` class | `Symbol` type alias | `FerricSymbol` class |
 | String default | str → Symbol | string → String | string → String |
 | Integer overflow | Python int is arbitrary | int64 native | `number` / `bigint` adaptive |

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -873,8 +873,13 @@ Ferric's engine core is reachable from other languages via `ferric-rules-ffi`
   `Coordinator`, `Manager`) plus a Temporal activity wrapper.
 - **Python**: `crates/ferric-rules-python` exposes `import ferric` through
   `cp39-abi3` wheels for GIL-enabled CPython 3.9 through 3.13. Python 3.14,
-  free-threaded CPython, and other interpreters are not currently supported;
-  see the [Python package release contract](python-package-release.md).
+  free-threaded CPython, subinterpreters, and other interpreters are not
+  currently supported. Ordinary `Engine` operations remain bound to their
+  creator thread; synchronous, idempotent `close()` and final-reference cleanup
+  may run on any supported Python thread and destroy the native engine exactly
+  once. See the package
+  [threading and lifecycle contract](../crates/ferric-rules-python/README.md#threading-and-lifecycle-contract)
+  and [Python package release contract](python-package-release.md).
 - **CLI**: the `ferric` binary (`crates/ferric-rules-cli`) runs `.clp` files
   batch-style or drops you into a REPL. `ferric check [--json] file.clp`
   validates without running; `ferric run` executes.


### PR DESCRIPTION
Closes #146

## Summary

- move Python native-engine ownership out of creator-thread TLS and into an exactly-once mutex-owned lifecycle cell
- preserve creator-thread affinity for ordinary operations while making `close()`, context exit, and final-reference destruction synchronous and safe from any supported Python thread
- document the lifecycle contract and add deterministic foreign-finalizer, interpreter-teardown, constructor-identity, concurrency, and bounded-stress coverage

## Root cause

The Python handle stored its native engine in a thread-local registry. If CPython released the final Python reference on a different thread, that thread could not reach the creator thread's TLS entry, so native destruction never ran.

The replacement keeps the native engine directly owned by the Python object behind `Mutex<Option<_>>`. Runtime access still checks the creator thread first. Cleanup atomically takes and destroys the engine exactly once, including during foreign-thread deallocation and supported main-interpreter shutdown.

## Validation

- `just preflight-pr`
- focused Python threading/lifecycle suite: 36/36
- full testing-feature Python suite: 313/313
- default-feature Python suite: 297 passed, 16 expected testing-only skips
- strict Cargo checks, all-target/all-feature Clippy, Ruff, docs sync, and diff checks
- archived clean-base regression: foreign final-reference and atexit teardown cases both fail before the fix and pass after it
- independent 2,000-engine foreign-worker stress returns the live native-engine count to baseline