### PR TITLE
[FR-PY-002] Release the GIL during long Python engine operations

### DIFF
--- a/crates/ferric-rules-pinned/src/worker.rs
+++ b/crates/ferric-rules-pinned/src/worker.rs
@@ -118,11 +118,12 @@ fn drain_more_per_item(rx: &Receiver<Request>, engine: &mut Engine, max: usize) 
 
 /// Run the engine with cooperative cancellation.
 ///
-/// Splits a user-requested [`RunLimit`] into chunks of [`CANCEL_CHUNK_SIZE`]
-/// firings, starting with [`Engine::run`] and then continuing the same logical
-/// run between cancellation checks. The sticky `closed` flag ensures shutdown
-/// also interrupts every accepted run while the queue drains. When either
-/// flag flips to `true`, returns with
+/// Establishes fresh-run state with [`Engine::run`] and `RunLimit::Count(0)`, then
+/// splits positive work into [`CANCEL_CHUNK_SIZE`] continuation chunks between
+/// cancellation checks. The zero-fire entry clears prior halt and diagnostic
+/// state before control is observed without firing a rule. The sticky `closed`
+/// flag ensures shutdown also interrupts every accepted run while the queue
+/// drains. When either flag flips to `true`, returns with
 /// [`HaltReason::HaltRequested`] and the rules fired so far.
 ///
 /// Note: the [`HaltReason::HaltRequested`] return code is the merged
@@ -138,8 +139,12 @@ pub(crate) fn run_with_cancel(
     cancel: &AtomicBool,
     closed: &AtomicBool,
 ) -> Result<RunResult, EngineError> {
+    // Every accepted logical run enters the native fresh-run path exactly
+    // once, even when its limit is zero or external control is already set.
+    // Count(0) fires nothing while clearing prior halt and diagnostic state.
+    let entry_result = engine.run(RunLimit::Count(0))?;
     let mut total = 0usize;
-    let mut first_chunk = true;
+    let mut ran_positive_chunk = false;
     let mut remaining = match limit {
         RunLimit::Unlimited => usize::MAX,
         RunLimit::Count(n) => n,
@@ -153,30 +158,24 @@ pub(crate) fn run_with_cancel(
             });
         }
         if remaining == 0 {
-            return Ok(RunResult {
-                rules_fired: total,
-                halt_reason: HaltReason::LimitReached,
-            });
+            return if ran_positive_chunk {
+                Ok(RunResult {
+                    rules_fired: total,
+                    halt_reason: HaltReason::LimitReached,
+                })
+            } else {
+                Ok(entry_result)
+            };
         }
         let step = remaining.min(CANCEL_CHUNK_SIZE);
-        let r = if first_chunk {
-            first_chunk = false;
-            engine.run(RunLimit::Count(step))?
-        } else {
-            engine.continue_run(RunLimit::Count(step))?
-        };
+        ran_positive_chunk = true;
+        let r = engine.continue_run(RunLimit::Count(step))?;
         total = total.saturating_add(r.rules_fired);
         remaining = remaining.saturating_sub(r.rules_fired);
-        // Engine::run reports LimitReached when the limit-th firing requests
-        // a halt because the loop reaches its count bound before re-checking
-        // the flag. Preserve that rule-side halt before another chunk can
-        // clear it on entry.
-        if engine.is_halted() {
-            return Ok(RunResult {
-                rules_fired: total,
-                halt_reason: HaltReason::HaltRequested,
-            });
-        }
+        // Preserve every native terminal from the chunk which already
+        // started. Only an inner LimitReached can need repair: when its
+        // limit-th firing requested a rule-side halt, the engine's flag is the
+        // stronger terminal before another chunk can clear it on entry.
         if matches!(
             r.halt_reason,
             HaltReason::AgendaEmpty | HaltReason::HaltRequested | HaltReason::ActionError
@@ -186,6 +185,51 @@ pub(crate) fn run_with_cancel(
                 halt_reason: r.halt_reason,
             });
         }
+        if r.halt_reason == HaltReason::LimitReached && engine.is_halted() {
+            return Ok(RunResult {
+                rules_fired: total,
+                halt_reason: HaltReason::HaltRequested,
+            });
+        }
         // LimitReached on the inner chunk just means "we firedCHUNK_SIZE, loop".
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preset_cancel_still_enters_fresh_run_without_firing() {
+        let mut engine = Engine::with_rules(
+            r"
+            (deffacts initial (ready))
+            (defrule halt-then-fault
+                (declare (salience 100))
+                =>
+                (halt)
+                (/ 1 0))
+            (defrule must-remain-pending (ready) => (assert (unexpected)))
+            ",
+        )
+        .unwrap();
+
+        let first = engine.run(RunLimit::Unlimited).unwrap();
+        assert_eq!(first.rules_fired, 1);
+        assert_eq!(first.halt_reason, HaltReason::ActionError);
+        assert!(engine.is_halted());
+        assert_eq!(engine.action_diagnostics().len(), 1);
+        let pending_before = engine.agenda_len();
+        assert!(pending_before > 0);
+
+        let cancel = AtomicBool::new(true);
+        let closed = AtomicBool::new(false);
+        let canceled = run_with_cancel(&mut engine, RunLimit::Unlimited, &cancel, &closed).unwrap();
+
+        assert_eq!(canceled.rules_fired, 0);
+        assert_eq!(canceled.halt_reason, HaltReason::HaltRequested);
+        assert!(!engine.is_halted());
+        assert!(engine.action_diagnostics().is_empty());
+        assert_eq!(engine.agenda_len(), pending_before);
     }
 }

--- a/crates/ferric-rules-pinned/tests/diagnostics.rs
+++ b/crates/ferric-rules-pinned/tests/diagnostics.rs
@@ -37,3 +37,31 @@ fn run_stops_at_first_action_diagnostic_without_consuming_later_work() {
     assert_eq!(next.halt_reason, HaltReason::ActionError);
     assert_eq!(next_diagnostic_count, 1);
 }
+
+#[test]
+fn started_chunk_action_error_wins_over_an_earlier_rule_halt() {
+    let engine = PinnedEngine::new(PinnedEngineOptions::default()).unwrap();
+    engine
+        .load_str("(defrule halt-then-fault => (halt) (/ 1 0))")
+        .unwrap();
+    engine.reset().unwrap();
+
+    let result = engine.run(RunLimit::Unlimited).unwrap();
+    let diagnostic_count = engine
+        .with_engine(|engine| Ok(engine.action_diagnostics().len()))
+        .unwrap();
+
+    assert_eq!(result.rules_fired, 1);
+    assert_eq!(result.halt_reason, HaltReason::ActionError);
+    assert_eq!(diagnostic_count, 1);
+
+    let zero = engine.run(RunLimit::Count(0)).unwrap();
+    let (halted_after_zero, diagnostics_after_zero) = engine
+        .with_engine(|engine| Ok((engine.is_halted(), engine.action_diagnostics().len())))
+        .unwrap();
+
+    assert_eq!(zero.rules_fired, 0);
+    assert_eq!(zero.halt_reason, HaltReason::LimitReached);
+    assert!(!halted_after_zero);
+    assert_eq!(diagnostics_after_zero, 0);
+}

