### PR TITLE
[FR-RELEASE-003] Add native Rust artifact CI coverage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,6 @@ crates/ferric-rules-python/LICENSE-APACHE text eol=lf
 crates/ferric-rules-python/wheel-targets.json text eol=lf
 docs/python-package-release.md text eol=lf
 scripts/musl_static_libgcc_linker.py text eol=lf
+
+# Keep native Rust target provenance byte-identical on Windows.
+crates/ferric-rules-cli/release-targets.json text eol=lf

--- a/.github/workflows/rust-native-artifacts.yml
+++ b/.github/workflows/rust-native-artifacts.yml
@@ -1,0 +1,187 @@
+name: Rust Native Artifacts
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CANDIDATE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+  RUST_TOOLCHAIN: "1.93.0"
+
+jobs:
+  native-rust:
+    name: Native Rust (${{ matrix.target }})
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x86_64-gnu
+            runner: ubuntu-24.04
+            rust_target: x86_64-unknown-linux-gnu
+            family: linux
+            libc: glibc
+          - target: linux-aarch64-gnu
+            runner: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-gnu
+            family: linux
+            libc: glibc
+          - target: linux-x86_64-musl
+            runner: ubuntu-24.04
+            rust_target: x86_64-unknown-linux-musl
+            family: linux
+            libc: musl
+            container_image: python:3.12-alpine@sha256:6d43704baacd1bfbe7c295d7f13079d5d8104ed33568873133f8fc69980419df
+          - target: linux-aarch64-musl
+            runner: ubuntu-24.04-arm
+            rust_target: aarch64-unknown-linux-musl
+            family: linux
+            libc: musl
+            container_image: python:3.12-alpine@sha256:6d43704baacd1bfbe7c295d7f13079d5d8104ed33568873133f8fc69980419df
+          - target: macos-x86_64
+            runner: macos-15-intel
+            rust_target: x86_64-apple-darwin
+            family: macos
+            libc: none
+          - target: macos-aarch64
+            runner: macos-15
+            rust_target: aarch64-apple-darwin
+            family: macos
+            libc: none
+          - target: windows-x86_64-msvc
+            runner: windows-2025
+            rust_target: x86_64-pc-windows-msvc
+            family: windows
+            libc: msvc
+    runs-on: ${{ matrix.runner }}
+    env:
+      RUST_TARGET: ${{ matrix.rust_target }}
+      TARGET_ID: ${{ matrix.target }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Bind evidence to the candidate tree
+        shell: bash
+        run: echo "CANDIDATE_TREE=$(git rev-parse 'HEAD^{tree}')" >> "$GITHUB_ENV"
+      - uses: dtolnay/rust-toolchain@stable
+        if: matrix.libc != 'musl'
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          targets: ${{ matrix.rust_target }}
+      - uses: actions/setup-python@v5
+        if: matrix.libc != 'musl'
+        with:
+          python-version: "3.12"
+      - name: Build, package, install, and smoke on the native host
+        if: matrix.libc != 'musl'
+        shell: bash
+        env:
+          EVIDENCE_DIR: ${{ runner.temp }}/rust-native-evidence/${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          python scripts/test-rust-native-artifact.py \
+            --declaration crates/ferric-rules-cli/release-targets.json \
+            --target-id "$TARGET_ID" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --candidate-tree "$CANDIDATE_TREE" \
+            --output-dir "$EVIDENCE_DIR"
+          test -f "$EVIDENCE_DIR/receipt.json"
+      - name: Build, package, install, and smoke in native musl
+        if: matrix.libc == 'musl'
+        shell: bash
+        env:
+          EVIDENCE_DIR: ${{ runner.temp }}/rust-native-evidence/${{ matrix.target }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            --env CANDIDATE_SHA \
+            --env CANDIDATE_TREE \
+            --env CARGO_TERM_COLOR \
+            --env EVIDENCE_DIR \
+            --env RUSTFLAGS \
+            --env RUST_TARGET \
+            --env RUST_TOOLCHAIN \
+            --env TARGET_ID \
+            --volume "$GITHUB_WORKSPACE:/workspace:ro" \
+            --volume "${{ runner.temp }}:${{ runner.temp }}" \
+            --workdir /workspace \
+            "${{ matrix.container_image }}" \
+            sh -euxc '
+              apk add --no-cache binutils build-base curl file git
+              curl --proto "=https" --tlsv1.2 -sSf \
+                https://sh.rustup.rs --output /tmp/rustup-init.sh
+              sh /tmp/rustup-init.sh -y --profile minimal \
+                --default-host "$RUST_TARGET" \
+                --default-toolchain "$RUST_TOOLCHAIN"
+              export PATH="/root/.cargo/bin:$PATH"
+              git config --global --add safe.directory /workspace
+              python3 scripts/test-rust-native-artifact.py \
+                --declaration crates/ferric-rules-cli/release-targets.json \
+                --target-id "$TARGET_ID" \
+                --candidate-sha "$CANDIDATE_SHA" \
+                --candidate-tree "$CANDIDATE_TREE" \
+                --output-dir "$EVIDENCE_DIR"
+              test -f "$EVIDENCE_DIR/receipt.json"
+            '
+      - name: Upload exact native evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-native-${{ matrix.target }}-${{ env.CANDIDATE_SHA }}
+          path: ${{ runner.temp }}/rust-native-evidence/${{ matrix.target }}/
+          if-no-files-found: error
+          retention-days: 30
+
+  native-rust-required:
+    name: Rust Native Artifacts
+    if: always()
+    needs: native-rust
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Require every native matrix row
+        if: needs.native-rust.result != 'success'
+        env:
+          NATIVE_RUST_PASSED: ${{ needs.native-rust.result == 'success' }}
+        run: |
+          echo "native-rust success: $NATIVE_RUST_PASSED"
+          exit 1
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Bind aggregate verification to the candidate tree
+        run: echo "CANDIDATE_TREE=$(git rev-parse 'HEAD^{tree}')" >> "$GITHUB_ENV"
+      - name: Download all native target evidence
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rust-native-*-${{ env.CANDIDATE_SHA }}
+          path: ${{ runner.temp }}/rust-native-downloads
+      - name: Verify the exact candidate artifact set
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/verify-rust-native-artifacts.py \
+            --declaration crates/ferric-rules-cli/release-targets.json \
+            --artifacts-dir "${{ runner.temp }}/rust-native-downloads" \
+            --candidate-sha "$CANDIDATE_SHA" \
+            --candidate-tree "$CANDIDATE_TREE" \
+            --output-dir "${{ runner.temp }}/rust-native-verified"
+      - name: Upload one verified native bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-native-verified-${{ env.CANDIDATE_SHA }}
+          path: ${{ runner.temp }}/rust-native-verified/
+          if-no-files-found: error
+          retention-days: 30

--- a/crates/ferric-rules-cli/release-targets.json
+++ b/crates/ferric-rules-cli/release-targets.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": 1,
+  "artifact_contract": {
+    "packages": [
+      "ferric-rules",
+      "ferric-rules-cli"
+    ],
+    "binary": "ferric",
+    "install_all_features": true,
+    "execution": "native",
+    "distribution": "ci-evidence-only"
+  },
+  "targets": [
+    {
+      "id": "linux-x86_64-gnu",
+      "runner": "ubuntu-24.04",
+      "rust_target": "x86_64-unknown-linux-gnu",
+      "family": "linux",
+      "architecture": "x86_64",
+      "libc": "glibc",
+      "native_environment": "ubuntu-24.04",
+      "conformance": "native"
+    },
+    {
+      "id": "linux-aarch64-gnu",
+      "runner": "ubuntu-24.04-arm",
+      "rust_target": "aarch64-unknown-linux-gnu",
+      "family": "linux",
+      "architecture": "aarch64",
+      "libc": "glibc",
+      "native_environment": "ubuntu-24.04-arm",
+      "conformance": "native"
+    },
+    {
+      "id": "linux-x86_64-musl",
+      "runner": "ubuntu-24.04",
+      "rust_target": "x86_64-unknown-linux-musl",
+      "family": "linux",
+      "architecture": "x86_64",
+      "libc": "musl",
+      "native_environment": "python:3.12-alpine@sha256:6d43704baacd1bfbe7c295d7f13079d5d8104ed33568873133f8fc69980419df",
+      "conformance": "native"
+    },
+    {
+      "id": "linux-aarch64-musl",
+      "runner": "ubuntu-24.04-arm",
+      "rust_target": "aarch64-unknown-linux-musl",
+      "family": "linux",
+      "architecture": "aarch64",
+      "libc": "musl",
+      "native_environment": "python:3.12-alpine@sha256:6d43704baacd1bfbe7c295d7f13079d5d8104ed33568873133f8fc69980419df",
+      "conformance": "native"
+    },
+    {
+      "id": "macos-x86_64",
+      "runner": "macos-15-intel",
+      "rust_target": "x86_64-apple-darwin",
+      "family": "macos",
+      "architecture": "x86_64",
+      "libc": "none",
+      "native_environment": "macos-15-intel",
+      "conformance": "native"
+    },
+    {
+      "id": "macos-aarch64",
+      "runner": "macos-15",
+      "rust_target": "aarch64-apple-darwin",
+      "family": "macos",
+      "architecture": "aarch64",
+      "libc": "none",
+      "native_environment": "macos-15",
+      "conformance": "native"
+    },
+    {
+      "id": "windows-x86_64-msvc",
+      "runner": "windows-2025",
+      "rust_target": "x86_64-pc-windows-msvc",
+      "family": "windows",
+      "architecture": "x86_64",
+      "libc": "msvc",
+      "native_environment": "windows-2025",
+      "conformance": "native"
+    }
+  ]
+}

--- a/crates/ferric-rules/tests/tracing_ci_contract.rs
+++ b/crates/ferric-rules/tests/tracing_ci_contract.rs
@@ -1,5 +1,9 @@
 use std::path::Path;
 
+fn normalize_line_endings(contents: &str) -> String {
+    contents.replace("\r\n", "\n").replace('\r', "\n")
+}
+
 fn workflow_job<'a>(workflow: &'a str, id: &str) -> &'a str {
     let marker = format!("\n  {id}:\n");
     assert_eq!(
@@ -41,8 +45,10 @@ fn just_recipe<'a>(justfile: &'a str, name: &str) -> &'a str {
 #[test]
 fn required_tracing_job_runs_the_repository_gate_unconditionally() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
-    let workflow = std::fs::read_to_string(workspace_root.join(".github/workflows/ci.yml"))
-        .expect("CI workflow should be readable");
+    let workflow = normalize_line_endings(
+        &std::fs::read_to_string(workspace_root.join(".github/workflows/ci.yml"))
+            .expect("CI workflow should be readable"),
+    );
     let job = workflow_job(&workflow, "tracing");
 
     for required in [
@@ -93,8 +99,10 @@ fn required_tracing_job_runs_the_repository_gate_unconditionally() {
 #[test]
 fn tracing_gate_covers_the_locked_full_workspace_configuration() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
-    let justfile = std::fs::read_to_string(workspace_root.join("justfile"))
-        .expect("justfile should be readable");
+    let justfile = normalize_line_endings(
+        &std::fs::read_to_string(workspace_root.join("justfile"))
+            .expect("justfile should be readable"),
+    );
     let expected_recipe = r"    cargo check --workspace --features tracing --locked
     cargo clippy --workspace --all-targets --features tracing --locked -- -D warnings
     cargo test --workspace --features tracing --locked";
@@ -107,5 +115,24 @@ fn tracing_gate_covers_the_locked_full_workspace_configuration() {
     assert!(
         !recipe.contains("--exclude"),
         "check-tracing must not exclude any workspace package"
+    );
+}
+
+#[test]
+fn contract_parsers_accept_windows_line_endings() {
+    let workflow = normalize_line_endings(
+        "name: CI\r\n\r\njobs:\r\n  tracing:\r\n    name: Tracing Feature\r\n  next:\r\n    name: Next\r\n",
+    );
+    assert_eq!(
+        workflow_job(&workflow, "tracing"),
+        "    name: Tracing Feature"
+    );
+
+    let justfile = normalize_line_endings(
+        "set shell := [\"bash\", \"-uc\"]\r\n\r\ncheck-tracing:\r\n    cargo check --workspace --features tracing --locked\r\n\r\nnext:\r\n    true\r\n",
+    );
+    assert_eq!(
+        just_recipe(&justfile, "check-tracing"),
+        "    cargo check --workspace --features tracing --locked"
     );
 }

--- a/docs/rust-package-release.md
+++ b/docs/rust-package-release.md
@@ -26,6 +26,76 @@ unpublished internal dependencies back to the local sources so first-release
 package and dry-run checks work before crates.io contains them; Cargo
 configuration is not included in the package archives.
 
+## Native facade and CLI target contract
+
+The distributed Rust artifacts covered by the native matrix are the
+`ferric-rules` facade source package and the `ferric-rules-cli` source package.
+The machine-readable source of truth is
+[`release-targets.json`](../crates/ferric-rules-cli/release-targets.json). It
+limits the package set to `ferric-rules` and `ferric-rules-cli`, names `ferric`
+as the evidence binary, requires an all-feature install, and labels that binary
+`ci-evidence-only`. Each target records its family, native environment, C
+library, and `native` conformance. The declaration contains exactly these
+rows:
+
+| Target ID | Rust target | Native evidence environment | Declared libc |
+| --- | --- | --- | --- |
+| `linux-x86_64-gnu` | `x86_64-unknown-linux-gnu` | Ubuntu 24.04 x86-64 | `glibc` |
+| `linux-aarch64-gnu` | `aarch64-unknown-linux-gnu` | Ubuntu 24.04 AArch64 | `glibc` |
+| `linux-x86_64-musl` | `x86_64-unknown-linux-musl` | matching-architecture, digest-pinned Alpine container on Ubuntu 24.04 x86-64 | `musl` 1.2.x |
+| `linux-aarch64-musl` | `aarch64-unknown-linux-musl` | matching-architecture, digest-pinned Alpine container on Ubuntu 24.04 AArch64 | `musl` 1.2.x |
+| `macos-x86_64` | `x86_64-apple-darwin` | macOS 15 Intel | `none` |
+| `macos-aarch64` | `aarch64-apple-darwin` | macOS 15 Apple silicon | `none` |
+| `windows-x86_64-msvc` | `x86_64-pc-windows-msvc` | Windows 2025 x86-64 | `msvc` |
+
+Each row is build-and-execute evidence on the declared OS and architecture.
+The musl rows execute inside a matching-architecture musl userspace without
+CPU emulation. Cross-compilation alone is non-conformance and cannot satisfy a
+row. Unlisted targets are not part of the supported Rust/CLI release matrix and
+must not be advertised as such.
+
+The Ubuntu 24.04 glibc environment is the continuously tested source-build
+environment, not a claim that an uploaded binary has a particular historical
+glibc compatibility floor. Likewise, this matrix does not declare a macOS
+deployment minimum. The project currently distributes Cargo source packages,
+not downloadable per-target CLI binaries; binaries retained by CI are test
+evidence only.
+
+For pushes to `main`, pull requests targeting `main`, and manual dispatches,
+the path-unfiltered `Rust Native Artifacts` workflow checks out the immutable
+pull-request head (or push commit) directly. On every row it:
+
+1. uses Rust 1.93.0 and verifies that the compiler host and observed runtime
+   match the declaration;
+2. runs release-profile, all-feature facade and CLI tests and builds the CLI;
+3. packages the facade and CLI source crates;
+4. installs the all-feature CLI from its source path into a temporary prefix
+   outside the worktree; and
+5. executes the installed binary from outside the worktree, covering version
+   metadata, Unicode paths and output, CRLF input, snapshot creation/loading,
+   REPL EOF, documented process exit codes, and native dynamic dependencies.
+
+Every row retains the two `.crate` files, the installed CLI binary, dynamic
+dependency output, and a receipt containing the candidate commit/tree,
+toolchain and runtime identities, commands, and artifact SHA-256 digests. A
+fail-closed aggregate job requires all seven rows, compares each receipt with
+the target declaration and direct candidate, rechecks every retained hash, and
+retains one candidate-SHA-named verified evidence bundle. That aggregate
+exposes the stable `Rust Native Artifacts` check context; changes to the formal
+required-status ruleset remain outside this lane.
+
+This native portability lane is intentionally narrower than the clean-room
+install contract in [FR-RELEASE-008 (#153)](https://github.com/plx/ferric-rules/issues/153).
+Here, `cargo install --path` reads the candidate source tree while placing and
+executing the binary outside it. Issue #153 owns installation from extracted
+`.crate` files, empty-cache and offline registry-like reconstruction, package
+omission and version-skew cases, uninstall behavior, and the complete
+clean-consumer CLI suite. Binding-specific C, Go, Node, and Python matrices
+remain with [FR-DIST-008 (#124)](https://github.com/plx/ferric-rules/issues/124),
+and workspace-wide all-feature, hardening, audit, scaling, Miri, sanitizer, and
+fuzz status policy remains with
+[FR-RELEASE-004 (#150)](https://github.com/plx/ferric-rules/issues/150).
+
 ## Local artifact verification
 
 Run:

--- a/justfile
+++ b/justfile
@@ -383,6 +383,14 @@ doc-open:
 verify-rust-packages:
     ./scripts/verify-rust-packages.sh
 
+# Build, install, and smoke one declared native Rust target outside the worktree
+rust-native-artifact-smoke target candidate_sha candidate_tree output:
+    python3 scripts/test-rust-native-artifact.py --declaration crates/ferric-rules-cli/release-targets.json --target-id "{{target}}" --candidate-sha "{{candidate_sha}}" --candidate-tree "{{candidate_tree}}" --output-dir "{{output}}"
+
+# Verify and retain the exact seven-target native Rust evidence bundle
+rust-native-artifacts-verify artifacts candidate_sha candidate_tree output:
+    python3 scripts/verify-rust-native-artifacts.py --declaration crates/ferric-rules-cli/release-targets.json --artifacts-dir "{{artifacts}}" --candidate-sha "{{candidate_sha}}" --candidate-tree "{{candidate_tree}}" --output-dir "{{output}}"
+
 # ── Licensing ────────────────────────────────────────────────────────────────
 
 # Regenerate Rust third-party license notices from the locked Cargo graph

--- a/scripts/test-rust-native-artifact.py
+++ b/scripts/test-rust-native-artifact.py
@@ -1,0 +1,931 @@
+#!/usr/bin/env python3
+"""Build, install, and smoke one declared native Rust/CLI target."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CARGO_TEST_COMMAND = (
+    "cargo",
+    "test",
+    "--release",
+    "-p",
+    "ferric-rules",
+    "-p",
+    "ferric-rules-cli",
+    "--all-features",
+    "--locked",
+)
+CARGO_BUILD_COMMAND = (
+    "cargo",
+    "build",
+    "--release",
+    "-p",
+    "ferric-rules-cli",
+    "--all-features",
+    "--locked",
+)
+CARGO_PACKAGE_COMMANDS = (
+    ("cargo", "package", "-p", "ferric-rules", "--all-features", "--locked"),
+    (
+        "cargo",
+        "package",
+        "-p",
+        "ferric-rules-cli",
+        "--all-features",
+        "--locked",
+    ),
+)
+
+MANDATORY_COMMAND_NAMES = (
+    "rustc-verbose",
+    "cargo-verbose",
+    "release-test",
+    "release-build",
+    "package-facade",
+    "package-cli",
+    "install-cli",
+    "cli-version-command",
+    "cli-version-flag",
+    "cli-help",
+    "cli-check-crlf-unicode",
+    "cli-run-crlf-unicode",
+    "cli-snapshot",
+    "cli-snapshot-repl-eof",
+    "cli-invalid-source",
+    "cli-usage-error",
+    "dynamic-dependencies",
+)
+
+SMOKE_NAMES = (
+    "outside-worktree-install",
+    "version",
+    "unicode-path",
+    "crlf-source",
+    "snapshot-restore",
+    "repl-eof",
+    "exit-codes",
+    "dynamic-dependencies",
+)
+
+ARTIFACT_CONTRACT_KEYS = {
+    "packages",
+    "binary",
+    "install_all_features",
+    "execution",
+    "distribution",
+}
+TARGET_KEYS = {
+    "id",
+    "runner",
+    "rust_target",
+    "family",
+    "architecture",
+    "libc",
+    "native_environment",
+    "conformance",
+}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read JSON from {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def _require_exact_keys(value: Mapping[str, Any], expected: set[str], context: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise ValueError(
+            f"{context} keys differ: missing={sorted(expected - actual)}, "
+            f"extra={sorted(actual - expected)}"
+        )
+
+
+def _validate_declaration(value: dict[str, Any]) -> None:
+    _require_exact_keys(value, {"schema_version", "artifact_contract", "targets"}, "declaration")
+    if value["schema_version"] != 1:
+        raise ValueError("release declaration schema_version must be 1")
+    contract = value["artifact_contract"]
+    if not isinstance(contract, dict):
+        raise ValueError("artifact_contract must be an object")
+    _require_exact_keys(contract, ARTIFACT_CONTRACT_KEYS, "artifact_contract")
+    expected_contract = {
+        "packages": ["ferric-rules", "ferric-rules-cli"],
+        "binary": "ferric",
+        "install_all_features": True,
+        "execution": "native",
+        "distribution": "ci-evidence-only",
+    }
+    if contract != expected_contract:
+        raise ValueError("artifact_contract differs from the native Rust CI contract")
+    targets = value["targets"]
+    if not isinstance(targets, list) or len(targets) != 7:
+        raise ValueError("release declaration must contain exactly 7 targets")
+    identifiers: set[str] = set()
+    for index, target in enumerate(targets):
+        if not isinstance(target, dict):
+            raise ValueError(f"targets[{index}] must be an object")
+        _require_exact_keys(target, TARGET_KEYS, f"targets[{index}]")
+        target_id = target["id"]
+        if not isinstance(target_id, str) or not target_id:
+            raise ValueError(f"targets[{index}].id must be non-empty")
+        if target_id in identifiers:
+            raise ValueError(f"duplicate target id {target_id}")
+        identifiers.add(target_id)
+        if target["conformance"] != "native":
+            raise ValueError(f"{target_id} is not native conformance")
+        if target["family"] not in {"linux", "macos", "windows"}:
+            raise ValueError(f"unsupported family for {target_id}")
+        if target["libc"] not in {"glibc", "musl", "none", "msvc"}:
+            raise ValueError(f"unsupported libc for {target_id}")
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.resolve().relative_to(root.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _normalize_argument(argument: str, roots: Mapping[str, Path]) -> str:
+    normalized = argument.replace("\\", "/")
+    candidates = sorted(
+        ((token, str(path.resolve()).replace("\\", "/")) for token, path in roots.items()),
+        key=lambda item: len(item[1]),
+        reverse=True,
+    )
+    for token, prefix in candidates:
+        if normalized == prefix:
+            return token
+        if normalized.startswith(prefix + "/"):
+            return token + normalized[len(prefix) :]
+    return normalized
+
+
+def _command_record(
+    *,
+    name: str,
+    argv: Sequence[str],
+    expected_exit: int,
+    actual_exit: int,
+    roots: Mapping[str, Path],
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "argv": [_normalize_argument(str(argument), roots) for argument in argv],
+        "expected_exit": expected_exit,
+        "actual_exit": actual_exit,
+    }
+
+
+def _run(
+    argv: Sequence[str],
+    *,
+    cwd: Path = REPO_ROOT,
+    env: Mapping[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(argument) for argument in argv],
+        cwd=cwd,
+        env=None if env is None else dict(env),
+        input=input_text,
+        text=True,
+        encoding="utf-8",
+        errors="strict",
+        capture_output=True,
+        check=False,
+    )
+
+
+def _run_expected(
+    *,
+    name: str,
+    argv: Sequence[str],
+    expected_exit: int,
+    commands: list[dict[str, Any]],
+    roots: Mapping[str, Path],
+    cwd: Path = REPO_ROOT,
+    env: Mapping[str, str] | None = None,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    result = _run(argv, cwd=cwd, env=env, input_text=input_text)
+    commands.append(
+        _command_record(
+            name=name,
+            argv=argv,
+            expected_exit=expected_exit,
+            actual_exit=result.returncode,
+            roots=roots,
+        )
+    )
+    if result.returncode != expected_exit:
+        raise RuntimeError(
+            f"{name} exited {result.returncode}, expected {expected_exit}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def _parse_verbose_version(output: str, tool: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for line in output.splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key in {"release", "host", "commit-hash"}:
+            fields[key] = value.strip()
+    missing = {"release", "host", "commit-hash"} - set(fields)
+    if missing:
+        raise RuntimeError(f"{tool} verbose version omitted {sorted(missing)}")
+    return {
+        "release": fields["release"],
+        "host": fields["host"],
+        "commit_hash": fields["commit-hash"],
+    }
+
+
+def _normalize_architecture(machine: str) -> str:
+    value = machine.lower()
+    if value in {"amd64", "x64", "x86_64"}:
+        return "x86_64"
+    if value in {"arm64", "aarch64"}:
+        return "aarch64"
+    return value
+
+
+def _observed_environment(target: Mapping[str, Any]) -> dict[str, Any]:
+    system = platform.system().lower()
+    family = {"darwin": "macos", "windows": "windows", "linux": "linux"}.get(system, system)
+    architecture = _normalize_architecture(platform.machine())
+    libc = str(target["libc"])
+    libc_version: str | None = None
+    if family == "linux":
+        observed_libc, observed_version = platform.libc_ver()
+        observed_libc = observed_libc.lower()
+        if libc == "glibc" and observed_libc not in {"glibc", "libc"}:
+            version_result = _run(["ldd", "--version"])
+            combined = (version_result.stdout + version_result.stderr).lower()
+            if "glibc" not in combined and "gnu libc" not in combined:
+                raise RuntimeError("declared glibc target is not executing on glibc")
+        if libc == "musl":
+            version_result = _run(["ldd", "--version"])
+            combined = version_result.stdout + version_result.stderr
+            if "musl" not in combined.lower():
+                raise RuntimeError("declared musl target is not executing in a musl runtime")
+            match = re.search(r"Version\s+(1\.2\.\d+)", combined, flags=re.IGNORECASE)
+            if match is None:
+                raise RuntimeError("musl runtime version is not an observed 1.2.x release")
+            observed_version = match.group(1)
+        libc_version = observed_version or observed_libc or libc
+    if family != target["family"]:
+        raise RuntimeError(f"runner family {family} does not match {target['family']}")
+    if architecture != target["architecture"]:
+        raise RuntimeError(
+            f"runner architecture {architecture} does not match {target['architecture']}"
+        )
+    return {
+        "family": family,
+        "architecture": architecture,
+        "libc": libc,
+        "libc_version": libc_version,
+        "platform": platform.platform(),
+    }
+
+
+def _assert_json_diagnostics(stderr: str) -> None:
+    lines = [line for line in stderr.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError("invalid-source smoke emitted no JSON diagnostics")
+    for line in lines:
+        try:
+            diagnostic = json.loads(line)
+        except json.JSONDecodeError as error:
+            raise RuntimeError(f"invalid JSON diagnostic: {line}") from error
+        if not isinstance(diagnostic, dict):
+            raise RuntimeError("JSON diagnostic must be an object")
+        for key in ("command", "level", "kind", "message"):
+            if not isinstance(diagnostic.get(key), str) or not diagnostic[key]:
+                raise RuntimeError(f"JSON diagnostic omitted {key}")
+
+
+def run_cli_smokes(*, binary: Path, scratch_root: Path) -> list[dict[str, Any]]:
+    """Run the observable CLI contract from a Unicode, spaced, outside-worktree path."""
+
+    binary = binary.resolve()
+    scratch_root = scratch_root.resolve()
+    smoke_root = scratch_root / "outside-worktree Unicode space Ω"
+    smoke_root.mkdir(parents=True, exist_ok=False)
+    roots = {"$INSTALL": binary.parent.parent, "$SMOKE": scratch_root}
+    commands: list[dict[str, Any]] = []
+
+    source = smoke_root / "规则 unicode CRLF.clp"
+    source_text = (
+        '(deffacts start (message "Unicode café 世界"))\n'
+        "(defrule emit (message ?text) => (printout t ?text crlf))\n"
+    )
+    source.write_bytes(source_text.replace("\n", "\r\n").encode("utf-8"))
+    if b"\r\n" not in source.read_bytes():
+        raise RuntimeError("CRLF smoke fixture was not written with CRLF bytes")
+
+    invalid = smoke_root / "invalid source.clp"
+    invalid.write_bytes(b"(defrule broken\r\n")
+    snapshot = smoke_root / "snapshot state.json"
+
+    version = _run_expected(
+        name="cli-version-command",
+        argv=[str(binary), "version"],
+        expected_exit=0,
+        commands=commands,
+        roots=roots,
+        cwd=smoke_root,
+    )
+    expected_version = f"ferric {_workspace_version()}"
+    if version.stdout.strip() != expected_version:
+        raise RuntimeError("version command did not identify the exact package version")
+
+    version_flag = _run_expected(
+        name="cli-version-flag",
+        argv=[str(binary), "--version"],
+        expected_exit=0,
+        commands=commands,
+        roots=roots,
+        cwd=smoke_root,
+    )
+    if version_flag.stdout.strip() != expected_version:
+        raise RuntimeError("--version did not identify the exact package version")
+    if version.stdout.strip() != version_flag.stdout.strip():
+        raise RuntimeError("version command and --version disagree")
+
+    help_result = _run_expected(
+        name="cli-help",
+        argv=[str(binary), "--help"],
+        expected_exit=0,
+        commands=commands,
+        roots=roots,
+        cwd=smoke_root,
+    )
+    if "snapshot" not in help_result.stdout.lower() or "--trace" not in help_result.stdout:
+        raise RuntimeError("all-features CLI help omitted snapshot or tracing")
+
+    _run_expected(
+        name="cli-check-crlf-unicode",
+        argv=[str(binary), "check", str(source)],
+        expected_exit=0,
+        commands=commands,
+        roots=roots,
+        cwd=smoke_root,
+    )
+    run_result = _run_expected(
+        name="cli-run-crlf-unicode",
+        argv=[str(binary), "run", str(source)],
+        expected_exit=0,
+        commands=commands,
+        roots=roots,
+        cwd=smoke_root,
+    )
+    if run_result.stdout != "Unicode café 世界\n":
+        raise RuntimeError("Unicode run smoke did not preserve the exact output line")
+
+    _run_expected(
+        name="cli-snapshot",
+        argv=[
+            str(binary),
+            "snapshot",
+            "--json",
+            str(source),
+            "--output",
+            str(snapshot),
+            "--format",
+            "json",
+        ],
+        expected_exit=0,
+        commands=commands,
+        roots=roots,
+        cwd=smoke_root,
+    )
+    if not snapshot.is_file() or snapshot.stat().st_size == 0:
+        raise RuntimeError("snapshot smoke produced no snapshot")
+
+    _run_expected(
+        name="cli-snapshot-repl-eof",
+        argv=[
+            str(binary),
+            "repl",
+            "--snapshot",
+            str(snapshot),
+            "--snapshot-format",
+            "json",
+        ],
+        expected_exit=0,
+        commands=commands,
+        roots=roots,
+        cwd=smoke_root,
+        input_text="",
+    )
+
+    invalid_result = _run_expected(
+        name="cli-invalid-source",
+        argv=[str(binary), "check", "--json", str(invalid)],
+        expected_exit=1,
+        commands=commands,
+        roots=roots,
+        cwd=smoke_root,
+    )
+    _assert_json_diagnostics(invalid_result.stderr)
+
+    usage = _run_expected(
+        name="cli-usage-error",
+        argv=[str(binary)],
+        expected_exit=2,
+        commands=commands,
+        roots=roots,
+        cwd=smoke_root,
+    )
+    if not usage.stderr.strip():
+        raise RuntimeError("usage-error smoke emitted no diagnostic")
+
+    return commands
+
+
+def validate_dynamic_dependency_report(*, family: str, libc: str, report: str) -> None:
+    """Reject vacuous, missing, or wrong-libc native dependency reports."""
+
+    normalized = report.strip().lower()
+    if not normalized:
+        raise ValueError("dynamic dependency report is empty")
+    if "not found" in normalized or "could not be found" in normalized:
+        raise RuntimeError("dynamic dependency report contains a missing library")
+    normalized_repo = str(REPO_ROOT.resolve()).replace("\\", "/").casefold()
+    normalized_report = report.replace("\\", "/").casefold()
+    if normalized_repo in normalized_report:
+        raise RuntimeError("dynamic dependency report references the repository worktree")
+    if family == "linux" and libc == "musl":
+        probe_names = ("ldd", "readelf -l", "file")
+        markers = list(re.finditer(r"^\[probe (ldd|readelf -l|file)\]\n", report, re.MULTILINE))
+        if tuple(match.group(1) for match in markers) != probe_names:
+            raise RuntimeError("musl dependency report has incomplete probe sections")
+        probes: dict[str, tuple[int, str]] = {}
+        for index, (probe, marker) in enumerate(zip(probe_names, markers, strict=True)):
+            end = markers[index + 1].start() if index + 1 < len(markers) else len(report)
+            section = report[marker.end() : end]
+            status = re.match(r"(?:argv=[^\r\n]*\r?\n)?exit=(-?\d+)(?:\r?\n|$)", section)
+            if status is None:
+                raise RuntimeError(f"musl dependency report omitted {probe} status")
+            probes[probe] = (int(status.group(1)), section[status.end() :])
+        if probes["readelf -l"][0] != 0 or probes["file"][0] != 0:
+            raise RuntimeError("musl dependency inspection probe failed")
+        if "ld-linux" in normalized or "glibc" in normalized:
+            raise RuntimeError("musl artifact references a glibc interpreter")
+        if re.search(r"(?<!musl[-_.])libc\.so\.6", normalized):
+            raise RuntimeError("musl artifact references glibc libc.so.6")
+        readelf_report = probes["readelf -l"][1].lower()
+        file_report = probes["file"][1].lower()
+        interpreters = re.findall(
+            r"requesting program interpreter:\s*([^\]\r\n]+)",
+            readelf_report,
+        )
+        has_interpreter_segment = (
+            re.search(r"^\s*interp(?:\s|$)", readelf_report, re.MULTILINE) is not None
+            or "program interpreter" in readelf_report
+        )
+        if has_interpreter_segment:
+            if len(interpreters) != 1:
+                raise RuntimeError("musl readelf evidence has an ambiguous interpreter")
+            interpreter = interpreters[0].strip()
+            if (
+                not interpreter.startswith("/")
+                or any(character.isspace() for character in interpreter)
+                or not interpreter.rsplit("/", 1)[-1].startswith("ld-musl")
+            ):
+                raise RuntimeError("musl readelf evidence has a non-musl interpreter path")
+        elif re.search(r"\bstatic(?:ally|-pie)?\b", file_report) is None:
+            raise RuntimeError(
+                "musl file evidence does not corroborate a no-interpreter static binary"
+            )
+    elif family == "linux" and libc == "glibc":
+        if "libc.so.6" not in normalized:
+            raise RuntimeError("glibc dependency report omitted libc.so.6")
+    elif family == "macos":
+        if ".dylib" not in normalized:
+            raise RuntimeError("Mach-O dependency report omitted dylibs")
+    elif family == "windows":
+        if ".dll" not in normalized or "dependencies" not in normalized:
+            raise RuntimeError("PE dependency report omitted DLL dependencies")
+    else:
+        raise ValueError(f"unsupported dependency report family/libc: {family}/{libc}")
+
+
+def _find_dumpbin() -> Path:
+    direct = shutil.which("dumpbin")
+    if direct:
+        return Path(direct)
+    program_files_x86 = os.environ.get("PROGRAMFILES(X86)")
+    if not program_files_x86:
+        raise RuntimeError("ProgramFiles(x86) is unavailable; cannot locate dumpbin")
+    vswhere = Path(program_files_x86) / "Microsoft Visual Studio" / "Installer" / "vswhere.exe"
+    if not vswhere.is_file():
+        raise RuntimeError(f"cannot locate vswhere at {vswhere}")
+    result = _run(
+        [
+            str(vswhere),
+            "-latest",
+            "-products",
+            "*",
+            "-requires",
+            "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+            "-property",
+            "installationPath",
+        ]
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        raise RuntimeError(f"vswhere could not locate Visual Studio: {result.stderr}")
+    tools = Path(result.stdout.strip()) / "VC" / "Tools" / "MSVC"
+    matches = sorted(tools.glob("*/bin/Hostx64/x64/dumpbin.exe"), reverse=True)
+    if not matches:
+        raise RuntimeError(f"cannot locate dumpbin beneath {tools}")
+    return matches[0]
+
+
+def _inspect_dynamic_dependencies(
+    *, binary: Path, target: Mapping[str, Any]
+) -> tuple[str, str, list[str], str]:
+    family = str(target["family"])
+    libc = str(target["libc"])
+    if family == "linux" and libc == "musl":
+        ldd_argv = ["ldd", str(binary)]
+        ldd_result = _run(ldd_argv, cwd=binary.parent)
+        readelf_argv = ["readelf", "-l", str(binary)]
+        readelf_result = _run(readelf_argv, cwd=binary.parent)
+        file_result = _run(["file", str(binary)], cwd=binary.parent)
+        if readelf_result.returncode != 0:
+            raise RuntimeError(f"readelf failed for musl binary: {readelf_result.stderr}")
+        if file_result.returncode != 0:
+            raise RuntimeError(f"file failed for musl binary: {file_result.stderr}")
+        report = (
+            "[probe ldd]\n"
+            f"argv=ldd {binary}\n"
+            f"exit={ldd_result.returncode}\n"
+            f"stdout:\n{ldd_result.stdout}\n"
+            f"stderr:\n{ldd_result.stderr}\n"
+            "[probe readelf -l]\n"
+            f"argv=readelf -l {binary}\n"
+            f"exit={readelf_result.returncode}\n"
+            f"stdout:\n{readelf_result.stdout}\n"
+            f"stderr:\n{readelf_result.stderr}\n"
+            "[probe file]\n"
+            f"argv=file {binary}\n"
+            f"exit={file_result.returncode}\n"
+            f"stdout:\n{file_result.stdout}\n"
+            f"stderr:\n{file_result.stderr}"
+        )
+        kind = (
+            "musl"
+            if "requesting program interpreter:" in readelf_result.stdout.lower()
+            else "static"
+        )
+        display_argv = readelf_argv
+        tool = "readelf"
+    elif family == "linux":
+        display_argv = ["ldd", str(binary)]
+        result = _run(display_argv, cwd=binary.parent)
+        if result.returncode != 0:
+            raise RuntimeError(f"ldd failed: {result.stdout}{result.stderr}")
+        report = result.stdout + result.stderr
+        tool = "ldd"
+        kind = "glibc"
+    elif family == "macos":
+        display_argv = ["otool", "-L", str(binary)]
+        result = _run(display_argv, cwd=binary.parent)
+        if result.returncode != 0:
+            raise RuntimeError(f"otool failed: {result.stdout}{result.stderr}")
+        report = result.stdout + result.stderr
+        tool = "otool"
+        kind = "mach-o"
+    elif family == "windows":
+        dumpbin = _find_dumpbin()
+        actual_argv = [str(dumpbin), "/dependents", str(binary)]
+        result = _run(actual_argv, cwd=binary.parent)
+        if result.returncode != 0:
+            raise RuntimeError(f"dumpbin failed: {result.stdout}{result.stderr}")
+        display_argv = ["dumpbin", "/dependents", str(binary)]
+        report = result.stdout + result.stderr
+        tool = "dumpbin"
+        kind = "pe"
+    else:
+        raise ValueError(f"unsupported target family {family}")
+    validate_dynamic_dependency_report(family=family, libc=libc, report=report)
+    return tool, kind, display_argv, report
+
+
+def _verify_package_vcs(archive: Path, candidate_sha: str) -> None:
+    try:
+        with tarfile.open(archive, mode="r:gz") as package:
+            members = [
+                member
+                for member in package.getmembers()
+                if member.name.endswith("/.cargo_vcs_info.json")
+            ]
+            if len(members) != 1:
+                raise RuntimeError(f"{archive.name} has {len(members)} Cargo VCS records")
+            extracted = package.extractfile(members[0])
+            if extracted is None:
+                raise RuntimeError(f"cannot read Cargo VCS record in {archive.name}")
+            vcs = json.loads(extracted.read().decode("utf-8"))
+    except (tarfile.TarError, json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise RuntimeError(f"cannot inspect {archive}: {error}") from error
+    git = vcs.get("git", {}) if isinstance(vcs, dict) else {}
+    if not isinstance(git, dict):
+        raise RuntimeError(f"{archive.name} Cargo VCS git record is invalid")
+    if git.get("sha1") != candidate_sha:
+        raise RuntimeError(f"{archive.name} is not tied to candidate {candidate_sha}")
+    if "dirty" in git and git["dirty"] is not False:
+        raise RuntimeError(f"{archive.name} was packaged from a dirty worktree")
+
+
+def _package_record(*, archive: Path, name: str, version: str) -> dict[str, Any]:
+    return {
+        "name": name,
+        "version": version,
+        "filename": f"packages/{archive.name}",
+        "sha256": _sha256(archive),
+        "size": archive.stat().st_size,
+    }
+
+
+def _workspace_version() -> str:
+    import tomllib
+
+    with (REPO_ROOT / "Cargo.toml").open("rb") as handle:
+        manifest = tomllib.load(handle)
+    version = manifest.get("workspace", {}).get("package", {}).get("version")
+    if not isinstance(version, str) or not version:
+        raise RuntimeError("workspace package version is missing")
+    return version
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def build_native_evidence(
+    *,
+    declaration_path: Path,
+    target_id: str,
+    candidate_sha: str,
+    candidate_tree: str,
+    output_dir: Path,
+) -> dict[str, Any]:
+    declaration_path = declaration_path.resolve()
+    output_dir = output_dir.resolve()
+    declaration = _load_json(declaration_path)
+    _validate_declaration(declaration)
+    target = next((item for item in declaration["targets"] if item["id"] == target_id), None)
+    if target is None:
+        raise ValueError(f"target {target_id} is not declared")
+    if not re.fullmatch(r"[0-9a-f]{40}", candidate_sha):
+        raise ValueError("candidate SHA must be a lowercase 40-character Git SHA")
+    if not re.fullmatch(r"[0-9a-f]{40}", candidate_tree):
+        raise ValueError("candidate tree must be a lowercase 40-character Git object ID")
+    if _is_within(output_dir, REPO_ROOT):
+        raise ValueError("native evidence output must be outside the repository worktree")
+    output_dir.mkdir(parents=True, exist_ok=False)
+    packages_dir = output_dir / "packages"
+    binary_dir = output_dir / "bin"
+    packages_dir.mkdir()
+    binary_dir.mkdir()
+
+    actual_sha = _run(["git", "rev-parse", "HEAD"]).stdout.strip()
+    actual_tree = _run(["git", "rev-parse", "HEAD^{tree}"]).stdout.strip()
+    if actual_sha != candidate_sha or actual_tree != candidate_tree:
+        raise RuntimeError(
+            f"checkout is {actual_sha}/{actual_tree}, expected {candidate_sha}/{candidate_tree}"
+        )
+
+    work_parent = output_dir.parent
+    with tempfile.TemporaryDirectory(
+        prefix=f"rust-native-{target_id}-", dir=work_parent
+    ) as temporary:
+        scratch_root = Path(temporary)
+        cargo_target = scratch_root / "cargo-target"
+        install_root = scratch_root / "install"
+        roots = {
+            "$REPO": REPO_ROOT,
+            "$INSTALL": install_root,
+            "$SMOKE": scratch_root,
+            "$EVIDENCE": output_dir,
+        }
+        cargo_env = os.environ.copy()
+        cargo_env["CARGO_TARGET_DIR"] = str(cargo_target)
+        commands: list[dict[str, Any]] = []
+
+        rustc_verbose = _run_expected(
+            name="rustc-verbose",
+            argv=["rustc", "-vV"],
+            expected_exit=0,
+            commands=commands,
+            roots=roots,
+            env=cargo_env,
+        )
+        cargo_verbose = _run_expected(
+            name="cargo-verbose",
+            argv=["cargo", "-vV"],
+            expected_exit=0,
+            commands=commands,
+            roots=roots,
+            env=cargo_env,
+        )
+        toolchain = {
+            "rustc": _parse_verbose_version(rustc_verbose.stdout, "rustc"),
+            "cargo": _parse_verbose_version(cargo_verbose.stdout, "cargo"),
+        }
+        for tool, identity in toolchain.items():
+            if identity["host"] != target["rust_target"]:
+                raise RuntimeError(
+                    f"{tool} host {identity['host']} does not match {target['rust_target']}"
+                )
+        environment = _observed_environment(target)
+
+        target_args = [
+            "--target",
+            target["rust_target"],
+            "--target-dir",
+            str(cargo_target),
+        ]
+        _run_expected(
+            name="release-test",
+            argv=[*CARGO_TEST_COMMAND, *target_args],
+            expected_exit=0,
+            commands=commands,
+            roots=roots,
+            env=cargo_env,
+        )
+        _run_expected(
+            name="release-build",
+            argv=[*CARGO_BUILD_COMMAND, *target_args],
+            expected_exit=0,
+            commands=commands,
+            roots=roots,
+            env=cargo_env,
+        )
+
+        package_names = ("ferric-rules", "ferric-rules-cli")
+        package_command_names = ("package-facade", "package-cli")
+        for record_name, package_command in zip(
+            package_command_names, CARGO_PACKAGE_COMMANDS, strict=True
+        ):
+            _run_expected(
+                name=record_name,
+                argv=[*package_command, *target_args],
+                expected_exit=0,
+                commands=commands,
+                roots=roots,
+                env=cargo_env,
+            )
+
+        install_argv = [
+            "cargo",
+            "install",
+            "--path",
+            str(REPO_ROOT / "crates" / "ferric-rules-cli"),
+            "--root",
+            str(install_root),
+            "--all-features",
+            "--locked",
+            *target_args,
+        ]
+        _run_expected(
+            name="install-cli",
+            argv=install_argv,
+            expected_exit=0,
+            commands=commands,
+            roots=roots,
+            env=cargo_env,
+        )
+
+        executable_name = "ferric.exe" if target["family"] == "windows" else "ferric"
+        installed_binary = install_root / "bin" / executable_name
+        if (
+            not installed_binary.is_file()
+            or installed_binary.is_symlink()
+            or installed_binary.stat().st_size == 0
+        ):
+            raise RuntimeError(f"cargo install did not produce {installed_binary}")
+
+        commands.extend(run_cli_smokes(binary=installed_binary, scratch_root=scratch_root))
+
+        dynamic_tool, dynamic_kind, dynamic_argv, report = _inspect_dynamic_dependencies(
+            binary=installed_binary, target=target
+        )
+        commands.append(
+            _command_record(
+                name="dynamic-dependencies",
+                argv=dynamic_argv,
+                expected_exit=0,
+                actual_exit=0,
+                roots=roots,
+            )
+        )
+        if tuple(command["name"] for command in commands) != MANDATORY_COMMAND_NAMES:
+            raise RuntimeError("native command evidence is incomplete or out of order")
+
+        output_binary = binary_dir / executable_name
+        shutil.copy2(installed_binary, output_binary)
+        report_path = output_dir / "dynamic-dependencies.txt"
+        report_path.write_text(report.rstrip() + "\n", encoding="utf-8")
+
+        version = _workspace_version()
+        package_records: list[dict[str, Any]] = []
+        for package_name in package_names:
+            archive = cargo_target / "package" / f"{package_name}-{version}.crate"
+            if not archive.is_file():
+                raise RuntimeError(f"cargo package did not produce {archive}")
+            _verify_package_vcs(archive, candidate_sha)
+            destination = packages_dir / archive.name
+            shutil.copy2(archive, destination)
+            package_records.append(
+                _package_record(archive=destination, name=package_name, version=version)
+            )
+
+        receipt = {
+            "schema_version": 1,
+            "candidate": {"sha": candidate_sha, "tree": candidate_tree},
+            "artifact_contract": declaration["artifact_contract"],
+            "target": target,
+            "declaration_sha256": _sha256(declaration_path),
+            "toolchain": toolchain,
+            "environment": environment,
+            "commands": commands,
+            "packages": package_records,
+            "installed_binary": {
+                "filename": f"bin/{output_binary.name}",
+                "sha256": _sha256(output_binary),
+                "size": output_binary.stat().st_size,
+            },
+            "smokes": [{"name": name, "status": "passed"} for name in SMOKE_NAMES],
+            "dynamic_dependencies": {
+                "tool": dynamic_tool,
+                "kind": dynamic_kind,
+                "filename": report_path.name,
+                "sha256": _sha256(report_path),
+            },
+        }
+        _write_json(output_dir / "receipt.json", receipt)
+        return receipt
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--declaration", type=Path, required=True)
+    parser.add_argument("--target-id", required=True)
+    parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument("--candidate-tree", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    receipt = build_native_evidence(
+        declaration_path=args.declaration,
+        target_id=args.target_id,
+        candidate_sha=args.candidate_sha,
+        candidate_tree=args.candidate_tree,
+        output_dir=args.output_dir,
+    )
+    print(
+        f"native Rust evidence passed for {receipt['target']['id']} "
+        f"at {receipt['candidate']['sha']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-rust-native-artifacts.py
+++ b/scripts/verify-rust-native-artifacts.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""Verify and retain the exact seven-target native Rust evidence bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import sys
+import tarfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+MANDATORY_COMMAND_NAMES = (
+    "rustc-verbose",
+    "cargo-verbose",
+    "release-test",
+    "release-build",
+    "package-facade",
+    "package-cli",
+    "install-cli",
+    "cli-version-command",
+    "cli-version-flag",
+    "cli-help",
+    "cli-check-crlf-unicode",
+    "cli-run-crlf-unicode",
+    "cli-snapshot",
+    "cli-snapshot-repl-eof",
+    "cli-invalid-source",
+    "cli-usage-error",
+    "dynamic-dependencies",
+)
+
+SMOKE_NAMES = (
+    "outside-worktree-install",
+    "version",
+    "unicode-path",
+    "crlf-source",
+    "snapshot-restore",
+    "repl-eof",
+    "exit-codes",
+    "dynamic-dependencies",
+)
+
+RECEIPT_KEYS = {
+    "schema_version",
+    "candidate",
+    "artifact_contract",
+    "target",
+    "declaration_sha256",
+    "toolchain",
+    "environment",
+    "commands",
+    "packages",
+    "installed_binary",
+    "smokes",
+    "dynamic_dependencies",
+}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read JSON from {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return value
+
+
+def _require_exact_keys(value: Mapping[str, Any], expected: set[str], context: str) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise ValueError(
+            f"{context} keys differ: missing={sorted(expected - actual)}, "
+            f"extra={sorted(actual - expected)}"
+        )
+
+
+def _require_hex(value: Any, length: int, context: str) -> str:
+    if not isinstance(value, str) or re.fullmatch(rf"[0-9a-f]{{{length}}}", value) is None:
+        raise ValueError(f"{context} must be {length} lowercase hexadecimal characters")
+    return value
+
+
+def _require_nonempty_string(value: Any, context: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{context} must be a non-empty string")
+    return value
+
+
+def _expected_commands(target: Mapping[str, Any]) -> list[list[str]]:
+    rust_target = str(target["rust_target"])
+    target_args = ["--target", rust_target, "--target-dir", "$SMOKE/cargo-target"]
+    binary_name = "ferric.exe" if target["family"] == "windows" else "ferric"
+    binary = f"$INSTALL/bin/{binary_name}"
+    smoke_root = "$SMOKE/outside-worktree Unicode space Ω"
+    source = f"{smoke_root}/规则 unicode CRLF.clp"
+    invalid = f"{smoke_root}/invalid source.clp"
+    snapshot = f"{smoke_root}/snapshot state.json"
+    if target["libc"] == "musl":
+        dependency = ["readelf", "-l", binary]
+    elif target["family"] == "macos":
+        dependency = ["otool", "-L", binary]
+    elif target["family"] == "windows":
+        dependency = ["dumpbin", "/dependents", binary]
+    else:
+        dependency = ["ldd", binary]
+    return [
+        ["rustc", "-vV"],
+        ["cargo", "-vV"],
+        [
+            "cargo",
+            "test",
+            "--release",
+            "-p",
+            "ferric-rules",
+            "-p",
+            "ferric-rules-cli",
+            "--all-features",
+            "--locked",
+            *target_args,
+        ],
+        [
+            "cargo",
+            "build",
+            "--release",
+            "-p",
+            "ferric-rules-cli",
+            "--all-features",
+            "--locked",
+            *target_args,
+        ],
+        [
+            "cargo",
+            "package",
+            "-p",
+            "ferric-rules",
+            "--all-features",
+            "--locked",
+            *target_args,
+        ],
+        [
+            "cargo",
+            "package",
+            "-p",
+            "ferric-rules-cli",
+            "--all-features",
+            "--locked",
+            *target_args,
+        ],
+        [
+            "cargo",
+            "install",
+            "--path",
+            "$REPO/crates/ferric-rules-cli",
+            "--root",
+            "$INSTALL",
+            "--all-features",
+            "--locked",
+            *target_args,
+        ],
+        [binary, "version"],
+        [binary, "--version"],
+        [binary, "--help"],
+        [binary, "check", source],
+        [binary, "run", source],
+        [
+            binary,
+            "snapshot",
+            "--json",
+            source,
+            "--output",
+            snapshot,
+            "--format",
+            "json",
+        ],
+        [binary, "repl", "--snapshot", snapshot, "--snapshot-format", "json"],
+        [binary, "check", "--json", invalid],
+        [binary],
+        dependency,
+    ]
+
+
+def _validate_toolchain(toolchain: Any, target: Mapping[str, Any]) -> None:
+    if not isinstance(toolchain, dict):
+        raise ValueError("toolchain must be an object")
+    _require_exact_keys(toolchain, {"rustc", "cargo"}, "toolchain")
+    for tool in ("rustc", "cargo"):
+        identity = toolchain[tool]
+        if not isinstance(identity, dict):
+            raise ValueError(f"toolchain.{tool} must be an object")
+        _require_exact_keys(identity, {"release", "host", "commit_hash"}, f"toolchain.{tool}")
+        if identity["release"] != "1.93.0":
+            raise ValueError(f"toolchain.{tool}.release must be 1.93.0")
+        if identity["host"] != target["rust_target"]:
+            raise ValueError(f"toolchain.{tool}.host does not match the target")
+        _require_hex(identity["commit_hash"], 40, f"toolchain.{tool}.commit_hash")
+
+
+def _validate_environment(environment: Any, target: Mapping[str, Any]) -> None:
+    if not isinstance(environment, dict):
+        raise ValueError("environment must be an object")
+    _require_exact_keys(
+        environment,
+        {"family", "architecture", "libc", "libc_version", "platform"},
+        "environment",
+    )
+    for key in ("family", "architecture", "libc"):
+        if environment[key] != target[key]:
+            raise ValueError(f"environment.{key} does not match target.{key}")
+    if target["family"] == "linux":
+        libc_version = _require_nonempty_string(
+            environment["libc_version"], "environment.libc_version"
+        )
+        if target["libc"] == "musl" and re.fullmatch(r"1\.2\.\d+", libc_version) is None:
+            raise ValueError("environment.libc_version must be an observed musl 1.2.x")
+    elif environment["libc_version"] is not None:
+        raise ValueError("environment.libc_version must be null outside Linux")
+    _require_nonempty_string(environment["platform"], "environment.platform")
+
+
+def _validate_commands(commands: Any, target: Mapping[str, Any]) -> None:
+    if not isinstance(commands, list) or len(commands) != len(MANDATORY_COMMAND_NAMES):
+        raise ValueError("commands must contain the exact mandatory command sequence")
+    expected_argv = _expected_commands(target)
+    for index, (command, name, argv) in enumerate(
+        zip(commands, MANDATORY_COMMAND_NAMES, expected_argv, strict=True)
+    ):
+        if not isinstance(command, dict):
+            raise ValueError(f"commands[{index}] must be an object")
+        _require_exact_keys(
+            command,
+            {"name", "argv", "expected_exit", "actual_exit"},
+            f"commands[{index}]",
+        )
+        if command["name"] != name:
+            raise ValueError(f"commands[{index}] must be {name}")
+        if command["argv"] != argv:
+            raise ValueError(f"commands[{index}].argv differs from the normalized contract")
+        expected_exit = 1 if name == "cli-invalid-source" else 2 if name == "cli-usage-error" else 0
+        if command["expected_exit"] != expected_exit:
+            raise ValueError(f"commands[{index}].expected_exit differs")
+        if command["actual_exit"] != expected_exit:
+            raise ValueError(f"commands[{index}] did not pass")
+
+
+def _validate_dynamic_dependency_report(*, family: str, libc: str, report: str) -> None:
+    normalized = report.strip().lower()
+    if not normalized:
+        raise ValueError("dynamic dependency report is empty")
+    if "not found" in normalized or "could not be found" in normalized:
+        raise ValueError("dynamic dependency report contains a missing library")
+    normalized_repo = str(REPO_ROOT.resolve()).replace("\\", "/").casefold()
+    normalized_report = report.replace("\\", "/").casefold()
+    if normalized_repo in normalized_report:
+        raise ValueError("dynamic dependency report references the repository worktree")
+    if family == "linux" and libc == "musl":
+        probe_names = ("ldd", "readelf -l", "file")
+        markers = list(re.finditer(r"^\[probe (ldd|readelf -l|file)\]\n", report, re.MULTILINE))
+        if tuple(match.group(1) for match in markers) != probe_names:
+            raise ValueError("musl dependency report has incomplete probe sections")
+        probes: dict[str, tuple[int, str]] = {}
+        for index, (probe, marker) in enumerate(zip(probe_names, markers, strict=True)):
+            end = markers[index + 1].start() if index + 1 < len(markers) else len(report)
+            section = report[marker.end() : end]
+            status = re.match(r"(?:argv=[^\r\n]*\r?\n)?exit=(-?\d+)(?:\r?\n|$)", section)
+            if status is None:
+                raise ValueError(f"musl dependency report omitted {probe} status")
+            probes[probe] = (int(status.group(1)), section[status.end() :])
+        if probes["readelf -l"][0] != 0 or probes["file"][0] != 0:
+            raise ValueError("musl dependency inspection probe failed")
+        if "ld-linux" in normalized or "glibc" in normalized:
+            raise ValueError("musl evidence references a glibc interpreter")
+        if re.search(r"(?<!musl[-_.])libc\.so\.6", normalized):
+            raise ValueError("musl evidence references glibc libc.so.6")
+        readelf_report = probes["readelf -l"][1].lower()
+        file_report = probes["file"][1].lower()
+        interpreters = re.findall(
+            r"requesting program interpreter:\s*([^\]\r\n]+)",
+            readelf_report,
+        )
+        has_interpreter_segment = (
+            re.search(r"^\s*interp(?:\s|$)", readelf_report, re.MULTILINE) is not None
+            or "program interpreter" in readelf_report
+        )
+        if has_interpreter_segment:
+            if len(interpreters) != 1:
+                raise ValueError("musl readelf evidence has an ambiguous interpreter")
+            interpreter = interpreters[0].strip()
+            if (
+                not interpreter.startswith("/")
+                or any(character.isspace() for character in interpreter)
+                or not interpreter.rsplit("/", 1)[-1].startswith("ld-musl")
+            ):
+                raise ValueError("musl readelf evidence has a non-musl interpreter path")
+        elif re.search(r"\bstatic(?:ally|-pie)?\b", file_report) is None:
+            raise ValueError(
+                "musl file evidence does not corroborate a no-interpreter static binary"
+            )
+    elif family == "linux" and libc == "glibc":
+        if "libc.so.6" not in normalized:
+            raise ValueError("glibc evidence omitted libc.so.6")
+    elif family == "macos":
+        if ".dylib" not in normalized:
+            raise ValueError("Mach-O evidence omitted dylibs")
+    elif family == "windows":
+        if ".dll" not in normalized or "dependencies" not in normalized:
+            raise ValueError("PE evidence omitted DLL dependencies")
+    else:
+        raise ValueError(f"unsupported dependency report family/libc {family}/{libc}")
+
+
+def _safe_evidence_tree(root: Path, target_id: str, candidate_sha: str) -> dict[str, Path]:
+    if root.name != f"rust-native-{target_id}-{candidate_sha}":
+        raise ValueError(f"unexpected artifact directory {root.name}")
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError(f"artifact root is not a real directory: {root}")
+    for current, directories, files in os.walk(root, followlinks=False):
+        current_path = Path(current)
+        for name in [*directories, *files]:
+            path = current_path / name
+            if path.is_symlink():
+                raise ValueError(f"artifact evidence contains symlink {path}")
+    expected_directories = {root / "packages", root / "bin"}
+    actual_directories = {path for path in root.rglob("*") if path.is_dir()}
+    if actual_directories != expected_directories:
+        raise ValueError(f"unexpected directories in {root}")
+    expected_files = {
+        root / "receipt.json",
+        root / "dynamic-dependencies.txt",
+        root / "bin" / ("ferric.exe" if target_id.startswith("windows-") else "ferric"),
+    }
+    package_files = set((root / "packages").glob("*.crate"))
+    expected_files.update(package_files)
+    actual_files = {path for path in root.rglob("*") if path.is_file()}
+    if actual_files != expected_files:
+        raise ValueError(f"unexpected files in {root}")
+    if len(package_files) != 2:
+        raise ValueError(f"{root} must contain exactly two source packages")
+    return {
+        "receipt": root / "receipt.json",
+        "report": root / "dynamic-dependencies.txt",
+        "binary": root / "bin" / ("ferric.exe" if target_id.startswith("windows-") else "ferric"),
+    }
+
+
+def _validate_file_record(record: Any, *, root: Path, context: str) -> Path:
+    if not isinstance(record, dict):
+        raise ValueError(f"{context} must be an object")
+    required = {"filename", "sha256", "size"}
+    if context.startswith("packages["):
+        required.update({"name", "version"})
+    _require_exact_keys(record, required, context)
+    filename = _require_nonempty_string(record["filename"], f"{context}.filename")
+    relative = Path(filename)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(f"{context}.filename is not a safe relative path")
+    path = root / relative
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"{context} file is missing: {path}")
+    if record["sha256"] != _sha256(path):
+        raise ValueError(f"{context} sha256 does not match {path}")
+    if record["size"] != path.stat().st_size:
+        raise ValueError(f"{context} size does not match {path}")
+    return path
+
+
+def _validate_package_vcs(path: Path, candidate_sha: str) -> None:
+    try:
+        with tarfile.open(path, mode="r:gz") as package:
+            records = [
+                member
+                for member in package.getmembers()
+                if member.name.endswith("/.cargo_vcs_info.json")
+            ]
+            if len(records) != 1:
+                raise ValueError(f"{path.name} must contain exactly one Cargo VCS record")
+            extracted = package.extractfile(records[0])
+            if extracted is None:
+                raise ValueError(f"cannot read Cargo VCS record in {path.name}")
+            vcs = json.loads(extracted.read().decode("utf-8"))
+    except (tarfile.TarError, json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise ValueError(f"cannot inspect Cargo VCS record in {path}: {error}") from error
+    git = vcs.get("git", {}) if isinstance(vcs, dict) else {}
+    if not isinstance(git, dict):
+        raise ValueError(f"{path.name} Cargo VCS git record is invalid")
+    if git.get("sha1") != candidate_sha:
+        raise ValueError(f"{path.name} Cargo VCS SHA does not match the candidate")
+    if "dirty" in git and git["dirty"] is not False:
+        raise ValueError(f"{path.name} Cargo VCS record is not clean")
+
+
+def _validate_receipt(
+    *,
+    receipt_path: Path,
+    declaration: Mapping[str, Any],
+    declaration_sha256: str,
+    declared_target: Mapping[str, Any],
+    candidate_sha: str,
+    candidate_tree: str,
+) -> dict[str, Any]:
+    receipt = _load_json(receipt_path)
+    _require_exact_keys(receipt, RECEIPT_KEYS, str(receipt_path))
+    if receipt["schema_version"] != 1:
+        raise ValueError("receipt schema_version must be 1")
+    if receipt["candidate"] != {"sha": candidate_sha, "tree": candidate_tree}:
+        raise ValueError("receipt candidate SHA/tree drifted")
+    if receipt["declaration_sha256"] != declaration_sha256:
+        raise ValueError("receipt declaration_sha256 drifted")
+    if receipt["artifact_contract"] != declaration["artifact_contract"]:
+        raise ValueError("receipt artifact_contract drifted")
+    if receipt["target"] != declared_target:
+        raise ValueError("receipt target declaration drifted")
+    _validate_toolchain(receipt["toolchain"], declared_target)
+    _validate_environment(receipt["environment"], declared_target)
+    _validate_commands(receipt["commands"], declared_target)
+
+    root = receipt_path.parent
+    files = _safe_evidence_tree(root, declared_target["id"], candidate_sha)
+    packages = receipt["packages"]
+    if not isinstance(packages, list) or len(packages) != 2:
+        raise ValueError("receipt packages must contain exactly two records")
+    expected_packages = declaration["artifact_contract"]["packages"]
+    if [
+        package.get("name") for package in packages if isinstance(package, dict)
+    ] != expected_packages:
+        raise ValueError("receipt package order or names drifted")
+    versions: set[str] = set()
+    for index, package in enumerate(packages):
+        path = _validate_file_record(package, root=root, context=f"packages[{index}]")
+        expected_prefix = f"packages/{package['name']}-{package['version']}"
+        if package["filename"] != expected_prefix + ".crate" or path.suffix != ".crate":
+            raise ValueError(f"packages[{index}] filename drifted")
+        _validate_package_vcs(path, candidate_sha)
+        versions.add(package["version"])
+    if len(versions) != 1:
+        raise ValueError("source package versions differ")
+
+    binary = receipt["installed_binary"]
+    binary_path = _validate_file_record(binary, root=root, context="installed_binary")
+    if binary_path != files["binary"]:
+        raise ValueError("installed_binary path drifted")
+    if binary_path.stat().st_size == 0:
+        raise ValueError("installed binary is empty")
+
+    smokes = receipt["smokes"]
+    if not isinstance(smokes, list) or len(smokes) != len(SMOKE_NAMES):
+        raise ValueError("receipt smokes are incomplete")
+    for index, (smoke, expected_name) in enumerate(zip(smokes, SMOKE_NAMES, strict=True)):
+        if not isinstance(smoke, dict):
+            raise ValueError(f"smokes[{index}] must be an object")
+        _require_exact_keys(smoke, {"name", "status"}, f"smokes[{index}]")
+        if smoke != {"name": expected_name, "status": "passed"}:
+            raise ValueError(f"smokes[{index}] did not pass the exact contract")
+
+    dynamic = receipt["dynamic_dependencies"]
+    if not isinstance(dynamic, dict):
+        raise ValueError("dynamic_dependencies must be an object")
+    _require_exact_keys(dynamic, {"tool", "kind", "filename", "sha256"}, "dynamic_dependencies")
+    if dynamic["filename"] != "dynamic-dependencies.txt":
+        raise ValueError("dynamic dependency report filename drifted")
+    if dynamic["sha256"] != _sha256(files["report"]):
+        raise ValueError("dynamic dependency report sha256 drifted")
+    _validate_dynamic_dependency_report(
+        family=declared_target["family"],
+        libc=declared_target["libc"],
+        report=files["report"].read_text(encoding="utf-8"),
+    )
+    expected_tool = (
+        "readelf"
+        if declared_target["libc"] == "musl"
+        else "otool"
+        if declared_target["family"] == "macos"
+        else "dumpbin"
+        if declared_target["family"] == "windows"
+        else "ldd"
+    )
+    if dynamic["tool"] != expected_tool:
+        raise ValueError("dynamic dependency tool drifted")
+    expected_kinds = (
+        {"static", "musl"}
+        if declared_target["libc"] == "musl"
+        else {
+            "mach-o"
+            if declared_target["family"] == "macos"
+            else "pe"
+            if declared_target["family"] == "windows"
+            else "glibc"
+        }
+    )
+    if dynamic["kind"] not in expected_kinds:
+        raise ValueError("dynamic dependency kind drifted")
+    return receipt
+
+
+def _copy_verified_tree(source: Path, destination: Path) -> None:
+    shutil.copytree(source, destination, symlinks=False)
+
+
+def verify_artifact_set(
+    *,
+    declaration_path: Path,
+    artifacts_dir: Path,
+    candidate_sha: str,
+    candidate_tree: str,
+    output_dir: Path,
+) -> dict[str, Any]:
+    """Verify exactly 7 native receipts and copy their immutable evidence bundle."""
+
+    declaration_path = declaration_path.resolve()
+    artifacts_dir = artifacts_dir.resolve()
+    output_dir = output_dir.resolve()
+    _require_hex(candidate_sha, 40, "candidate_sha")
+    _require_hex(candidate_tree, 40, "candidate_tree")
+    declaration = _load_json(declaration_path)
+    _require_exact_keys(
+        declaration, {"schema_version", "artifact_contract", "targets"}, "declaration"
+    )
+    if declaration["schema_version"] != 1:
+        raise ValueError("declaration schema_version must be 1")
+    targets = declaration["targets"]
+    if not isinstance(targets, list) or len(targets) != 7:
+        raise ValueError("release declaration must contain exactly 7 targets")
+    by_id: dict[str, dict[str, Any]] = {}
+    for target in targets:
+        if not isinstance(target, dict) or not isinstance(target.get("id"), str):
+            raise ValueError("release declaration contains an invalid target")
+        if target["id"] in by_id:
+            raise ValueError(f"duplicate declared target {target['id']}")
+        by_id[target["id"]] = target
+
+    receipt_paths = sorted(artifacts_dir.rglob("receipt.json"))
+    if len(receipt_paths) != 7:
+        raise ValueError(
+            f"artifact set must contain exactly 7 receipts, found {len(receipt_paths)}"
+        )
+    declaration_digest = _sha256(declaration_path)
+    receipts: dict[str, dict[str, Any]] = {}
+    roots: dict[str, Path] = {}
+    for receipt_path in receipt_paths:
+        preliminary = _load_json(receipt_path)
+        target_id = (
+            preliminary.get("target", {}).get("id")
+            if isinstance(preliminary.get("target"), dict)
+            else None
+        )
+        if not isinstance(target_id, str) or target_id not in by_id:
+            raise ValueError(f"receipt declares unsupported target {target_id!r}")
+        if target_id in receipts:
+            raise ValueError(f"duplicate receipt for target {target_id}")
+        receipts[target_id] = _validate_receipt(
+            receipt_path=receipt_path,
+            declaration=declaration,
+            declaration_sha256=declaration_digest,
+            declared_target=by_id[target_id],
+            candidate_sha=candidate_sha,
+            candidate_tree=candidate_tree,
+        )
+        roots[target_id] = receipt_path.parent
+    if set(receipts) != set(by_id):
+        raise ValueError("artifact receipt target coverage is not exact")
+
+    top_level = {path for path in artifacts_dir.iterdir()}
+    if top_level != set(roots.values()):
+        raise ValueError("artifact download contains unexpected top-level entries")
+    if output_dir.exists():
+        raise ValueError(f"verified output already exists: {output_dir}")
+    evidence_dir = output_dir / "evidence"
+    evidence_dir.mkdir(parents=True)
+    shutil.copy2(declaration_path, output_dir / "release-targets.json")
+
+    manifest_targets: list[dict[str, Any]] = []
+    for target in targets:
+        target_id = target["id"]
+        destination = evidence_dir / roots[target_id].name
+        _copy_verified_tree(roots[target_id], destination)
+        receipt = receipts[target_id]
+        manifest_targets.append(
+            {
+                "id": target_id,
+                "evidence": f"evidence/{destination.name}",
+                "packages": receipt["packages"],
+                "installed_binary": receipt["installed_binary"],
+                "dynamic_dependencies": receipt["dynamic_dependencies"],
+            }
+        )
+    manifest = {
+        "schema_version": 1,
+        "candidate": {"sha": candidate_sha, "tree": candidate_tree},
+        "declaration_sha256": declaration_digest,
+        "artifact_contract": declaration["artifact_contract"],
+        "targets": manifest_targets,
+    }
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--declaration", type=Path, required=True)
+    parser.add_argument("--artifacts-dir", type=Path, required=True)
+    parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument("--candidate-tree", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    manifest = verify_artifact_set(
+        declaration_path=args.declaration,
+        artifacts_dir=args.artifacts_dir,
+        candidate_sha=args.candidate_sha,
+        candidate_tree=args.candidate_tree,
+        output_dir=args.output_dir,
+    )
+    print(
+        f"verified native Rust artifact bundle for {len(manifest['targets'])} targets "
+        f"at {manifest['candidate']['sha']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ferric-tools/tests/test_rust_native_artifacts.py
+++ b/tools/ferric-tools/tests/test_rust_native_artifacts.py
@@ -1,0 +1,1071 @@
+"""Adversarial tests for native Rust dependency and evidence verification."""
+
+import copy
+import hashlib
+import importlib.util
+import io
+import json
+import pathlib
+import shutil
+import sys
+import tarfile
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+HARNESS = REPO_ROOT / "scripts" / "test-rust-native-artifact.py"
+VERIFIER = REPO_ROOT / "scripts" / "verify-rust-native-artifacts.py"
+
+CANDIDATE_SHA = "1" * 40
+CANDIDATE_TREE = "2" * 40
+
+TARGETS = [
+    {
+        "id": "linux-x86_64-gnu",
+        "runner": "ubuntu-24.04",
+        "rust_target": "x86_64-unknown-linux-gnu",
+        "family": "linux",
+        "architecture": "x86_64",
+        "libc": "glibc",
+        "native_environment": "github-hosted runner",
+        "conformance": "native",
+    },
+    {
+        "id": "linux-aarch64-gnu",
+        "runner": "ubuntu-24.04-arm",
+        "rust_target": "aarch64-unknown-linux-gnu",
+        "family": "linux",
+        "architecture": "aarch64",
+        "libc": "glibc",
+        "native_environment": "github-hosted runner",
+        "conformance": "native",
+    },
+    {
+        "id": "linux-x86_64-musl",
+        "runner": "ubuntu-24.04",
+        "rust_target": "x86_64-unknown-linux-musl",
+        "family": "linux",
+        "architecture": "x86_64",
+        "libc": "musl",
+        "native_environment": "matching-architecture Alpine container",
+        "conformance": "native",
+    },
+    {
+        "id": "linux-aarch64-musl",
+        "runner": "ubuntu-24.04-arm",
+        "rust_target": "aarch64-unknown-linux-musl",
+        "family": "linux",
+        "architecture": "aarch64",
+        "libc": "musl",
+        "native_environment": "matching-architecture Alpine container",
+        "conformance": "native",
+    },
+    {
+        "id": "macos-x86_64",
+        "runner": "macos-15-intel",
+        "rust_target": "x86_64-apple-darwin",
+        "family": "macos",
+        "architecture": "x86_64",
+        "libc": "none",
+        "native_environment": "github-hosted runner",
+        "conformance": "native",
+    },
+    {
+        "id": "macos-aarch64",
+        "runner": "macos-15",
+        "rust_target": "aarch64-apple-darwin",
+        "family": "macos",
+        "architecture": "aarch64",
+        "libc": "none",
+        "native_environment": "github-hosted runner",
+        "conformance": "native",
+    },
+    {
+        "id": "windows-x86_64-msvc",
+        "runner": "windows-2025",
+        "rust_target": "x86_64-pc-windows-msvc",
+        "family": "windows",
+        "architecture": "x86_64",
+        "libc": "msvc",
+        "native_environment": "github-hosted runner",
+        "conformance": "native",
+    },
+]
+
+ARTIFACT_CONTRACT = {
+    "packages": ["ferric-rules", "ferric-rules-cli"],
+    "binary": "ferric",
+    "install_all_features": True,
+    "execution": "native",
+    "distribution": "ci-evidence-only",
+}
+
+SMOKE_NAMES = [
+    "outside-worktree-install",
+    "version",
+    "unicode-path",
+    "crlf-source",
+    "snapshot-restore",
+    "repl-eof",
+    "exit-codes",
+    "dynamic-dependencies",
+]
+
+MANDATORY_COMMAND_NAMES = (
+    "rustc-verbose",
+    "cargo-verbose",
+    "release-test",
+    "release-build",
+    "package-facade",
+    "package-cli",
+    "install-cli",
+    "cli-version-command",
+    "cli-version-flag",
+    "cli-help",
+    "cli-check-crlf-unicode",
+    "cli-run-crlf-unicode",
+    "cli-snapshot",
+    "cli-snapshot-repl-eof",
+    "cli-invalid-source",
+    "cli-usage-error",
+    "dynamic-dependencies",
+)
+
+MUSL_STATIC_REPORT = """[probe ldd]
+exit=1
+statically linked
+[probe readelf -l]
+exit=0
+Elf file type is EXEC
+Program Headers:
+  LOAD
+[probe file]
+exit=0
+ELF 64-bit executable, statically linked
+"""
+
+MUSL_DYNAMIC_REPORT = """[probe ldd]
+exit=0
+/lib/ld-musl-x86_64.so.1 (0x1)
+[probe readelf -l]
+exit=0
+Program Headers:
+  INTERP
+      [Requesting program interpreter: /lib/ld-musl-x86_64.so.1]
+[probe file]
+exit=0
+ELF 64-bit executable, dynamically linked
+"""
+
+MUSL_GLIBC_REPORT = """[probe ldd]
+exit=0
+/lib64/ld-linux-x86-64.so.2
+libc.so.6 => /lib/libc.so.6 (0x1)
+[probe readelf -l]
+exit=0
+Program Headers:
+  INTERP
+      [Requesting program interpreter: /lib64/ld-linux-x86-64.so.2]
+[probe file]
+exit=0
+ELF 64-bit executable, dynamically linked
+"""
+
+MUSL_AMBIGUOUS_REPORT = """[probe ldd]
+exit=0
+[probe readelf -l]
+exit=0
+Program Headers:
+  INTERP
+[probe file]
+exit=0
+ELF 64-bit executable, dynamically linked
+"""
+
+MUSL_CONTRADICTORY_REPORT = """[probe ldd]
+exit=1
+statically linked
+[probe readelf -l]
+exit=0
+Program Headers:
+  INTERP
+[probe file]
+exit=0
+ELF 64-bit executable, statically linked
+"""
+
+MUSL_FALSE_STATIC_REPORT = """[probe ldd]
+exit=1
+statically linked
+[probe readelf -l]
+exit=0
+Program Headers:
+  LOAD
+[probe file]
+exit=0
+ELF 64-bit executable, dynamically linked
+"""
+
+MUSL_NONPATH_INTERPRETER_REPORT = """[probe ldd]
+exit=0
+ld-musl
+[probe readelf -l]
+exit=0
+Program Headers:
+  INTERP
+      [Requesting program interpreter: ld-musl]
+[probe file]
+exit=0
+ELF 64-bit executable, dynamically linked
+"""
+
+FAKE_FERRIC = r"""#!/usr/bin/env python3
+import json
+import pathlib
+import re
+import sys
+
+binary = pathlib.Path(__file__)
+args = sys.argv[1:]
+stdin = sys.stdin.buffer.read() if args and args[0] == "repl" else b""
+source = next((pathlib.Path(arg) for arg in args if arg.endswith(".clp")), None)
+record = {"argv": args, "cwd": str(pathlib.Path.cwd()), "stdin_size": len(stdin)}
+if source is not None and source.exists():
+    content = source.read_bytes()
+    record.update(
+        source=str(source),
+        source_has_crlf=b"\r\n" in content,
+        source_has_unicode=any(ord(char) > 127 for char in str(source)),
+        source_has_space=" " in str(source),
+    )
+with binary.with_name("fake-ferric-calls.jsonl").open("a", encoding="utf-8") as log:
+    log.write(json.dumps(record) + "\n")
+
+if not args:
+    print("Usage: ferric <COMMAND>", file=sys.stderr)
+    raise SystemExit(2)
+if args in (["version"], ["--version"]):
+    print("ferric 0.1.0")
+    raise SystemExit(0)
+if args == ["--help"]:
+    print("Usage: ferric [--trace PATH] <COMMAND>\nCommands: snapshot")
+    raise SystemExit(0)
+if args[0] in {"check", "run", "snapshot"}:
+    if source is None or not source.exists():
+        raise SystemExit(1)
+    if "invalid" in source.name:
+        print(
+            json.dumps(
+                {
+                    "command": args[0],
+                    "level": "error",
+                    "kind": "load_error",
+                    "message": "invalid fixture",
+                }
+            ),
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    path_checks = ["source_has_crlf", "source_has_unicode", "source_has_space"]
+    if not all(record[key] for key in path_checks):
+        raise SystemExit(90)
+    if args[0] == "run":
+        text = source.read_text(encoding="utf-8")
+        match = re.search(r'message\s+"([^"]+)"', text)
+        print(match.group(1) if match else "Ferric Unicode ✓")
+    if args[0] == "snapshot":
+        option = "--output" if "--output" in args else "-o"
+        output = pathlib.Path(args[args.index(option) + 1])
+        output.write_bytes(b"fake snapshot")
+    raise SystemExit(0)
+if args[0] == "repl":
+    raise SystemExit(0)
+raise SystemExit(2)
+"""
+
+
+def _load_script(path: pathlib.Path, name: str):
+    assert path.is_file(), f"missing required native Rust script: {path}"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sha256(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_json(path: pathlib.Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_crate(
+    path: pathlib.Path,
+    package: str,
+    *,
+    candidate_sha: str = CANDIDATE_SHA,
+    dirty: object = False,
+    include_dirty: bool = True,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    root = f"{package}-0.1.0"
+    git: dict[str, object] = {"sha1": candidate_sha}
+    if include_dirty:
+        git["dirty"] = dirty
+    vcs = json.dumps(
+        {"git": git, "path_in_vcs": ""},
+        sort_keys=True,
+    ).encode()
+    manifest = f'[package]\nname = "{package}"\nversion = "0.1.0"\n'.encode()
+    with tarfile.open(path, mode="w:gz") as archive:
+        for name, content in [
+            (f"{root}/.cargo_vcs_info.json", vcs),
+            (f"{root}/Cargo.toml", manifest),
+        ]:
+            member = tarfile.TarInfo(name)
+            member.size = len(content)
+            member.mtime = 0
+            member.mode = 0o644
+            archive.addfile(member, io.BytesIO(content))
+
+
+def _declaration(tmp_path: pathlib.Path) -> pathlib.Path:
+    path = tmp_path / "release-targets.json"
+    _write_json(
+        path,
+        {
+            "schema_version": 1,
+            "artifact_contract": ARTIFACT_CONTRACT,
+            "targets": TARGETS,
+        },
+    )
+    return path
+
+
+def _dependency_kind(target: dict[str, str]) -> tuple[str, str, str]:
+    if target["family"] == "macos":
+        return "otool", "mach-o", "ferric:\n\t/usr/lib/libSystem.B.dylib"
+    if target["family"] == "windows":
+        return "dumpbin", "pe", "Image has the following dependencies:\nKERNEL32.dll"
+    if target["libc"] == "musl":
+        return "readelf", "static", MUSL_STATIC_REPORT.rstrip()
+    return "ldd", "glibc", "libc.so.6 => /lib/libc.so.6 (0x1)"
+
+
+def _command_entries(
+    binary: str, dependency_tool: str, rust_target: str
+) -> list[dict[str, object]]:
+    installed_binary = f"$INSTALL/bin/{binary}"
+    smoke_root = "$SMOKE/outside-worktree Unicode space Ω"
+    source = f"{smoke_root}/规则 unicode CRLF.clp"
+    invalid = f"{smoke_root}/invalid source.clp"
+    snapshot = f"{smoke_root}/snapshot state.json"
+    target_args = ["--target", rust_target, "--target-dir", "$SMOKE/cargo-target"]
+    dependency_argv = {
+        "ldd": ["ldd", installed_binary],
+        "readelf": ["readelf", "-l", installed_binary],
+        "otool": ["otool", "-L", installed_binary],
+        "dumpbin": ["dumpbin", "/dependents", installed_binary],
+    }[dependency_tool]
+    commands = {
+        "rustc-verbose": ["rustc", "-vV"],
+        "cargo-verbose": ["cargo", "-vV"],
+        "release-test": [
+            "cargo",
+            "test",
+            "--release",
+            "-p",
+            "ferric-rules",
+            "-p",
+            "ferric-rules-cli",
+            "--all-features",
+            "--locked",
+            *target_args,
+        ],
+        "release-build": [
+            "cargo",
+            "build",
+            "--release",
+            "-p",
+            "ferric-rules-cli",
+            "--all-features",
+            "--locked",
+            *target_args,
+        ],
+        "package-facade": [
+            "cargo",
+            "package",
+            "-p",
+            "ferric-rules",
+            "--all-features",
+            "--locked",
+            *target_args,
+        ],
+        "package-cli": [
+            "cargo",
+            "package",
+            "-p",
+            "ferric-rules-cli",
+            "--all-features",
+            "--locked",
+            *target_args,
+        ],
+        "install-cli": [
+            "cargo",
+            "install",
+            "--path",
+            "$REPO/crates/ferric-rules-cli",
+            "--root",
+            "$INSTALL",
+            "--all-features",
+            "--locked",
+            *target_args,
+        ],
+        "cli-version-command": [installed_binary, "version"],
+        "cli-version-flag": [installed_binary, "--version"],
+        "cli-help": [installed_binary, "--help"],
+        "cli-check-crlf-unicode": [installed_binary, "check", source],
+        "cli-run-crlf-unicode": [installed_binary, "run", source],
+        "cli-snapshot": [
+            installed_binary,
+            "snapshot",
+            "--json",
+            source,
+            "--output",
+            snapshot,
+            "--format",
+            "json",
+        ],
+        "cli-snapshot-repl-eof": [
+            installed_binary,
+            "repl",
+            "--snapshot",
+            snapshot,
+            "--snapshot-format",
+            "json",
+        ],
+        "cli-invalid-source": [installed_binary, "check", "--json", invalid],
+        "cli-usage-error": [installed_binary],
+        "dynamic-dependencies": dependency_argv,
+    }
+    expected_exits = {"cli-invalid-source": 1, "cli-usage-error": 2}
+    return [
+        {
+            "name": name,
+            "argv": commands[name],
+            "expected_exit": expected_exits.get(name, 0),
+            "actual_exit": expected_exits.get(name, 0),
+        }
+        for name in MANDATORY_COMMAND_NAMES
+    ]
+
+
+def _artifact_set(tmp_path: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    declaration = _declaration(tmp_path)
+    declaration_sha256 = _sha256(declaration)
+    artifacts = tmp_path / "artifacts"
+
+    for target in TARGETS:
+        root = artifacts / f"rust-native-{target['id']}-{CANDIDATE_SHA}"
+        binary_name = "ferric.exe" if target["family"] == "windows" else "ferric"
+        binary = root / "bin" / binary_name
+        binary.parent.mkdir(parents=True, exist_ok=True)
+        binary.write_bytes(f"binary:{target['id']}".encode())
+
+        packages = []
+        for package in ARTIFACT_CONTRACT["packages"]:
+            archive = root / "packages" / f"{package}-0.1.0.crate"
+            _write_crate(archive, package)
+            packages.append(
+                {
+                    "name": package,
+                    "version": "0.1.0",
+                    "filename": archive.relative_to(root).as_posix(),
+                    "sha256": _sha256(archive),
+                    "size": archive.stat().st_size,
+                }
+            )
+
+        tool, kind, report_text = _dependency_kind(target)
+        report = root / "dynamic-dependencies.txt"
+        report.write_text(report_text + "\n", encoding="utf-8")
+        receipt = {
+            "schema_version": 1,
+            "candidate": {"sha": CANDIDATE_SHA, "tree": CANDIDATE_TREE},
+            "artifact_contract": ARTIFACT_CONTRACT,
+            "target": target,
+            "declaration_sha256": declaration_sha256,
+            "toolchain": {
+                "rustc": {
+                    "release": "1.93.0",
+                    "host": target["rust_target"],
+                    "commit_hash": "3" * 40,
+                },
+                "cargo": {
+                    "release": "1.93.0",
+                    "host": target["rust_target"],
+                    "commit_hash": "4" * 40,
+                },
+            },
+            "environment": {
+                "family": target["family"],
+                "architecture": target["architecture"],
+                "libc": target["libc"],
+                "libc_version": (
+                    "2.39"
+                    if target["libc"] == "glibc"
+                    else "1.2.5"
+                    if target["libc"] == "musl"
+                    else None
+                ),
+                "platform": target["native_environment"],
+            },
+            "commands": _command_entries(binary.name, tool, target["rust_target"]),
+            "packages": packages,
+            "installed_binary": {
+                "filename": binary.relative_to(root).as_posix(),
+                "sha256": _sha256(binary),
+                "size": binary.stat().st_size,
+            },
+            "smokes": [{"name": name, "status": "passed"} for name in SMOKE_NAMES],
+            "dynamic_dependencies": {
+                "tool": tool,
+                "kind": kind,
+                "filename": report.name,
+                "sha256": _sha256(report),
+            },
+        }
+        _write_json(root / "receipt.json", receipt)
+
+    return declaration, artifacts
+
+
+@pytest.mark.parametrize(
+    "report",
+    [
+        MUSL_STATIC_REPORT,
+        MUSL_DYNAMIC_REPORT,
+    ],
+)
+def test_musl_dependency_audit_accepts_only_static_or_musl_runtime(report: str):
+    harness = _load_script(HARNESS, "rust_native_harness_accept")
+    harness.validate_dynamic_dependency_report(family="linux", libc="musl", report=report)
+
+
+@pytest.mark.parametrize(
+    "report",
+    [
+        MUSL_GLIBC_REPORT,
+        MUSL_STATIC_REPORT.replace("statically linked", "not found", 1),
+        MUSL_CONTRADICTORY_REPORT,
+        MUSL_FALSE_STATIC_REPORT,
+        MUSL_NONPATH_INTERPRETER_REPORT,
+        "statically linked\n",
+        "",
+    ],
+)
+def test_musl_dependency_audit_rejects_glibc_missing_or_vacuous_reports(report: str):
+    harness = _load_script(HARNESS, "rust_native_harness_reject")
+    with pytest.raises((RuntimeError, ValueError)):
+        harness.validate_dynamic_dependency_report(family="linux", libc="musl", report=report)
+
+
+def test_dependency_audit_rejects_missing_library_on_every_dynamic_platform():
+    harness = _load_script(HARNESS, "rust_native_harness_missing")
+    for family, libc in [("linux", "glibc"), ("macos", "none"), ("windows", "msvc")]:
+        with pytest.raises((RuntimeError, ValueError)):
+            harness.validate_dynamic_dependency_report(
+                family=family,
+                libc=libc,
+                report="required-library => not found\n",
+            )
+
+
+def test_harness_decodes_subprocess_evidence_as_utf8(monkeypatch: pytest.MonkeyPatch):
+    harness = _load_script(HARNESS, "rust_native_harness_utf8_subprocess")
+    captured: dict[str, object] = {}
+
+    def fake_run(*_args, **kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(harness.subprocess, "run", fake_run)
+
+    harness._run(["unicode-output-probe"])
+
+    assert captured["encoding"] == "utf-8"
+
+
+def test_cli_smoke_harness_really_exercises_unicode_crlf_snapshot_and_exit_codes(
+    tmp_path: pathlib.Path,
+):
+    if sys.platform == "win32":
+        pytest.skip("the fake executable seam is exercised by the portable Python-tools job")
+    harness = _load_script(HARNESS, "rust_native_harness_cli_smoke")
+    binary = tmp_path / "install" / "bin" / "ferric"
+    binary.parent.mkdir(parents=True)
+    binary.write_text(FAKE_FERRIC, encoding="utf-8")
+    binary.chmod(0o755)
+    scratch = tmp_path / "outside repository scratch"
+
+    commands_evidence = harness.run_cli_smokes(binary=binary, scratch_root=scratch)
+
+    assert commands_evidence == _command_entries(binary.name, "ldd", "unused")[7:16]
+    assert all(command["expected_exit"] == command["actual_exit"] for command in commands_evidence)
+    records = [
+        json.loads(line)
+        for line in binary.with_name("fake-ferric-calls.jsonl").read_text().splitlines()
+    ]
+    commands = [record["argv"] for record in records]
+    assert ["version"] in commands
+    assert ["--version"] in commands
+    assert ["--help"] in commands
+    assert [] in commands
+    assert any(command and command[0] == "snapshot" for command in commands)
+    assert any(command and command[0] == "repl" and "--snapshot" in command for command in commands)
+    source_records = [record for record in records if "source" in record]
+    assert source_records
+    assert all(record["source_has_crlf"] for record in source_records)
+    assert all(record["source_has_unicode"] for record in source_records)
+    assert all(record["source_has_space"] for record in source_records)
+
+
+@pytest.mark.parametrize(
+    ("replacement", "error"),
+    [
+        ('print("ferric 9.9.9")', "version"),
+        (
+            'print((match.group(1) if match else "Ferric Unicode ✓") + " extra")',
+            "Unicode",
+        ),
+    ],
+)
+def test_cli_smoke_harness_rejects_inexact_version_or_unicode_output(
+    tmp_path: pathlib.Path, replacement: str, error: str
+):
+    if sys.platform == "win32":
+        pytest.skip("the fake executable seam is exercised by the portable Python-tools job")
+    harness = _load_script(HARNESS, f"rust_native_harness_cli_inexact_{error.lower()}")
+    binary = tmp_path / "install" / "bin" / "ferric"
+    binary.parent.mkdir(parents=True)
+    if error == "version":
+        fake = FAKE_FERRIC.replace('print("ferric 0.1.0")', replacement)
+    else:
+        fake = FAKE_FERRIC.replace(
+            'print(match.group(1) if match else "Ferric Unicode ✓")', replacement
+        )
+    binary.write_text(fake, encoding="utf-8")
+    binary.chmod(0o755)
+
+    with pytest.raises(RuntimeError, match=error):
+        harness.run_cli_smokes(
+            binary=binary,
+            scratch_root=tmp_path / "outside repository scratch",
+        )
+
+
+def test_verifier_accepts_and_retains_one_exact_seven_target_bundle(tmp_path: pathlib.Path):
+    verifier = _load_script(VERIFIER, "rust_native_verifier_valid")
+    declaration, artifacts = _artifact_set(tmp_path)
+    output = tmp_path / "verified"
+
+    manifest = verifier.verify_artifact_set(
+        declaration_path=declaration,
+        artifacts_dir=artifacts,
+        candidate_sha=CANDIDATE_SHA,
+        candidate_tree=CANDIDATE_TREE,
+        output_dir=output,
+    )
+
+    assert manifest["candidate"] == {"sha": CANDIDATE_SHA, "tree": CANDIDATE_TREE}
+    assert len(manifest["targets"]) == 7
+    assert (output / "manifest.json").is_file()
+    assert len(list(output.rglob("receipt.json"))) == 7
+    assert len(list(output.rglob("*.crate"))) == 14
+    assert len(list(output.rglob("dynamic-dependencies.txt"))) == 7
+    assert len(list(output.rglob("bin/ferric"))) == 6
+    assert len(list(output.rglob("bin/ferric.exe"))) == 1
+
+
+def _receipt_for(artifacts: pathlib.Path, target_id: str) -> pathlib.Path:
+    matches = list(artifacts.rglob(f"rust-native-{target_id}-*/receipt.json"))
+    assert len(matches) == 1
+    return matches[0]
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "candidate-sha",
+        "candidate-tree",
+        "declaration-digest",
+        "target-declaration",
+        "package-digest",
+        "binary-digest",
+        "empty-binary-rehashed",
+        "dependency-digest",
+        "dependency-tool",
+        "dependency-kind",
+        "dependency-filename",
+        "failed-smoke",
+        "missing-smoke",
+        "extra-receipt-field",
+        "unexpected-package",
+        "path-traversal",
+        "missing-toolchain",
+        "missing-environment",
+        "missing-commands",
+        "extra-candidate-field",
+        "extra-toolchain-field",
+        "extra-tool-field",
+        "extra-environment-field",
+        "extra-package-field",
+        "extra-binary-field",
+        "extra-smoke-field",
+        "extra-dynamic-field",
+        "rustc-release",
+        "cargo-release",
+        "toolchain-host",
+        "cargo-host",
+        "environment-family",
+        "environment-architecture",
+        "environment-libc",
+        "missing-command",
+        "command-order",
+        "command-exit",
+        "command-expected",
+        "command-schema",
+        "command-argv",
+        "command-root-leak",
+    ],
+)
+def test_verifier_rejects_tampered_receipts(tmp_path: pathlib.Path, mutation: str):
+    verifier = _load_script(VERIFIER, f"rust_native_verifier_{mutation.replace('-', '_')}")
+    declaration, artifacts = _artifact_set(tmp_path)
+    receipt_path = _receipt_for(artifacts, "linux-x86_64-gnu")
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+
+    if mutation == "candidate-sha":
+        receipt["candidate"]["sha"] = "3" * 40
+    elif mutation == "candidate-tree":
+        receipt["candidate"]["tree"] = "3" * 40
+    elif mutation == "declaration-digest":
+        receipt["declaration_sha256"] = "3" * 64
+    elif mutation == "target-declaration":
+        receipt["target"]["runner"] = "ubuntu-latest"
+    elif mutation == "package-digest":
+        receipt["packages"][0]["sha256"] = "3" * 64
+    elif mutation == "binary-digest":
+        receipt["installed_binary"]["sha256"] = "3" * 64
+    elif mutation == "empty-binary-rehashed":
+        binary = receipt_path.parent / receipt["installed_binary"]["filename"]
+        binary.write_bytes(b"")
+        receipt["installed_binary"]["sha256"] = _sha256(binary)
+        receipt["installed_binary"]["size"] = 0
+    elif mutation == "dependency-digest":
+        receipt["dynamic_dependencies"]["sha256"] = "3" * 64
+    elif mutation == "dependency-tool":
+        receipt["dynamic_dependencies"]["tool"] = "cat"
+    elif mutation == "dependency-kind":
+        receipt["dynamic_dependencies"]["kind"] = "static"
+    elif mutation == "dependency-filename":
+        receipt["dynamic_dependencies"]["filename"] = "../dynamic-dependencies.txt"
+    elif mutation == "failed-smoke":
+        receipt["smokes"][0]["status"] = "failed"
+    elif mutation == "missing-smoke":
+        receipt["smokes"].pop()
+    elif mutation == "extra-receipt-field":
+        receipt["unverified"] = True
+    elif mutation == "unexpected-package":
+        receipt["packages"][0]["name"] = "other-package"
+    elif mutation == "path-traversal":
+        receipt["installed_binary"]["filename"] = "../ferric"
+    elif mutation == "missing-toolchain":
+        del receipt["toolchain"]
+    elif mutation == "missing-environment":
+        del receipt["environment"]
+    elif mutation == "missing-commands":
+        del receipt["commands"]
+    elif mutation == "extra-candidate-field":
+        receipt["candidate"]["ref"] = "refs/heads/main"
+    elif mutation == "extra-toolchain-field":
+        receipt["toolchain"]["channel"] = "stable"
+    elif mutation == "extra-tool-field":
+        receipt["toolchain"]["rustc"]["verbose"] = True
+    elif mutation == "extra-environment-field":
+        receipt["environment"]["runner"] = "ubuntu-latest"
+    elif mutation == "extra-package-field":
+        receipt["packages"][0]["unchecked"] = True
+    elif mutation == "extra-binary-field":
+        receipt["installed_binary"]["unchecked"] = True
+    elif mutation == "extra-smoke-field":
+        receipt["smokes"][0]["detail"] = "unchecked"
+    elif mutation == "extra-dynamic-field":
+        receipt["dynamic_dependencies"]["unchecked"] = True
+    elif mutation == "rustc-release":
+        receipt["toolchain"]["rustc"]["release"] = "1.92.0"
+    elif mutation == "cargo-release":
+        receipt["toolchain"]["cargo"]["release"] = "1.92.0"
+    elif mutation == "toolchain-host":
+        receipt["toolchain"]["rustc"]["host"] = "x86_64-pc-windows-msvc"
+    elif mutation == "cargo-host":
+        receipt["toolchain"]["cargo"]["host"] = "x86_64-pc-windows-msvc"
+    elif mutation == "environment-family":
+        receipt["environment"]["family"] = "windows"
+    elif mutation == "environment-architecture":
+        receipt["environment"]["architecture"] = "aarch64"
+    elif mutation == "environment-libc":
+        receipt["environment"]["libc"] = "musl"
+    elif mutation == "missing-command":
+        receipt["commands"].pop()
+    elif mutation == "command-order":
+        receipt["commands"][0], receipt["commands"][1] = (
+            receipt["commands"][1],
+            receipt["commands"][0],
+        )
+    elif mutation == "command-exit":
+        receipt["commands"][0]["actual_exit"] = 1
+    elif mutation == "command-expected":
+        receipt["commands"][0]["expected_exit"] = 99
+        receipt["commands"][0]["actual_exit"] = 99
+    elif mutation == "command-schema":
+        receipt["commands"][0]["ignored"] = True
+    elif mutation == "command-argv":
+        receipt["commands"][8]["argv"][-1] = "--help"
+    elif mutation == "command-root-leak":
+        receipt["commands"][7]["argv"][0] = "/tmp/install/bin/ferric"
+    else:
+        raise AssertionError(f"unknown mutation {mutation}")
+    _write_json(receipt_path, receipt)
+
+    with pytest.raises((RuntimeError, ValueError)):
+        verifier.verify_artifact_set(
+            declaration_path=declaration,
+            artifacts_dir=artifacts,
+            candidate_sha=CANDIDATE_SHA,
+            candidate_tree=CANDIDATE_TREE,
+            output_dir=tmp_path / "verified",
+        )
+
+
+@pytest.mark.parametrize(
+    ("target_id", "report"),
+    [
+        ("linux-x86_64-gnu", ""),
+        ("linux-x86_64-gnu", "libmissing.so => not found\n"),
+        (
+            "linux-x86_64-musl",
+            MUSL_GLIBC_REPORT,
+        ),
+        (
+            "linux-x86_64-musl",
+            MUSL_AMBIGUOUS_REPORT,
+        ),
+        (
+            "linux-x86_64-musl",
+            MUSL_CONTRADICTORY_REPORT,
+        ),
+        (
+            "linux-x86_64-musl",
+            MUSL_FALSE_STATIC_REPORT,
+        ),
+        (
+            "linux-x86_64-musl",
+            MUSL_NONPATH_INTERPRETER_REPORT,
+        ),
+        (
+            "linux-x86_64-gnu",
+            f"{REPO_ROOT}/target/release/ferric\nlibc.so.6 => /lib/libc.so.6 (0x1)\n",
+        ),
+    ],
+)
+def test_verifier_revalidates_rehashed_dependency_report_semantics(
+    tmp_path: pathlib.Path, target_id: str, report: str
+):
+    verifier = _load_script(
+        VERIFIER,
+        f"rust_native_verifier_dependency_semantics_{target_id.replace('-', '_')}",
+    )
+    declaration, artifacts = _artifact_set(tmp_path)
+    receipt_path = _receipt_for(artifacts, target_id)
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    report_path = receipt_path.parent / receipt["dynamic_dependencies"]["filename"]
+    report_path.write_text(report, encoding="utf-8")
+    receipt["dynamic_dependencies"]["sha256"] = _sha256(report_path)
+    _write_json(receipt_path, receipt)
+
+    with pytest.raises((RuntimeError, ValueError)):
+        verifier.verify_artifact_set(
+            declaration_path=declaration,
+            artifacts_dir=artifacts,
+            candidate_sha=CANDIDATE_SHA,
+            candidate_tree=CANDIDATE_TREE,
+            output_dir=tmp_path / "verified",
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ["candidate-sha", "dirty-true", "dirty-null", "dirty-string", "dirty-number"],
+)
+def test_verifier_revalidates_rehashed_package_vcs_provenance(
+    tmp_path: pathlib.Path, mutation: str
+):
+    verifier = _load_script(VERIFIER, f"rust_native_verifier_package_vcs_{mutation}")
+    declaration, artifacts = _artifact_set(tmp_path)
+    receipt_path = _receipt_for(artifacts, "linux-x86_64-gnu")
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    package = receipt["packages"][0]
+    archive = receipt_path.parent / package["filename"]
+    dirty = {
+        "candidate-sha": False,
+        "dirty-true": True,
+        "dirty-null": None,
+        "dirty-string": "false",
+        "dirty-number": 0,
+    }[mutation]
+    _write_crate(
+        archive,
+        package["name"],
+        candidate_sha="f" * 40 if mutation == "candidate-sha" else CANDIDATE_SHA,
+        dirty=dirty,
+    )
+    package["sha256"] = _sha256(archive)
+    package["size"] = archive.stat().st_size
+    _write_json(receipt_path, receipt)
+
+    with pytest.raises((RuntimeError, ValueError)):
+        verifier.verify_artifact_set(
+            declaration_path=declaration,
+            artifacts_dir=artifacts,
+            candidate_sha=CANDIDATE_SHA,
+            candidate_tree=CANDIDATE_TREE,
+            output_dir=tmp_path / "verified",
+        )
+
+
+@pytest.mark.parametrize(
+    ("mutation", "version"),
+    [
+        ("missing", None),
+        ("null", None),
+        ("empty", ""),
+        ("generic", "musl"),
+        ("old", "1.1.24"),
+        ("new", "1.3.0"),
+        ("unrelated", "9.9.9"),
+    ],
+)
+def test_verifier_requires_observed_musl_1_2_version(
+    tmp_path: pathlib.Path, mutation: str, version: object
+):
+    verifier = _load_script(VERIFIER, f"rust_native_verifier_musl_version_{mutation}")
+    declaration, artifacts = _artifact_set(tmp_path)
+    receipt_path = _receipt_for(artifacts, "linux-x86_64-musl")
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    if mutation == "missing":
+        del receipt["environment"]["libc_version"]
+    else:
+        receipt["environment"]["libc_version"] = version
+    _write_json(receipt_path, receipt)
+
+    with pytest.raises((RuntimeError, ValueError)):
+        verifier.verify_artifact_set(
+            declaration_path=declaration,
+            artifacts_dir=artifacts,
+            candidate_sha=CANDIDATE_SHA,
+            candidate_tree=CANDIDATE_TREE,
+            output_dir=tmp_path / "verified",
+        )
+
+
+def test_verifier_accepts_cargo_clean_vcs_record_with_omitted_dirty(
+    tmp_path: pathlib.Path,
+):
+    verifier = _load_script(VERIFIER, "rust_native_verifier_cargo_omitted_dirty")
+    declaration, artifacts = _artifact_set(tmp_path)
+    receipt_path = _receipt_for(artifacts, "linux-x86_64-gnu")
+    receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    package = receipt["packages"][0]
+    archive = receipt_path.parent / package["filename"]
+    _write_crate(archive, package["name"], include_dirty=False)
+    package["sha256"] = _sha256(archive)
+    package["size"] = archive.stat().st_size
+    _write_json(receipt_path, receipt)
+
+    verifier.verify_artifact_set(
+        declaration_path=declaration,
+        artifacts_dir=artifacts,
+        candidate_sha=CANDIDATE_SHA,
+        candidate_tree=CANDIDATE_TREE,
+        output_dir=tmp_path / "verified",
+    )
+
+
+@pytest.mark.parametrize("unexpected", ["file", "directory", "symlink"])
+def test_verifier_rejects_unexpected_or_linked_artifact_entries(
+    tmp_path: pathlib.Path, unexpected: str
+):
+    verifier = _load_script(VERIFIER, f"rust_native_verifier_layout_{unexpected}")
+    declaration, artifacts = _artifact_set(tmp_path)
+    receipt = _receipt_for(artifacts, "linux-x86_64-gnu")
+    root = receipt.parent
+
+    if unexpected == "file":
+        (root / "unverified.txt").write_text("not in receipt", encoding="utf-8")
+    elif unexpected == "directory":
+        (root / "unverified").mkdir()
+    elif unexpected == "symlink":
+        link = root / "binary-link"
+        try:
+            link.symlink_to(root / "bin" / "ferric")
+        except OSError as error:
+            pytest.skip(f"symlink unavailable: {error}")
+    else:
+        raise AssertionError(f"unknown unexpected entry {unexpected}")
+
+    with pytest.raises((RuntimeError, ValueError)):
+        verifier.verify_artifact_set(
+            declaration_path=declaration,
+            artifacts_dir=artifacts,
+            candidate_sha=CANDIDATE_SHA,
+            candidate_tree=CANDIDATE_TREE,
+            output_dir=tmp_path / "verified",
+        )
+
+
+@pytest.mark.parametrize("mutation", ["missing", "duplicate", "extra"])
+def test_verifier_rejects_inexact_target_coverage(tmp_path: pathlib.Path, mutation: str):
+    verifier = _load_script(VERIFIER, f"rust_native_verifier_coverage_{mutation}")
+    declaration, artifacts = _artifact_set(tmp_path)
+    source = _receipt_for(artifacts, "linux-x86_64-gnu").parent
+
+    if mutation == "missing":
+        shutil.rmtree(_receipt_for(artifacts, "macos-aarch64").parent)
+    elif mutation == "duplicate":
+        shutil.copytree(
+            source,
+            artifacts / f"rust-native-linux-x86_64-gnu-{CANDIDATE_SHA}-duplicate",
+        )
+    elif mutation == "extra":
+        extra = artifacts / f"rust-native-unsupported-target-{CANDIDATE_SHA}"
+        shutil.copytree(source, extra)
+        receipt = json.loads((source / "receipt.json").read_text(encoding="utf-8"))
+        receipt["target"] = copy.deepcopy(receipt["target"])
+        receipt["target"]["id"] = "unsupported-target"
+        _write_json(extra / "receipt.json", receipt)
+    else:
+        raise AssertionError(f"unknown mutation {mutation}")
+
+    with pytest.raises((RuntimeError, ValueError)):
+        verifier.verify_artifact_set(
+            declaration_path=declaration,
+            artifacts_dir=artifacts,
+            candidate_sha=CANDIDATE_SHA,
+            candidate_tree=CANDIDATE_TREE,
+            output_dir=tmp_path / "verified",
+        )

--- a/tools/ferric-tools/tests/test_rust_native_ci_policy.py
+++ b/tools/ferric-tools/tests/test_rust_native_ci_policy.py
@@ -1,0 +1,374 @@
+"""Keep the declared Rust/CLI release matrix native, complete, and fail-closed."""
+
+import importlib.util
+import json
+import pathlib
+import re
+import sys
+import tomllib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+DECLARATION = REPO_ROOT / "crates" / "ferric-rules-cli" / "release-targets.json"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "rust-native-artifacts.yml"
+HARNESS = REPO_ROOT / "scripts" / "test-rust-native-artifact.py"
+VERIFIER = REPO_ROOT / "scripts" / "verify-rust-native-artifacts.py"
+RUST_TOOLCHAIN = REPO_ROOT / "rust-toolchain.toml"
+GITATTRIBUTES = REPO_ROOT / ".gitattributes"
+
+ALPINE_IMAGE = (
+    "python:3.12-alpine@sha256:6d43704baacd1bfbe7c295d7f13079d5d8104ed33568873133f8fc69980419df"
+)
+
+EXPECTED_TARGETS = {
+    "linux-x86_64-gnu": {
+        "runner": "ubuntu-24.04",
+        "rust_target": "x86_64-unknown-linux-gnu",
+        "family": "linux",
+        "architecture": "x86_64",
+        "libc": "glibc",
+        "native_environment": "ubuntu-24.04",
+    },
+    "linux-aarch64-gnu": {
+        "runner": "ubuntu-24.04-arm",
+        "rust_target": "aarch64-unknown-linux-gnu",
+        "family": "linux",
+        "architecture": "aarch64",
+        "libc": "glibc",
+        "native_environment": "ubuntu-24.04-arm",
+    },
+    "linux-x86_64-musl": {
+        "runner": "ubuntu-24.04",
+        "rust_target": "x86_64-unknown-linux-musl",
+        "family": "linux",
+        "architecture": "x86_64",
+        "libc": "musl",
+        "native_environment": ALPINE_IMAGE,
+    },
+    "linux-aarch64-musl": {
+        "runner": "ubuntu-24.04-arm",
+        "rust_target": "aarch64-unknown-linux-musl",
+        "family": "linux",
+        "architecture": "aarch64",
+        "libc": "musl",
+        "native_environment": ALPINE_IMAGE,
+    },
+    "macos-x86_64": {
+        "runner": "macos-15-intel",
+        "rust_target": "x86_64-apple-darwin",
+        "family": "macos",
+        "architecture": "x86_64",
+        "libc": "none",
+        "native_environment": "macos-15-intel",
+    },
+    "macos-aarch64": {
+        "runner": "macos-15",
+        "rust_target": "aarch64-apple-darwin",
+        "family": "macos",
+        "architecture": "aarch64",
+        "libc": "none",
+        "native_environment": "macos-15",
+    },
+    "windows-x86_64-msvc": {
+        "runner": "windows-2025",
+        "rust_target": "x86_64-pc-windows-msvc",
+        "family": "windows",
+        "architecture": "x86_64",
+        "libc": "msvc",
+        "native_environment": "windows-2025",
+    },
+}
+
+EXPECTED_PACKAGES = [
+    "ferric-rules",
+    "ferric-rules-cli",
+]
+
+MANDATORY_COMMAND_NAMES = (
+    "rustc-verbose",
+    "cargo-verbose",
+    "release-test",
+    "release-build",
+    "package-facade",
+    "package-cli",
+    "install-cli",
+    "cli-version-command",
+    "cli-version-flag",
+    "cli-help",
+    "cli-check-crlf-unicode",
+    "cli-run-crlf-unicode",
+    "cli-snapshot",
+    "cli-snapshot-repl-eof",
+    "cli-invalid-source",
+    "cli-usage-error",
+    "dynamic-dependencies",
+)
+
+
+def _job(workflow: str, name: str) -> str:
+    match = re.search(
+        rf"(?ms)^  {re.escape(name)}:\n(?P<job>.*?)(?=^  [a-z][a-z0-9-]+:\n|\Z)",
+        workflow,
+    )
+    assert match is not None, f"workflow must define the {name} job"
+    return match.group("job")
+
+
+def _load_script(path: pathlib.Path, name: str):
+    assert path.is_file(), f"missing required native Rust script: {path}"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _workflow_text() -> str:
+    assert WORKFLOW.is_file(), f"missing required native Rust workflow: {WORKFLOW}"
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _declaration() -> dict[str, object]:
+    assert DECLARATION.is_file(), f"missing Rust/CLI release declaration: {DECLARATION}"
+    return json.loads(DECLARATION.read_text(encoding="utf-8"))
+
+
+def _matrix_rows(job: str) -> dict[str, dict[str, str]]:
+    matrix = re.search(
+        r"(?ms)^      matrix:\n        include:\n(?P<rows>.*?)(?=^    runs-on:)",
+        job,
+    )
+    assert matrix is not None, "native-rust must use an explicit include matrix"
+    rows: dict[str, dict[str, str]] = {}
+    for match in re.finditer(
+        r"(?ms)^          - target: (?P<target>[^\n]+)\n"
+        r"(?P<body>.*?)(?=^          - target:|\Z)",
+        matrix.group("rows"),
+    ):
+        target = match.group("target").strip('"')
+        assert target not in rows, f"duplicate native matrix target: {target}"
+        rows[target] = {
+            key: value.strip().strip('"')
+            for key, value in re.findall(
+                r"(?m)^            ([a-z_]+): ([^\n#]+?)(?:\s+#.*)?$", match.group("body")
+            )
+        }
+    return rows
+
+
+def _assert_direct_candidate_checkout(job: str) -> None:
+    checkout = re.search(
+        r"(?ms)^      - uses: actions/checkout@v4\n(?P<with>        with:\n(?:          .*\n)+)",
+        job,
+    )
+    assert checkout is not None, "job must check out an explicit immutable candidate"
+    checkout_with = checkout.group("with")
+    assert "ref:" in checkout_with
+    assert "github.event.pull_request.head.sha" in checkout_with
+    assert "github.sha" in checkout_with
+    assert "fetch-depth: 0" in checkout_with
+
+
+def test_release_declaration_is_the_exact_non_vacuous_native_matrix():
+    declaration = _declaration()
+
+    assert declaration["schema_version"] == 1
+    assert declaration["artifact_contract"]["packages"] == EXPECTED_PACKAGES
+    assert declaration["artifact_contract"]["binary"] == "ferric"
+    assert declaration["artifact_contract"]["install_all_features"] is True
+    assert declaration["artifact_contract"]["execution"] == "native"
+    assert declaration["artifact_contract"]["distribution"] == "ci-evidence-only"
+
+    targets = declaration["targets"]
+    assert len(targets) == 7
+    by_id = {target["id"]: target for target in targets}
+    assert len(by_id) == len(targets), "release target IDs must be unique"
+    assert by_id.keys() == EXPECTED_TARGETS.keys()
+    for target_id, expected in EXPECTED_TARGETS.items():
+        actual = by_id[target_id]
+        for key, value in expected.items():
+            assert actual.get(key) == value, f"{target_id}.{key} drifted"
+        assert actual.get("conformance") == "native"
+
+
+def test_workflow_matrix_exactly_matches_the_release_declaration():
+    workflow = _workflow_text()
+    declaration = _declaration()
+    declared = {target["id"]: target for target in declaration["targets"]}
+    job = _job(workflow, "native-rust")
+    rows = _matrix_rows(job)
+
+    assert rows.keys() == EXPECTED_TARGETS.keys()
+    for target_id, row in rows.items():
+        target = declared[target_id]
+        for key in ["runner", "rust_target", "family", "libc"]:
+            assert row.get(key) == target.get(key), f"matrix {target_id}.{key} drifted"
+        expected_image = target["native_environment"] if target["libc"] == "musl" else None
+        assert row.get("container_image") == expected_image, (
+            f"matrix {target_id}.container_image drifted"
+        )
+
+    assert "    runs-on: ${{ matrix.runner }}\n" in job
+    assert "      fail-fast: false\n" in job
+    assert "    timeout-minutes: 45\n" in job
+    assert "continue-on-error" not in workflow
+    assert "cross-compile" not in job.lower()
+    _assert_direct_candidate_checkout(job)
+
+
+def test_each_native_job_packages_installs_and_smokes_outside_the_worktree():
+    workflow = _workflow_text()
+    job = _job(workflow, "native-rust")
+
+    for command in [
+        "scripts/test-rust-native-artifact.py",
+        "--declaration crates/ferric-rules-cli/release-targets.json",
+        '--target-id "$TARGET_ID"',
+        '--candidate-sha "$CANDIDATE_SHA"',
+        '--candidate-tree "$CANDIDATE_TREE"',
+    ]:
+        assert command in job, f"native-rust is missing `{command}`"
+    assert "          python scripts/test-rust-native-artifact.py" in job
+    assert "              python3 scripts/test-rust-native-artifact.py" in job
+
+    assert "runner.temp" in job
+    assert "rust-native-evidence/${{ matrix.target }}" in job
+    assert "name: rust-native-${{ matrix.target }}-${{ env.CANDIDATE_SHA }}" in job
+    assert "receipt.json" in job
+    assert "if-no-files-found: error" in job
+    assert "retention-days: 30" in job
+
+    # The musl rows must compile, install, execute, and inspect in Alpine on a
+    # same-architecture runner. A target-only build on glibc is not evidence.
+    assert "if: matrix.libc == 'musl'" in job
+    assert "docker run" in job
+    assert "${{ runner.temp }}" in job
+    assert "${{ matrix.container_image }}" in job
+    assert "rustup" in job
+    assert re.search(r"apk add --no-cache [^\n]*\bbinutils\b", job)
+
+    # These observable smokes are intentionally locked at the workflow/harness
+    # boundary so a matrix cannot pass after silently dropping one category.
+    harness_module = _load_script(HARNESS, "rust_native_artifact_harness_policy")
+    assert harness_module.CARGO_TEST_COMMAND == (
+        "cargo",
+        "test",
+        "--release",
+        "-p",
+        "ferric-rules",
+        "-p",
+        "ferric-rules-cli",
+        "--all-features",
+        "--locked",
+    )
+    assert harness_module.CARGO_BUILD_COMMAND == (
+        "cargo",
+        "build",
+        "--release",
+        "-p",
+        "ferric-rules-cli",
+        "--all-features",
+        "--locked",
+    )
+    assert harness_module.CARGO_PACKAGE_COMMANDS == (
+        ("cargo", "package", "-p", "ferric-rules", "--all-features", "--locked"),
+        (
+            "cargo",
+            "package",
+            "-p",
+            "ferric-rules-cli",
+            "--all-features",
+            "--locked",
+        ),
+    )
+    assert harness_module.MANDATORY_COMMAND_NAMES == MANDATORY_COMMAND_NAMES
+
+    harness = HARNESS.read_text(encoding="utf-8").lower()
+    for required in [
+        "install",
+        "--path",
+        "--root",
+        "--all-features",
+        "--locked",
+        "version",
+        "unicode",
+        "crlf",
+        "snapshot",
+        "repl",
+        "exit",
+        "dynamic",
+        "dependency",
+        "readelf",
+        "[probe readelf -l]",
+        "candidate_sha",
+        "candidate_tree",
+    ]:
+        assert required in harness, f"artifact harness lost its {required} contract"
+
+
+def test_stable_aggregate_verifies_and_retains_the_exact_candidate_bundle():
+    workflow = _workflow_text()
+    job = _job(workflow, "native-rust-required")
+
+    assert "    name: Rust Native Artifacts\n" in job
+    assert "    needs: native-rust\n" in job
+    assert "    if: always()\n" in job
+    assert ("if: needs.native-rust.result != 'success'" in job and "exit 1" in job) or (
+        "NATIVE_RUST_PASSED: ${{ needs.native-rust.result == 'success' }}" in job
+        and 'test "$NATIVE_RUST_PASSED" = true' in job
+    )
+    _assert_direct_candidate_checkout(job)
+    for required in [
+        "actions/download-artifact@v4",
+        "rust-native-*",
+        "scripts/verify-rust-native-artifacts.py",
+        "--declaration crates/ferric-rules-cli/release-targets.json",
+        '--candidate-sha "$CANDIDATE_SHA"',
+        '--candidate-tree "$CANDIDATE_TREE"',
+        "actions/upload-artifact@v4",
+        "rust-native-verified",
+        "if-no-files-found: error",
+        "runner.temp",
+        "retention-days: 30",
+    ]:
+        assert required in job, f"native-rust-required is missing `{required}`"
+    assert "name: rust-native-verified-${{ env.CANDIDATE_SHA }}" in job
+
+    verifier = VERIFIER.read_text(encoding="utf-8").lower()
+    for required in [
+        "candidate_sha",
+        "candidate_tree",
+        "declaration_sha256",
+        "packages",
+        "installed_binary",
+        "sha256",
+        "receipt.json",
+        "exactly 7",
+        "toolchain",
+        "environment",
+        "commands",
+        "expected_exit",
+        "actual_exit",
+    ]:
+        assert required in verifier, f"aggregate verifier lost its {required} contract"
+
+
+def test_workflow_trigger_and_permissions_make_the_stable_gate_unskippable():
+    workflow = _workflow_text()
+    toolchain = tomllib.loads(RUST_TOOLCHAIN.read_text(encoding="utf-8"))
+
+    assert workflow.startswith("name: Rust Native Artifacts\n")
+    assert re.search(r"(?m)^  push:\n    branches: \[main]$", workflow)
+    assert re.search(r"(?m)^  pull_request:\n    branches: \[main]$", workflow)
+    assert re.search(r"(?m)^  workflow_dispatch:$", workflow)
+    assert "paths:" not in workflow
+    assert "paths-ignore:" not in workflow
+    assert re.search(r"(?m)^permissions:\n  contents: read$", workflow)
+    assert toolchain["toolchain"]["channel"] == "1.93.0"
+    assert re.search(r'(?m)^  RUST_TOOLCHAIN: "1\.93\.0"$', workflow)
+
+
+def test_release_declaration_bytes_are_stable_across_native_checkouts():
+    attributes = GITATTRIBUTES.read_text(encoding="utf-8").splitlines()
+
+    assert "crates/ferric-rules-cli/release-targets.json text eol=lf" in attributes


### PR DESCRIPTION
Closes #149

## Summary

- declare the exact seven native Rust facade/CLI targets, runners, architectures, and libc environments
- add an unconditional direct-head workflow that builds, release-tests, packages, path-installs, and exercises each target natively
- retain strict per-target receipts and a fail-closed, candidate-bound verified artifact bundle behind the stable `Rust Native Artifacts` aggregate check
- add adversarial policy/provenance tests and document the support and scope boundaries

## Why

The Rust facade and CLI had no machine-readable native support contract or dedicated native artifact gate. Existing primary CI was Ubuntu-centric and did not prove that the installed CLI, source packages, dynamic dependencies, and candidate provenance agreed across the declared OS/architecture/libc matrix.

The retained binaries are CI evidence only; this does not introduce downloadable prebuilt CLI products or historical glibc/macOS deployment-floor claims. Clean-room installation remains #153, binding matrices remain #124, and formal required-status/ruleset hardening remains #150.

## Validation

- `just preflight-pr` outside the sandbox: pass
- focused native policy/adversarial suite: 89 passed
- full ferric-tools suite: 722 passed
- exact commit `7057f816351c87e3bc850969023f70a74324bd03` native macOS-aarch64 harness: pass, including release tests/build, both Cargo packages, outside-worktree install, Unicode/CRLF/snapshot/exit smokes, dependency inspection, and Cargo VCS provenance
- Ruff lint/format, `py_compile`, `actionlint`, Cargo metadata/package-list validation, and `git diff --check`: pass
