### PR TITLE
[FR-RELEASE-001] Gate the tracing feature configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,19 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
       - run: ./scripts/preflight.sh test
 
+  tracing:
+    name: Tracing Feature
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@just
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          components: clippy
+      - run: just check-tracing
+
   rust-package-artifact:
     name: Rust Package Artifact
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -606,6 +606,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/ferric-rules-python/tests/test_python_package_artifacts.py
+++ b/crates/ferric-rules-python/tests/test_python_package_artifacts.py
@@ -635,6 +635,23 @@ def test_sbom_rejects_an_unexpected_native_component(tmp_path, contract, version
         package_lib.validate_wheel(wheel, contract, version)
 
 
+def test_sdist_accepts_a_top_level_runtime_rust_integration_test(
+    tmp_path, contract, version
+):
+    sdist = _write_sdist(
+        tmp_path,
+        contract,
+        version,
+        extra_files={
+            "crates/ferric-rules-runtime/tests/smoke.rs": b"#[test]\nfn smoke() {}\n"
+        },
+    )
+
+    inspection = package_lib.validate_sdist(sdist, contract, version)
+
+    assert inspection.filename == package_lib.expected_sdist_filename(contract, version)
+
+
 @pytest.mark.parametrize(
     ("options", "message"),
     [
@@ -645,6 +662,18 @@ def test_sbom_rejects_an_unexpected_native_component(tmp_path, contract, version
         ),
         (
             {"extra_files": {"crates/unlisted/src/lib.rs": b"secret"}},
+            "unexpected publish payload",
+        ),
+        (
+            {
+                "extra_files": {
+                    "crates/ferric-rules-runtime/tests/nested/smoke.rs": b"secret"
+                }
+            },
+            "unexpected publish payload",
+        ),
+        (
+            {"extra_files": {"crates/ferric-rules-runtime/tests/smoke.txt": b"secret"}},
             "unexpected publish payload",
         ),
         ({"omit": ("LICENSE-MIT",)}, "missing members"),

--- a/crates/ferric-rules-runtime/Cargo.toml
+++ b/crates/ferric-rules-runtime/Cargo.toml
@@ -31,6 +31,8 @@ tracing = { workspace = true, optional = true }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 criterion = { workspace = true }
+tracing = { workspace = true, features = ["std"] }
+tracing-subscriber = { workspace = true }
 serde_json = { workspace = true }
 ciborium = { workspace = true }
 rmp-serde = { workspace = true }

--- a/crates/ferric-rules-runtime/tests/tracing_smoke.rs
+++ b/crates/ferric-rules-runtime/tests/tracing_smoke.rs
@@ -1,0 +1,168 @@
+#![cfg(feature = "tracing")]
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+
+use ferric_rules_runtime::{Engine, EngineConfig, HaltReason, RunLimit};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::{Layer, Registry};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RecordKind {
+    Span,
+    Event,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct TraceRecord {
+    kind: RecordKind,
+    name: String,
+    fields: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Default)]
+struct RecordingLayer {
+    records: Arc<Mutex<Vec<TraceRecord>>>,
+}
+
+impl RecordingLayer {
+    fn snapshot(&self) -> Vec<TraceRecord> {
+        let records = self.records.lock().expect("trace recorder lock poisoned");
+        records
+            .iter()
+            .map(|record| TraceRecord {
+                kind: record.kind,
+                name: record.name.clone(),
+                fields: record.fields.clone(),
+            })
+            .collect()
+    }
+
+    fn push(&self, record: TraceRecord) {
+        self.records
+            .lock()
+            .expect("trace recorder lock poisoned")
+            .push(record);
+    }
+}
+
+impl<S> Layer<S> for RecordingLayer
+where
+    S: Subscriber,
+{
+    fn on_new_span(
+        &self,
+        attributes: &tracing::span::Attributes<'_>,
+        _id: &tracing::span::Id,
+        _context: Context<'_, S>,
+    ) {
+        let mut visitor = FieldVisitor::default();
+        attributes.record(&mut visitor);
+        self.push(TraceRecord {
+            kind: RecordKind::Span,
+            name: attributes.metadata().name().to_owned(),
+            fields: visitor.fields,
+        });
+    }
+
+    fn on_event(&self, event: &Event<'_>, _context: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+        self.push(TraceRecord {
+            kind: RecordKind::Event,
+            name: event.metadata().name().to_owned(),
+            fields: visitor.fields,
+        });
+    }
+}
+
+#[derive(Default)]
+struct FieldVisitor {
+    fields: BTreeMap<String, String>,
+}
+
+impl Visit for FieldVisitor {
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_string());
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.fields
+            .insert(field.name().to_owned(), value.to_owned());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        self.fields
+            .insert(field.name().to_owned(), format!("{value:?}"));
+    }
+}
+
+#[test]
+fn trace_enabled_engine_run_reaches_a_subscriber_with_completion_fields() {
+    let recorder = RecordingLayer::default();
+    let subscriber = Registry::default().with(recorder.clone());
+
+    let result = tracing::subscriber::with_default(subscriber, || {
+        let mut engine = Engine::new(EngineConfig::utf8());
+        engine
+            .load_str(
+                r"
+                (deffacts startup (ready))
+                (defrule fire-once
+                    (ready)
+                    =>
+                    (assert (done)))
+                ",
+            )
+            .expect("tracing smoke rules should load");
+        engine.reset().expect("tracing smoke engine should reset");
+        engine
+            .run(RunLimit::Unlimited)
+            .expect("tracing smoke engine should run")
+    });
+
+    assert_eq!(result.rules_fired, 1);
+    assert_eq!(result.halt_reason, HaltReason::AgendaEmpty);
+
+    let records = recorder.snapshot();
+    for expected_span in ["engine_load_str", "engine_reset", "engine_run"] {
+        assert!(
+            records
+                .iter()
+                .any(|record| { record.kind == RecordKind::Span && record.name == expected_span }),
+            "trace subscriber did not observe {expected_span}; records: {records:#?}"
+        );
+    }
+
+    let completion = records
+        .iter()
+        .find(|record| {
+            record.kind == RecordKind::Event
+                && record.fields.get("message").map(String::as_str) == Some("engine_run_complete")
+        })
+        .unwrap_or_else(|| {
+            panic!("trace subscriber did not observe engine_run_complete: {records:#?}")
+        });
+    assert_eq!(
+        completion.fields.get("rules_fired").map(String::as_str),
+        Some("1")
+    );
+    assert_eq!(
+        completion.fields.get("halt_reason").map(String::as_str),
+        Some("agenda_empty")
+    );
+}