--- a/crates/ferric-rules-python/README.md
+++ b/crates/ferric-rules-python/README.md
@@ -54,22 +54,70 @@ with ferric.Engine.from_snapshot(snapshot, format=ferric.Format.JSON) as restore
     assert restored.fact_count == 2
 ```
 
-## Threading and lifecycle contract
+## Threading, GIL, and lifecycle contract
 
 An `Engine` is operationally bound to the OS thread that constructed it.
-Every operation on an existing handle except `close()` and context-manager
-exit checks that affinity before inspecting lifecycle state. A call from
-another thread raises `FerricRuntimeError` with a `wrong thread` diagnostic and
-does not touch engine state; this remains the result for a foreign-thread
-operation even after the handle has been closed.
+Every ordinary operation on an existing handle checks that affinity before
+inspecting lifecycle state. A call from another thread raises
+`FerricRuntimeError` with a `wrong thread` diagnostic and does not touch engine
+state; this remains the result for a foreign-thread ordinary operation while
+the owner is doing detached work and after the handle has been closed.
 
-`close()` is the lifecycle exception: it may be called from any supported
-Python thread. It is synchronous and idempotent, and returning `None` means
-that the native engine has already been destroyed. An operation that has
-already entered completes before `close()` can take ownership; once `close()`
-wins, later creator-thread operations raise
-`FerricRuntimeError("engine has been closed")`. Context-manager exit is also
-allowed on any supported Python thread and applies the same close barrier.
+The following potentially long operations release the GIL around their native
+CPU or filesystem phase:
+
+- ruleset loading: `Engine.from_source()`, `load()`, and `load_file()`;
+- execution: `run()`; and
+- snapshots: `serialize()`, `Engine.from_snapshot()`, `save_snapshot()`, and
+  `Engine.from_snapshot_file()` when snapshot support is built.
+
+This list is exact. Fact APIs (including `assert_string()`), `step()`,
+`reset()`, `clear()`, properties, introspection, protocols, and channel I/O
+continue to execute while holding the GIL.
+
+Ferric copies or extracts Python-owned source, snapshot, path, and format
+inputs before releasing the GIL. An existing-handle call reserves the engine's
+exclusive native-operation lease before detaching, then runs on the same OS
+thread that admitted it. The native result or error becomes Rust-owned before
+the GIL is reacquired and Python objects or exceptions are created. Releasing
+the GIL therefore lets unrelated Python threads and independent engines make
+progress without moving an `Engine` reference to another OS thread or making
+ordinary operations cross-thread-safe.
+
+`halt()` is a narrow control exception to affinity. It is prompt, idempotent,
+and callable from any supported Python thread. It signals only a `run()` that
+is already active; an idle, closing, or closed call is a no-op that returns
+`None`, does not set `is_halted`, and does not affect a future run. It does not
+wait for the active run to return.
+
+An active `run()` checks the control signal before each chunk of at most 64
+rule firings and before reporting finite-limit exhaustion. A chunk already in
+progress finishes first. An engine error or a natural `AGENDA_EMPTY`,
+`ACTION_ERROR`, or rule-side `HALT_REQUESTED` result fixed by that chunk is
+preserved; otherwise a halt or close observed at the next check returns a
+successful partial `RunResult` with `HaltReason.HALT_REQUESTED`. The bound is in
+rule firings, not wall-clock time: one rule action can itself take an
+unbounded amount of time.
+
+`close()` and context-manager exit are the lifecycle exceptions to affinity.
+The first close marks the handle closing, signals an active run, and releases
+the GIL across the entire wait for an admitted native phase and the native
+destruction itself. It is synchronous and idempotent; every concurrent closer
+returns `None` only after the engine has been destroyed exactly once. A
+previously admitted operation keeps its own native result or error. Close does
+not cancel admitted load, serialization, or file work, so it waits for that
+work to finish naturally and has no general wall-clock latency guarantee. Once
+close wins admission, later creator-thread operations raise
+`FerricRuntimeError("engine has been closed")`. Context-manager exit applies
+the same barrier and still returns `False` so it does not suppress exceptions.
+
+Detachment does not change the existing exception taxonomy. Parse and compile
+failures retain their current Ferric subclasses, snapshot codec failures
+remain `FerricError`, and snapshot-file access failures remain
+`OSError`/`PyIOError`; `load_file()` retains its existing `FerricError`
+mapping. `save_snapshot()` serializes before writing;
+`from_snapshot_file()` reads before deserializing. A concurrent close never
+replaces the result or error of work that was already admitted.
 
 If the final Python reference is released without an explicit close, Ferric
 destroys the native engine exactly once on whichever Python thread performs
@@ -77,14 +125,15 @@ deallocation. Cleanup does not wait for a future creator-thread call, a
 thread-local cleanup pass, a worker thread, or a Python callback. This same
 Rust-only path is safe when CPython deallocates an engine during supported
 main-interpreter shutdown. The creator thread may exit while another thread
-still owns the Python handle; operations remain unavailable from other
-threads, but a later `close()` or final-reference drop still reclaims it.
+still owns the Python handle; ordinary operations remain unavailable from
+other threads, but a later `close()` or final-reference drop still reclaims it.
 
-The raw `Engine` does not provide an asynchronous `aclose()` method and this
-lifecycle guarantee does not make its ordinary operations cross-thread-safe.
-GIL release for long operations and a serialized pinned/async facade are
-separate work. CPython subinterpreters, free-threaded CPython, and alternate
-Python interpreters are outside the current support contract.
+The raw `Engine` has no asynchronous `aclose()` method, cross-thread ordinary
+operation queue, or awaitable API. A public pinned facade with FIFO
+cross-thread calls and queued cancellation remains tracked in
+[issue #190](https://github.com/plx/ferric-rules/issues/190). CPython
+subinterpreters, free-threaded CPython, and alternate Python interpreters are
+outside the current support contract.
 
 ## Building from source
 

--- a/crates/ferric-rules-python/src/engine.rs
+++ b/crates/ferric-rules-python/src/engine.rs
@@ -6,8 +6,8 @@
 //! access.
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Mutex, MutexGuard};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread::{self, ThreadId};
 
 use pyo3::prelude::*;
@@ -16,7 +16,9 @@ use pyo3::types::{PyDict, PyList, PyTuple};
 use ferric_rules_core::FactId;
 use ferric_rules_runtime::config::EngineConfig;
 use ferric_rules_runtime::execution::RunLimit;
-use ferric_rules_runtime::Engine;
+use ferric_rules_runtime::{
+    Engine, EngineError, HaltReason as NativeHaltReason, RunResult as NativeRunResult,
+};
 use slotmap::{Key, KeyData};
 
 use crate::config::{Encoding, Strategy};
@@ -29,6 +31,9 @@ use crate::value::{python_to_value, value_to_python};
 
 /// Global counter for assigning unique engine IDs.
 static NEXT_ENGINE_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Maximum native rule firings between external cancellation checks.
+const RUN_CANCEL_CHUNK_SIZE: usize = 64;
 
 /// Live engine instance count (testing instrumentation only).
 #[cfg(feature = "testing")]
@@ -81,11 +86,110 @@ impl OwnedThreadAffineEngine {
 // SAFETY: `OwnedThreadAffineEngine` is private and is only stored behind
 // `PyEngine`'s mutex. Runtime access is granted only after checking that the
 // current thread is the engine's creator, and the mutex prevents that access
-// from overlapping destruction. Sending the wrapper is therefore used only
-// to drop the whole, exclusively owned engine. This is the same
-// destruction-only exception documented by `ferric_engine_free_unchecked`;
-// it does not make engine operations transferable between threads.
+// from overlapping destruction. Actual cross-thread movement is used only to
+// drop the whole, exclusively owned engine, matching the destruction-only
+// exception documented by `ferric_engine_free_unchecked`. Construction also
+// returns this wrapper through `Python::allow_threads`, whose closure executes
+// synchronously on the invoking OS thread; that round trip does not transfer
+// runtime access to another thread.
 unsafe impl Send for OwnedThreadAffineEngine {}
+
+/// Exclusive, creator-thread engine access for one GIL-released native phase.
+///
+/// `PyO3` 0.23 models `Ungil` as `Send` on stable Rust. `Engine` is deliberately
+/// `!Send`, so this narrow lease supplies only that conservative marker bound.
+/// It is never exposed or stored and is consumed directly by
+/// `Python::allow_threads`.
+struct GilReleasedEngineOperation<'a> {
+    engine: &'a mut Engine,
+    invoking_thread: ThreadId,
+}
+
+impl<'a> GilReleasedEngineOperation<'a> {
+    fn new(engine: &'a mut Engine) -> Self {
+        Self {
+            engine,
+            invoking_thread: thread::current().id(),
+        }
+    }
+
+    fn run<F, R>(self, operation: F) -> R
+    where
+        F: FnOnce(&mut Engine) -> R,
+    {
+        debug_assert_eq!(thread::current().id(), self.invoking_thread);
+        operation(self.engine)
+    }
+}
+
+// SAFETY: PyO3 documents that `Python::allow_threads` releases the GIL around
+// a synchronous call on the invoking OS thread; it does not launch a thread.
+// `PyEngine` creates this private lease only after the creator-thread check and
+// while holding the engine mutex, moves it directly into that call, and keeps
+// the mutex reserved until the call returns. No API can move or retain it.
+unsafe impl Send for GilReleasedEngineOperation<'_> {}
+
+/// A per-run cancellation token published only while a run is active.
+#[derive(Default)]
+struct ActiveRunControl {
+    active: Mutex<Option<Arc<AtomicBool>>>,
+}
+
+impl ActiveRunControl {
+    fn publish<'a>(&'a self, closing: &AtomicBool) -> ActiveRunGuard<'a> {
+        let token = Arc::new(AtomicBool::new(false));
+        let mut active = lock_unpoisoned(&self.active);
+        *active = Some(Arc::clone(&token));
+
+        // Close stores `closing` before taking this mutex. Publishing under
+        // the same mutex and then rechecking closes the opposite race: either
+        // close observes this token or the run observes closing.
+        if closing.load(Ordering::Acquire) {
+            token.store(true, Ordering::Release);
+        }
+        drop(active);
+
+        ActiveRunGuard {
+            control: self,
+            token,
+        }
+    }
+
+    fn cancel_active(&self) {
+        if let Some(token) = lock_unpoisoned(&self.active).as_ref() {
+            token.store(true, Ordering::Release);
+        }
+    }
+}
+
+struct ActiveRunGuard<'a> {
+    control: &'a ActiveRunControl,
+    token: Arc<AtomicBool>,
+}
+
+impl ActiveRunGuard<'_> {
+    fn token(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.token)
+    }
+}
+
+impl Drop for ActiveRunGuard<'_> {
+    fn drop(&mut self) {
+        let mut active = lock_unpoisoned(&self.control.active);
+        if active
+            .as_ref()
+            .is_some_and(|token| Arc::ptr_eq(token, &self.token))
+        {
+            active.take();
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+enum SnapshotFileError {
+    Io(std::io::Error),
+    Serialization(ferric_rules_runtime::SerializationError),
+}
 
 fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex
@@ -105,6 +209,84 @@ fn make_config(strategy: Option<Strategy>, encoding: Option<Encoding>) -> Engine
     config
 }
 
+fn run_with_external_cancel(
+    engine: &mut Engine,
+    limit: RunLimit,
+    cancel: &AtomicBool,
+    closing: &AtomicBool,
+) -> Result<NativeRunResult, EngineError> {
+    // Every accepted logical run enters the native fresh-run path exactly
+    // once, even when its limit is zero or external control is already set.
+    // Count(0) fires nothing while clearing prior halt and diagnostic state.
+    let entry_result = engine.run(RunLimit::Count(0))?;
+    let mut total = 0usize;
+    let mut ran_positive_chunk = false;
+    let mut remaining = match limit {
+        RunLimit::Unlimited => usize::MAX,
+        RunLimit::Count(count) => count,
+    };
+
+    loop {
+        // Cancellation precedes every positive firing chunk and a finite-limit
+        // result. A terminal result from an already-started positive chunk is
+        // handled below before control reaches this check again.
+        if cancel.load(Ordering::Acquire) || closing.load(Ordering::Acquire) {
+            return Ok(NativeRunResult {
+                rules_fired: total,
+                halt_reason: NativeHaltReason::HaltRequested,
+            });
+        }
+        if remaining == 0 {
+            return if ran_positive_chunk {
+                Ok(NativeRunResult {
+                    rules_fired: total,
+                    halt_reason: NativeHaltReason::LimitReached,
+                })
+            } else {
+                Ok(entry_result)
+            };
+        }
+
+        let chunk = remaining.min(RUN_CANCEL_CHUNK_SIZE);
+        ran_positive_chunk = true;
+        let result = engine.continue_run(RunLimit::Count(chunk))?;
+        total = total.saturating_add(result.rules_fired);
+        remaining = remaining.saturating_sub(result.rules_fired);
+
+        // Preserve every native terminal from the chunk which already
+        // started. Only an inner LimitReached can need repair: when its
+        // limit-th firing requested a rule-side halt, the engine's flag is the
+        // stronger terminal before another chunk can clear it on entry.
+        if matches!(
+            result.halt_reason,
+            NativeHaltReason::AgendaEmpty
+                | NativeHaltReason::HaltRequested
+                | NativeHaltReason::ActionError
+        ) {
+            return Ok(NativeRunResult {
+                rules_fired: total,
+                halt_reason: result.halt_reason,
+            });
+        }
+        if result.halt_reason == NativeHaltReason::LimitReached && engine.is_halted() {
+            return Ok(NativeRunResult {
+                rules_fired: total,
+                halt_reason: NativeHaltReason::HaltRequested,
+            });
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
+fn snapshot_file_error_to_pyerr(error: SnapshotFileError) -> PyErr {
+    match error {
+        SnapshotFileError::Io(error) => pyo3::exceptions::PyIOError::new_err(error.to_string()),
+        SnapshotFileError::Serialization(error) => {
+            crate::error::FerricError::new_err(error.to_string())
+        }
+    }
+}
+
 /// The Ferric rules engine.
 ///
 /// Thread-affine: must be used only from the thread that created it.
@@ -117,23 +299,27 @@ fn make_config(strategy: Option<Strategy>, encoding: Option<Encoding>) -> Engine
 pub struct PyEngine {
     engine_id: u64,
     creator_thread: ThreadId,
+    closing: AtomicBool,
+    active_run: ActiveRunControl,
     engine: Mutex<Option<OwnedThreadAffineEngine>>,
 }
 
 impl PyEngine {
     fn from_engine(engine: Engine) -> Self {
+        Self::from_owned_engine(OwnedThreadAffineEngine::new(engine))
+    }
+
+    fn from_owned_engine(engine: OwnedThreadAffineEngine) -> Self {
         Self {
             engine_id: NEXT_ENGINE_ID.fetch_add(1, Ordering::Relaxed),
             creator_thread: thread::current().id(),
-            engine: Mutex::new(Some(OwnedThreadAffineEngine::new(engine))),
+            closing: AtomicBool::new(false),
+            active_run: ActiveRunControl::default(),
+            engine: Mutex::new(Some(engine)),
         }
     }
 
-    /// Check thread, lock the live engine, and run a closure with mutable access.
-    fn with_engine<F, R>(&self, f: F) -> PyResult<R>
-    where
-        F: FnOnce(&mut Engine) -> PyResult<R>,
-    {
+    fn ensure_creator_thread(&self) -> PyResult<()> {
         let current = thread::current().id();
         if current != self.creator_thread {
             return Err(FerricRuntimeError::new_err(format!(
@@ -141,11 +327,78 @@ impl PyEngine {
                 self.creator_thread, current,
             )));
         }
+        Ok(())
+    }
+
+    fn closed_error() -> PyErr {
+        FerricRuntimeError::new_err("engine has been closed")
+    }
+
+    /// Check thread, lock the live engine, and run a closure with mutable access.
+    fn with_engine<F, R>(&self, f: F) -> PyResult<R>
+    where
+        F: FnOnce(&mut Engine) -> PyResult<R>,
+    {
+        self.ensure_creator_thread()?;
         let mut state = lock_unpoisoned(&self.engine);
-        let engine = state
-            .as_mut()
-            .ok_or_else(|| FerricRuntimeError::new_err("engine has been closed"))?;
+        if self.closing.load(Ordering::Acquire) {
+            return Err(Self::closed_error());
+        }
+        let engine = state.as_mut().ok_or_else(Self::closed_error)?;
         f(engine.get_mut())
+    }
+
+    /// Reserve the live engine, release the GIL for one native phase, and
+    /// return its owned result after reacquiring the GIL and releasing the
+    /// engine reservation.
+    fn with_engine_allow_threads<F, R>(&self, py: Python<'_>, operation: F) -> PyResult<R>
+    where
+        F: FnOnce(&mut Engine) -> R + Send,
+        R: Send,
+    {
+        self.ensure_creator_thread()?;
+        let mut state = lock_unpoisoned(&self.engine);
+        if self.closing.load(Ordering::Acquire) {
+            return Err(Self::closed_error());
+        }
+        let engine = state.as_mut().ok_or_else(Self::closed_error)?.get_mut();
+        let lease = GilReleasedEngineOperation::new(engine);
+        let result = py.allow_threads(move || lease.run(operation));
+        drop(state);
+        Ok(result)
+    }
+
+    fn run_allow_threads(
+        &self,
+        py: Python<'_>,
+        limit: RunLimit,
+    ) -> PyResult<Result<NativeRunResult, EngineError>> {
+        self.ensure_creator_thread()?;
+        let mut state = lock_unpoisoned(&self.engine);
+        if self.closing.load(Ordering::Acquire) {
+            return Err(Self::closed_error());
+        }
+        let engine = state.as_mut().ok_or_else(Self::closed_error)?.get_mut();
+
+        // Publication occurs after admission and before releasing the GIL.
+        let active_run = self.active_run.publish(&self.closing);
+        let cancel = active_run.token();
+        let closing = &self.closing;
+        let lease = GilReleasedEngineOperation::new(engine);
+        let result = py.allow_threads(move || {
+            lease.run(|engine| run_with_external_cancel(engine, limit, &cancel, closing))
+        });
+
+        // The run is no longer signalable before its exclusive engine lease is
+        // released, so a later halt cannot latch onto a future run.
+        drop(active_run);
+        drop(state);
+        Ok(result)
+    }
+
+    fn begin_close(&self) {
+        self.closing.store(true, Ordering::Release);
+        self.active_run.cancel_active();
     }
 
     /// Destroy the engine exactly once while holding the state mutex so every
@@ -160,6 +413,7 @@ impl PyEngine {
 
 impl Drop for PyEngine {
     fn drop(&mut self) {
+        self.begin_close();
         self.destroy_engine();
     }
 }
@@ -183,13 +437,19 @@ impl PyEngine {
     #[staticmethod]
     #[pyo3(signature = (source, *, strategy=None, encoding=None))]
     fn from_source(
+        py: Python<'_>,
         source: &str,
         strategy: Option<Strategy>,
         encoding: Option<Encoding>,
     ) -> PyResult<Self> {
         let config = make_config(strategy, encoding);
-        let engine = Engine::with_rules_config(source, config).map_err(init_error_to_pyerr)?;
-        Ok(Self::from_engine(engine))
+        let source = source.to_owned();
+        let engine = py.allow_threads(move || {
+            Engine::with_rules_config(&source, config).map(OwnedThreadAffineEngine::new)
+        });
+        engine
+            .map(Self::from_owned_engine)
+            .map_err(init_error_to_pyerr)
     }
 
     // -- Context manager --
@@ -202,38 +462,41 @@ impl PyEngine {
     #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
     fn __exit__(
         &self,
+        py: Python<'_>,
         _exc_type: Option<&Bound<'_, PyAny>>,
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
     ) -> bool {
-        self.close();
+        self.close(py);
         false // don't suppress exceptions
     }
 
     /// Explicitly close and destroy this engine from any supported Python thread.
     ///
+    /// Closing requests cancellation of an active run, releases the GIL while
+    /// waiting for admitted native work, and returns after native destruction.
     /// After calling `close()`, later ordinary engine operations raise
     /// `FerricRuntimeError`; close and context-manager exit remain idempotent.
-    fn close(&self) {
-        self.destroy_engine();
+    fn close(&self, py: Python<'_>) {
+        self.begin_close();
+        py.allow_threads(|| self.destroy_engine());
     }
 
     // -- Loading --
 
     /// Load CLIPS source into the engine.
-    fn load(&self, source: &str) -> PyResult<()> {
-        self.with_engine(|engine| {
-            engine.load_str(source).map_err(load_errors_to_pyerr)?;
-            Ok(())
-        })
+    fn load(&self, py: Python<'_>, source: &str) -> PyResult<()> {
+        let source = source.to_owned();
+        let result =
+            self.with_engine_allow_threads(py, move |engine| engine.load_str(&source).map(|_| ()))?;
+        result.map_err(load_errors_to_pyerr)
     }
 
     /// Load CLIPS source from a file path (str or os.PathLike).
-    fn load_file(&self, path: PathBuf) -> PyResult<()> {
-        self.with_engine(|engine| {
-            engine.load_file(&path).map_err(load_errors_to_pyerr)?;
-            Ok(())
-        })
+    fn load_file(&self, py: Python<'_>, path: PathBuf) -> PyResult<()> {
+        let result =
+            self.with_engine_allow_threads(py, move |engine| engine.load_file(&path).map(|_| ()))?;
+        result.map_err(load_errors_to_pyerr)
     }
 
     // -- Fact operations --
@@ -387,15 +650,13 @@ impl PyEngine {
     ///
     /// * `limit` -- Maximum number of rule firings (default: unlimited).
     #[pyo3(signature = (*, limit=None))]
-    fn run(&self, limit: Option<usize>) -> PyResult<RunResult> {
-        self.with_engine(|engine| {
-            let run_limit = match limit {
-                Some(n) => RunLimit::Count(n),
-                None => RunLimit::Unlimited,
-            };
-            let result = engine.run(run_limit).map_err(engine_error_to_pyerr)?;
-            Ok(result.into())
-        })
+    fn run(&self, py: Python<'_>, limit: Option<usize>) -> PyResult<RunResult> {
+        let run_limit = match limit {
+            Some(count) => RunLimit::Count(count),
+            None => RunLimit::Unlimited,
+        };
+        let result = self.run_allow_threads(py, run_limit)?;
+        result.map(Into::into).map_err(engine_error_to_pyerr)
     }
 
     /// Fire a single rule activation. Returns `FiredRule` or `None`.
@@ -412,12 +673,13 @@ impl PyEngine {
         })
     }
 
-    /// Request the engine to halt.
-    fn halt(&self) -> PyResult<()> {
-        self.with_engine(|engine| {
-            engine.halt();
-            Ok(())
-        })
+    /// Promptly request cancellation of the currently active run from any
+    /// supported Python thread.
+    ///
+    /// This operation is idempotent and does not latch onto a future run when
+    /// the engine is idle or already closed.
+    fn halt(&self) {
+        self.active_run.cancel_active();
     }
 
     /// Reset the engine: clear facts and re-assert deffacts.
@@ -605,13 +867,10 @@ impl PyEngine {
         py: Python<'py>,
         format: Option<crate::config::Format>,
     ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
-        self.with_engine(|engine| {
-            let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
-            let bytes = engine
-                .serialize(fmt)
-                .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
-            Ok(pyo3::types::PyBytes::new(py, &bytes))
-        })
+        let format = format.unwrap_or(crate::config::Format::Bincode).into();
+        let bytes = self.with_engine_allow_threads(py, move |engine| engine.serialize(format))?;
+        let bytes = bytes.map_err(|error| crate::error::FerricError::new_err(error.to_string()))?;
+        Ok(pyo3::types::PyBytes::new(py, &bytes))
     }
 
     /// Create an engine by deserializing a snapshot.
@@ -623,11 +882,19 @@ impl PyEngine {
     #[staticmethod]
     #[cfg(feature = "serde")]
     #[pyo3(signature = (data, *, format=None))]
-    fn from_snapshot(data: &[u8], format: Option<crate::config::Format>) -> PyResult<Self> {
-        let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
-        let engine = Engine::deserialize(data, fmt)
-            .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
-        Ok(Self::from_engine(engine))
+    fn from_snapshot(
+        py: Python<'_>,
+        data: &[u8],
+        format: Option<crate::config::Format>,
+    ) -> PyResult<Self> {
+        let data = data.to_vec();
+        let format = format.unwrap_or(crate::config::Format::Bincode).into();
+        let engine = py.allow_threads(move || {
+            Engine::deserialize(&data, format).map(OwnedThreadAffineEngine::new)
+        });
+        engine
+            .map(Self::from_owned_engine)
+            .map_err(|error| crate::error::FerricError::new_err(error.to_string()))
     }
 
     /// Save a serialized engine snapshot to a file.
@@ -638,16 +905,20 @@ impl PyEngine {
     /// * `format` -- Serialization format (default: `Format.BINCODE`).
     #[cfg(feature = "serde")]
     #[pyo3(signature = (path, *, format=None))]
-    fn save_snapshot(&self, path: PathBuf, format: Option<crate::config::Format>) -> PyResult<()> {
-        self.with_engine(|engine| {
-            let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
+    fn save_snapshot(
+        &self,
+        py: Python<'_>,
+        path: PathBuf,
+        format: Option<crate::config::Format>,
+    ) -> PyResult<()> {
+        let format = format.unwrap_or(crate::config::Format::Bincode).into();
+        let result = self.with_engine_allow_threads(py, move |engine| {
             let bytes = engine
-                .serialize(fmt)
-                .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
-            std::fs::write(&path, &bytes)
-                .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
-            Ok(())
-        })
+                .serialize(format)
+                .map_err(SnapshotFileError::Serialization)?;
+            std::fs::write(path, bytes).map_err(SnapshotFileError::Io)
+        })?;
+        result.map_err(snapshot_file_error_to_pyerr)
     }
 
     /// Create an engine by deserializing a snapshot from a file.
@@ -659,13 +930,21 @@ impl PyEngine {
     #[staticmethod]
     #[cfg(feature = "serde")]
     #[pyo3(signature = (path, *, format=None))]
-    fn from_snapshot_file(path: PathBuf, format: Option<crate::config::Format>) -> PyResult<Self> {
-        let data = std::fs::read(&path)
-            .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
-        let fmt = format.unwrap_or(crate::config::Format::Bincode).into();
-        let engine = Engine::deserialize(&data, fmt)
-            .map_err(|e| crate::error::FerricError::new_err(e.to_string()))?;
-        Ok(Self::from_engine(engine))
+    fn from_snapshot_file(
+        py: Python<'_>,
+        path: PathBuf,
+        format: Option<crate::config::Format>,
+    ) -> PyResult<Self> {
+        let format = format.unwrap_or(crate::config::Format::Bincode).into();
+        let engine = py.allow_threads(move || {
+            let data = std::fs::read(path).map_err(SnapshotFileError::Io)?;
+            let engine =
+                Engine::deserialize(&data, format).map_err(SnapshotFileError::Serialization)?;
+            Ok(OwnedThreadAffineEngine::new(engine))
+        });
+        engine
+            .map(Self::from_owned_engine)
+            .map_err(snapshot_file_error_to_pyerr)
     }
 
     // -- Python protocols --

--- a/crates/ferric-rules-python/tests/fixtures/gil_release_handoff.py
+++ b/crates/ferric-rules-python/tests/fixtures/gil_release_handoff.py
@@ -1,0 +1,250 @@
+"""Subprocess handoffs for GIL release and same-engine lifecycle ordering."""
+
+import os
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+import ferric
+
+
+_BLOCKING_SWITCH_INTERVAL_SECONDS = 1_000.0
+
+
+def _with_worker_handoff(
+    owner_call, worker_call, *, repeat_worker_until_owner_returns=False
+):
+    ready = threading.Event()
+    gate = threading.Lock()
+    gate.acquire()
+    entered = threading.Event()
+    owner_done = threading.Event()
+    worker_results = []
+    worker_errors = []
+
+    def worker():
+        ready.set()
+        gate.acquire()
+        entered.set()
+        try:
+            if repeat_worker_until_owner_returns:
+                results = []
+                while not owner_done.is_set() or len(results) < 2:
+                    results.append(worker_call())
+                    time.sleep(0)
+                worker_results.append(results)
+            else:
+                worker_results.append(worker_call())
+        except BaseException as exc:  # surfaced on the owner thread below
+            worker_errors.append(exc)
+        finally:
+            gate.release()
+
+    # A failing owner operation must not keep this subprocess alive forever if
+    # the worker is blocked on the other end of a FIFO. Successful cases still
+    # require the worker to finish below.
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    assert ready.wait(timeout=5), "handoff worker did not park"
+
+    previous_interval = sys.getswitchinterval()
+    sys.setswitchinterval(_BLOCKING_SWITCH_INTERVAL_SECONDS)
+    try:
+        gate.release()
+        entered_before_call = entered.is_set()
+        owner_result = owner_call()
+        entered_during_call = entered.is_set()
+    finally:
+        owner_done.set()
+        sys.setswitchinterval(previous_interval)
+        thread.join(timeout=5)
+
+    assert not thread.is_alive(), "handoff worker did not finish"
+    assert not entered_before_call, "worker ran before the native call"
+    assert entered_during_call, "native call retained the GIL"
+    assert worker_errors == []
+    return owner_result, worker_results
+
+
+def _looping_engine():
+    return ferric.Engine.from_source(
+        """
+        (deffacts initial (counter 0))
+        (defrule loop
+            ?fact <- (counter ?value)
+            =>
+            (retract ?fact)
+            (assert (counter (+ ?value 1))))
+        """
+    )
+
+
+def _foreign_halt():
+    engine = _looping_engine()
+
+    result, worker_results = _with_worker_handoff(
+        engine.run, engine.halt, repeat_worker_until_owner_returns=True
+    )
+
+    assert len(worker_results) == 1
+    assert len(worker_results[0]) >= 2
+    assert all(value is None for value in worker_results[0])
+    assert result.halt_reason == ferric.HaltReason.HALT_REQUESTED
+    assert not engine.is_halted
+    continued = engine.run(limit=1)
+    assert continued.rules_fired == 1
+    assert continued.halt_reason == ferric.HaltReason.LIMIT_REACHED
+    engine.close()
+
+
+def _foreign_close():
+    baseline = (
+        ferric.engine_instance_count()
+        if hasattr(ferric, "engine_instance_count")
+        else None
+    )
+    engine = _looping_engine()
+    if baseline is not None:
+        assert ferric.engine_instance_count() == baseline + 1
+
+    result, worker_results = _with_worker_handoff(engine.run, engine.close)
+
+    assert worker_results == [None]
+    assert result.halt_reason == ferric.HaltReason.HALT_REQUESTED
+    if baseline is not None:
+        assert ferric.engine_instance_count() == baseline
+    assert engine.close() is None
+
+
+def _close_during_serialize():
+    engine = ferric.Engine()
+    fact_count = 20_000
+    engine.assert_string(
+        " ".join(
+            f"(payload {index} {index % 97} token-{index})"
+            for index in range(fact_count)
+        )
+    )
+
+    snapshot, worker_results = _with_worker_handoff(
+        lambda: engine.serialize(format=ferric.Format.JSON), engine.close
+    )
+
+    assert worker_results == [None]
+    restored = ferric.Engine.from_snapshot(snapshot, format=ferric.Format.JSON)
+    assert restored.fact_count == fact_count
+    restored.close()
+
+
+def _wrong_thread_during_run():
+    engine = ferric.Engine.from_source(
+        "(defrule consume ?fact <- (work ?value) => (retract ?fact))"
+    )
+    fact_count = 20_000
+    engine.assert_string(" ".join(f"(work {index})" for index in range(fact_count)))
+
+    def call_from_wrong_thread():
+        try:
+            engine.fact_count
+        except ferric.FerricRuntimeError as exc:
+            return str(exc)
+        raise AssertionError("ordinary foreign call unexpectedly succeeded")
+
+    result, worker_results = _with_worker_handoff(engine.run, call_from_wrong_thread)
+
+    assert result.rules_fired == fact_count
+    assert result.halt_reason == ferric.HaltReason.AGENDA_EMPTY
+    assert len(worker_results) == 1
+    assert "wrong thread" in worker_results[0]
+
+
+def _load_fifo(directory):
+    path = directory / "source.fifo"
+    os.mkfifo(path)
+    engine = ferric.Engine()
+    fact_count = 2_000
+    source = (
+        "(deffacts fifo "
+        + " ".join(f"(payload {index})" for index in range(fact_count))
+        + ")"
+    )
+
+    def write_source():
+        path.write_text(source, encoding="utf-8")
+
+    _, worker_results = _with_worker_handoff(
+        lambda: engine.load_file(path), write_source
+    )
+
+    assert worker_results == [None]
+    engine.reset()
+    assert engine.fact_count == fact_count
+
+
+def _save_fifo(directory):
+    path = directory / "snapshot.fifo"
+    os.mkfifo(path)
+    engine = ferric.Engine()
+    engine.assert_fact("fifo", "save")
+
+    def read_snapshot():
+        return path.read_bytes()
+
+    _, worker_results = _with_worker_handoff(
+        lambda: engine.save_snapshot(path), read_snapshot
+    )
+
+    assert len(worker_results) == 1
+    restored = ferric.Engine.from_snapshot(worker_results[0])
+    assert restored.fact_count == 1
+
+
+def _from_snapshot_fifo(directory):
+    path = directory / "snapshot.fifo"
+    os.mkfifo(path)
+    source = ferric.Engine()
+    source.assert_fact("fifo", "load")
+    snapshot = source.serialize()
+    source.close()
+
+    def write_snapshot():
+        path.write_bytes(snapshot)
+
+    restored, worker_results = _with_worker_handoff(
+        lambda: ferric.Engine.from_snapshot_file(path), write_snapshot
+    )
+
+    assert worker_results == [None]
+    assert restored.fact_count == 1
+
+
+def main():
+    scenario = sys.argv[1]
+    if scenario == "foreign_halt":
+        _foreign_halt()
+    elif scenario == "foreign_close":
+        _foreign_close()
+    elif scenario == "close_serialize":
+        _close_during_serialize()
+    elif scenario == "wrong_thread_during_run":
+        _wrong_thread_during_run()
+    else:
+        if not hasattr(os, "mkfifo"):
+            raise RuntimeError("FIFO scenarios require os.mkfifo")
+        with tempfile.TemporaryDirectory() as raw_directory:
+            directory = Path(raw_directory)
+            if scenario == "load_fifo":
+                _load_fifo(directory)
+            elif scenario == "save_fifo":
+                _save_fifo(directory)
+            elif scenario == "from_snapshot_fifo":
+                _from_snapshot_fifo(directory)
+            else:
+                raise AssertionError(f"unknown scenario: {scenario}")
+    print(f"ok:{scenario}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/ferric-rules-python/tests/test_execution.py
+++ b/crates/ferric-rules-python/tests/test_execution.py
@@ -93,17 +93,17 @@ class TestHalt:
         result = engine.run()
         assert result.halt_reason == ferric.HaltReason.HALT_REQUESTED
 
-    def test_is_halted_property(self, engine):
+    def test_idle_halt_does_not_latch(self, engine):
         assert not engine.is_halted
-        engine.halt()
-        assert engine.is_halted
+        assert engine.halt() is None
+        assert not engine.is_halted
 
 
 class TestReset:
-    def test_reset_clears_halt(self):
+    def test_reset_after_idle_halt_remains_usable(self):
         engine = ferric.Engine()
-        engine.halt()
-        assert engine.is_halted
+        assert engine.halt() is None
+        assert not engine.is_halted
         engine.reset()
         assert not engine.is_halted
 

--- a/crates/ferric-rules-python/tests/test_gil_release.py
+++ b/crates/ferric-rules-python/tests/test_gil_release.py
@@ -1,0 +1,365 @@
+"""FR-PY-002 conformance tests for releasing the GIL around native work."""
+
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+import ferric
+
+
+_BLOCKING_SWITCH_INTERVAL_SECONDS = 1_000.0
+_HANDOFF_FIXTURE = Path(__file__).with_name("fixtures") / "gil_release_handoff.py"
+
+
+class _RedirectablePath:
+    """PathLike whose target can change while the native call is detached."""
+
+    def __init__(self, path):
+        self.path = path
+        self.fspath_calls = 0
+
+    def __fspath__(self):
+        self.fspath_calls += 1
+        return str(self.path)
+
+
+def _large_deffacts_source(fact_count):
+    return (
+        "(deffacts bulk "
+        + " ".join(f"(payload {index})" for index in range(fact_count))
+        + ")"
+    )
+
+
+def _large_json_snapshot(fact_count):
+    engine = ferric.Engine()
+    engine.assert_string(
+        " ".join(
+            f"(payload {index} {index % 97} token-{index})"
+            for index in range(fact_count)
+        )
+    )
+    return engine.serialize(format=ferric.Format.JSON)
+
+
+def _call_with_parked_python_thread(call, *, worker_call=None):
+    """Call native work and report whether a parked Python thread ran inside it."""
+    ready = threading.Event()
+    gate = threading.Lock()
+    gate.acquire()
+    progressed = threading.Event()
+    worker_errors = []
+
+    def worker():
+        ready.set()
+        gate.acquire()
+        try:
+            if worker_call is not None:
+                worker_call()
+        except BaseException as exc:
+            worker_errors.append(exc)
+        finally:
+            progressed.set()
+            gate.release()
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    assert ready.wait(timeout=5), "progress worker did not park"
+
+    previous_interval = sys.getswitchinterval()
+    sys.setswitchinterval(_BLOCKING_SWITCH_INTERVAL_SECONDS)
+    try:
+        gate.release()
+        progressed_before_call = progressed.is_set()
+        result = call()
+        progressed_during_call = progressed.is_set()
+    finally:
+        sys.setswitchinterval(previous_interval)
+        thread.join(timeout=5)
+
+    assert not thread.is_alive(), "progress worker did not finish"
+    assert not progressed_before_call, "worker ran before the native call"
+    assert worker_errors == []
+    assert progressed_during_call, "native call retained the GIL"
+    return result
+
+
+def test_long_run_releases_gil_and_preserves_result():
+    engine = ferric.Engine.from_source(
+        "(defrule consume ?fact <- (work ?value) => (retract ?fact))"
+    )
+    fact_count = 20_000
+    engine.assert_string(" ".join(f"(work {index})" for index in range(fact_count)))
+
+    result = _call_with_parked_python_thread(engine.run)
+
+    assert result.rules_fired == fact_count
+    assert result.halt_reason == ferric.HaltReason.AGENDA_EMPTY
+    assert engine.fact_count == 0
+
+
+def test_large_serialization_releases_gil_and_roundtrips():
+    engine = ferric.Engine()
+    fact_count = 20_000
+    engine.assert_string(
+        " ".join(
+            f"(payload {index} {index % 97} token-{index})"
+            for index in range(fact_count)
+        )
+    )
+
+    snapshot = _call_with_parked_python_thread(
+        lambda: engine.serialize(format=ferric.Format.JSON)
+    )
+
+    assert isinstance(snapshot, bytes)
+    restored = ferric.Engine.from_snapshot(snapshot, format=ferric.Format.JSON)
+    assert restored.fact_count == fact_count
+
+
+def test_large_from_source_releases_gil_and_preserves_state():
+    fact_count = 50_000
+    source = _large_deffacts_source(fact_count)
+
+    engine = _call_with_parked_python_thread(lambda: ferric.Engine.from_source(source))
+
+    assert engine.fact_count == fact_count
+
+
+def test_large_load_releases_gil_and_preserves_state():
+    fact_count = 50_000
+    source = _large_deffacts_source(fact_count)
+    engine = ferric.Engine()
+
+    _call_with_parked_python_thread(lambda: engine.load(source))
+
+    engine.reset()
+    assert engine.fact_count == fact_count
+
+
+def test_large_load_file_releases_gil_and_preserves_state(tmp_path):
+    fact_count = 50_000
+    source = _large_deffacts_source(fact_count)
+    path = tmp_path / "large.clp"
+    path.write_text(source, encoding="utf-8")
+    path_argument = _RedirectablePath(path)
+    engine = ferric.Engine()
+
+    _call_with_parked_python_thread(
+        lambda: engine.load_file(path_argument),
+        worker_call=lambda: setattr(path_argument, "path", tmp_path / "missing.clp"),
+    )
+
+    assert path_argument.fspath_calls == 1
+    engine.reset()
+    assert engine.fact_count == fact_count
+
+
+def test_large_from_snapshot_releases_gil_and_preserves_state():
+    fact_count = 20_000
+    snapshot = _large_json_snapshot(fact_count)
+
+    restored = _call_with_parked_python_thread(
+        lambda: ferric.Engine.from_snapshot(snapshot, format=ferric.Format.JSON)
+    )
+
+    assert restored.fact_count == fact_count
+
+
+def test_large_save_snapshot_releases_gil_and_preserves_file(tmp_path):
+    fact_count = 20_000
+    engine = ferric.Engine.from_snapshot(
+        _large_json_snapshot(fact_count), format=ferric.Format.JSON
+    )
+    path = tmp_path / "large.json"
+    alternate_path = tmp_path / "wrong.json"
+    path_argument = _RedirectablePath(path)
+
+    _call_with_parked_python_thread(
+        lambda: engine.save_snapshot(path_argument, format=ferric.Format.JSON),
+        worker_call=lambda: setattr(path_argument, "path", alternate_path),
+    )
+
+    assert path_argument.fspath_calls == 1
+    assert not alternate_path.exists()
+    restored = ferric.Engine.from_snapshot_file(path, format=ferric.Format.JSON)
+    assert restored.fact_count == fact_count
+
+
+def test_large_from_snapshot_file_releases_gil_and_preserves_state(tmp_path):
+    fact_count = 20_000
+    path = tmp_path / "large.json"
+    path.write_bytes(_large_json_snapshot(fact_count))
+    path_argument = _RedirectablePath(path)
+
+    restored = _call_with_parked_python_thread(
+        lambda: ferric.Engine.from_snapshot_file(
+            path_argument, format=ferric.Format.JSON
+        ),
+        worker_call=lambda: setattr(path_argument, "path", tmp_path / "missing.json"),
+    )
+
+    assert path_argument.fspath_calls == 1
+    assert restored.fact_count == fact_count
+
+
+def test_detached_operations_preserve_result_and_error_mapping(tmp_path):
+    malformed_source = "(defrule incomplete"
+    malformed_source_path = tmp_path / "malformed.clp"
+    malformed_source_path.write_text(malformed_source, encoding="utf-8")
+    malformed_snapshot_path = tmp_path / "malformed.bin"
+    malformed_snapshot_path.write_bytes(b"not a snapshot")
+    missing_parent = tmp_path / "missing" / "snapshot.bin"
+
+    with pytest.raises(ferric.FerricParseError, match="unclosed parenthesis"):
+        ferric.Engine.from_source(malformed_source)
+    with pytest.raises(ferric.FerricParseError, match="unclosed parenthesis"):
+        ferric.Engine().load(malformed_source)
+    with pytest.raises(ferric.FerricParseError, match="unclosed parenthesis"):
+        ferric.Engine().load_file(malformed_source_path)
+    with pytest.raises(ferric.FerricError, match="deserialization failed"):
+        ferric.Engine.from_snapshot(b"not a snapshot")
+    with pytest.raises(ferric.FerricError, match="deserialization failed"):
+        ferric.Engine.from_snapshot_file(malformed_snapshot_path)
+    with pytest.raises(OSError):
+        ferric.Engine().save_snapshot(missing_parent)
+
+    action_error = ferric.Engine.from_source("(defrule fail => (/ 1 0))").run()
+    assert action_error.rules_fired == 1
+    assert action_error.halt_reason == ferric.HaltReason.ACTION_ERROR
+
+
+def test_same_rule_action_error_wins_over_native_halt_state():
+    engine = ferric.Engine.from_source("(defrule halt-then-fault => (halt) (/ 1 0))")
+
+    result = engine.run()
+
+    assert engine.is_halted
+    assert result.rules_fired == 1
+    assert result.halt_reason == ferric.HaltReason.ACTION_ERROR
+    assert len(engine.diagnostics) == 1
+    assert "division by zero" in engine.diagnostics[0]
+
+
+def test_zero_limit_run_clears_prior_halt_and_action_diagnostics():
+    engine = ferric.Engine.from_source("(defrule halt-then-fault => (halt) (/ 1 0))")
+    first = engine.run()
+    assert first.halt_reason == ferric.HaltReason.ACTION_ERROR
+    assert engine.is_halted
+    assert len(engine.diagnostics) == 1
+
+    result = engine.run(limit=0)
+
+    assert result.rules_fired == 0
+    assert result.halt_reason == ferric.HaltReason.LIMIT_REACHED
+    assert not engine.is_halted
+    assert engine.diagnostics == []
+
+
+def test_rule_halt_on_detached_chunk_boundary_repairs_limit_result():
+    engine = ferric.Engine.from_source("""
+        (defrule count-to-boundary
+            ?fact <- (counter ?value&:(< ?value 65))
+            =>
+            (retract ?fact)
+            (assert (counter (+ ?value 1)))
+            (if (= ?value 63) then (halt)))
+        (deffacts initial (counter 0))
+    """)
+
+    result = engine.run(limit=64)
+
+    assert result.rules_fired == 64
+    assert result.halt_reason == ferric.HaltReason.HALT_REQUESTED
+
+
+def test_idle_and_closed_halt_are_idempotent_and_do_not_latch():
+    engine = ferric.Engine.from_source(
+        "(deffacts initial (ready)) (defrule fire (ready) => (assert (done)))"
+    )
+
+    assert engine.halt() is None
+    assert engine.halt() is None
+    assert not engine.is_halted
+    result = engine.run()
+    assert result.rules_fired == 1
+    assert result.halt_reason == ferric.HaltReason.AGENDA_EMPTY
+    assert not engine.is_halted
+
+    engine.close()
+    assert engine.halt() is None
+
+
+def test_foreign_idle_and_closed_halt_are_noops():
+    engine = ferric.Engine()
+    results = []
+    errors = []
+
+    def halt_from_foreign_thread():
+        try:
+            results.append(engine.halt())
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=halt_from_foreign_thread)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert results == [None]
+    assert not engine.is_halted
+
+    engine.close()
+    thread = threading.Thread(target=halt_from_foreign_thread)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert results == [None, None]
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "foreign_halt",
+        "foreign_close",
+        "close_serialize",
+        "wrong_thread_during_run",
+    ],
+)
+def test_active_native_phase_lifecycle_handoff_is_bounded(scenario):
+    result = subprocess.run(
+        [sys.executable, str(_HANDOFF_FIXTURE), scenario],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout == f"ok:{scenario}\n"
+    assert result.stderr == ""
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFOs")
+@pytest.mark.parametrize(
+    "scenario",
+    ["load_fifo", "save_fifo", "from_snapshot_fifo"],
+)
+def test_file_operation_releases_gil_for_fifo_handoff(scenario):
+    result = subprocess.run(
+        [sys.executable, str(_HANDOFF_FIXTURE), scenario],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout == f"ok:{scenario}\n"
+    assert result.stderr == ""

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -143,9 +143,11 @@ contract covers GIL-enabled CPython 3.9 through 3.13 across seven native wheel
 targets; see [`python-package-release.md`](python-package-release.md). Located
 in `crates/ferric-rules-python/`; tests are in `tests/*.py`.
 
-- `engine.rs` — `PyEngine`; ordinary access remains creator-thread-affine,
-  while a mutex-guarded destruction-only ownership path makes synchronous
-  `close()` and final-reference cleanup exact from any supported Python thread.
+- `engine.rs` — `PyEngine`; ordinary access remains creator-thread-affine. An
+  exclusive same-thread operation lease releases the GIL for the documented
+  load, run, snapshot, and file cohort, while active-run control makes
+  `halt()` and synchronous `close()` safe from any supported Python thread.
+  Final-reference cleanup remains exact without transferring runtime access.
 - `fact.rs` — `Fact`, `FactType`.
 - `value.rs` — `Symbol`, `ClipsString` (preserves symbol/string distinction).
 - `config.rs` — `Strategy`, `Encoding`, `Format` (serde feature).

--- a/docs/python-package-release.md
+++ b/docs/python-package-release.md
@@ -32,6 +32,15 @@ coverage. Supported main-interpreter shutdown includes Rust-only, exactly-once
 cleanup of `Engine` objects regardless of the Python thread that releases the
 final reference; it does not imply extension loading in a subinterpreter.
 
+On those supported GIL-enabled interpreters, the runtime releases the GIL only
+for the explicitly documented `Engine` load, run, snapshot, and file-operation
+cohort and while `close()` (including context-manager exit) waits for and
+destroys native state. The native engine remains on its creator OS thread, and
+ordinary calls remain creator-thread-affine. This behavior neither admits a
+free-threaded build nor expands the interpreter, ABI, or platform matrix above;
+the complete ordering and lifecycle semantics live in the package
+[threading, GIL, and lifecycle contract](../crates/ferric-rules-python/README.md#threading-gil-and-lifecycle-contract).
+
 ## ABI decision
 
 The project uses `abi3-py39` instead of per-minor CPython wheels. The baseline

--- a/docs/typescript-binding-api.md
+++ b/docs/typescript-binding-api.md
@@ -1358,11 +1358,11 @@ packages/ferric/
 
 | Aspect | Python | Go | TypeScript |
 |--------|--------|----|------------|
-| Thread safety | Creator-thread-affine operations; any-thread cleanup | LockOSThread / Coordinator | Worker threads |
+| Thread safety | Creator-thread-affine ordinary operations; selected native work releases the GIL | LockOSThread / Coordinator | Worker threads |
 | Sync API | All methods sync | All methods sync | `Engine` (sync) |
 | Async API | N/A | `context.Context` on Run | `EngineHandle` (Promise + AbortSignal) |
-| Concurrency | N/A | Coordinator + Manager | `EnginePool` |
-| Cancellation | N/A | `context.Context` | `AbortSignal` |
+| Concurrency | No cross-thread queue | Coordinator + Manager | `EnginePool` |
+| Cancellation | Active-run halt / close | `context.Context` | `AbortSignal` |
 | Resource cleanup | Any-thread `close()` / context exit + final-reference drop | `Close()` (io.Closer) | `close()` + `Symbol.dispose` |
 | Value distinction | `Symbol` class / `ClipsString` class | `Symbol` type alias | `FerricSymbol` class |
 | String default | str → Symbol | string → String | string → String |

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -875,10 +875,12 @@ Ferric's engine core is reachable from other languages via `ferric-rules-ffi`
   `cp39-abi3` wheels for GIL-enabled CPython 3.9 through 3.13. Python 3.14,
   free-threaded CPython, subinterpreters, and other interpreters are not
   currently supported. Ordinary `Engine` operations remain bound to their
-  creator thread; synchronous, idempotent `close()` and final-reference cleanup
-  may run on any supported Python thread and destroy the native engine exactly
-  once. See the package
-  [threading and lifecycle contract](../crates/ferric-rules-python/README.md#threading-and-lifecycle-contract)
+  creator thread, while the exact load/run/snapshot/file cohort releases the
+  GIL without moving native engine access. Active-run-only `halt()` and
+  synchronous, idempotent `close()` may run on any supported Python thread;
+  close and final-reference cleanup destroy the native engine exactly once.
+  See the package
+  [threading, GIL, and lifecycle contract](../crates/ferric-rules-python/README.md#threading-gil-and-lifecycle-contract)
   and [Python package release contract](python-package-release.md).
 - **CLI**: the `ferric` binary (`crates/ferric-rules-cli`) runs `.clp` files
   batch-style or drops you into a REPL. `ferric check [--json] file.clp`


### PR DESCRIPTION
Closes #147

## Summary

- release the GIL around the documented ruleset load, run, serialization, snapshot, and file-operation cohort
- preserve raw `Engine` creator-thread affinity with an exclusive same-thread native operation lease and owned inputs/results across GIL handoff
- make active-run `halt()` and synchronous `close()` safe from any supported Python thread, using bounded firing chunks while preserving native terminal results and admitted errors
- document the threading, lifecycle, ordering, and exception contracts and add direct, subprocess, and FIFO regression coverage
- align the existing pinned worker’s fresh-run and terminal-precedence behavior with the Python run path

## Scope boundaries

- ordinary cross-thread calls, FIFO dispatch, and an async/pinned Python facade remain tracked by #190
- serialization and load exception taxonomy remains unchanged; #188 and #189 remain separate follow-up work

## Validation

- `just preflight-pr`
- default Python binding suite: 318 passed, 16 skipped
- testing-feature Python binding suite: 334 passed
- `cargo test -p ferric-rules-pinned`: 38 passed