--- a/crates/ferric-rules/Cargo.toml
+++ b/crates/ferric-rules/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 readme.workspace = true
+exclude = ["tests/tracing_ci_contract.rs"]
 
 [features]
 serde = ["ferric-rules-runtime/serde"]

--- a/crates/ferric-rules/tests/tracing_ci_contract.rs
+++ b/crates/ferric-rules/tests/tracing_ci_contract.rs
@@ -1,0 +1,111 @@
+use std::path::Path;
+
+fn workflow_job<'a>(workflow: &'a str, id: &str) -> &'a str {
+    let marker = format!("\n  {id}:\n");
+    assert_eq!(
+        workflow.matches(&marker).count(),
+        1,
+        "CI workflow must define exactly one dedicated `{id}` job"
+    );
+    let start = workflow
+        .find(&marker)
+        .unwrap_or_else(|| panic!("CI workflow must define a dedicated `{id}` job"));
+    let tail = &workflow[start + marker.len()..];
+    let end = tail
+        .match_indices('\n')
+        .find_map(|(newline, _)| {
+            let next_line = &tail[newline + 1..];
+            let remainder = next_line.strip_prefix("  ")?;
+            (!remainder.starts_with(char::is_whitespace)).then_some(newline)
+        })
+        .unwrap_or(tail.len());
+    &tail[..end]
+}
+
+fn just_recipe<'a>(justfile: &'a str, name: &str) -> &'a str {
+    let marker = format!("\n{name}:\n");
+    let start = justfile
+        .find(&marker)
+        .unwrap_or_else(|| panic!("justfile must define the `{name}` recipe"));
+    let tail = &justfile[start + marker.len()..];
+    let mut end = 0;
+    for line in tail.split_inclusive('\n') {
+        if !line.trim().is_empty() && !line.starts_with(char::is_whitespace) {
+            break;
+        }
+        end += line.len();
+    }
+    tail[..end].trim_end()
+}
+
+#[test]
+fn required_tracing_job_runs_the_repository_gate_unconditionally() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let workflow = std::fs::read_to_string(workspace_root.join(".github/workflows/ci.yml"))
+        .expect("CI workflow should be readable");
+    let job = workflow_job(&workflow, "tracing");
+
+    for required in [
+        "    name: Tracing Feature\n",
+        "    runs-on: ubuntu-latest\n",
+        "    timeout-minutes: 30\n",
+        "      - uses: actions/checkout@v4\n",
+        "      - uses: taiki-e/install-action@just\n",
+        "      - uses: dtolnay/rust-toolchain@stable\n",
+        "          toolchain: ${{ env.RUST_TOOLCHAIN }}\n",
+        "          components: clippy\n",
+        "      - run: just check-tracing\n",
+    ] {
+        assert!(
+            job.contains(required),
+            "tracing CI job is missing `{}`",
+            required.trim()
+        );
+    }
+
+    for forbidden in [
+        "\n    needs:",
+        "\n    strategy:",
+        "\n      matrix:",
+        "continue-on-error:",
+    ] {
+        assert!(
+            !job.contains(forbidden),
+            "tracing CI job must be unconditional; found `{}`",
+            forbidden.trim()
+        );
+    }
+    assert!(
+        job.lines().all(|line| {
+            let line = line.trim_start();
+            !line.starts_with("if:") && !line.starts_with("- if:")
+        }),
+        "tracing CI job must not condition either the job or one of its steps"
+    );
+    for path_filter in ["\n    paths:", "\n    paths-ignore:"] {
+        assert!(
+            !workflow.contains(path_filter),
+            "CI workflow path filters must not skip the required tracing job"
+        );
+    }
+}
+
+#[test]
+fn tracing_gate_covers_the_locked_full_workspace_configuration() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let justfile = std::fs::read_to_string(workspace_root.join("justfile"))
+        .expect("justfile should be readable");
+    let expected_recipe = r"    cargo check --workspace --features tracing --locked
+    cargo clippy --workspace --all-targets --features tracing --locked -- -D warnings
+    cargo test --workspace --features tracing --locked";
+    let recipe = just_recipe(&justfile, "check-tracing");
+
+    assert_eq!(
+        recipe, expected_recipe,
+        "check-tracing must contain exactly the locked full-workspace check, clippy, and test commands"
+    );
+    assert!(
+        !recipe.contains("--exclude"),
+        "check-tracing must not exclude any workspace package"
+    );
+}

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -293,7 +293,8 @@ thresholds). Scaling regression: `just scaling-check` runs facade-crate
   `py-lint(-fix)`, `go-lint` (auto-installs golangci-lint).
 - Composite: `check`, `preflight`, `preflight-pr` (fmt + clippy + tests +
   cargo check + Python + Go lint). **Required before any PR push.**
-- Tracing: `check-tracing` (feature gate build+clippy+test).
+- Tracing: `check-tracing` (locked full-workspace feature gate
+  check+clippy+test), validated by the `Tracing Feature` CI job.
 - Bench: `bench`, `bench-engine`, `bench-waltz`, `bench-serde`,
   `bench-manners`, `bench-join`, `bench-churn`, `bench-negation`,
   `bench-thresholds`, `bench-compare`, `scaling-check`.
@@ -322,8 +323,10 @@ thresholds). Scaling regression: `just scaling-check` runs facade-crate
 - `serde` (per crate, propagated `parser → core → runtime → ffi → facade`) —
   enables engine serialization; required for Go bindings' serialization and
   CLI snapshot commands. `slotmap`/`smallvec` serde features always on.
-- `tracing` — optional tracing spans (runtime + core); validated by
-  `just check-tracing`.
+- `tracing` — optional tracing spans and events. The facade, pinned, FFI,
+  Python, and CLI feature declarations propagate tracing into the runtime and
+  core as appropriate. The locked full-workspace `just check-tracing` command
+  and `Tracing Feature` CI job validate this configuration.
 - `testing` (ferric-rules-python only) — exposes `engine_instance_count` for
   teardown-leak tests.
 

--- a/justfile
+++ b/justfile
@@ -223,9 +223,9 @@ check-examples-sync:
 
 # Check that tracing feature compiles and passes clippy + tests
 check-tracing:
-    cargo check --workspace --exclude ferric-rules-python --features tracing
-    cargo clippy --workspace --exclude ferric-rules-python --features tracing --all-targets -- -D warnings
-    cargo test --workspace --exclude ferric-rules-python --features tracing
+    cargo check --workspace --features tracing --locked
+    cargo clippy --workspace --all-targets --features tracing --locked -- -D warnings
+    cargo test --workspace --features tracing --locked
 
 # ── Benchmarks ───────────────────────────────────────────────────────────────
 

--- a/scripts/python_package_lib.py
+++ b/scripts/python_package_lib.py
@@ -1367,8 +1367,11 @@ def _allowed_sdist_relative_path(relative: PurePosixPath) -> bool:
         return tail.suffix == ".rs"
     if crate == "ferric-rules-core" and tail.parts[0] == "proptest-regressions":
         return tail.suffix == ".txt"
-    if crate == "ferric-rules-runtime" and tail.parts[:2] == ("tests", "fixtures"):
-        return tail.suffix == ".clp"
+    if crate == "ferric-rules-runtime" and tail.parts[0] == "tests":
+        if len(tail.parts) == 2:
+            return tail.suffix == ".rs"
+        if tail.parts[:2] == ("tests", "fixtures"):
+            return tail.suffix == ".clp"
     return False
 
 


### PR DESCRIPTION
Closes #148

## What changed

- make `just check-tracing` the locked, full-workspace check/clippy/test gate, including the Python crate
- add an unconditional `Tracing Feature` job to the existing push/PR CI workflow
- add a scoped-subscriber runtime smoke that proves real load/reset/run spans and completion fields
- add repository contract tests for the CI job and exact Just recipe
- document tracing feature propagation and the durable gate
- admit top-level runtime Rust integration tests into the deterministic Python sdist contract, with explicit positive and adversarial validation

## Root cause

The original tracing audit at `dd366eb` failed on `used_underscore_binding` and `needless_return`. Later work structurally removed both diagnostics, so current main was incidentally green without any new lint suppression. The remaining release gap was durable coverage: the local recipe excluded Python, was not locked, and CI never ran it.

## Validation

- `just preflight-pr`
- `just check-tracing`
- `cargo metadata --format-version 1 --locked --features tracing --no-deps`
- focused tracing smoke: 1/1
- CI/Just contract tests: 2/2
- Python sdist contract subset: 10/10
- full Python packaging artifact module: 61/61
- `actionlint .github/workflows/ci.yml`
- Ruff format/check and `git diff --check`

The historical `dd366eb` tracing failure and an exact-base 0/2 CI-contract RED were reproduced before the fix.

## Scope notes

This adds an always-run CI context but does not mutate repository rulesets. The live ruleset still literally requires only `PR Compatibility Gate`; making `Tracing Feature` a protected required context needs separately authorized repository administration. Broader all-feature/toolchain/matrix hardening remains #150.